### PR TITLE
docs: update README interactive debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ The container has `KUBECONFIG=/kubeconfig` set by default, so you just need to m
 
 > **Note:** The images are OCI-compliant and work with both Podman and Docker. Examples for both are provided below.
 
-**Interactive Debugging:**
+**Shell Access:**
 
-The container includes kubectl, oc, and debugging utilities for interactive troubleshooting:
+The container also bundles migration tools and CLI utilities that can be used directly from a shell session:
 
 **Podman:**
 ```bash
@@ -64,14 +64,29 @@ docker run -it --rm \
   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
 ```
 
-Once inside the container, use kubectl/oc/wget/curl:
+Available tools:
+- `rhai-cli`
+- `kubectl` (latest stable)
+- `oc` (latest stable)
+- `jq`
+- `wget`
+- `curl`
+- `tar`
+- `gzip`
+- `bash`
+
+Example usage:
 ```bash
+oc login --token=sha256~xxxx --server=https://api.my-cluster.p3.openshiftapps.com:6443
+
 kubectl get pods -n opendatahub
 oc get dsci
-kubectl-odh lint --target-version 3.3.0
+
+rhai-cli lint --target-version 3.3.0
 ```
 
-Available tools: `kubectl` (latest stable), `oc` (latest stable), `wget`, `curl`, `tar`, `gzip`, `bash`
+The `rhai-cli` binary is located at `/opt/rhai-cli/bin/rhai-cli` (already on `PATH`).
+Upgrade helper scripts are located at `/opt/rhai-upgrade-helpers`.
 
 **Token Authentication:**
 


### PR DESCRIPTION
- Fix CLI name from kubectl-odh to rhai-cli
- Add oc login example for interactive sessions
- Add rhai-cli binary and upgrade helper scripts locations
- Add jq to available tools list
- Format tools list as bullet points

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed "Interactive Debugging" to "Shell Access" and expanded guidance for shell-based workflows.
  * Added a consolidated "Available tools" list (rhai-cli, kubectl, oc, jq, wget, curl, tar, gzip, bash).
  * Updated examples to reflect current tooling and shell flow (rhai-cli lint).
  * Added high-level installation/location notes for included utilities and preserved token-based login guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->