### PR TITLE
refactor: return errors from registry constructors and introduce SemVersion pflag type

### DIFF
--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -67,15 +67,17 @@ const cmdExample = `
 `
 
 // AddCommand adds the lint command to the root command.
-func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) error {
 	streams := genericiooptions.IOStreams{
 		In:     root.InOrStdin(),
 		Out:    root.OutOrStdout(),
 		ErrOut: root.ErrOrStderr(),
 	}
 
-	// Create command with ConfigFlags from parent to ensure CLI auth flags are used
-	command := lintpkg.NewCommand(streams, flags)
+	command, err := lintpkg.NewCommand(streams, flags)
+	if err != nil {
+		return fmt.Errorf("initializing lint command: %w", err)
+	}
 
 	cmd := &cobra.Command{
 		Use:           cmdName,
@@ -83,9 +85,8 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		Long:          cmdLong,
 		Example:       cmdExample,
 		SilenceUsage:  true,
-		SilenceErrors: true, // We'll handle error output manually based on --quiet flag
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// Complete phase
 			if err := command.Complete(); err != nil {
 				if command.Verbose {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
@@ -94,7 +95,6 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 				return fmt.Errorf("completing command: %w", err)
 			}
 
-			// Validate phase
 			if err := command.Validate(); err != nil {
 				if command.Verbose {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
@@ -103,7 +103,6 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 				return fmt.Errorf("validating command: %w", err)
 			}
 
-			// Run phase
 			err := command.Run(cmd.Context())
 			if err != nil {
 				if command.Verbose {
@@ -117,8 +116,9 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		},
 	}
 
-	// Register flags using AddFlags method
 	command.AddFlags(cmd.Flags())
 
 	root.AddCommand(cmd)
+
+	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,7 +26,14 @@ func main() {
 	flags.AddFlags(cmd.PersistentFlags())
 
 	version.AddCommand(cmd, flags)
-	lint.AddCommand(cmd, flags)
+
+	if err := lint.AddCommand(cmd, flags); err != nil {
+		if _, writeErr := os.Stderr.WriteString(err.Error() + "\n"); writeErr != nil {
+			os.Exit(1)
+		}
+
+		os.Exit(1)
+	}
 
 	if err := cmd.Execute(); err != nil {
 		if _, writeErr := os.Stderr.WriteString(err.Error() + "\n"); writeErr != nil {

--- a/cmd/migrate/list/list.go
+++ b/cmd/migrate/list/list.go
@@ -1,6 +1,8 @@
 package list
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -40,8 +42,12 @@ func AddCommand(
 	parent *cobra.Command,
 	flags *genericclioptions.ConfigFlags,
 	streams genericiooptions.IOStreams,
-) {
-	command := migrate.NewListCommand(streams)
+) error {
+	command, err := migrate.NewListCommand(streams)
+	if err != nil {
+		return fmt.Errorf("initializing list command: %w", err)
+	}
+
 	command.ConfigFlags = flags
 
 	cmd := &cobra.Command{
@@ -67,4 +73,6 @@ func AddCommand(
 
 	command.AddFlags(cmd.Flags())
 	parent.AddCommand(cmd)
+
+	return nil
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -1,6 +1,8 @@
 package migrate
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -54,7 +56,7 @@ const cmdExample = `
 `
 
 // AddCommand adds the migrate command to the root command.
-func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) error {
 	streams := genericiooptions.IOStreams{
 		In:     root.InOrStdin(),
 		Out:    root.OutOrStdout(),
@@ -70,9 +72,19 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		SilenceErrors: true,
 	}
 
-	list.AddCommand(cmd, flags, streams)
-	prepare.AddCommand(cmd, flags, streams)
-	run.AddCommand(cmd, flags, streams)
+	if err := list.AddCommand(cmd, flags, streams); err != nil {
+		return fmt.Errorf("adding list subcommand: %w", err)
+	}
+
+	if err := prepare.AddCommand(cmd, flags, streams); err != nil {
+		return fmt.Errorf("adding prepare subcommand: %w", err)
+	}
+
+	if err := run.AddCommand(cmd, flags, streams); err != nil {
+		return fmt.Errorf("adding run subcommand: %w", err)
+	}
 
 	root.AddCommand(cmd)
+
+	return nil
 }

--- a/cmd/migrate/prepare/prepare.go
+++ b/cmd/migrate/prepare/prepare.go
@@ -1,6 +1,8 @@
 package prepare
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -50,8 +52,12 @@ func AddCommand(
 	parent *cobra.Command,
 	flags *genericclioptions.ConfigFlags,
 	streams genericiooptions.IOStreams,
-) {
-	command := migrate.NewPrepareCommand(streams)
+) error {
+	command, err := migrate.NewPrepareCommand(streams)
+	if err != nil {
+		return fmt.Errorf("initializing prepare command: %w", err)
+	}
+
 	command.ConfigFlags = flags
 
 	cmd := &cobra.Command{
@@ -77,4 +83,6 @@ func AddCommand(
 
 	command.AddFlags(cmd.Flags())
 	parent.AddCommand(cmd)
+
+	return nil
 }

--- a/cmd/migrate/run/run.go
+++ b/cmd/migrate/run/run.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -47,8 +49,12 @@ func AddCommand(
 	parent *cobra.Command,
 	flags *genericclioptions.ConfigFlags,
 	streams genericiooptions.IOStreams,
-) {
-	command := migrate.NewRunCommand(streams)
+) error {
+	command, err := migrate.NewRunCommand(streams)
+	if err != nil {
+		return fmt.Errorf("initializing run command: %w", err)
+	}
+
 	command.ConfigFlags = flags
 
 	cmd := &cobra.Command{
@@ -74,4 +80,6 @@ func AddCommand(
 
 	command.AddFlags(cmd.Flags())
 	parent.AddCommand(cmd)
+
+	return nil
 }

--- a/docs/lint/architecture.md
+++ b/docs/lint/architecture.md
@@ -82,43 +82,43 @@ func NewCommand(
     streams genericiooptions.IOStreams,
     configFlags *genericclioptions.ConfigFlags,
     options ...CommandOption,
-) *Command {
-    registry := check.NewRegistry()
-
-    // Explicitly register all checks (no global state, full test isolation)
-    // Components (13)
-    registry.MustRegister(codeflare.NewRemovalCheck())
-    registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
-    registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
-    registry.MustRegister(datasciencepipelines.NewInstructLabRemovalCheck())
-    registry.MustRegister(datasciencepipelines.NewRenamingCheck())
-    registry.MustRegister(kserve.NewServerlessRemovalCheck())
-    registry.MustRegister(kserve.NewInferenceServiceConfigCheck())
-    registry.MustRegister(kserve.NewServiceMeshOperatorCheck())
-    registry.MustRegister(kserve.NewServiceMeshRemovalCheck())
-    registry.MustRegister(kueue.NewManagementStateCheck())
-    registry.MustRegister(kueue.NewOperatorInstalledCheck())
-    registry.MustRegister(modelmesh.NewRemovalCheck())
-    registry.MustRegister(trainingoperator.NewDeprecationCheck())
-
-    // Dependencies (2)
-    registry.MustRegister(certmanager.NewCheck())
-    registry.MustRegister(openshift.NewCheck())
-
-    // Workloads (8)
-    registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())
-    registry.MustRegister(guardrails.NewOtelMigrationCheck())
-    registry.MustRegister(kserveworkloads.NewAcceleratorMigrationCheck())
-    registry.MustRegister(kserveworkloads.NewImpactedWorkloadsCheck())
-    registry.MustRegister(notebook.NewAcceleratorMigrationCheck())
-    registry.MustRegister(notebook.NewImpactedWorkloadsCheck())
-    registry.MustRegister(ray.NewImpactedWorkloadsCheck())
-    registry.MustRegister(trainingoperatorworkloads.NewImpactedWorkloadsCheck())
+) (*Command, error) {
+    registry, err := check.NewRegistry(
+        // Components (13)
+        codeflare.NewRemovalCheck(),
+        dashboard.NewAcceleratorProfileMigrationCheck(),
+        dashboard.NewHardwareProfileMigrationCheck(),
+        datasciencepipelines.NewInstructLabRemovalCheck(),
+        datasciencepipelines.NewRenamingCheck(),
+        kserve.NewServerlessRemovalCheck(),
+        kserve.NewInferenceServiceConfigCheck(),
+        kserve.NewServiceMeshOperatorCheck(),
+        kserve.NewServiceMeshRemovalCheck(),
+        kueue.NewManagementStateCheck(),
+        kueue.NewOperatorInstalledCheck(),
+        modelmesh.NewRemovalCheck(),
+        trainingoperator.NewDeprecationCheck(),
+        // Dependencies (2)
+        certmanager.NewCheck(),
+        openshift.NewCheck(),
+        // Workloads (8)
+        guardrails.NewImpactedWorkloadsCheck(),
+        guardrails.NewOtelMigrationCheck(),
+        kserveworkloads.NewAcceleratorMigrationCheck(),
+        kserveworkloads.NewImpactedWorkloadsCheck(),
+        notebook.NewAcceleratorMigrationCheck(),
+        notebook.NewImpactedWorkloadsCheck(),
+        ray.NewImpactedWorkloadsCheck(),
+        trainingoperatorworkloads.NewImpactedWorkloadsCheck(),
+    )
+    if err != nil {
+        return nil, fmt.Errorf("registering checks: %w", err)
+    }
 
     return &Command{
         SharedOptions: shared,
         registry:      registry,
-    }
+    }, nil
 }
 ```
 
@@ -344,15 +344,27 @@ The lint command uses a `Command` struct (not `Options`) with constructor `NewCo
 
 ```go
 type Command struct {
-    shared        *SharedOptions
-    targetVersion string
+    *SharedOptions
+    TargetVersion version.SemVersion  // implements pflag.Value
+    registry      *check.CheckRegistry
 }
 
-func NewCommand(opts CommandOptions) *Command {
-    return &Command{
-        shared:        opts.Shared,
-        targetVersion: opts.TargetVersion,
+func NewCommand(
+    streams genericiooptions.IOStreams,
+    configFlags *genericclioptions.ConfigFlags,
+    options ...CommandOption,
+) (*Command, error) {
+    registry, err := check.NewRegistry(/* checks... */)
+    if err != nil {
+        return nil, fmt.Errorf("registering checks: %w", err)
     }
+
+    c := &Command{
+        SharedOptions: NewSharedOptions(streams, configFlags),
+        registry:      registry,
+    }
+    // ... apply options ...
+    return c, nil
 }
 ```
 

--- a/docs/lint/writing-checks.md
+++ b/docs/lint/writing-checks.md
@@ -79,11 +79,14 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 }
 ```
 
-**Registration:** Checks are explicitly registered in `pkg/lint/command.go`:
+**Registration:** Checks are explicitly registered in `pkg/lint/command.go` via `check.NewRegistry(...)`:
 
 ```go
 // In NewCommand()
-registry.MustRegister(dashboard.NewCheck())
+registry, err := check.NewRegistry(
+    dashboard.NewCheck(),
+    // ... other checks
+)
 ```
 
 ### Using BaseCheck
@@ -129,31 +132,31 @@ func NewCommand(
     streams genericiooptions.IOStreams,
     configFlags *genericclioptions.ConfigFlags,
     options ...CommandOption,
-) *Command {
-    registry := check.NewRegistry()
-
-    // Explicitly register all checks
-    // Components (11)
-    registry.MustRegister(codeflare.NewRemovalCheck())
-    registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
-    registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
-    registry.MustRegister(datasciencepipelines.NewInstructLabRemovalCheck())
-    // ... additional component checks
-
-    // Dependencies (2)
-    registry.MustRegister(certmanager.NewCheck())
-    // ... additional dependency checks
-
-    // Workloads (7)
-    registry.MustRegister(guardrails.NewOtelMigrationCheck())
-    registry.MustRegister(kserveworkloads.NewAcceleratorMigrationCheck())
-    registry.MustRegister(notebook.NewImpactedWorkloadsCheck())
-    // ... additional workload checks
+) (*Command, error) {
+    registry, err := check.NewRegistry(
+        // Components (13)
+        codeflare.NewRemovalCheck(),
+        dashboard.NewAcceleratorProfileMigrationCheck(),
+        dashboard.NewHardwareProfileMigrationCheck(),
+        datasciencepipelines.NewInstructLabRemovalCheck(),
+        // ... additional component checks
+        // Dependencies (2)
+        certmanager.NewCheck(),
+        // ... additional dependency checks
+        // Workloads (13)
+        guardrails.NewOtelMigrationCheck(),
+        kserveworkloads.NewAcceleratorMigrationCheck(),
+        notebook.NewImpactedWorkloadsCheck(),
+        // ... additional workload checks
+    )
+    if err != nil {
+        return nil, fmt.Errorf("registering checks: %w", err)
+    }
 
     return &Command{
         SharedOptions: shared,
         registry:      registry,
-    }
+    }, nil
 }
 ```
 
@@ -849,8 +852,8 @@ func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*resu
         Run(ctx, validate.Removal("CodeFlare is enabled (state: %s) but will be removed in RHOAI 3.x"))
 }
 
-// Registration is done explicitly in pkg/lint/command.go:
-// registry.MustRegister(codeflare.NewRemovalCheck())
+// Registration is done explicitly in pkg/lint/command.go via check.NewRegistry(...)
+// e.g. codeflare.NewRemovalCheck() is passed to check.NewRegistry()
 ```
 
 **Note:** For complex checks that don't fit the builder pattern, you can still write checks without builders using `c.NewResult()` and manually fetching resources via `client.GetDataScienceCluster(ctx, target.Client)`.

--- a/docs/migrate/implementation-plan.md
+++ b/docs/migrate/implementation-plan.md
@@ -67,8 +67,8 @@ type ActionRegistry struct {
 ```
 Pattern matching via `ListByPattern()`, similar to CheckRegistry
 
-**File:** `pkg/migrate/action/global.go`
-Global registry with `MustRegisterAction()` for auto-registration
+**File:** `pkg/migrate/action/registry.go`
+Variadic `NewActionRegistry(actions ...Action) (*ActionRegistry, error)` constructor with error-returning `Register(actions ...Action) error`
 
 #### 1.3 Action Executor
 **File:** `pkg/migrate/action/executor.go`
@@ -116,7 +116,7 @@ type ActionStep struct {
 **File:** `cmd/migrate/migrate.go`
 
 Cobra command wrapper with:
-- Blank imports for action auto-registration (e.g., `_ "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"`)
+- Explicit action registration via `action.NewActionRegistry(...)` (see Explicit Registration Pattern below)
 - Three-phase execution: Complete → Validate → Run
 - Pattern from `cmd/lint/lint.go:83-140`
 
@@ -389,16 +389,11 @@ if step1.Status == result.StepFailed {
 }
 ```
 
-### Auto-Registration Pattern
+### Explicit Registration Pattern
 ```go
-// In rhbok.go
-func init() {
-    action.MustRegisterAction(&RHBOKMigrationAction{})
-}
-
-// In cmd/migrate/migrate.go
-import (
-    _ "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+// Actions are registered explicitly in each command constructor:
+registry, err := action.NewActionRegistry(
+    &rhbok.RHBOKMigrationAction{},
 )
 ```
 

--- a/pkg/backup/command.go
+++ b/pkg/backup/command.go
@@ -96,14 +96,17 @@ func (c *Command) Complete() error {
 		}
 	}
 
-	// Create registry - always needed even if empty
-	c.depRegistry = dependencies.NewRegistry()
-
-	// Only register resolvers if dependency resolution is enabled
+	var resolvers []dependencies.Resolver
 	if c.Dependencies {
-		c.depRegistry.MustRegister(notebooks.NewResolver())
-		c.depRegistry.MustRegister(dspa.NewResolver())
+		resolvers = append(resolvers, notebooks.NewResolver(), dspa.NewResolver())
 	}
+
+	registry, err := dependencies.NewRegistry(resolvers...)
+	if err != nil {
+		return fmt.Errorf("creating dependency registry: %w", err)
+	}
+
+	c.depRegistry = registry
 
 	return nil
 }

--- a/pkg/backup/dependencies/registry.go
+++ b/pkg/backup/dependencies/registry.go
@@ -1,6 +1,7 @@
 package dependencies
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -11,25 +12,33 @@ type Registry struct {
 	resolvers []Resolver
 }
 
-// NewRegistry creates a new resolver registry.
-func NewRegistry() *Registry {
-	return &Registry{
-		resolvers: make([]Resolver, 0),
+// NewRegistry creates a new resolver registry, optionally registering the provided resolvers.
+// Returns an error if any resolver is nil.
+func NewRegistry(resolvers ...Resolver) (*Registry, error) {
+	r := &Registry{
+		resolvers: make([]Resolver, 0, len(resolvers)),
 	}
+
+	if err := r.Register(resolvers...); err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
-// Register adds a resolver to the registry.
-func (r *Registry) Register(resolver Resolver) {
-	r.resolvers = append(r.resolvers, resolver)
-}
-
-// MustRegister registers a resolver and panics if the resolver is nil.
-// Use this for explicit registration in command construction.
-func (r *Registry) MustRegister(resolver Resolver) {
-	if resolver == nil {
-		panic("cannot register nil resolver")
+// Register adds one or more resolvers to the registry.
+// The operation is atomic: either all resolvers are registered or none are.
+// Returns an error if any resolver is nil.
+func (r *Registry) Register(resolvers ...Resolver) error {
+	for _, resolver := range resolvers {
+		if resolver == nil {
+			return errors.New("cannot register nil resolver")
+		}
 	}
-	r.Register(resolver)
+
+	r.resolvers = append(r.resolvers, resolvers...)
+
+	return nil
 }
 
 // GetResolver finds the appropriate resolver for the given GVR.

--- a/pkg/backup/pipeline/resolver_test.go
+++ b/pkg/backup/pipeline/resolver_test.go
@@ -20,7 +20,8 @@ func TestResolverStage(t *testing.T) {
 
 	t.Run("should process workloads without resolver", func(t *testing.T) {
 		io := iostreams.NewIOStreams(nil, nil, nil)
-		registry := dependencies.NewRegistry()
+		registry, err := dependencies.NewRegistry()
+		g.Expect(err).ToNot(HaveOccurred())
 
 		resolver := &pipeline.ResolverStage{
 			Client:      nil,
@@ -61,7 +62,8 @@ func TestResolverStage(t *testing.T) {
 
 	t.Run("should handle context cancellation", func(t *testing.T) {
 		io := iostreams.NewIOStreams(nil, nil, nil)
-		registry := dependencies.NewRegistry()
+		registry, err := dependencies.NewRegistry()
+		g.Expect(err).ToNot(HaveOccurred())
 
 		resolver := &pipeline.ResolverStage{
 			Client:      nil,
@@ -76,14 +78,15 @@ func TestResolverStage(t *testing.T) {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel() // Cancel immediately
 
-		err := resolver.Run(cancelCtx, 1, input, output)
+		err = resolver.Run(cancelCtx, 1, input, output)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("resolver"))
 	})
 
 	t.Run("should process multiple workloads with multiple workers", func(t *testing.T) {
 		io := iostreams.NewIOStreams(nil, nil, nil)
-		registry := dependencies.NewRegistry()
+		registry, err := dependencies.NewRegistry()
+		g.Expect(err).ToNot(HaveOccurred())
 
 		resolver := &pipeline.ResolverStage{
 			Client:      nil,
@@ -122,7 +125,8 @@ func TestResolverStage(t *testing.T) {
 
 	t.Run("should handle worker timeout", func(t *testing.T) {
 		io := iostreams.NewIOStreams(nil, nil, nil)
-		registry := dependencies.NewRegistry()
+		registry, err := dependencies.NewRegistry()
+		g.Expect(err).ToNot(HaveOccurred())
 
 		resolver := &pipeline.ResolverStage{
 			Client:      nil,
@@ -141,7 +145,7 @@ func TestResolverStage(t *testing.T) {
 		// Wait for timeout
 		time.Sleep(10 * time.Millisecond)
 
-		err := resolver.Run(timeoutCtx, 1, input, output)
+		err = resolver.Run(timeoutCtx, 1, input, output)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("resolver"))
 	})

--- a/pkg/lint/check/executor_bench_test.go
+++ b/pkg/lint/check/executor_bench_test.go
@@ -101,22 +101,23 @@ func BenchmarkExecuteSelective_SingleCheck(b *testing.B) {
 
 // setupBenchmarkRegistry creates a registry with representative checks.
 func setupBenchmarkRegistry() *check.CheckRegistry {
-	registry := check.NewRegistry()
+	checks := make([]check.Check, 0, 15)
 
-	// Register multiple checks across categories to simulate realistic load
-	// Components (5 checks)
 	for i := range 5 {
-		_ = registry.Register(newBenchmarkCheck("components", i))
+		checks = append(checks, newBenchmarkCheck("components", i))
 	}
 
-	// Services (5 checks)
 	for i := range 5 {
-		_ = registry.Register(newBenchmarkCheck("services", i))
+		checks = append(checks, newBenchmarkCheck("services", i))
 	}
 
-	// Workloads (5 checks)
 	for i := range 5 {
-		_ = registry.Register(newBenchmarkCheck("workloads", i))
+		checks = append(checks, newBenchmarkCheck("workloads", i))
+	}
+
+	registry, err := check.NewRegistry(checks...)
+	if err != nil {
+		panic(err)
 	}
 
 	return registry

--- a/pkg/lint/check/registration_test.go
+++ b/pkg/lint/check/registration_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 // Test 1: Duplicate Registration Error.
-func TestRegistry_Register_DuplicateCheckPanic(t *testing.T) {
+func TestRegistry_Register_DuplicateCheckError(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry() // Isolated registry for testing
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create mock check with specific ID
 	mockCheck := mocks.NewMockCheck()
@@ -23,7 +24,7 @@ func TestRegistry_Register_DuplicateCheckPanic(t *testing.T) {
 	mockCheck.On("Group").Return(check.GroupComponent)
 
 	// First registration should succeed
-	err := registry.Register(mockCheck)
+	err = registry.Register(mockCheck)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Second registration with same ID should fail
@@ -37,8 +38,8 @@ func TestRegistry_Register_DuplicateCheckPanic(t *testing.T) {
 func TestRegistry_Register_Success(t *testing.T) {
 	g := NewWithT(t)
 
-	// Create new registry for isolation
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create mock check
 	mockCheck := mocks.NewMockCheck()
@@ -46,8 +47,7 @@ func TestRegistry_Register_Success(t *testing.T) {
 	mockCheck.On("Name").Return("Test Success")
 	mockCheck.On("Group").Return(check.GroupComponent)
 
-	// Register via registry method
-	err := registry.Register(mockCheck)
+	err = registry.Register(mockCheck)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Verify registration
@@ -56,41 +56,41 @@ func TestRegistry_Register_Success(t *testing.T) {
 	g.Expect(retrieved.ID()).To(Equal("test.success"))
 }
 
-// Test 3: MustRegisterCheck Panic on Duplicate.
-func TestMustRegisterCheck_PanicOnDuplicate(t *testing.T) {
+// Test 3: Duplicate Registration via Register returns error.
+func TestRegistry_Register_DuplicateReturnsError(t *testing.T) {
 	g := NewWithT(t)
 
-	// Create isolated registry for testing
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create first mock check
 	mockCheck1 := mocks.NewMockCheck()
-	mockCheck1.On("ID").Return("test.panic")
-	mockCheck1.On("Name").Return("Test Panic 1")
+	mockCheck1.On("ID").Return("test.dup")
+	mockCheck1.On("Name").Return("Test Dup 1")
 	mockCheck1.On("Group").Return(check.GroupComponent)
 
-	// Register first check
-	err := registry.Register(mockCheck1)
+	err = registry.Register(mockCheck1)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create second mock with same ID
 	mockCheck2 := mocks.NewMockCheck()
-	mockCheck2.On("ID").Return("test.panic")
-	mockCheck2.On("Name").Return("Test Panic 2")
+	mockCheck2.On("ID").Return("test.dup")
+	mockCheck2.On("Name").Return("Test Dup 2")
 	mockCheck2.On("Group").Return(check.GroupComponent)
 
 	// Attempt to register duplicate should return error
 	err = registry.Register(mockCheck2)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("already registered"))
-	g.Expect(err.Error()).To(ContainSubstring("test.panic"))
+	g.Expect(err.Error()).To(ContainSubstring("test.dup"))
 }
 
 // Test 4: Concurrent Registration Safety.
 func TestRegistry_ConcurrentRegistration(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Launch 10 goroutines trying to register checks concurrently
 	const numGoroutines = 10
@@ -132,7 +132,8 @@ func TestRegistry_ConcurrentRegistration(t *testing.T) {
 func TestRegistry_ListByGroup(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Register checks in different groups
 	componentCheck := mocks.NewMockCheck()
@@ -147,7 +148,7 @@ func TestRegistry_ListByGroup(t *testing.T) {
 	workloadCheck.On("ID").Return("workload.test")
 	workloadCheck.On("Group").Return(check.GroupWorkload)
 
-	err := registry.Register(componentCheck)
+	err = registry.Register(componentCheck)
 	g.Expect(err).ToNot(HaveOccurred())
 	err = registry.Register(dependencyCheck)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -174,7 +175,8 @@ func TestRegistry_ListByGroup(t *testing.T) {
 func TestRegistry_ListBySelector(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Register checks in different groups
 	componentCheck := mocks.NewMockCheck()
@@ -185,7 +187,7 @@ func TestRegistry_ListBySelector(t *testing.T) {
 	dependencyCheck.On("ID").Return("dependency.test")
 	dependencyCheck.On("Group").Return(check.GroupDependency)
 
-	err := registry.Register(componentCheck)
+	err = registry.Register(componentCheck)
 	g.Expect(err).ToNot(HaveOccurred())
 	err = registry.Register(dependencyCheck)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/lint/check/registry.go
+++ b/pkg/lint/check/registry.go
@@ -11,34 +11,38 @@ type CheckRegistry struct {
 	checks map[string]Check
 }
 
-// NewRegistry creates a new check registry.
-func NewRegistry() *CheckRegistry {
-	return &CheckRegistry{
+// NewRegistry creates a new check registry, optionally registering the provided checks.
+// Returns an error if any check has a duplicate ID.
+func NewRegistry(checks ...Check) (*CheckRegistry, error) {
+	r := &CheckRegistry{
 		checks: make(map[string]Check),
 	}
+
+	if err := r.Register(checks...); err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
-// Register adds a check to the registry
-// Returns error if a check with the same ID already exists.
-func (r *CheckRegistry) Register(check Check) error {
+// Register adds one or more checks to the registry.
+// The operation is atomic: either all checks are registered or none are.
+// Returns an error if a check with the same ID already exists.
+func (r *CheckRegistry) Register(checks ...Check) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if _, exists := r.checks[check.ID()]; exists {
-		return fmt.Errorf("check with ID %s already registered", check.ID())
+	for _, c := range checks {
+		if _, exists := r.checks[c.ID()]; exists {
+			return fmt.Errorf("check with ID %s already registered", c.ID())
+		}
 	}
 
-	r.checks[check.ID()] = check
+	for _, c := range checks {
+		r.checks[c.ID()] = c
+	}
 
 	return nil
-}
-
-// MustRegister registers a check and panics if registration fails.
-// Use this for check registration in command construction where failure is unrecoverable.
-func (r *CheckRegistry) MustRegister(check Check) {
-	if err := r.Register(check); err != nil {
-		panic(fmt.Sprintf("failed to register check %s: %v", check.ID(), err))
-	}
 }
 
 // Get looks up a check by ID, returning the check and whether it exists.

--- a/pkg/lint/check/registry_test.go
+++ b/pkg/lint/check/registry_test.go
@@ -12,7 +12,8 @@ import (
 func TestCheckRegistry_ListByPattern(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Register test checks
 	mockChecks := []struct {
@@ -127,7 +128,8 @@ func TestCheckRegistry_ListByPattern(t *testing.T) {
 func TestCheckRegistry_ListByPatterns_MultiplePatterns(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Register test checks
 	mockChecks := []struct {
@@ -219,7 +221,8 @@ func TestCheckRegistry_ListByPatterns_MultiplePatterns(t *testing.T) {
 func TestCheckRegistry_ListByPatterns_InvalidPattern(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	mockCheck := mocks.NewMockCheck()
 	mockCheck.On("ID").Return("components.dashboard")
@@ -228,7 +231,7 @@ func TestCheckRegistry_ListByPatterns_InvalidPattern(t *testing.T) {
 	g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 	// Invalid glob pattern in any position should return error
-	_, err := registry.ListByPatterns([]string{"services.*", "["}, "")
+	_, err = registry.ListByPatterns([]string{"services.*", "["}, "")
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("pattern matching"))
 }
@@ -236,7 +239,8 @@ func TestCheckRegistry_ListByPatterns_InvalidPattern(t *testing.T) {
 func TestCheckRegistry_ListByPattern_InvalidPattern(t *testing.T) {
 	g := NewWithT(t)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 
 	mockCheck := mocks.NewMockCheck()
 	mockCheck.On("ID").Return("components.dashboard")
@@ -245,7 +249,7 @@ func TestCheckRegistry_ListByPattern_InvalidPattern(t *testing.T) {
 	g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 	// Invalid glob pattern should return error
-	_, err := registry.ListByPattern("[", "")
+	_, err = registry.ListByPattern("[", "")
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("pattern matching"))
 }

--- a/pkg/lint/check/selector_test.go
+++ b/pkg/lint/check/selector_test.go
@@ -49,7 +49,8 @@ func TestMatchesPattern_Wildcard(t *testing.T) {
 			mockCheck.On("Group").Return(tt.group)
 
 			// matchesPattern is not exported, so we test through ListByPattern
-			registry := check.NewRegistry()
+			registry, err := check.NewRegistry()
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 			results, err := registry.ListByPattern(tt.pattern, "")
@@ -139,7 +140,8 @@ func TestMatchesPattern_GroupShortcuts(t *testing.T) {
 			mockCheck.On("ID").Return(tt.checkID)
 			mockCheck.On("Group").Return(tt.group)
 
-			registry := check.NewRegistry()
+			registry, err := check.NewRegistry()
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 			results, err := registry.ListByPattern(tt.pattern, "")
@@ -187,7 +189,8 @@ func TestMatchesPattern_ExactMatch(t *testing.T) {
 			mockCheck.On("ID").Return(tt.checkID)
 			mockCheck.On("Group").Return(tt.group)
 
-			registry := check.NewRegistry()
+			registry, err := check.NewRegistry()
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 			results, err := registry.ListByPattern(tt.pattern, "")
@@ -263,7 +266,8 @@ func TestMatchesPattern_GlobPatterns(t *testing.T) {
 			mockCheck.On("ID").Return(tt.checkID)
 			mockCheck.On("Group").Return(tt.group)
 
-			registry := check.NewRegistry()
+			registry, err := check.NewRegistry()
+			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 			results, err := registry.ListByPattern(tt.pattern, "")
@@ -286,11 +290,12 @@ func TestMatchesPattern_InvalidPattern(t *testing.T) {
 	mockCheck.On("ID").Return("components.dashboard")
 	mockCheck.On("Group").Return(check.GroupComponent)
 
-	registry := check.NewRegistry()
+	registry, err := check.NewRegistry()
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registry.Register(mockCheck)).To(Succeed())
 
 	// Invalid glob pattern should return error
-	_, err := registry.ListByPattern("[", "")
+	_, err = registry.ListByPattern("[", "")
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("invalid pattern"))
 }

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -44,12 +44,9 @@ type Command struct {
 	*SharedOptions
 
 	// TargetVersion is the optional target version for upgrade assessment.
-	// If empty, runs in lint mode (validates current state).
+	// If not set, runs in lint mode (validates current state).
 	// If set, runs in upgrade mode (assesses upgrade readiness to target version).
-	TargetVersion string
-
-	// parsedTargetVersion is the parsed semver version (upgrade mode only)
-	parsedTargetVersion *semver.Version
+	TargetVersion version.SemVersion
 
 	// currentClusterVersion stores the detected OpenShift AI version (populated during Run)
 	currentClusterVersion string
@@ -70,67 +67,67 @@ func NewCommand(
 	streams genericiooptions.IOStreams,
 	configFlags *genericclioptions.ConfigFlags,
 	options ...CommandOption,
-) *Command {
-	shared := NewSharedOptions(streams, configFlags)
-	registry := check.NewRegistry()
-
-	// Explicitly register all checks (no global state, full test isolation)
-	// Components (13)
-	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
-	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
-	registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
-	registry.MustRegister(datasciencepipelines.NewRenamingCheck())
-	registry.MustRegister(kserve.NewServerlessRemovalCheck())
-	registry.MustRegister(kserve.NewKuadrantReadinessCheck())
-	registry.MustRegister(kserve.NewAuthorinoTLSReadinessCheck())
-	registry.MustRegister(kserve.NewServiceMeshOperatorCheck())
-	registry.MustRegister(kserve.NewServiceMeshRemovalCheck())
-	registry.MustRegister(kueue.NewManagementStateCheck())
-	registry.MustRegister(kueue.NewOperatorInstalledCheck())
-	registry.MustRegister(modelmesh.NewRemovalCheck())
-	registry.MustRegister(trainingoperator.NewDeprecationCheck())
-
-	// Dependencies (2)
-	registry.MustRegister(certmanager.NewCheck())
-	registry.MustRegister(openshift.NewCheck())
-
-	// Workloads (16)
-	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
-	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
-	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
-	registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())
-	registry.MustRegister(guardrails.NewOtelMigrationCheck())
-	registry.MustRegister(kserveworkloads.NewInferenceServiceConfigCheck())
-	registry.MustRegister(kserveworkloads.NewAcceleratorMigrationCheck())
-	registry.MustRegister(kserveworkloads.NewHardwareProfileMigrationCheck())
-	registry.MustRegister(kserveworkloads.NewImpactedWorkloadsCheck())
-	registry.MustRegister(llamastackworkloads.NewConfigCheck())
-	registry.MustRegister(notebook.NewAcceleratorMigrationCheck())
-	registry.MustRegister(notebook.NewContainerNameCheck())
-	registry.MustRegister(notebook.NewHardwareProfileMigrationCheck())
-	registry.MustRegister(notebook.NewConnectionIntegrityCheck())
-	registry.MustRegister(notebook.NewHardwareProfileIntegrityCheck())
-	registry.MustRegister(notebook.NewImpactedWorkloadsCheck())
-	registry.MustRegister(notebook.NewRunningWorkloadsCheck())
-	registry.MustRegister(ray.NewImpactedWorkloadsCheck())
-	registry.MustRegister(trainingoperatorworkloads.NewImpactedWorkloadsCheck())
+) (*Command, error) {
+	registry, err := check.NewRegistry(
+		// Components (13)
+		raycomponent.NewCodeFlareRemovalCheck(),
+		dashboard.NewAcceleratorProfileMigrationCheck(),
+		dashboard.NewHardwareProfileMigrationCheck(),
+		datasciencepipelines.NewRenamingCheck(),
+		kserve.NewServerlessRemovalCheck(),
+		kserve.NewKuadrantReadinessCheck(),
+		kserve.NewAuthorinoTLSReadinessCheck(),
+		kserve.NewServiceMeshOperatorCheck(),
+		kserve.NewServiceMeshRemovalCheck(),
+		kueue.NewManagementStateCheck(),
+		kueue.NewOperatorInstalledCheck(),
+		modelmesh.NewRemovalCheck(),
+		trainingoperator.NewDeprecationCheck(),
+		// Dependencies (2)
+		certmanager.NewCheck(),
+		openshift.NewCheck(),
+		// Workloads (19)
+		ray.NewAppWrapperCleanupCheck(),
+		datasciencepipelinesworkloads.NewInstructLabRemovalCheck(),
+		datasciencepipelinesworkloads.NewStoredVersionRemovalCheck(),
+		guardrails.NewImpactedWorkloadsCheck(),
+		guardrails.NewOtelMigrationCheck(),
+		kserveworkloads.NewInferenceServiceConfigCheck(),
+		kserveworkloads.NewAcceleratorMigrationCheck(),
+		kserveworkloads.NewHardwareProfileMigrationCheck(),
+		kserveworkloads.NewImpactedWorkloadsCheck(),
+		llamastackworkloads.NewConfigCheck(),
+		notebook.NewAcceleratorMigrationCheck(),
+		notebook.NewContainerNameCheck(),
+		notebook.NewHardwareProfileMigrationCheck(),
+		notebook.NewConnectionIntegrityCheck(),
+		notebook.NewHardwareProfileIntegrityCheck(),
+		notebook.NewImpactedWorkloadsCheck(),
+		notebook.NewRunningWorkloadsCheck(),
+		ray.NewImpactedWorkloadsCheck(),
+		trainingoperatorworkloads.NewImpactedWorkloadsCheck(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("registering checks: %w", err)
+	}
 
 	c := &Command{
-		SharedOptions: shared,
+		SharedOptions: NewSharedOptions(streams, configFlags),
 		registry:      registry,
 	}
 
-	// Apply functional options
 	for _, opt := range options {
-		opt(c)
+		if err := opt(c); err != nil {
+			return nil, fmt.Errorf("applying command option: %w", err)
+		}
 	}
 
-	return c
+	return c, nil
 }
 
 // AddFlags registers command-specific flags with the provided FlagSet.
 func (c *Command) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescTargetVersion)
+	fs.Var(&c.TargetVersion, "target-version", flagDescTargetVersion)
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescOutput)
 	fs.StringArrayVar(&c.CheckSelectors, "checks", []string{"*"}, flagDescChecks)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
@@ -153,17 +150,6 @@ func (c *Command) Complete() error {
 	if !c.Verbose && !c.Debug {
 		c.IO = iostreams.NewQuietWrapper(c.IO)
 	}
-
-	// Parse target version if provided (upgrade mode)
-	if c.TargetVersion != "" {
-		// Use ParseTolerant to accept partial versions (e.g., "3.0" → "3.0.0")
-		targetVer, err := semver.ParseTolerant(c.TargetVersion)
-		if err != nil {
-			return fmt.Errorf("invalid target version %q: %w", c.TargetVersion, err)
-		}
-		c.parsedTargetVersion = &targetVer
-	}
-	// If no target version provided, we're in lint mode (will use current version)
 
 	return nil
 }
@@ -202,7 +188,7 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 
 	// Determine mode: upgrade (with --target-version) or lint (without --target-version)
-	if c.TargetVersion != "" {
+	if c.TargetVersion.IsSet() {
 		return c.runUpgradeMode(ctx, currentVersion)
 	}
 
@@ -320,12 +306,12 @@ func (c *Command) runLintMode(ctx context.Context, clusterVersion *semver.Versio
 // runUpgradeMode assesses upgrade readiness for a target version.
 func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Version) error {
 	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
-	c.IO.Errorf("Target OpenShift AI version: %s\n", c.TargetVersion)
+	c.IO.Errorf("Target OpenShift AI version: %s\n", c.TargetVersion.String())
 
 	// Same major.minor means no upgrade checks are needed (checked before
 	// the downgrade guard so that e.g. --target-version 2.25 with current
 	// 2.25.2 is treated as "same version", not as a downgrade).
-	if version.SameMajorMinor(currentVersion, c.parsedTargetVersion) {
+	if version.SameMajorMinor(currentVersion, c.TargetVersion.Version()) {
 		c.IO.Fprintln()
 		c.IO.Fprintln("Environment:")
 		c.IO.Fprintf("  OpenShift AI version: %s", currentVersion.String())
@@ -342,12 +328,12 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 	}
 
 	// Check if target version is older than current
-	if c.parsedTargetVersion.LT(*currentVersion) {
+	if c.TargetVersion.Version().LT(*currentVersion) {
 		return fmt.Errorf("target version %s is older than current version %s (downgrades not supported)",
-			c.TargetVersion, currentVersion.String())
+			c.TargetVersion.String(), currentVersion.String())
 	}
 
-	c.IO.Errorf("Assessing upgrade readiness: %s → %s\n", currentVersion.String(), c.TargetVersion)
+	c.IO.Errorf("Assessing upgrade readiness: %s → %s\n", currentVersion.String(), c.TargetVersion.String())
 
 	// Execute checks using target version for applicability filtering
 	c.IO.Errorf("Running upgrade compatibility checks...")
@@ -356,8 +342,8 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 	// Create check target with BOTH current and target versions for upgrade checks
 	checkTarget := check.Target{
 		Client:         c.Client,
-		CurrentVersion: currentVersion,        // The version we're upgrading FROM
-		TargetVersion:  c.parsedTargetVersion, // The version we're upgrading TO
+		CurrentVersion: currentVersion,            // The version we're upgrading FROM
+		TargetVersion:  c.TargetVersion.Version(), // The version we're upgrading TO
 		Resource:       nil,
 		IO:             c.IO,
 		Debug:          c.Debug,
@@ -427,11 +413,7 @@ func (c *Command) formatAndOutputResults(
 	resultsByGroup map[check.CheckGroup][]check.CheckExecution,
 ) error {
 	clusterVer := &c.currentClusterVersion
-	var targetVer *string
-	if c.TargetVersion != "" {
-		targetVer = &c.TargetVersion
-	}
-
+	var targetVer *string // always nil in lint mode
 	ocpVer := c.openShiftVersionPtr()
 
 	// Flatten results to sorted array
@@ -487,7 +469,8 @@ func (c *Command) formatAndOutputUpgradeResults(
 	resultsByGroup map[check.CheckGroup][]check.CheckExecution,
 ) error {
 	clusterVer := &c.currentClusterVersion
-	targetVer := &c.TargetVersion
+	targetVerStr := c.TargetVersion.String()
+	targetVer := &targetVerStr
 	ocpVer := c.openShiftVersionPtr()
 
 	// Flatten results to sorted array
@@ -521,7 +504,7 @@ func (c *Command) outputUpgradeTable(ctx context.Context, _ string, results []ch
 		ShowImpactedObjects: c.Verbose,
 		VersionInfo: &VersionInfo{
 			RHOAICurrentVersion: c.currentClusterVersion,
-			RHOAITargetVersion:  c.TargetVersion,
+			RHOAITargetVersion:  c.TargetVersion.String(),
 			OpenShiftVersion:    c.currentOpenShiftVersion,
 		},
 	}

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -210,15 +210,19 @@ func ValidateCheckSelector(selector string) error {
 //
 // Example:
 //
-//	cmd := lint.NewCommand(streams, configFlags,
+//	cmd, err := lint.NewCommand(streams, configFlags,
 //	    lint.WithTargetVersion("3.0"),
 //	)
-type CommandOption func(*Command)
+type CommandOption func(*Command) error
 
 // WithTargetVersion returns a CommandOption that sets the target version.
-func WithTargetVersion(version string) CommandOption {
-	return func(c *Command) {
-		c.TargetVersion = version
+func WithTargetVersion(v string) CommandOption {
+	return func(c *Command) error {
+		if err := c.TargetVersion.Set(v); err != nil {
+			return fmt.Errorf("setting target version: %w", err)
+		}
+
+		return nil
 	}
 }
 

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -32,13 +32,14 @@ func TestLintMode_NoVersionFlag(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		cmd := lint.NewCommand(streams, testConfigFlags())
+		cmd, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
-		g.Expect(cmd.TargetVersion).To(BeEmpty())
+		g.Expect(cmd.TargetVersion.IsSet()).To(BeFalse())
 
 		// Without --target-version, Run() will short-circuit when
 		// current and target versions share the same major.minor
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
@@ -55,15 +56,15 @@ func TestUpgradeMode_WithVersionFlag(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		// Use current non-deprecated constructor
-		cmd := lint.NewCommand(streams, testConfigFlags())
+		cmd, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		// Set --target-version flag (upgrade mode)
-		cmd.TargetVersion = "3.0.0"
-		g.Expect(cmd.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(cmd.TargetVersion.Set("3.0.0")).To(Succeed())
+		g.Expect(cmd.TargetVersion.String()).To(Equal("3.0.0"))
 
 		// Upgrade mode should accept target version
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 }
@@ -80,11 +81,11 @@ func TestLintMode_CheckTargetVersionMatches(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		command := lint.NewCommand(streams, testConfigFlags())
-		g.Expect(command).ToNot(BeNil())
+		command, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		// Verify no --target-version flag set (lint mode)
-		g.Expect(command.TargetVersion).To(BeEmpty())
+		g.Expect(command.TargetVersion.IsSet()).To(BeFalse())
 
 		// In lint mode, Run() detects that current == target (same major.minor)
 		// and short-circuits with a "no checks will be executed" message
@@ -103,15 +104,15 @@ func TestUpgradeMode_CheckTargetVersionDiffers(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		command := lint.NewCommand(streams, testConfigFlags())
-		g.Expect(command).ToNot(BeNil())
+		command, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		// Set --target-version flag (upgrade mode)
-		command.TargetVersion = "3.0.0"
-		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.TargetVersion.Set("3.0.0")).To(Succeed())
+		g.Expect(command.TargetVersion.String()).To(Equal("3.0.0"))
 
-		// Verify version parses correctly in Complete
-		err := command.Complete()
+		// Verify upgrade mode is configured
+		err = command.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// In upgrade mode, Run() delegates to runUpgradeMode() when
@@ -132,17 +133,18 @@ func TestIntegration_LintAndUpgradeModes(t *testing.T) {
 		}
 
 		// Test lint mode configuration
-		lintCmd := lint.NewCommand(streams, testConfigFlags())
-		g.Expect(lintCmd).ToNot(BeNil())
-		g.Expect(lintCmd.TargetVersion).To(BeEmpty())
+		lintCmd, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(lintCmd.TargetVersion.IsSet()).To(BeFalse())
 
 		// Test upgrade mode configuration
-		upgradeCmd := lint.NewCommand(streams, testConfigFlags())
-		upgradeCmd.TargetVersion = "3.0.0"
-		g.Expect(upgradeCmd.TargetVersion).To(Equal("3.0.0"))
+		upgradeCmd, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(upgradeCmd.TargetVersion.Set("3.0.0")).To(Succeed())
+		g.Expect(upgradeCmd.TargetVersion.String()).To(Equal("3.0.0"))
 
 		// Verify both modes complete successfully
-		err := lintCmd.Complete()
+		err = lintCmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = upgradeCmd.Complete()
@@ -176,8 +178,8 @@ func TestCommand_AddFlags(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		command := lint.NewCommand(streams, testConfigFlags())
-		g.Expect(command).ToNot(BeNil())
+		command, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		// Create a FlagSet and call AddFlags
 		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
@@ -203,8 +205,8 @@ func TestCommand_ImplementsInterface(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		command := lint.NewCommand(streams, testConfigFlags())
-		g.Expect(command).ToNot(BeNil())
+		command, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		// Verify interface implementation at compile time
 		var _ cmd.Command = command
@@ -223,8 +225,8 @@ func TestCommand_NewCommand(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		command := lint.NewCommand(streams, testConfigFlags())
-		g.Expect(command).ToNot(BeNil())
+		command, err := lint.NewCommand(streams, testConfigFlags())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		// Per FR-014, SharedOptions should be initialized internally
 		g.Expect(command.SharedOptions).ToNot(BeNil())
@@ -246,12 +248,11 @@ func TestCommand_FunctionalOptions(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		command := lint.NewCommand(streams, testConfigFlags(),
+		command, err := lint.NewCommand(streams, testConfigFlags(),
 			lint.WithTargetVersion("3.0.0"),
 		)
-
-		g.Expect(command).ToNot(BeNil())
-		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.TargetVersion.String()).To(Equal("3.0.0"))
 		g.Expect(command.IO).ToNot(BeNil())
 	})
 }

--- a/pkg/migrate/action/registry.go
+++ b/pkg/migrate/action/registry.go
@@ -12,30 +12,36 @@ type ActionRegistry struct {
 	actions map[string]Action
 }
 
-func NewActionRegistry() *ActionRegistry {
-	return &ActionRegistry{
+func NewActionRegistry(actions ...Action) (*ActionRegistry, error) {
+	r := &ActionRegistry{
 		actions: make(map[string]Action),
 	}
+
+	if err := r.Register(actions...); err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
-func (r *ActionRegistry) Register(action Action) error {
+// Register adds one or more actions to the registry.
+// The operation is atomic: either all actions are registered or none are.
+// Returns an error if an action with the same ID already exists.
+func (r *ActionRegistry) Register(actions ...Action) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	id := action.ID()
-	if _, exists := r.actions[id]; exists {
-		return fmt.Errorf("action with ID %q already registered", id)
+	for _, a := range actions {
+		if _, exists := r.actions[a.ID()]; exists {
+			return fmt.Errorf("action with ID %q already registered", a.ID())
+		}
 	}
 
-	r.actions[id] = action
+	for _, a := range actions {
+		r.actions[a.ID()] = a
+	}
 
 	return nil
-}
-
-func (r *ActionRegistry) MustRegister(action Action) {
-	if err := r.Register(action); err != nil {
-		panic(err)
-	}
 }
 
 func (r *ActionRegistry) Get(id string) (Action, bool) {

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -42,17 +41,16 @@ type ListCommand struct {
 	registry *action.ActionRegistry
 }
 
-func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
-	shared := NewSharedOptions(streams)
-	registry := action.NewActionRegistry()
-
-	// Explicitly register all actions (no global state, full test isolation)
-	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+func NewListCommand(streams genericiooptions.IOStreams) (*ListCommand, error) {
+	registry, err := newDefaultActionRegistry()
+	if err != nil {
+		return nil, fmt.Errorf("registering actions: %w", err)
+	}
 
 	return &ListCommand{
-		SharedOptions: shared,
+		SharedOptions: NewSharedOptions(streams),
 		registry:      registry,
-	}
+	}, nil
 }
 
 func (c *ListCommand) AddFlags(fs *pflag.FlagSet) {

--- a/pkg/migrate/command_list_test.go
+++ b/pkg/migrate/command_list_test.go
@@ -14,30 +14,33 @@ func TestListCommand_Validate(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("should require target version when all is false", func(t *testing.T) {
-		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewListCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = ""
 		cmd.ShowAll = false
 
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("target-version"))
 	})
 
 	t.Run("should not require target version when all is true", func(t *testing.T) {
-		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewListCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = ""
 		cmd.ShowAll = true
 
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("should reject both all and target-version together", func(t *testing.T) {
-		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewListCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 		cmd.ShowAll = true
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = cmd.Validate()
@@ -46,10 +49,11 @@ func TestListCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should validate successfully with target version", func(t *testing.T) {
-		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewListCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = cmd.Validate()
@@ -61,18 +65,20 @@ func TestListCommand_Complete(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("should parse valid target version", func(t *testing.T) {
-		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewListCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("should reject invalid target version", func(t *testing.T) {
-		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewListCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "invalid"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid target version"))
 	})

--- a/pkg/migrate/command_options.go
+++ b/pkg/migrate/command_options.go
@@ -8,6 +8,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
@@ -83,4 +85,17 @@ func (o *SharedOptions) Validate() error {
 	}
 
 	return nil
+}
+
+// newDefaultActionRegistry creates an action registry with all known migration actions.
+// Centralizes the action list so additions are made in one place.
+func newDefaultActionRegistry() (*action.ActionRegistry, error) {
+	r, err := action.NewActionRegistry(
+		&rhbok.RHBOKMigrationAction{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create action registry: %w", err)
+	}
+
+	return r, nil
 }

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -36,17 +35,16 @@ type PrepareCommand struct {
 	registry *action.ActionRegistry
 }
 
-func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
-	shared := NewSharedOptions(streams)
-	registry := action.NewActionRegistry()
-
-	// Explicitly register all actions (no global state, full test isolation)
-	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+func NewPrepareCommand(streams genericiooptions.IOStreams) (*PrepareCommand, error) {
+	registry, err := newDefaultActionRegistry()
+	if err != nil {
+		return nil, fmt.Errorf("registering actions: %w", err)
+	}
 
 	return &PrepareCommand{
-		SharedOptions: shared,
+		SharedOptions: NewSharedOptions(streams),
 		registry:      registry,
-	}
+	}, nil
 }
 
 func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {

--- a/pkg/migrate/command_prepare_test.go
+++ b/pkg/migrate/command_prepare_test.go
@@ -14,31 +14,34 @@ func TestPrepareCommand_Validate(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("should require migration ID", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{}
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("migration"))
 	})
 
 	t.Run("should require target version", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = ""
 
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("target-version"))
 	})
 
 	t.Run("should validate successfully with required fields", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = cmd.Validate()
@@ -46,11 +49,12 @@ func TestPrepareCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should accept multiple migration IDs", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{"migration1", "migration2", "migration3"}
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = cmd.Validate()
@@ -63,57 +67,63 @@ func TestPrepareCommand_Complete(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("should parse valid target version", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("should reject invalid target version", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "invalid"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid target version"))
 	})
 
 	t.Run("should accept partial version format", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("should set default output directory with timestamp", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 		cmd.OutputDir = ""
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.OutputDir).ToNot(BeEmpty())
 		g.Expect(cmd.OutputDir).To(ContainSubstring("backup-migrate-"))
 	})
 
 	t.Run("should preserve custom output directory", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 		cmd.OutputDir = "/custom/path"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.OutputDir).To(Equal("/custom/path"))
 	})
 
 	t.Run("should always enable verbose mode", func(t *testing.T) {
-		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 		cmd.Verbose = false
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.Verbose).To(BeTrue())
 	})

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -33,17 +32,16 @@ type RunCommand struct {
 	registry *action.ActionRegistry
 }
 
-func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
-	shared := NewSharedOptions(streams)
-	registry := action.NewActionRegistry()
-
-	// Explicitly register all actions (no global state, full test isolation)
-	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+func NewRunCommand(streams genericiooptions.IOStreams) (*RunCommand, error) {
+	registry, err := newDefaultActionRegistry()
+	if err != nil {
+		return nil, fmt.Errorf("registering actions: %w", err)
+	}
 
 	return &RunCommand{
-		SharedOptions: shared,
+		SharedOptions: NewSharedOptions(streams),
 		registry:      registry,
-	}
+	}, nil
 }
 
 func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {

--- a/pkg/migrate/command_run_test.go
+++ b/pkg/migrate/command_run_test.go
@@ -14,31 +14,34 @@ func TestRunCommand_Validate(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("should require migration ID", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{}
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("migration"))
 	})
 
 	t.Run("should require target version", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = ""
 
-		err := cmd.Validate()
+		err = cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("target-version"))
 	})
 
 	t.Run("should validate successfully with required fields", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = cmd.Validate()
@@ -46,11 +49,12 @@ func TestRunCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should accept multiple migration IDs", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.MigrationIDs = []string{"migration1", "migration2", "migration3"}
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
 		err = cmd.Validate()
@@ -63,38 +67,42 @@ func TestRunCommand_Complete(t *testing.T) {
 	g := NewWithT(t)
 
 	t.Run("should parse valid target version", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "3.0.0"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("should reject invalid target version", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.TargetVersion = "invalid"
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("invalid target version"))
 	})
 
 	t.Run("should enable verbose when dry-run is true", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.DryRun = true
 		cmd.Verbose = false
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.Verbose).To(BeTrue())
 	})
 
 	t.Run("should enable verbose when dry-run is false", func(t *testing.T) {
-		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd, err := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		g.Expect(err).ToNot(HaveOccurred())
 		cmd.DryRun = false
 		cmd.Verbose = false
 
-		err := cmd.Complete()
+		err = cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.Verbose).To(BeTrue()) // Always enabled for migrate run
 	})

--- a/pkg/util/version/semversion.go
+++ b/pkg/util/version/semversion.go
@@ -1,0 +1,47 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
+// SemVersion is a pflag.Value-compatible type that stores both the raw version
+// string and its parsed semver representation. Validation happens at Set time,
+// giving fail-fast behavior when used as a CLI flag.
+type SemVersion struct {
+	raw    string
+	parsed *semver.Version
+}
+
+func (v *SemVersion) String() string {
+	return v.raw
+}
+
+// Set parses and validates the version string using semver.ParseTolerant,
+// accepting partial versions like "3.0" (normalized to "3.0.0").
+func (v *SemVersion) Set(val string) error {
+	parsed, err := semver.ParseTolerant(val)
+	if err != nil {
+		return fmt.Errorf("invalid version %q: %w", val, err)
+	}
+
+	v.raw = val
+	v.parsed = &parsed
+
+	return nil
+}
+
+func (v *SemVersion) Type() string {
+	return "version"
+}
+
+// IsSet returns true if a version has been successfully parsed.
+func (v *SemVersion) IsSet() bool {
+	return v.parsed != nil
+}
+
+// Version returns the parsed semver, or nil if not set.
+func (v *SemVersion) Version() *semver.Version {
+	return v.parsed
+}

--- a/tests/integration/lint/diagnostic_cr_test.go
+++ b/tests/integration/lint/diagnostic_cr_test.go
@@ -47,8 +47,7 @@ func TestDiagnosticCR_EndToEndExecution(t *testing.T) {
 
 	// Create a test check that validates CR structure
 	testCheck := &testDiagnosticCheck{}
-	registry := check.NewRegistry()
-	err := registry.Register(testCheck)
+	registry, err := check.NewRegistry(testCheck)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create executor and target


### PR DESCRIPTION
Registry constructors (check.NewRegistry, dependencies.NewRegistry,
action.NewRegistry) now return (*Registry, error) instead of panicking
via MustRegister, propagating registration errors to callers.

Replace the TargetVersion string + parsedTargetVersion *semver.Version
pair in the lint Command with a single version.SemVersion type that
implements pflag.Value, validating at flag-parse time.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands now fail fast with clear, propagated initialization errors instead of proceeding silently; subcommand wiring errors are surfaced.

* **New Features**
  * Target-version flag now validates semantic versions and exposes parsed version info for upgrade flows.

* **Chores**
  * Command/action registration and initialization made explicit to improve reliability and error reporting.

* **Tests & Docs**
  * Tests and documentation updated to reflect the new initialization and registration patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->