### PR TITLE
chore: fix import ordering after org migration

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -3,11 +3,12 @@ package backup
 import (
 	"fmt"
 
-	backuppkg "github.com/opendatahub-io/odh-cli/pkg/backup"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	backuppkg "github.com/opendatahub-io/odh-cli/pkg/backup"
 )
 
 const (

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -3,11 +3,12 @@ package lint
 import (
 	"fmt"
 
-	lintpkg "github.com/opendatahub-io/odh-cli/pkg/lint"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	lintpkg "github.com/opendatahub-io/odh-cli/pkg/lint"
 )
 
 const (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"os"
 
-	"github.com/opendatahub-io/odh-cli/cmd/lint"
-	"github.com/opendatahub-io/odh-cli/cmd/version"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/opendatahub-io/odh-cli/cmd/lint"
+	"github.com/opendatahub-io/odh-cli/cmd/version"
 )
 
 func main() {

--- a/cmd/migrate/list/list.go
+++ b/cmd/migrate/list/list.go
@@ -1,11 +1,12 @@
 package list
 
 import (
-	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 )
 
 const (

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -1,13 +1,14 @@
 package migrate
 
 import (
-	"github.com/opendatahub-io/odh-cli/cmd/migrate/list"
-	"github.com/opendatahub-io/odh-cli/cmd/migrate/prepare"
-	"github.com/opendatahub-io/odh-cli/cmd/migrate/run"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/cmd/migrate/list"
+	"github.com/opendatahub-io/odh-cli/cmd/migrate/prepare"
+	"github.com/opendatahub-io/odh-cli/cmd/migrate/run"
 )
 
 const (

--- a/cmd/migrate/prepare/prepare.go
+++ b/cmd/migrate/prepare/prepare.go
@@ -1,11 +1,12 @@
 package prepare
 
 import (
-	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 )
 
 const (

--- a/cmd/migrate/run/run.go
+++ b/cmd/migrate/run/run.go
@@ -1,11 +1,12 @@
 package run
 
 import (
-	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 )
 
 const (

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/internal/version"
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/opendatahub-io/odh-cli/internal/version"
 )
 
 const (

--- a/pkg/backup/command.go
+++ b/pkg/backup/command.go
@@ -7,17 +7,18 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
-	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/dspa"
-	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/notebooks"
-	"github.com/opendatahub-io/odh-cli/pkg/backup/pipeline"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
+	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/dspa"
+	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/notebooks"
+	"github.com/opendatahub-io/odh-cli/pkg/backup/pipeline"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 )
 
 const (

--- a/pkg/backup/command_options.go
+++ b/pkg/backup/command_options.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 const DefaultTimeout = 10 * time.Minute

--- a/pkg/backup/dependencies/dspa/resolver.go
+++ b/pkg/backup/dependencies/dspa/resolver.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (

--- a/pkg/backup/dependencies/dspa/resolver_test.go
+++ b/pkg/backup/dependencies/dspa/resolver_test.go
@@ -3,15 +3,15 @@ package dspa_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/dspa"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/dspa"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/backup/dependencies/notebooks/resolver.go
+++ b/pkg/backup/dependencies/notebooks/resolver.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Resolver resolves dependencies for Kubeflow Notebooks.

--- a/pkg/backup/dependencies/notebooks/resolver_test.go
+++ b/pkg/backup/dependencies/notebooks/resolver_test.go
@@ -3,15 +3,15 @@ package notebooks_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/notebooks"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies/notebooks"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/backup/dependencies/resolver.go
+++ b/pkg/backup/dependencies/resolver.go
@@ -3,10 +3,10 @@ package dependencies
 import (
 	"context"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // Dependency represents a discovered dependency resource.

--- a/pkg/backup/pipeline/discovery.go
+++ b/pkg/backup/pipeline/discovery.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // DiscoveryStage lists workload instances and sends them to output channel.

--- a/pkg/backup/pipeline/resolver.go
+++ b/pkg/backup/pipeline/resolver.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-	"golang.org/x/sync/errgroup"
 )
 
 // ResolverStage resolves dependencies for workload instances.

--- a/pkg/backup/pipeline/resolver_test.go
+++ b/pkg/backup/pipeline/resolver_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
 	"github.com/opendatahub-io/odh-cli/pkg/backup/pipeline"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/backup/pipeline/types.go
+++ b/pkg/backup/pipeline/types.go
@@ -1,10 +1,10 @@
 package pipeline
 
 import (
-	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
 )
 
 // WorkloadItem represents a workload instance to back up.

--- a/pkg/backup/pipeline/writer.go
+++ b/pkg/backup/pipeline/writer.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 // WriteResourceFunc is a function that writes a resource.

--- a/pkg/backup/pipeline/writer_test.go
+++ b/pkg/backup/pipeline/writer_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/backup/dependencies"
 	"github.com/opendatahub-io/odh-cli/pkg/backup/pipeline"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/lint/check/base_test.go
+++ b/pkg/lint/check/base_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"

--- a/pkg/lint/check/condition.go
+++ b/pkg/lint/check/condition.go
@@ -3,9 +3,9 @@ package check
 import (
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 )
 
 // ConditionOption is a functional option for customizing condition creation.

--- a/pkg/lint/check/condition_test.go
+++ b/pkg/lint/check/condition_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/check/executor.go
+++ b/pkg/lint/check/executor.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 // CheckExecution bundles a check with its execution result and any error encountered.

--- a/pkg/lint/check/executor_bench_test.go
+++ b/pkg/lint/check/executor_bench_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // BenchmarkExecuteSelective_FullSuite benchmarks execution of all checks.

--- a/pkg/lint/check/result/result.go
+++ b/pkg/lint/check/result/result.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 )
 
 const (

--- a/pkg/lint/check/result/result_test.go
+++ b/pkg/lint/check/result/result_test.go
@@ -3,12 +3,12 @@ package result_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/check/target.go
+++ b/pkg/lint/check/target.go
@@ -2,10 +2,11 @@ package check
 
 import (
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 // Target holds all context needed for executing diagnostic checks, including cluster version and optional resource.

--- a/pkg/lint/check/testutil/target.go
+++ b/pkg/lint/check/testutil/target.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 	olmclientset "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 )
 
 // TargetConfig holds all parameters needed to build a check.Target for tests.

--- a/pkg/lint/check/validate/accelerator.go
+++ b/pkg/lint/check/validate/accelerator.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/pkg/lint/check/validate/component.go
+++ b/pkg/lint/check/validate/component.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"slices"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // ComponentBuilder provides a fluent API for component-based validation.

--- a/pkg/lint/check/validate/dsci.go
+++ b/pkg/lint/check/validate/dsci.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // DSCIBuilder provides a fluent API for DSCInitialization-based validation.

--- a/pkg/lint/check/validate/operator.go
+++ b/pkg/lint/check/validate/operator.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"slices"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ConditionBuilder is a function that creates a condition based on operator presence and version.

--- a/pkg/lint/check/validate/validate_test.go
+++ b/pkg/lint/check/validate/validate_test.go
@@ -6,12 +6,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/constants"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
@@ -20,6 +14,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/check/validate/workload.go
+++ b/pkg/lint/check/validate/workload.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // WorkloadRequest contains the pre-fetched data passed to the workload validation function.

--- a/pkg/lint/check/validate/workload_test.go
+++ b/pkg/lint/check/validate/workload_test.go
@@ -6,12 +6,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,6 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/lint/checks/components/codeflare/codeflare_test.go
+++ b/pkg/lint/checks/components/codeflare/codeflare_test.go
@@ -3,15 +3,15 @@ package codeflare_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/codeflare"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/dashboard/acceleratorprofile_migration.go
+++ b/pkg/lint/checks/components/dashboard/acceleratorprofile_migration.go
@@ -3,14 +3,14 @@ package dashboard
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // AcceleratorProfileMigrationCheck detects legacy AcceleratorProfiles that will be auto-migrated to

--- a/pkg/lint/checks/components/dashboard/acceleratorprofile_migration_test.go
+++ b/pkg/lint/checks/components/dashboard/acceleratorprofile_migration_test.go
@@ -4,16 +4,17 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/dashboard"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/dashboard/hardwareprofile_migration.go
+++ b/pkg/lint/checks/components/dashboard/hardwareprofile_migration.go
@@ -3,14 +3,14 @@ package dashboard
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const hardwareProfileCheckType = "hardwareprofile-migration"

--- a/pkg/lint/checks/components/dashboard/hardwareprofile_migration_test.go
+++ b/pkg/lint/checks/components/dashboard/hardwareprofile_migration_test.go
@@ -4,16 +4,17 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/dashboard"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/datasciencepipelines/renaming.go
+++ b/pkg/lint/checks/components/datasciencepipelines/renaming.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -11,8 +13,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/lint/checks/components/datasciencepipelines/renaming_test.go
+++ b/pkg/lint/checks/components/datasciencepipelines/renaming_test.go
@@ -3,15 +3,15 @@ package datasciencepipelines_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/kserve/serverless.go
+++ b/pkg/lint/checks/components/kserve/serverless.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -13,8 +15,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const checkType = "serverless-removal"

--- a/pkg/lint/checks/components/kserve/serverless_test.go
+++ b/pkg/lint/checks/components/kserve/serverless_test.go
@@ -3,16 +3,16 @@ package kserve_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/kueue/kueue.go
+++ b/pkg/lint/checks/components/kueue/kueue.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -11,8 +13,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/lint/checks/components/kueue/kueue_operator_installed.go
+++ b/pkg/lint/checks/components/kueue/kueue_operator_installed.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -11,8 +13,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/lint/checks/components/kueue/kueue_operator_installed_test.go
+++ b/pkg/lint/checks/components/kueue/kueue_operator_installed_test.go
@@ -3,15 +3,16 @@ package kueue_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kueue"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kueue"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/kueue/kueue_test.go
+++ b/pkg/lint/checks/components/kueue/kueue_test.go
@@ -3,15 +3,15 @@ package kueue_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/modelmesh/modelmesh_test.go
+++ b/pkg/lint/checks/components/modelmesh/modelmesh_test.go
@@ -3,15 +3,15 @@ package modelmesh_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/modelmesh"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/components/trainingoperator/trainingoperator.go
+++ b/pkg/lint/checks/components/trainingoperator/trainingoperator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -11,8 +13,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const checkType = "deprecation"

--- a/pkg/lint/checks/components/trainingoperator/trainingoperator_test.go
+++ b/pkg/lint/checks/components/trainingoperator/trainingoperator_test.go
@@ -3,15 +3,15 @@ package trainingoperator_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/dependencies/certmanager/certmanager.go
+++ b/pkg/lint/checks/dependencies/certmanager/certmanager.go
@@ -3,11 +3,11 @@ package certmanager
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const kind = "certmanager"

--- a/pkg/lint/checks/dependencies/certmanager/certmanager_test.go
+++ b/pkg/lint/checks/dependencies/certmanager/certmanager_test.go
@@ -3,14 +3,15 @@ package certmanager_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/dependencies/openshift/openshift.go
+++ b/pkg/lint/checks/dependencies/openshift/openshift.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/lint/checks/dependencies/openshift/openshift_test.go
+++ b/pkg/lint/checks/dependencies/openshift/openshift_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/dependencies/servicemeshoperator/servicemeshoperator.go
+++ b/pkg/lint/checks/dependencies/servicemeshoperator/servicemeshoperator.go
@@ -3,12 +3,12 @@ package servicemeshoperator
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/lint/checks/dependencies/servicemeshoperator/servicemeshoperator_test.go
+++ b/pkg/lint/checks/dependencies/servicemeshoperator/servicemeshoperator_test.go
@@ -3,13 +3,14 @@ package servicemeshoperator_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemeshoperator"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemeshoperator"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/services/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/services/servicemesh/servicemesh.go
@@ -5,15 +5,15 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // RemovalCheck validates that ServiceMesh is disabled before upgrading to 3.x.

--- a/pkg/lint/checks/services/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/services/servicemesh/servicemesh_test.go
@@ -3,15 +3,15 @@ package servicemesh_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/services/servicemesh"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/codeflare/impacted.go
+++ b/pkg/lint/checks/workloads/codeflare/impacted.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -12,8 +14,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const kind = "codeflare"

--- a/pkg/lint/checks/workloads/codeflare/impacted_test.go
+++ b/pkg/lint/checks/workloads/codeflare/impacted_test.go
@@ -3,15 +3,15 @@ package codeflare_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/codeflare"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 	"strconv"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -14,11 +19,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/inspect"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal_test.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal_test.go
@@ -3,15 +3,15 @@ package datasciencepipelines_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/guardrails/impacted.go
+++ b/pkg/lint/checks/workloads/guardrails/impacted.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -12,8 +14,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (

--- a/pkg/lint/checks/workloads/guardrails/impacted_support.go
+++ b/pkg/lint/checks/workloads/guardrails/impacted_support.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 	"strings"
 
+	"sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-	"sigs.k8s.io/yaml"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (

--- a/pkg/lint/checks/workloads/guardrails/impacted_test.go
+++ b/pkg/lint/checks/workloads/guardrails/impacted_test.go
@@ -3,15 +3,15 @@ package guardrails_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/guardrails"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/guardrails/otel_migration_support.go
+++ b/pkg/lint/checks/workloads/guardrails/otel_migration_support.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // hasDeprecatedOtelFields returns true if the object contains a non-empty otelExporter section.

--- a/pkg/lint/checks/workloads/guardrails/otel_migration_test.go
+++ b/pkg/lint/checks/workloads/guardrails/otel_migration_test.go
@@ -3,15 +3,15 @@ package guardrails_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/guardrails"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/kserve/accelerator_migration.go
+++ b/pkg/lint/checks/workloads/kserve/accelerator_migration.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -13,8 +15,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const ConditionTypeISVCAcceleratorProfileCompatible = "AcceleratorProfileCompatible"

--- a/pkg/lint/checks/workloads/kserve/accelerator_migration_test.go
+++ b/pkg/lint/checks/workloads/kserve/accelerator_migration_test.go
@@ -3,15 +3,15 @@ package kserve_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/kserve/impacted.go
+++ b/pkg/lint/checks/workloads/kserve/impacted.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -14,9 +17,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (

--- a/pkg/lint/checks/workloads/kserve/impacted_support.go
+++ b/pkg/lint/checks/workloads/kserve/impacted_support.go
@@ -4,16 +4,16 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // isImpactedISVC returns true for InferenceServices with Serverless or ModelMesh deployment mode.

--- a/pkg/lint/checks/workloads/kserve/impacted_test.go
+++ b/pkg/lint/checks/workloads/kserve/impacted_test.go
@@ -3,15 +3,15 @@ package kserve_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/kserve/inferenceservice_config.go
+++ b/pkg/lint/checks/workloads/kserve/inferenceservice_config.go
@@ -7,6 +7,10 @@ import (
 	"slices"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -17,10 +21,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // inferenceServiceConfigName is the name of the KServe configuration ConfigMap.

--- a/pkg/lint/checks/workloads/kserve/inferenceservice_config_test.go
+++ b/pkg/lint/checks/workloads/kserve/inferenceservice_config_test.go
@@ -4,15 +4,15 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/llamastack/llamastack.go
+++ b/pkg/lint/checks/workloads/llamastack/llamastack.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -13,10 +17,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/pkg/lint/checks/workloads/llamastack/llamastack_support.go
+++ b/pkg/lint/checks/workloads/llamastack/llamastack_support.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 	"strings"
 
+	"sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-	"sigs.k8s.io/yaml"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // getEnvVars extracts environment variables from a LlamaStackDistribution.

--- a/pkg/lint/checks/workloads/llamastack/llamastack_test.go
+++ b/pkg/lint/checks/workloads/llamastack/llamastack_test.go
@@ -3,15 +3,15 @@ package llamastack_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/llamastack"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/notebook/accelerator_migration.go
+++ b/pkg/lint/checks/workloads/notebook/accelerator_migration.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -13,8 +15,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const ConditionTypeAcceleratorProfileCompatible = "AcceleratorProfileCompatible"

--- a/pkg/lint/checks/workloads/notebook/accelerator_migration_test.go
+++ b/pkg/lint/checks/workloads/notebook/accelerator_migration_test.go
@@ -3,15 +3,15 @@ package notebook_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/notebook"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/notebook/impacted.go
+++ b/pkg/lint/checks/workloads/notebook/impacted.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -18,9 +21,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (

--- a/pkg/lint/checks/workloads/notebook/impacted_test.go
+++ b/pkg/lint/checks/workloads/notebook/impacted_test.go
@@ -3,15 +3,15 @@ package notebook_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/notebook"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/ray/impacted.go
+++ b/pkg/lint/checks/workloads/ray/impacted.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"slices"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -13,8 +15,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/lint/checks/workloads/ray/impacted_support.go
+++ b/pkg/lint/checks/workloads/ray/impacted_support.go
@@ -3,11 +3,11 @@ package ray
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // newWorkloadCompatibilityCondition creates a compatibility condition based on workload count.

--- a/pkg/lint/checks/workloads/ray/impacted_test.go
+++ b/pkg/lint/checks/workloads/ray/impacted_test.go
@@ -3,14 +3,14 @@ package ray_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/ray"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/checks/workloads/trainingoperator/impacted.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -12,9 +15,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const (

--- a/pkg/lint/checks/workloads/trainingoperator/impacted_support.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted_support.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func (c *ImpactedWorkloadsCheck) newPyTorchJobCondition(

--- a/pkg/lint/checks/workloads/trainingoperator/impacted_test.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted_test.go
@@ -3,15 +3,15 @@ package trainingoperator_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -6,6 +6,11 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -33,10 +38,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube/discovery"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-	"github.com/spf13/pflag"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 // Verify Command implements cmd.Command interface at compile time.

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -9,6 +9,11 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
@@ -16,10 +21,6 @@ import (
 	printeryaml "github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 // OutputFormat represents the output format for lint commands.

--- a/pkg/lint/command_options_test.go
+++ b/pkg/lint/command_options_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/cmd"
-	"github.com/opendatahub-io/odh-cli/pkg/lint"
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/lint"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/migrate/action/action.go
+++ b/pkg/migrate/action/action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/blang/semver/v4"
+
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"

--- a/pkg/migrate/action/recorder_impl.go
+++ b/pkg/migrate/action/recorder_impl.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
+
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )

--- a/pkg/migrate/actions/kueue/rhbok/prepare_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/prepare_task.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 	"path/filepath"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/opendatahub-io/odh-cli/pkg/backup"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type prepareTask struct {

--- a/pkg/migrate/actions/kueue/rhbok/rhbok.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
@@ -13,10 +17,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
@@ -3,14 +3,14 @@ package rhbok
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (a *RHBOKMigrationAction) checkCurrentKueueState(

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -7,16 +7,17 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-	"github.com/spf13/pflag"
-	"sigs.k8s.io/yaml"
-
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 var _ cmd.Command = (*ListCommand)(nil)

--- a/pkg/migrate/command_list_test.go
+++ b/pkg/migrate/command_list_test.go
@@ -3,9 +3,9 @@ package migrate_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/migrate"
-
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/migrate/command_options.go
+++ b/pkg/migrate/command_options.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 type OutputFormat string

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-	"github.com/spf13/pflag"
-
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 var _ cmd.Command = (*PrepareCommand)(nil)

--- a/pkg/migrate/command_prepare_test.go
+++ b/pkg/migrate/command_prepare_test.go
@@ -3,9 +3,9 @@ package migrate_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/migrate"
-
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-	"github.com/spf13/pflag"
-
-	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
 var _ cmd.Command = (*RunCommand)(nil)

--- a/pkg/migrate/command_run_test.go
+++ b/pkg/migrate/command_run_test.go
@@ -3,9 +3,9 @@ package migrate_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/migrate"
-
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/printer/table/renderer_options.go
+++ b/pkg/printer/table/renderer_options.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/tw"
+
 	"github.com/opendatahub-io/odh-cli/pkg/util"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )

--- a/pkg/printer/yaml/renderer.go
+++ b/pkg/printer/yaml/renderer.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util"
 	"sigs.k8s.io/yaml"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util"
 )
 
 // Renderer provides a generic interface for rendering values as YAML.

--- a/pkg/printer/yaml/renderer_test.go
+++ b/pkg/printer/yaml/renderer_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
 	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
 )
 
 type testStruct struct {

--- a/pkg/util/client/config_test.go
+++ b/pkg/util/client/config_test.go
@@ -3,10 +3,10 @@ package client_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/client/helpers.go
+++ b/pkg/util/client/helpers.go
@@ -5,15 +5,15 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util"
-	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
 
 // namespacedNamer is satisfied by both *unstructured.Unstructured and *metav1.PartialObjectMetadata.

--- a/pkg/util/client/helpers_test.go
+++ b/pkg/util/client/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega/types"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -17,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/client/interfaces.go
+++ b/pkg/util/client/interfaces.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	olmclientset "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 
@@ -15,6 +14,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/metadata"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 )
 
 // Reader provides read-only access to Kubernetes resources.

--- a/pkg/util/components/components.go
+++ b/pkg/util/components/components.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"slices"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetManagementState queries a DSC component's management state.

--- a/pkg/util/inspect/inspect_test.go
+++ b/pkg/util/inspect/inspect_test.go
@@ -3,9 +3,9 @@ package inspect_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/inspect"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/inspect"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/jq/jq_test.go
+++ b/pkg/util/jq/jq_test.go
@@ -3,9 +3,9 @@ package jq_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/kube/annotations_test.go
+++ b/pkg/util/kube/annotations_test.go
@@ -3,10 +3,10 @@ package kube_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/kube/collections.go
+++ b/pkg/util/kube/collections.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // ToNamespacedNames converts objects with metadata to a slice of NamespacedName.

--- a/pkg/util/kube/collections_test.go
+++ b/pkg/util/kube/collections_test.go
@@ -3,10 +3,10 @@ package kube_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/util/kube/dependencies.go
+++ b/pkg/util/kube/dependencies.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"golang.org/x/sync/errgroup"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // FetchResourcesByName fetches resources by name from the cluster (parallel version).

--- a/pkg/util/kube/dependencies_test.go
+++ b/pkg/util/kube/dependencies_test.go
@@ -3,9 +3,9 @@ package kube_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/kube/discovery/resources.go
+++ b/pkg/util/kube/discovery/resources.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // ComponentAndService represents a discovered OpenShift AI component or service.

--- a/pkg/util/kube/discovery/workloads.go
+++ b/pkg/util/kube/discovery/workloads.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // DiscoverWorkloads discovers user-created workload resources via CRD labels

--- a/pkg/util/kube/olm/install.go
+++ b/pkg/util/kube/olm/install.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 const (

--- a/pkg/util/kube/olm/subscriptions.go
+++ b/pkg/util/kube/olm/subscriptions.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // SubscriptionInfo contains the subscription fields relevant for matching.

--- a/pkg/util/kube/resources.go
+++ b/pkg/util/kube/resources.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
 
 // ToUnstructured converts a typed Kubernetes object to *unstructured.Unstructured.

--- a/pkg/util/kube/resources_test.go
+++ b/pkg/util/kube/resources_test.go
@@ -3,11 +3,11 @@ package kube_test
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/util/test/mocks/check/check.go
+++ b/pkg/util/test/mocks/check/check.go
@@ -3,9 +3,10 @@ package mocks
 import (
 	"context"
 
+	"github.com/stretchr/testify/mock"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/stretchr/testify/mock"
 )
 
 // MockCheck is a mock implementation of check.Check interface using testify/mock.

--- a/pkg/util/version/detector.go
+++ b/pkg/util/version/detector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 

--- a/pkg/util/version/detector_test.go
+++ b/pkg/util/version/detector_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
@@ -16,6 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/version/helpers_test.go
+++ b/pkg/util/version/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 
 	. "github.com/onsi/gomega"

--- a/pkg/util/version/openshift.go
+++ b/pkg/util/version/openshift.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // DetectOpenShiftVersion queries the OpenShift ClusterVersion resource to determine the cluster version.

--- a/pkg/util/version/openshift_test.go
+++ b/pkg/util/version/openshift_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/version"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 
 	. "github.com/onsi/gomega"
 )

--- a/pkg/util/version/sources.go
+++ b/pkg/util/version/sources.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
 
 // DetectFromDataScienceCluster attempts to detect version from DataScienceCluster resource

--- a/tests/integration/lint/diagnostic_cr_test.go
+++ b/tests/integration/lint/diagnostic_cr_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
The previous refactor (7ca69f1) changed import paths from the old org to opendatahub-io but did not run make fmt afterward. This commit fixes the import ordering to match gci configuration (standard, third-party, k8s.io, blank line, then project imports).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized import statements across the codebase for improved code organization and consistency. Consolidated duplicate imports and standardized import grouping patterns. No functional changes to features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->