### PR TITLE
lint: sort table output by group, kind, impact, then check

### DIFF
--- a/pkg/lint/command_options_test.go
+++ b/pkg/lint/command_options_test.go
@@ -458,6 +458,87 @@ func TestOutputTable_VerboseNamespaceGroupingSorted(t *testing.T) {
 	g.Expect(mIdx).To(BeNumerically("<", zIdx))
 }
 
+func TestOutputTable_SortsByGroupKindImpactCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	mkCondition := func(impact result.Impact, msg string) result.Condition {
+		status := metav1.ConditionTrue
+		if impact == result.ImpactBlocking {
+			status = metav1.ConditionFalse
+		}
+
+		return result.Condition{
+			Condition: metav1.Condition{
+				Type:    "Validated",
+				Status:  status,
+				Reason:  "TestReason",
+				Message: msg,
+			},
+			Impact: impact,
+		}
+	}
+
+	mkExec := func(group string, kind string, name string, conditions ...result.Condition) check.CheckExecution {
+		return check.CheckExecution{
+			Result: &result.DiagnosticResult{
+				Group: group,
+				Kind:  kind,
+				Name:  name,
+				Status: result.DiagnosticStatus{
+					Conditions: conditions,
+				},
+			},
+		}
+	}
+
+	results := []check.CheckExecution{
+		// Deliberately unordered to exercise sorting.
+		mkExec("component", "kserve", "config-check", mkCondition(result.ImpactNone, "kserve-comp-info")),
+		mkExec("workload", "dashboard", "wl-check", mkCondition(result.ImpactAdvisory, "dashboard-wl-warn")),
+		mkExec("dependency", "openshift-platform", "dep-check", mkCondition(result.ImpactBlocking, "ocp-dep-crit")),
+		mkExec("dependency", "certmanager", "installed", mkCondition(result.ImpactNone, "cert-dep-info")),
+		mkExec("component", "dashboard", "removal", mkCondition(result.ImpactBlocking, "dashboard-comp-crit")),
+		mkExec("service", "dashboard", "svc-check", mkCondition(result.ImpactAdvisory, "dashboard-svc-warn")),
+		mkExec("component", "dashboard", "config-migration", mkCondition(result.ImpactAdvisory, "dashboard-comp-warn")),
+		mkExec("service", "kserve", "svc-check", mkCondition(result.ImpactBlocking, "kserve-svc-crit")),
+	}
+
+	var buf bytes.Buffer
+	err := lint.OutputTable(&buf, results, lint.TableOutputOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+
+	// Expected order (Group canonical -> Kind alpha -> Impact severity -> Check alpha):
+	//   dependency:  certmanager         info      installed
+	//   dependency:  openshift-platform  critical  dep-check
+	//   service:     dashboard           warning   svc-check
+	//   service:     kserve              critical  svc-check
+	//   component:   dashboard           critical  removal
+	//   component:   dashboard           warning   config-migration
+	//   component:   kserve              info      config-check
+	//   workload:    dashboard           warning   wl-check
+	expectedOrder := []string{
+		"cert-dep-info",
+		"ocp-dep-crit",
+		"dashboard-svc-warn",
+		"kserve-svc-crit",
+		"dashboard-comp-crit",
+		"dashboard-comp-warn",
+		"kserve-comp-info",
+		"dashboard-wl-warn",
+	}
+
+	prevIdx := -1
+	for _, msg := range expectedOrder {
+		idx := indexOf(output, msg)
+		g.Expect(idx).To(BeNumerically(">", prevIdx),
+			fmt.Sprintf("%q should appear after previous entry (prevIdx=%d, idx=%d)", msg, prevIdx, idx))
+
+		prevIdx = idx
+	}
+}
+
 // indexOf returns the index of the first occurrence of substr in s, or -1.
 func indexOf(s, substr string) int {
 	for i := 0; i <= len(s)-len(substr); i++ {


### PR DESCRIPTION
Sort table rows using canonical group order (dependency, service,
component, workload) as primary key, then kind alphabetically,
then impact severity (critical > warning > info), then check name.
Swap KIND and GROUP columns so KIND appears first in the table.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reordered table columns: KIND now appears before GROUP for improved layout
  * Test results are now sorted by Group, Kind, Impact, and Check name for consistent presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->