### PR TITLE
feat: use dynamic target version in lint check messages

### DIFF
--- a/pkg/lint/check/condition_test.go
+++ b/pkg/lint/check/condition_test.go
@@ -437,14 +437,14 @@ func TestNewCondition_WithMultipleFormatArgs(t *testing.T) {
 		check.ConditionTypeCompatible,
 		metav1.ConditionFalse,
 		check.WithReason(check.ReasonVersionIncompatible),
-		check.WithMessage("Found %d %s - will be impacted in RHOAI %s", 3, "InferenceServices", "3.x"),
+		check.WithMessage("Found %d %s - will be impacted in RHOAI %s", 3, "InferenceServices", "3.0"),
 	)
 
 	g.Expect(condition.Condition).To(MatchFields(IgnoreExtras, Fields{
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": Equal("Found 3 InferenceServices - will be impacted in RHOAI 3.x"),
+		"Message": Equal("Found 3 InferenceServices - will be impacted in RHOAI 3.0"),
 	}))
 }
 

--- a/pkg/lint/checks/components/codeflare/codeflare.go
+++ b/pkg/lint/checks/components/codeflare/codeflare.go
@@ -52,7 +52,7 @@ func (c *RemovalCheck) CanApply(ctx context.Context, target check.Target) (bool,
 // Validate executes the check against the provided target.
 func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	return validate.Component(c, target).
-		Run(ctx, validate.Removal("CodeFlare is enabled (state: %s) but will be removed in RHOAI 3.x",
+		Run(ctx, validate.Removal("CodeFlare is enabled (state: %s) but will be removed in RHOAI %s",
 			check.WithImpact(result.ImpactBlocking),
 			check.WithRemediation(c.CheckRemediation)))
 }

--- a/pkg/lint/checks/components/codeflare/codeflare_test.go
+++ b/pkg/lint/checks/components/codeflare/codeflare_test.go
@@ -77,7 +77,7 @@ func TestCodeFlareRemovalCheck_ManagedBlocking(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("enabled"), ContainSubstring("removed in RHOAI 3.x")),
+		"Message": And(ContainSubstring("enabled"), ContainSubstring("removed in RHOAI 3.0")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 	g.Expect(result.Annotations).To(And(

--- a/pkg/lint/checks/components/datasciencepipelines/renaming.go
+++ b/pkg/lint/checks/components/datasciencepipelines/renaming.go
@@ -59,12 +59,14 @@ func (c *RenamingCheck) Validate(ctx context.Context, target check.Target) (*res
 }
 
 func newRenamingCondition(_ context.Context, req *validate.ComponentRequest) ([]result.Condition, error) {
+	tv := version.MajorMinorLabel(req.TargetVersion)
+
 	return []result.Condition{
 		check.NewCondition(
 			check.ConditionTypeCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonComponentRenamed),
-			check.WithMessage("DataSciencePipelines component (state: %s) will be renamed to AIPipelines in DSC v2 (RHOAI 3.x). The field path changes from '.spec.components.datasciencepipelines' to '.spec.components.aipipelines'", req.ManagementState),
+			check.WithMessage("DataSciencePipelines component (state: %s) will be renamed to AIPipelines in DSC v2 (RHOAI %s). The field path changes from '.spec.components.datasciencepipelines' to '.spec.components.aipipelines'", req.ManagementState, tv),
 			check.WithImpact(result.ImpactAdvisory),
 			check.WithRemediation("No action required - the component will be automatically renamed. Update any automation referencing '.spec.components.datasciencepipelines' to use '.spec.components.aipipelines' after upgrade"),
 		),

--- a/pkg/lint/checks/components/kserve/serverless_test.go
+++ b/pkg/lint/checks/components/kserve/serverless_test.go
@@ -156,7 +156,7 @@ func TestKServeServerlessRemovalCheck_ServerlessManagedBlocking(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("serverless mode is enabled"), ContainSubstring("removed in RHOAI 3.x")),
+		"Message": And(ContainSubstring("serverless mode is enabled"), ContainSubstring("removed in RHOAI 3.0")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 	g.Expect(result.Annotations).To(And(
@@ -253,7 +253,7 @@ func TestKServeServerlessRemovalCheck_ServerlessRemovedReady(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionTrue),
 		"Reason":  Equal(check.ReasonVersionCompatible),
-		"Message": And(ContainSubstring("serverless mode is disabled"), ContainSubstring("ready for RHOAI 3.x upgrade")),
+		"Message": And(ContainSubstring("serverless mode is disabled"), ContainSubstring("ready for RHOAI 3.0 upgrade")),
 	}))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationComponentManagementState, constants.ManagementStateManaged))
 }

--- a/pkg/lint/checks/components/kueue/kueue.go
+++ b/pkg/lint/checks/components/kueue/kueue.go
@@ -63,13 +63,15 @@ func (c *ManagementStateCheck) CanApply(ctx context.Context, target check.Target
 func (c *ManagementStateCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	return validate.Component(c, target).
 		Run(ctx, func(_ context.Context, req *validate.ComponentRequest) error {
+			tv := version.MajorMinorLabel(req.TargetVersion)
+
 			switch req.ManagementState {
 			case constants.ManagementStateManaged:
 				req.Result.SetCondition(check.NewCondition(
 					check.ConditionTypeCompatible,
 					metav1.ConditionFalse,
 					check.WithReason(check.ReasonVersionIncompatible),
-					check.WithMessage("Kueue is managed by OpenShift AI (state: %s) but Managed option will be removed in RHOAI 3.x", req.ManagementState),
+					check.WithMessage("Kueue is managed by OpenShift AI (state: %s) but Managed option will be removed in RHOAI %s", req.ManagementState, tv),
 					check.WithImpact(result.ImpactBlocking),
 					check.WithRemediation(c.CheckRemediation),
 				))
@@ -78,7 +80,7 @@ func (c *ManagementStateCheck) Validate(ctx context.Context, target check.Target
 					check.ConditionTypeCompatible,
 					metav1.ConditionTrue,
 					check.WithReason(check.ReasonVersionCompatible),
-					check.WithMessage("Kueue managementState is %s — compatible with RHOAI 3.x", req.ManagementState),
+					check.WithMessage("Kueue managementState is %s — compatible with RHOAI %s", req.ManagementState, tv),
 				))
 			}
 

--- a/pkg/lint/checks/components/kueue/kueue_test.go
+++ b/pkg/lint/checks/components/kueue/kueue_test.go
@@ -106,7 +106,7 @@ func TestManagementStateCheck_UnmanagedAllowed(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionTrue),
 		"Reason":  Equal(check.ReasonVersionCompatible),
-		"Message": ContainSubstring("compatible with RHOAI 3.x"),
+		"Message": ContainSubstring("compatible with RHOAI 3.1"),
 	}))
 }
 

--- a/pkg/lint/checks/components/modelmesh/modelmesh.go
+++ b/pkg/lint/checks/components/modelmesh/modelmesh.go
@@ -51,7 +51,7 @@ func (c *RemovalCheck) CanApply(ctx context.Context, target check.Target) (bool,
 
 func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	return validate.Component(c, target).
-		Run(ctx, validate.Removal("ModelMesh is enabled (state: %s) but will be removed in RHOAI 3.x",
+		Run(ctx, validate.Removal("ModelMesh is enabled (state: %s) but will be removed in RHOAI %s",
 			check.WithImpact(result.ImpactBlocking),
 			check.WithRemediation(c.CheckRemediation)))
 }

--- a/pkg/lint/checks/components/modelmesh/modelmesh_test.go
+++ b/pkg/lint/checks/components/modelmesh/modelmesh_test.go
@@ -77,7 +77,7 @@ func TestModelmeshRemovalCheck_ManagedBlocking(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("enabled"), ContainSubstring("removed in RHOAI 3.x")),
+		"Message": And(ContainSubstring("enabled"), ContainSubstring("removed in RHOAI 3.0")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 	g.Expect(result.Annotations).To(And(

--- a/pkg/lint/checks/dependencies/openshift/openshift.go
+++ b/pkg/lint/checks/dependencies/openshift/openshift.go
@@ -48,6 +48,7 @@ func (c *Check) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	dr := c.NewResult()
+	tv := version.MajorMinorLabel(target.TargetVersion)
 
 	ver, err := version.DetectOpenShiftVersion(ctx, target.Client)
 
@@ -57,7 +58,7 @@ func (c *Check) Validate(
 			check.ConditionTypeCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonInsufficientData),
-			check.WithMessage("Unable to detect OpenShift version: %s. RHOAI 3.x requires OpenShift %s or later", err.Error(), minVersion.String()),
+			check.WithMessage("Unable to detect OpenShift version: %s. RHOAI %s requires OpenShift %s or later", err.Error(), tv, minVersion.String()),
 			check.WithImpact(result.ImpactBlocking),
 		))
 	case ver.GTE(minVersion):
@@ -65,15 +66,15 @@ func (c *Check) Validate(
 			check.ConditionTypeCompatible,
 			metav1.ConditionTrue,
 			check.WithReason(check.ReasonVersionCompatible),
-			check.WithMessage("OpenShift %s meets RHOAI 3.x minimum version requirement (%s+)", ver.String(), minVersion.String()),
+			check.WithMessage("OpenShift %s meets RHOAI %s minimum version requirement (%s+)", ver.String(), tv, minVersion.String()),
 		))
 	default:
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonVersionIncompatible),
-			check.WithMessage("OpenShift %s does not meet RHOAI 3.x minimum version requirement (%s+). Upgrade OpenShift to %s or later before upgrading RHOAI",
-				ver.String(), minVersion.String(), minVersion.String()),
+			check.WithMessage("OpenShift %s does not meet RHOAI %s minimum version requirement (%s+). Upgrade OpenShift to %s or later before upgrading RHOAI",
+				ver.String(), tv, minVersion.String(), minVersion.String()),
 			check.WithImpact(result.ImpactBlocking),
 		))
 	}

--- a/pkg/lint/checks/dependencies/openshift/openshift_test.go
+++ b/pkg/lint/checks/dependencies/openshift/openshift_test.go
@@ -53,7 +53,7 @@ func TestOpenShiftCheck_VersionMeetsRequirement(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionTrue),
 		"Reason":  Equal(check.ReasonVersionCompatible),
-		"Message": ContainSubstring("4.19.9 meets RHOAI 3.x minimum version requirement"),
+		"Message": ContainSubstring("4.19.9 meets RHOAI 3.0 minimum version requirement"),
 	}))
 }
 
@@ -107,7 +107,7 @@ func TestOpenShiftCheck_VersionBelowRequirement(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonVersionIncompatible),
 		"Message": And(
-			ContainSubstring("4.18.5 does not meet RHOAI 3.x minimum version requirement"),
+			ContainSubstring("4.18.5 does not meet RHOAI 3.0 minimum version requirement"),
 			ContainSubstring("4.19"),
 		),
 	}))
@@ -138,7 +138,7 @@ func TestOpenShiftCheck_PatchVersionBelowRequirement(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonVersionIncompatible),
 		"Message": And(
-			ContainSubstring("4.19.8 does not meet RHOAI 3.x minimum version requirement"),
+			ContainSubstring("4.19.8 does not meet RHOAI 3.0 minimum version requirement"),
 			ContainSubstring("4.19.9"),
 		),
 	}))

--- a/pkg/lint/checks/dependencies/servicemeshoperator/servicemeshoperator_test.go
+++ b/pkg/lint/checks/dependencies/servicemeshoperator/servicemeshoperator_test.go
@@ -34,7 +34,7 @@ func TestServiceMeshOperator2Check_NotInstalled(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionTrue),
 		"Reason":  Equal(check.ReasonVersionCompatible),
-		"Message": And(ContainSubstring("not installed"), ContainSubstring("ready for RHOAI 3.x")),
+		"Message": And(ContainSubstring("not installed"), ContainSubstring("ready for RHOAI 3.0")),
 	}))
 }
 
@@ -69,7 +69,7 @@ func TestServiceMeshOperator2Check_InstalledBlocking(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("no longer required by RHOAI 3.x"), ContainSubstring("should be removed")),
+		"Message": And(ContainSubstring("no longer required by RHOAI 3.0"), ContainSubstring("should be removed")),
 	}))
 	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator.v2.5.0"))
 }

--- a/pkg/lint/checks/services/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/services/servicemesh/servicemesh_test.go
@@ -105,7 +105,7 @@ func TestServiceMeshRemovalCheck_ManagedBlocking(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("enabled"), ContainSubstring("no longer required by RHOAI 3.x")),
+		"Message": And(ContainSubstring("enabled"), ContainSubstring("no longer required by RHOAI 3.0")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
@@ -187,7 +187,7 @@ func TestServiceMeshRemovalCheck_RemovedReady(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionTrue),
 		"Reason":  Equal(check.ReasonVersionCompatible),
-		"Message": And(ContainSubstring("disabled"), ContainSubstring("ready for RHOAI 3.x upgrade")),
+		"Message": And(ContainSubstring("disabled"), ContainSubstring("ready for RHOAI 3.0 upgrade")),
 	}))
 }
 

--- a/pkg/lint/checks/workloads/codeflare/impacted.go
+++ b/pkg/lint/checks/workloads/codeflare/impacted.go
@@ -84,6 +84,6 @@ func (c *ImpactedWorkloadsCheck) newAppWrapperCondition(
 		ConditionTypeAppWrapperCompatible,
 		metav1.ConditionTrue,
 		check.WithReason(check.ReasonVersionCompatible),
-		check.WithMessage("No AppWrapper(s) found - ready for RHOAI 3.x upgrade"),
+		check.WithMessage("No AppWrapper(s) found - ready for RHOAI %s upgrade", version.MajorMinorLabel(req.TargetVersion)),
 	)}, nil
 }

--- a/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
@@ -67,6 +67,7 @@ func (c *InstructLabRemovalCheck) Validate(ctx context.Context, target check.Tar
 				return err
 			}
 
+			tv := version.MajorMinorLabel(req.TargetVersion)
 			impactedDSPAs := make([]types.NamespacedName, 0)
 
 			for i := range dspas {
@@ -95,7 +96,7 @@ func (c *InstructLabRemovalCheck) Validate(ctx context.Context, target check.Tar
 					check.ConditionTypeCompatible,
 					metav1.ConditionFalse,
 					check.WithReason(check.ReasonFeatureRemoved),
-					check.WithMessage("Found %d DataSciencePipelinesApplication(s) with deprecated '.spec.apiServer.managedPipelines.instructLab' field - InstructLab feature was removed in RHOAI 3.x", len(impactedDSPAs)),
+					check.WithMessage("Found %d DataSciencePipelinesApplication(s) with deprecated '.spec.apiServer.managedPipelines.instructLab' field - InstructLab feature was removed in RHOAI %s", len(impactedDSPAs), tv),
 					check.WithImpact(result.ImpactAdvisory),
 					check.WithRemediation(c.CheckRemediation),
 				))
@@ -109,7 +110,7 @@ func (c *InstructLabRemovalCheck) Validate(ctx context.Context, target check.Tar
 				check.ConditionTypeCompatible,
 				metav1.ConditionTrue,
 				check.WithReason(check.ReasonVersionCompatible),
-				check.WithMessage("No DataSciencePipelinesApplications found using deprecated 'managedPipelines.instructLab' field - ready for RHOAI 3.x upgrade"),
+				check.WithMessage("No DataSciencePipelinesApplications found using deprecated 'managedPipelines.instructLab' field - ready for RHOAI %s upgrade", tv),
 			))
 
 			return nil

--- a/pkg/lint/checks/workloads/datasciencepipelines/stored_version_removal.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/stored_version_removal.go
@@ -23,8 +23,8 @@ const (
 	// The deprecated stored version that will be removed in 3.x.
 	deprecatedStoredVersion = "v1alpha1"
 
-	msgStoredVersionFound    = "Some DataSciencePipelinesApplication resources still use the deprecated %s API version which will be removed in RHOAI 3.x"
-	msgStoredVersionNotFound = "No DataSciencePipelinesApplication resources using deprecated %s API version - ready for RHOAI 3.x upgrade"
+	msgStoredVersionFound    = "Some DataSciencePipelinesApplication resources still use the deprecated %s API version which will be removed in RHOAI %s"
+	msgStoredVersionNotFound = "No DataSciencePipelinesApplication resources using deprecated %s API version - ready for RHOAI %s upgrade"
 	msgCRDNotFound           = "DataSciencePipelinesApplication CRD not found - DataSciencePipelines may not be installed"
 )
 
@@ -62,6 +62,7 @@ func (c *StoredVersionRemovalCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	dr := c.NewResult()
+	tv := version.MajorMinorLabel(target.TargetVersion)
 
 	if target.TargetVersion != nil {
 		dr.Annotations[check.AnnotationCheckTargetVersion] = target.TargetVersion.String()
@@ -105,7 +106,7 @@ func (c *StoredVersionRemovalCheck) Validate(
 			check.ConditionTypeCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonVersionIncompatible),
-			check.WithMessage(msgStoredVersionFound, deprecatedStoredVersion),
+			check.WithMessage(msgStoredVersionFound, deprecatedStoredVersion, tv),
 			check.WithImpact(result.ImpactBlocking),
 			check.WithRemediation(c.CheckRemediation),
 		))
@@ -117,7 +118,7 @@ func (c *StoredVersionRemovalCheck) Validate(
 		check.ConditionTypeCompatible,
 		metav1.ConditionTrue,
 		check.WithReason(check.ReasonVersionCompatible),
-		check.WithMessage(msgStoredVersionNotFound, deprecatedStoredVersion),
+		check.WithMessage(msgStoredVersionNotFound, deprecatedStoredVersion, tv),
 	))
 
 	return dr, nil

--- a/pkg/lint/checks/workloads/kserve/impacted.go
+++ b/pkg/lint/checks/workloads/kserve/impacted.go
@@ -142,12 +142,14 @@ func (c *ImpactedWorkloadsCheck) Validate(
 		return nil, err
 	}
 
-	// Each function appends its condition and impacted objects to the result
-	c.appendServerlessISVCCondition(dr, allISVCs)
-	c.appendModelMeshISVCCondition(dr, allISVCs)
-	c.appendModelMeshSRCondition(dr, impactedSRs)
+	tv := version.MajorMinorLabel(target.TargetVersion)
 
-	if err := c.appendRemovedRuntimeISVCCondition(dr, removedRuntimeISVCs); err != nil {
+	// Each function appends its condition and impacted objects to the result
+	c.appendServerlessISVCCondition(dr, allISVCs, tv)
+	c.appendModelMeshISVCCondition(dr, allISVCs, tv)
+	c.appendModelMeshSRCondition(dr, impactedSRs, tv)
+
+	if err := c.appendRemovedRuntimeISVCCondition(dr, removedRuntimeISVCs, tv); err != nil {
 		return nil, err
 	}
 

--- a/pkg/lint/checks/workloads/ray/impacted_support.go
+++ b/pkg/lint/checks/workloads/ray/impacted_support.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
 // newWorkloadCompatibilityCondition creates a compatibility condition based on workload count.
@@ -17,13 +18,14 @@ func (c *ImpactedWorkloadsCheck) newWorkloadCompatibilityCondition(
 	conditionType string,
 	count int,
 	workloadDescription string,
+	targetVersionLabel string,
 ) result.Condition {
 	if count > 0 {
 		return check.NewCondition(
 			conditionType,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonVersionIncompatible),
-			check.WithMessage("Found %d %s - will be impacted in RHOAI 3.x (CodeFlare not available)", count, workloadDescription),
+			check.WithMessage("Found %d %s - will be impacted in RHOAI %s (CodeFlare not available)", count, workloadDescription, targetVersionLabel),
 			check.WithImpact(result.ImpactAdvisory),
 			check.WithRemediation(c.CheckRemediation),
 		)
@@ -33,7 +35,7 @@ func (c *ImpactedWorkloadsCheck) newWorkloadCompatibilityCondition(
 		conditionType,
 		metav1.ConditionTrue,
 		check.WithReason(check.ReasonVersionCompatible),
-		check.WithMessage("No %s found - ready for RHOAI 3.x upgrade", workloadDescription),
+		check.WithMessage("No %s found - ready for RHOAI %s upgrade", workloadDescription, targetVersionLabel),
 	)
 }
 
@@ -45,5 +47,6 @@ func (c *ImpactedWorkloadsCheck) newCodeFlareRayClusterCondition(
 		ConditionTypeCodeFlareRayClusterCompatible,
 		len(req.Items),
 		"CodeFlare-managed RayCluster(s)",
+		version.MajorMinorLabel(req.TargetVersion),
 	)}, nil
 }

--- a/pkg/lint/checks/workloads/ray/impacted_test.go
+++ b/pkg/lint/checks/workloads/ray/impacted_test.go
@@ -88,7 +88,7 @@ func TestImpactedWorkloadsCheck_WithCodeFlareFinalizer(t *testing.T) {
 		"Reason": Equal(check.ReasonVersionIncompatible),
 		"Message": And(
 			ContainSubstring("Found 1 CodeFlare-managed RayCluster(s)"),
-			ContainSubstring("will be impacted in RHOAI 3.x"),
+			ContainSubstring("will be impacted in RHOAI 3.0"),
 		),
 	}))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
@@ -230,7 +230,7 @@ func TestImpactedWorkloadsCheck_MultipleClusters(t *testing.T) {
 		"Reason": Equal(check.ReasonVersionIncompatible),
 		"Message": And(
 			ContainSubstring("Found 2 CodeFlare-managed RayCluster(s)"),
-			ContainSubstring("will be impacted in RHOAI 3.x"),
+			ContainSubstring("will be impacted in RHOAI 3.0"),
 		),
 	}))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "2"))

--- a/pkg/util/version/helpers.go
+++ b/pkg/util/version/helpers.go
@@ -1,6 +1,20 @@
 package version
 
-import "github.com/blang/semver/v4"
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
+// MajorMinorLabel formats a semver version as "major.minor" for use in user-facing messages.
+// Returns "unknown" if version is nil.
+func MajorMinorLabel(v *semver.Version) string {
+	if v == nil {
+		return "unknown"
+	}
+
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
 
 // IsUpgradeFrom2xTo3x checks if the versions represent an upgrade from 2.x to 3.x specifically.
 // Future major versions (4.x+) may have different compatibility requirements.

--- a/pkg/util/version/helpers_test.go
+++ b/pkg/util/version/helpers_test.go
@@ -199,6 +199,45 @@ func TestIsVersionAtLeast(t *testing.T) {
 	}
 }
 
+func TestMajorMinorLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  *semver.Version
+		expected string
+	}{
+		{
+			name:     "nil version returns unknown",
+			version:  nil,
+			expected: "unknown",
+		},
+		{
+			name:     "3.0.0 returns 3.0",
+			version:  toVersionPtr("3.0.0"),
+			expected: "3.0",
+		},
+		{
+			name:     "3.3.1 returns 3.3",
+			version:  toVersionPtr("3.3.1"),
+			expected: "3.3",
+		},
+		{
+			name:     "2.17.0 returns 2.17",
+			version:  toVersionPtr("2.17.0"),
+			expected: "2.17",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := version.MajorMinorLabel(tt.version)
+
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
 func toVersionPtr(versionStr string) *semver.Version {
 	v := semver.MustParse(versionStr)
 


### PR DESCRIPTION
Replace hardcoded "RHOAI 3.x" in lint check condition messages with the
actual target version (e.g. "RHOAI 3.0", "RHOAI 3.3") derived from the
--target-version flag.

- Add version.MajorMinorLabel() helper to format semver as "major.minor"
- Embed full check.Target in ComponentRequest and WorkloadRequest so
  validation callbacks can access target version info
- Update validate.Removal() to auto-inject target version label
- Update all lint checks to use dynamic version in runtime messages
- Static check names/descriptions kept as-is (set at construction time)

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Diagnostic and validation messages now display explicit target version labels (e.g., "RHOAI 3.0") instead of generic placeholders (e.g., "3.x"), improving clarity about which components, services, and workloads are impacted or ready for upgrades. Tests and messaging across checks were aligned to the new, version-specific wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->