### PR TITLE
feat: add rhoai-upgrade-helpers and relocate binary to /opt/rhoai-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ ARG UPGRADE_HELPERS_REPO=https://github.com/red-hat-data-services/rhoai-upgrade-
 ARG UPGRADE_HELPERS_BRANCH=main
 
 RUN git clone --depth 1 --branch ${UPGRADE_HELPERS_BRANCH} \
-    ${UPGRADE_HELPERS_REPO} /opt/rhoai-upgrade-helpers \
-    && rm -rf /opt/rhoai-upgrade-helpers/.git
+    ${UPGRADE_HELPERS_REPO} /opt/rhai-upgrade-helpers \
+    && rm -rf /opt/rhai-upgrade-helpers/.git
 
 # Runtime stage
 FROM registry.access.redhat.com/ubi9/ubi:latest
@@ -90,14 +90,14 @@ RUN set -e; \
     rm -f openshift-client.tar.gz kubectl README.md
 
 # Copy binary from builder (cross-compiled for target platform)
-COPY --from=builder /workspace/bin/kubectl-odh /opt/rhoai-cli/bin/rhoai-cli
+COPY --from=builder /workspace/bin/kubectl-odh /opt/rhai-cli/bin/rhai-cli
 
-# Add rhoai-cli to PATH
-ENV PATH="/opt/rhoai-cli/bin:${PATH}"
+# Add rhai-cli to PATH
+ENV PATH="/opt/rhai-cli/bin:${PATH}"
 
 # Copy upgrade helpers from builder
-COPY --from=builder /opt/rhoai-upgrade-helpers /opt/rhoai-upgrade-helpers
+COPY --from=builder /opt/rhai-upgrade-helpers /opt/rhai-upgrade-helpers
 
-# Set entrypoint to rhoai-cli binary
+# Set entrypoint to rhai-cli binary
 # Users can override with --entrypoint /bin/bash for interactive debugging
-ENTRYPOINT ["/opt/rhoai-cli/bin/rhoai-cli"]
+ENTRYPOINT ["/opt/rhai-cli/bin/rhai-cli"]


### PR DESCRIPTION
- Clone rhoai-upgrade-helpers repo in builder stage and copy to
  /opt/rhoai-upgrade-helpers in runtime image (repo URL and branch
  configurable via build args)
- Move CLI binary from /usr/local/bin/kubectl-odh to
  /opt/rhoai-cli/bin/rhoai-cli and update ENTRYPOINT accordingly
- Add /opt/rhoai-cli/bin to PATH for convenient invocation

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The container now uses rhai-cli as the default command-line tool.
  * Upgrade helper tools are bundled and available inside the image.

* **Chores**
  * Build and runtime image configuration updated to include the new CLI and helpers.
  * Environment setup adjusted so the new CLI is on the default PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->