### PR TITLE
refactor: group CodeFlare checks under Ray kind

### DIFF
--- a/pkg/lint/check/validate/component.go
+++ b/pkg/lint/check/validate/component.go
@@ -80,6 +80,15 @@ type ComponentValidateFn func(ctx context.Context, req *ComponentRequest) error
 // Use with Complete as a higher-level alternative to Run when the callback only needs to set conditions.
 type ComponentConditionFn func(ctx context.Context, req *ComponentRequest) ([]result.Condition, error)
 
+// WithComponentName overrides the DSC component key used for management state queries.
+// By default, Component() derives the key from c.CheckKind(). Use this when the
+// user-facing kind differs from the DSC spec key (e.g., kind="ray" but DSC key="codeflare").
+func (b *ComponentBuilder) WithComponentName(name string) *ComponentBuilder {
+	b.componentName = name
+
+	return b
+}
+
 // InState specifies which management states trigger validation.
 // If the component is not in any of the specified states, a "not configured" result is returned.
 // If no states are specified (InState not called), validation runs for any configured state.

--- a/pkg/lint/checks/components/ray/codeflare_removal.go
+++ b/pkg/lint/checks/components/ray/codeflare_removal.go
@@ -1,4 +1,4 @@
-package codeflare
+package ray
 
 import (
 	"context"
@@ -13,22 +13,28 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
-const kind = "codeflare"
+const (
+	kind = "ray"
 
-// RemovalCheck validates that CodeFlare is disabled before upgrading to 3.x.
-type RemovalCheck struct {
+	// dscComponent is the DSC spec key for the CodeFlare component.
+	// The user-facing kind is "ray" but the DSC still uses "codeflare".
+	dscComponent = "codeflare"
+)
+
+// CodeFlareRemovalCheck validates that CodeFlare is disabled before upgrading to 3.x.
+type CodeFlareRemovalCheck struct {
 	check.BaseCheck
 }
 
-func NewRemovalCheck() *RemovalCheck {
-	return &RemovalCheck{
+func NewCodeFlareRemovalCheck() *CodeFlareRemovalCheck {
+	return &CodeFlareRemovalCheck{
 		BaseCheck: check.BaseCheck{
 			CheckGroup:       check.GroupComponent,
 			Kind:             kind,
 			Type:             check.CheckTypeRemoval,
-			CheckID:          "components.codeflare.removal",
-			CheckName:        "Components :: CodeFlare :: Removal (3.x)",
-			CheckDescription: "Validates that CodeFlare is disabled before upgrading from RHOAI 2.x to 3.x (component will be removed)",
+			CheckID:          "components.ray.codeflare-removal",
+			CheckName:        "Components :: Ray :: CodeFlare Removal (3.x)",
+			CheckDescription: "Validates that the CodeFlare security layer is disabled before upgrading from RHOAI 2.x to 3.x",
 			CheckRemediation: "Disable CodeFlare by setting managementState to 'Removed' in DataScienceCluster before upgrading",
 		},
 	}
@@ -36,7 +42,7 @@ func NewRemovalCheck() *RemovalCheck {
 
 // CanApply returns whether this check should run for the given target.
 // This check only applies when upgrading FROM 2.x TO 3.x and CodeFlare is Managed.
-func (c *RemovalCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+func (c *CodeFlareRemovalCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
 	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
 		return false, nil
 	}
@@ -46,12 +52,13 @@ func (c *RemovalCheck) CanApply(ctx context.Context, target check.Target) (bool,
 		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
-	return components.HasManagementState(dsc, kind, constants.ManagementStateManaged), nil
+	return components.HasManagementState(dsc, dscComponent, constants.ManagementStateManaged), nil
 }
 
 // Validate executes the check against the provided target.
-func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+func (c *CodeFlareRemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	return validate.Component(c, target).
+		WithComponentName(dscComponent).
 		Run(ctx, validate.Removal("CodeFlare is enabled (state: %s) but will be removed in RHOAI %s",
 			check.WithImpact(result.ImpactBlocking),
 			check.WithRemediation(c.CheckRemediation)))

--- a/pkg/lint/checks/components/ray/codeflare_removal_test.go
+++ b/pkg/lint/checks/components/ray/codeflare_removal_test.go
@@ -1,4 +1,4 @@
-package codeflare_test
+package ray_test
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/codeflare"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/ray"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
@@ -31,7 +31,7 @@ func TestCodeFlareRemovalCheck_CanApply_NoDSC(t *testing.T) {
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := codeflare.NewRemovalCheck()
+	chk := ray.NewCodeFlareRemovalCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 
 	g.Expect(err).To(HaveOccurred())
@@ -49,7 +49,7 @@ func TestCodeFlareRemovalCheck_CanApply_NotConfigured(t *testing.T) {
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := codeflare.NewRemovalCheck()
+	chk := ray.NewCodeFlareRemovalCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 
 	g.Expect(err).ToNot(HaveOccurred())
@@ -68,8 +68,8 @@ func TestCodeFlareRemovalCheck_ManagedBlocking(t *testing.T) {
 		TargetVersion:  "3.0.0",
 	})
 
-	codeflareCheck := codeflare.NewRemovalCheck()
-	result, err := codeflareCheck.Validate(ctx, target)
+	chk := ray.NewCodeFlareRemovalCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -87,9 +87,7 @@ func TestCodeFlareRemovalCheck_ManagedBlocking(t *testing.T) {
 }
 
 func TestCodeFlareRemovalCheck_CanApply_ManagementState(t *testing.T) {
-	g := NewWithT(t)
-
-	chk := codeflare.NewRemovalCheck()
+	chk := ray.NewCodeFlareRemovalCheck()
 
 	testCases := []struct {
 		name     string
@@ -103,6 +101,8 @@ func TestCodeFlareRemovalCheck_CanApply_ManagementState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			dsc := testutil.NewDSC(map[string]string{"codeflare": tc.state})
 			target := testutil.NewTarget(t, testutil.TargetConfig{
 				ListKinds:      listKinds,
@@ -121,10 +121,11 @@ func TestCodeFlareRemovalCheck_CanApply_ManagementState(t *testing.T) {
 func TestCodeFlareRemovalCheck_Metadata(t *testing.T) {
 	g := NewWithT(t)
 
-	codeflareCheck := codeflare.NewRemovalCheck()
+	chk := ray.NewCodeFlareRemovalCheck()
 
-	g.Expect(codeflareCheck.ID()).To(Equal("components.codeflare.removal"))
-	g.Expect(codeflareCheck.Name()).To(Equal("Components :: CodeFlare :: Removal (3.x)"))
-	g.Expect(codeflareCheck.Group()).To(Equal(check.GroupComponent))
-	g.Expect(codeflareCheck.Description()).ToNot(BeEmpty())
+	g.Expect(chk.ID()).To(Equal("components.ray.codeflare-removal"))
+	g.Expect(chk.Name()).To(Equal("Components :: Ray :: CodeFlare Removal (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupComponent))
+	g.Expect(chk.CheckKind()).To(Equal("ray"))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
 }

--- a/pkg/lint/checks/workloads/ray/impacted_test.go
+++ b/pkg/lint/checks/workloads/ray/impacted_test.go
@@ -20,9 +20,10 @@ const (
 	finalizerCodeFlareOAuth = "ray.openshift.ai/oauth-finalizer"
 )
 
-//nolint:gochecknoglobals // Test fixture - shared across test functions
+//nolint:gochecknoglobals // Test fixture - shared across test functions in ray_test package
 var listKinds = map[schema.GroupVersionResource]string{
 	resources.RayCluster.GVR():         resources.RayCluster.ListKind(),
+	resources.AppWrapper.GVR():         resources.AppWrapper.ListKind(),
 	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
 }
 

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -14,18 +14,17 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/codeflare"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/dashboard"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/modelmesh"
+	raycomponent "github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/ray"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemeshoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/services/servicemesh"
-	codeflareworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/codeflare"
 	datasciencepipelinesworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/guardrails"
 	kserveworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
@@ -77,7 +76,7 @@ func NewCommand(
 
 	// Explicitly register all checks (no global state, full test isolation)
 	// Components (11)
-	registry.MustRegister(codeflare.NewRemovalCheck())
+	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
 	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
 	registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
 	registry.MustRegister(datasciencepipelines.NewRenamingCheck())
@@ -98,7 +97,7 @@ func NewCommand(
 	registry.MustRegister(servicemesh.NewRemovalCheck())
 
 	// Workloads (13)
-	registry.MustRegister(codeflareworkloads.NewImpactedWorkloadsCheck())
+	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
 	registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())


### PR DESCRIPTION
CodeFlare is an implementation detail of the Ray component that adds
security to the kuberay-operator. Users don't need to understand the
distinction, so all CodeFlare checks now appear under kind "ray":

- Move components/codeflare/ -> components/ray/codeflare_removal.go
- Move workloads/codeflare/ -> workloads/ray/appwrapper_cleanup.go
- Add WithComponentName() to ComponentBuilder so the DSC query key
  ("codeflare") can differ from the user-facing kind ("ray")
- Update command.go imports and registrations

CLI output now shows a single coherent Ray category instead of
separate Ray and CodeFlare entries.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added component name override capability for validation checks, enabling customizable component identification in management state queries.

* **Refactor**
  * Reorganized and renamed validation checks from CodeFlare to Ray structure for improved framework alignment and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->