### PR TITLE
lint(kserve): move servicemesh checks from dependencies/services to kserve component

### DIFF
--- a/docs/lint/architecture.md
+++ b/docs/lint/architecture.md
@@ -86,7 +86,7 @@ func NewCommand(
     registry := check.NewRegistry()
 
     // Explicitly register all checks (no global state, full test isolation)
-    // Components (11)
+    // Components (13)
     registry.MustRegister(codeflare.NewRemovalCheck())
     registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
     registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
@@ -94,18 +94,16 @@ func NewCommand(
     registry.MustRegister(datasciencepipelines.NewRenamingCheck())
     registry.MustRegister(kserve.NewServerlessRemovalCheck())
     registry.MustRegister(kserve.NewInferenceServiceConfigCheck())
+    registry.MustRegister(kserve.NewServiceMeshOperatorCheck())
+    registry.MustRegister(kserve.NewServiceMeshRemovalCheck())
     registry.MustRegister(kueue.NewManagementStateCheck())
     registry.MustRegister(kueue.NewOperatorInstalledCheck())
     registry.MustRegister(modelmesh.NewRemovalCheck())
     registry.MustRegister(trainingoperator.NewDeprecationCheck())
 
-    // Dependencies (3)
+    // Dependencies (2)
     registry.MustRegister(certmanager.NewCheck())
     registry.MustRegister(openshift.NewCheck())
-    registry.MustRegister(servicemeshoperator.NewCheck())
-
-    // Services (1)
-    registry.MustRegister(servicemesh.NewRemovalCheck())
 
     // Workloads (8)
     registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())

--- a/docs/lint/writing-checks.md
+++ b/docs/lint/writing-checks.md
@@ -140,12 +140,9 @@ func NewCommand(
     registry.MustRegister(datasciencepipelines.NewInstructLabRemovalCheck())
     // ... additional component checks
 
-    // Dependencies (4)
+    // Dependencies (2)
     registry.MustRegister(certmanager.NewCheck())
     // ... additional dependency checks
-
-    // Services (1)
-    registry.MustRegister(servicemesh.NewRemovalCheck())
 
     // Workloads (7)
     registry.MustRegister(guardrails.NewOtelMigrationCheck())

--- a/pkg/lint/checks/components/kserve/servicemesh_operator.go
+++ b/pkg/lint/checks/components/kserve/servicemesh_operator.go
@@ -1,53 +1,47 @@
-package servicemeshoperator
+package kserve
 
 import (
 	"context"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
-const (
-	kind      = "servicemesh-operator-v2"
-	checkType = "upgrade"
-)
-
-// Check validates that Service Mesh Operator v2 is not installed when upgrading to 3.x,
+// ServiceMeshOperatorCheck validates that Service Mesh Operator v2 is not installed when upgrading to 3.x,
 // as it is no longer required by RHOAI 3.x (OpenShift 4.19+ handles service mesh internally).
-type Check struct {
+type ServiceMeshOperatorCheck struct {
 	check.BaseCheck
 }
 
-// NewCheck creates a new Service Mesh Operator v2 upgrade check.
-func NewCheck() *Check {
-	return &Check{
+func NewServiceMeshOperatorCheck() *ServiceMeshOperatorCheck {
+	return &ServiceMeshOperatorCheck{
 		BaseCheck: check.BaseCheck{
-			CheckGroup:       check.GroupDependency,
-			Kind:             kind,
-			Type:             checkType,
-			CheckID:          "dependencies.servicemeshoperator2.upgrade",
-			CheckName:        "Dependencies :: ServiceMeshOperator2 :: Upgrade (3.x)",
+			CheckGroup:       check.GroupComponent,
+			Kind:             constants.ComponentKServe,
+			Type:             "servicemesh-operator-upgrade",
+			CheckID:          "components.kserve.servicemesh-operator-upgrade",
+			CheckName:        "Components :: KServe :: ServiceMesh Operator Upgrade (3.x)",
 			CheckDescription: "Validates that Service Mesh Operator v2 is not installed when upgrading to RHOAI 3.x (no longer required, OpenShift 4.19+ handles service mesh internally)",
 		},
 	}
 }
 
-func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
+func (c *ServiceMeshOperatorCheck) CanApply(_ context.Context, target check.Target) (bool, error) {
 	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
 }
 
-func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+func (c *ServiceMeshOperatorCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	tv := version.MajorMinorLabel(target.TargetVersion)
 
 	return validate.Operator(c, target).
 		WithNames("servicemeshoperator").
 		WithChannels("stable", "v2.x").
 		WithConditionBuilder(func(found bool, operatorVersion string) result.Condition {
-			// Inverted logic: NOT finding the operator is good.
 			if !found {
 				return check.NewCondition(
 					check.ConditionTypeCompatible,

--- a/pkg/lint/checks/components/kserve/servicemesh_operator_test.go
+++ b/pkg/lint/checks/components/kserve/servicemesh_operator_test.go
@@ -1,4 +1,4 @@
-package servicemeshoperator_test
+package kserve_test
 
 import (
 	"testing"
@@ -10,13 +10,13 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemeshoperator"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kserve"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
 
-func TestServiceMeshOperator2Check_NotInstalled(t *testing.T) {
+func TestServiceMeshOperatorCheck_NotInstalled(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
@@ -25,8 +25,8 @@ func TestServiceMeshOperator2Check_NotInstalled(t *testing.T) {
 		TargetVersion: "3.0.0",
 	})
 
-	serviceMeshOperator2Check := servicemeshoperator.NewCheck()
-	result, err := serviceMeshOperator2Check.Validate(ctx, target)
+	chk := kserve.NewServiceMeshOperatorCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -38,7 +38,7 @@ func TestServiceMeshOperator2Check_NotInstalled(t *testing.T) {
 	}))
 }
 
-func TestServiceMeshOperator2Check_InstalledBlocking(t *testing.T) {
+func TestServiceMeshOperatorCheck_InstalledBlocking(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
@@ -60,8 +60,8 @@ func TestServiceMeshOperator2Check_InstalledBlocking(t *testing.T) {
 		TargetVersion: "3.0.0",
 	})
 
-	serviceMeshOperator2Check := servicemeshoperator.NewCheck()
-	result, err := serviceMeshOperator2Check.Validate(ctx, target)
+	chk := kserve.NewServiceMeshOperatorCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -74,13 +74,13 @@ func TestServiceMeshOperator2Check_InstalledBlocking(t *testing.T) {
 	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator.v2.5.0"))
 }
 
-func TestServiceMeshOperator2Check_Metadata(t *testing.T) {
+func TestServiceMeshOperatorCheck_Metadata(t *testing.T) {
 	g := NewWithT(t)
 
-	serviceMeshOperator2Check := servicemeshoperator.NewCheck()
+	chk := kserve.NewServiceMeshOperatorCheck()
 
-	g.Expect(serviceMeshOperator2Check.ID()).To(Equal("dependencies.servicemeshoperator2.upgrade"))
-	g.Expect(serviceMeshOperator2Check.Name()).To(Equal("Dependencies :: ServiceMeshOperator2 :: Upgrade (3.x)"))
-	g.Expect(serviceMeshOperator2Check.Group()).To(Equal(check.GroupDependency))
-	g.Expect(serviceMeshOperator2Check.Description()).ToNot(BeEmpty())
+	g.Expect(chk.ID()).To(Equal("components.kserve.servicemesh-operator-upgrade"))
+	g.Expect(chk.Name()).To(Equal("Components :: KServe :: ServiceMesh Operator Upgrade (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupComponent))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
 }

--- a/pkg/lint/checks/components/kserve/servicemesh_removal.go
+++ b/pkg/lint/checks/components/kserve/servicemesh_removal.go
@@ -1,4 +1,4 @@
-package servicemesh
+package kserve
 
 import (
 	"context"
@@ -16,34 +16,30 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
-// RemovalCheck validates that ServiceMesh is disabled before upgrading to 3.x.
-type RemovalCheck struct {
+// ServiceMeshRemovalCheck validates that ServiceMesh is disabled before upgrading to 3.x.
+type ServiceMeshRemovalCheck struct {
 	check.BaseCheck
 }
 
-// NewRemovalCheck creates a new ServiceMesh removal check.
-func NewRemovalCheck() *RemovalCheck {
-	return &RemovalCheck{
+func NewServiceMeshRemovalCheck() *ServiceMeshRemovalCheck {
+	return &ServiceMeshRemovalCheck{
 		BaseCheck: check.BaseCheck{
-			CheckGroup:       check.GroupService,
-			Kind:             "servicemesh",
-			Type:             check.CheckTypeRemoval,
-			CheckID:          "services.servicemesh.removal",
-			CheckName:        "Services :: ServiceMesh :: Removal (3.x)",
+			CheckGroup:       check.GroupComponent,
+			Kind:             constants.ComponentKServe,
+			Type:             "servicemesh-removal",
+			CheckID:          "components.kserve.servicemesh-removal",
+			CheckName:        "Components :: KServe :: ServiceMesh Removal (3.x)",
 			CheckDescription: "Validates that ServiceMesh is disabled before upgrading from RHOAI 2.x to 3.x (no longer required, OpenShift 4.19+ handles service mesh internally)",
 			CheckRemediation: "Disable ServiceMesh by setting managementState to 'Removed' in DSCInitialization before upgrading",
 		},
 	}
 }
 
-// CanApply returns whether this check should run for the given target.
-// This check only applies when upgrading FROM 2.x TO 3.x.
-func (c *RemovalCheck) CanApply(_ context.Context, target check.Target) (bool, error) {
+func (c *ServiceMeshRemovalCheck) CanApply(_ context.Context, target check.Target) (bool, error) {
 	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
 }
 
-// Validate executes the check against the provided target.
-func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+func (c *ServiceMeshRemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	tv := version.MajorMinorLabel(target.TargetVersion)
 
 	return validate.DSCI(c, target).Run(ctx, func(dr *result.DiagnosticResult, dsci *unstructured.Unstructured) error {

--- a/pkg/lint/checks/components/kserve/servicemesh_removal_test.go
+++ b/pkg/lint/checks/components/kserve/servicemesh_removal_test.go
@@ -1,4 +1,4 @@
-package servicemesh_test
+package kserve_test
 
 import (
 	"testing"
@@ -10,15 +10,15 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/services/servicemesh"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
 
-//nolint:gochecknoglobals // Test fixture - shared across test functions
-var listKinds = map[schema.GroupVersionResource]string{
+//nolint:gochecknoglobals // Test fixture - shared across test functions in this file
+var dsciListKinds = map[schema.GroupVersionResource]string{
 	resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
 }
 
@@ -26,14 +26,13 @@ func TestServiceMeshRemovalCheck_NoDSCI(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Create empty cluster (no DSCInitialization)
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:     listKinds,
+		ListKinds:     dsciListKinds,
 		TargetVersion: "3.0.0",
 	})
 
-	servicemeshCheck := servicemesh.NewRemovalCheck()
-	result, err := servicemeshCheck.Validate(ctx, target)
+	chk := kserve.NewServiceMeshRemovalCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -49,15 +48,14 @@ func TestServiceMeshRemovalCheck_NotConfigured(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Create DSCInitialization without serviceMesh
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:     listKinds,
+		ListKinds:     dsciListKinds,
 		Objects:       []*unstructured.Unstructured{testutil.NewDSCI("opendatahub")},
 		TargetVersion: "3.0.0",
 	})
 
-	servicemeshCheck := servicemesh.NewRemovalCheck()
-	result, err := servicemeshCheck.Validate(ctx, target)
+	chk := kserve.NewServiceMeshRemovalCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -73,7 +71,6 @@ func TestServiceMeshRemovalCheck_ManagedBlocking(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Create DSCInitialization with serviceMesh Managed (blocking upgrade)
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resources.DSCInitialization.APIVersion(),
@@ -91,13 +88,13 @@ func TestServiceMeshRemovalCheck_ManagedBlocking(t *testing.T) {
 	}
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:     listKinds,
+		ListKinds:     dsciListKinds,
 		Objects:       []*unstructured.Unstructured{dsci},
 		TargetVersion: "3.0.0",
 	})
 
-	servicemeshCheck := servicemesh.NewRemovalCheck()
-	result, err := servicemeshCheck.Validate(ctx, target)
+	chk := kserve.NewServiceMeshRemovalCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -114,7 +111,6 @@ func TestServiceMeshRemovalCheck_UnmanagedBlocking(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Create DSCInitialization with serviceMesh Unmanaged (also blocking)
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resources.DSCInitialization.APIVersion(),
@@ -132,13 +128,13 @@ func TestServiceMeshRemovalCheck_UnmanagedBlocking(t *testing.T) {
 	}
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:     listKinds,
+		ListKinds:     dsciListKinds,
 		Objects:       []*unstructured.Unstructured{dsci},
 		TargetVersion: "3.1.0",
 	})
 
-	servicemeshCheck := servicemesh.NewRemovalCheck()
-	result, err := servicemeshCheck.Validate(ctx, target)
+	chk := kserve.NewServiceMeshRemovalCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -155,7 +151,6 @@ func TestServiceMeshRemovalCheck_RemovedReady(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Create DSCInitialization with serviceMesh Removed (ready for upgrade)
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resources.DSCInitialization.APIVersion(),
@@ -173,13 +168,13 @@ func TestServiceMeshRemovalCheck_RemovedReady(t *testing.T) {
 	}
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:     listKinds,
+		ListKinds:     dsciListKinds,
 		Objects:       []*unstructured.Unstructured{dsci},
 		TargetVersion: "3.0.0",
 	})
 
-	servicemeshCheck := servicemesh.NewRemovalCheck()
-	result, err := servicemeshCheck.Validate(ctx, target)
+	chk := kserve.NewServiceMeshRemovalCheck()
+	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
@@ -194,10 +189,10 @@ func TestServiceMeshRemovalCheck_RemovedReady(t *testing.T) {
 func TestServiceMeshRemovalCheck_Metadata(t *testing.T) {
 	g := NewWithT(t)
 
-	servicemeshCheck := servicemesh.NewRemovalCheck()
+	chk := kserve.NewServiceMeshRemovalCheck()
 
-	g.Expect(servicemeshCheck.ID()).To(Equal("services.servicemesh.removal"))
-	g.Expect(servicemeshCheck.Name()).To(Equal("Services :: ServiceMesh :: Removal (3.x)"))
-	g.Expect(servicemeshCheck.Group()).To(Equal(check.GroupService))
-	g.Expect(servicemeshCheck.Description()).ToNot(BeEmpty())
+	g.Expect(chk.ID()).To(Equal("components.kserve.servicemesh-removal"))
+	g.Expect(chk.Name()).To(Equal("Components :: KServe :: ServiceMesh Removal (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupComponent))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
 }

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -23,8 +23,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemeshoperator"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/services/servicemesh"
 	datasciencepipelinesworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/guardrails"
 	kserveworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
@@ -75,7 +73,7 @@ func NewCommand(
 	registry := check.NewRegistry()
 
 	// Explicitly register all checks (no global state, full test isolation)
-	// Components (11)
+	// Components (13)
 	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
 	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
 	registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
@@ -83,18 +81,16 @@ func NewCommand(
 	registry.MustRegister(kserve.NewServerlessRemovalCheck())
 	registry.MustRegister(kserve.NewKuadrantReadinessCheck())
 	registry.MustRegister(kserve.NewAuthorinoTLSReadinessCheck())
+	registry.MustRegister(kserve.NewServiceMeshOperatorCheck())
+	registry.MustRegister(kserve.NewServiceMeshRemovalCheck())
 	registry.MustRegister(kueue.NewManagementStateCheck())
 	registry.MustRegister(kueue.NewOperatorInstalledCheck())
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())
 
-	// Dependencies (3)
+	// Dependencies (2)
 	registry.MustRegister(certmanager.NewCheck())
 	registry.MustRegister(openshift.NewCheck())
-	registry.MustRegister(servicemeshoperator.NewCheck())
-
-	// Services (1)
-	registry.MustRegister(servicemesh.NewRemovalCheck())
 
 	// Workloads (13)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())


### PR DESCRIPTION
ServiceMesh operator upgrade and ServiceMesh removal checks are
specific to the KServe component and belong under its check directory
rather than as standalone dependency/service checks.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
