### PR TITLE
lint(ray): show pre-upgrade backup status per RayCluster

### DIFF
--- a/pkg/lint/checks/workloads/ray/impacted.go
+++ b/pkg/lint/checks/workloads/ray/impacted.go
@@ -3,6 +3,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"io"
 	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,8 @@ import (
 const (
 	kind                    = "ray"
 	finalizerCodeFlareOAuth = "ray.openshift.ai/oauth-finalizer"
+	// RayPreUpgradeBackupAnnotation is set on RayClusters after the pre-upgrade backup is taken (value: RFC3339 UTC timestamp).
+	RayPreUpgradeBackupAnnotation = "odh.ray.io/pre-upgrade-backup-taken"
 )
 
 const (
@@ -60,7 +63,35 @@ func (c *ImpactedWorkloadsCheck) CanApply(ctx context.Context, target check.Targ
 	return components.HasManagementState(dsc, kind, constants.ManagementStateManaged), nil
 }
 
+// validateRayClustersWithBackupStatus sets conditions and ImpactedObjects from full metadata
+// so the pre-upgrade backup annotation (odh.ray.io/pre-upgrade-backup-taken) can be displayed per cluster.
+func (c *ImpactedWorkloadsCheck) validateRayClustersWithBackupStatus(
+	ctx context.Context,
+	req *validate.WorkloadRequest[*metav1.PartialObjectMetadata],
+) error {
+	conditions := c.newCodeFlareRayClusterCondition(ctx, req)
+	for _, cond := range conditions {
+		req.Result.SetCondition(cond)
+	}
+
+	// Preserve full metadata (including annotations) so the group renderer can show warning vs info.
+	req.Result.ImpactedObjects = make([]metav1.PartialObjectMetadata, 0, len(req.Items))
+	for i := range req.Items {
+		obj := req.Items[i].DeepCopy()
+		if obj.APIVersion == "" {
+			obj.APIVersion = resources.RayCluster.APIVersion()
+		}
+		if obj.Kind == "" {
+			obj.Kind = resources.RayCluster.Kind
+		}
+		req.Result.ImpactedObjects = append(req.Result.ImpactedObjects, *obj)
+	}
+
+	return nil
+}
+
 // Validate executes the check against the provided target.
+// ImpactedObjects are set from full metadata so the pre-upgrade backup annotation can be shown (warning vs info).
 func (c *ImpactedWorkloadsCheck) Validate(
 	ctx context.Context,
 	target check.Target,
@@ -69,5 +100,12 @@ func (c *ImpactedWorkloadsCheck) Validate(
 		Filter(func(cluster *metav1.PartialObjectMetadata) (bool, error) {
 			return slices.Contains(cluster.GetFinalizers(), finalizerCodeFlareOAuth), nil
 		}).
-		Complete(ctx, c.newCodeFlareRayClusterCondition)
+		Run(ctx, c.validateRayClustersWithBackupStatus)
+}
+
+// FormatVerboseOutput implements check.VerboseOutputFormatter.
+// Renders each RayCluster with [WARNING] when the pre-upgrade backup annotation is missing,
+// and [INFO] when present (odh.ray.io/pre-upgrade-backup-taken).
+func (c *ImpactedWorkloadsCheck) FormatVerboseOutput(out io.Writer, dr *result.DiagnosticResult) {
+	formatRayImpactedObjects(out, dr.ImpactedObjects)
 }


### PR DESCRIPTION
**Ray impacted workloads: show pre-upgrade backup status per cluster**
When the lint check lists CodeFlare-managed RayClusters, verbose output now shows each cluster’s pre-upgrade backup status:
No odh.ray.io/pre-upgrade-backup-taken → [WARNING] – pre-upgrade backup not taken
Has annotation → [INFO] – pre-upgrade backup taken

This uses an annotation set by the rhoai-upgrade-helpers Ray pre-upgrade script so users can see which RayClusters are backed up before upgrade.

Co-authored-by: Cursor <cursor@cursor.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks pre-upgrade backup status for Ray clusters in diagnostics, preserves cluster metadata, and shows per-cluster conditions.
  * Adds a verbose diagnostic view listing each Ray cluster (kind/namespace/name) and marking backed-up items as INFO and missing backups as WARNING.

* **Tests**
  * Added tests covering clusters with and without backup annotations to validate reporting and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->