### PR TITLE
refactor: streamline README to focus on container usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # odh-cli
 
-CLI tool for ODH (Open Data Hub) and RHOAI (Red Hat OpenShift AI) for interacting with ODH/RHOAI deployments on Kubernetes.
+CLI tool for RHOAI (Red Hat OpenShift AI) for interacting with RHOAI deployments on Kubernetes.
 
 ## Quick Start
 
@@ -12,14 +12,14 @@ Run the CLI using the pre-built container image:
 ```bash
 podman run --rm -ti \
   -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest lint --target-version 3.3.0
+  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
 ```
 
 **Docker:**
 ```bash
 docker run --rm -ti \
   -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest lint --target-version 3.3.0
+  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
 ```
 
 The container has `KUBECONFIG=/kubeconfig` set by default, so you just need to mount your kubeconfig to that path.
@@ -29,12 +29,12 @@ The container has `KUBECONFIG=/kubeconfig` set by default, so you just need to m
 > # Podman
 > podman run --rm -ti \
 >   -v $KUBECONFIG:/kubeconfig:Z \
->   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest lint --target-version 3.3.0
+>   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
 >
 > # Docker
 > docker run --rm -ti \
 >   -v $KUBECONFIG:/kubeconfig:Z \
->   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest lint --target-version 3.3.0
+>   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
 > ```
 
 **Available Tags:**
@@ -53,7 +53,7 @@ The container includes kubectl, oc, and debugging utilities for interactive trou
 podman run -it --rm \
   -v $KUBECONFIG:/kubeconfig \
   --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest
+  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
 ```
 
 **Docker:**
@@ -61,7 +61,7 @@ podman run -it --rm \
 docker run -it --rm \
   -v $KUBECONFIG:/kubeconfig \
   --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest
+  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
 ```
 
 Once inside the container, use kubectl/oc/wget/curl:
@@ -80,7 +80,7 @@ For environments where you have a token and server URL instead of a kubeconfig f
 **Podman:**
 ```bash
 podman run --rm -ti \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest \
+  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev \
   lint \
   --target-version 3.3.0 \
   --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
@@ -90,76 +90,19 @@ podman run --rm -ti \
 **Docker:**
 ```bash
 docker run --rm -ti \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest \
+  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev \
   lint \
   --target-version 3.3.0 \
   --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
   --server=https://api.my-cluster.p3.openshiftapps.com:6443
-```
-
-### Using Go Run (No Installation Required)
-
-If you have Go installed, you can run the CLI directly from GitHub without cloning:
-
-```bash
-# Show help
-go run github.com/opendatahub-io/odh-cli/cmd@latest --help
-
-# Show version
-go run github.com/opendatahub-io/odh-cli/cmd@latest version
-
-# Run lint command
-go run github.com/opendatahub-io/odh-cli/cmd@latest lint --target-version 3.3.0
-```
-
-> **Note:** Replace `@latest` with `@v1.2.3` to run a specific version, or `@main` for the latest development version.
-
-**Token Authentication:**
-
-```bash
-go run github.com/opendatahub-io/odh-cli/cmd@latest \
-  lint \
-  --target-version 3.3.0 \
-  --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-  --server=https://api.my-cluster.p3.openshiftapps.com:6443
-```
-
-**Available commands:**
-- `lint` - Validate cluster configuration and assess upgrade readiness
-- `version` - Display CLI version information
-
-### As kubectl Plugin
-
-Install the `kubectl-odh` binary to your PATH:
-
-```bash
-# Download from releases
-# Place in PATH as kubectl-odh
-# Use with kubectl
-kubectl odh lint --target-version 3.3.0
-kubectl odh version
 ```
 
 ## Documentation
 
 For detailed documentation, see:
+- [Alternative Usage Methods](docs/usage.md) - Using Go Run, kubectl plugin
 - [Design and Architecture](docs/design.md)
 - [Development Guide](docs/development.md)
 - [Lint Architecture](docs/lint/architecture.md)
 - [Writing Lint Checks](docs/lint/writing-checks.md)
 
-## Building from Source
-
-```bash
-make build
-```
-
-The binary will be available at `bin/kubectl-odh`.
-
-## Building Container Image
-
-```bash
-make publish
-```
-
-This builds a multi-platform container image (linux/amd64, linux/arm64).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -52,6 +52,14 @@ make clean
 - ❌ `gofmt` - Use `make fmt` instead
 - ❌ `goimports` - Use `make fmt` instead
 
+## Building Container Image
+
+```bash
+make publish
+```
+
+This builds a multi-platform container image (linux/amd64, linux/arm64).
+
 ## Test Commands
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,46 @@
+# Alternative Usage Methods
+
+For container-based usage (recommended), see the [README](../README.md).
+
+## Using Go Run (No Installation Required)
+
+If you have Go installed, you can run the CLI directly from GitHub without cloning:
+
+```bash
+# Show help
+go run github.com/opendatahub-io/odh-cli/cmd@latest --help
+
+# Show version
+go run github.com/opendatahub-io/odh-cli/cmd@latest version
+
+# Run lint command
+go run github.com/opendatahub-io/odh-cli/cmd@latest lint --target-version 3.3.0
+```
+
+> **Note:** Replace `@latest` with `@v1.2.3` to run a specific version, or `@main` for the latest development version.
+
+**Token Authentication:**
+
+```bash
+go run github.com/opendatahub-io/odh-cli/cmd@latest \
+  lint \
+  --target-version 3.3.0 \
+  --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+  --server=https://api.my-cluster.p3.openshiftapps.com:6443
+```
+
+**Available commands:**
+- `lint` - Validate cluster configuration and assess upgrade readiness
+- `version` - Display CLI version information
+
+## As kubectl Plugin
+
+Install the `kubectl-odh` binary to your PATH:
+
+```bash
+# Download from releases
+# Place in PATH as kubectl-odh
+# Use with kubectl
+kubectl odh lint --target-version 3.3.0
+kubectl odh version
+```


### PR DESCRIPTION
Move "Using Go Run" and "As kubectl Plugin" sections to docs/usage.md,
move "Building from Source" and "Building Container Image" to docs/setup.md,
remove ODH references from description, and use :dev image tag in examples.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Updated container image examples to use dev tag instead of latest
* Added "Alternative Usage Methods" documentation for container-based and kubectl plugin usage
* Added documentation for building multi-platform container images (linux/amd64, linux/arm64)
* Reorganized and streamlined Quick Start section
* Refocused README description on RHOAI deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->