### PR TITLE
lint: add version info and result verdict to status report

### DIFF
--- a/pkg/lint/check/result/result.go
+++ b/pkg/lint/check/result/result.go
@@ -359,16 +359,22 @@ func (r *DiagnosticResult) AddImpactedObjects(
 
 // DiagnosticResultList represents a list of diagnostic results.
 type DiagnosticResultList struct {
-	ClusterVersion *string             `json:"clusterVersion,omitempty" yaml:"clusterVersion,omitempty"`
-	TargetVersion  *string             `json:"targetVersion,omitempty"  yaml:"targetVersion,omitempty"`
-	Results        []*DiagnosticResult `json:"results"                  yaml:"results"`
+	ClusterVersion   *string             `json:"clusterVersion,omitempty"   yaml:"clusterVersion,omitempty"`
+	TargetVersion    *string             `json:"targetVersion,omitempty"    yaml:"targetVersion,omitempty"`
+	OpenShiftVersion *string             `json:"openShiftVersion,omitempty" yaml:"openShiftVersion,omitempty"`
+	Results          []*DiagnosticResult `json:"results"                    yaml:"results"`
 }
 
 // NewDiagnosticResultList creates a new list.
-func NewDiagnosticResultList(clusterVersion *string, targetVersion *string) *DiagnosticResultList {
+func NewDiagnosticResultList(
+	clusterVersion *string,
+	targetVersion *string,
+	openShiftVersion *string,
+) *DiagnosticResultList {
 	return &DiagnosticResultList{
-		ClusterVersion: clusterVersion,
-		TargetVersion:  targetVersion,
-		Results:        make([]*DiagnosticResult, 0),
+		ClusterVersion:   clusterVersion,
+		TargetVersion:    targetVersion,
+		OpenShiftVersion: openShiftVersion,
+		Results:          make([]*DiagnosticResult, 0),
 	}
 }

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -187,8 +187,6 @@ func TestCommand_AddFlags(t *testing.T) {
 		g.Expect(fs.Lookup("target-version")).ToNot(BeNil())
 		g.Expect(fs.Lookup("output")).ToNot(BeNil())
 		g.Expect(fs.Lookup("checks")).ToNot(BeNil())
-		g.Expect(fs.Lookup("fail-on-critical")).ToNot(BeNil())
-		g.Expect(fs.Lookup("fail-on-warning")).ToNot(BeNil())
 		g.Expect(fs.Lookup("timeout")).ToNot(BeNil())
 	})
 }

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -4,8 +4,6 @@ package lint
 const (
 	flagDescTargetVersion = "target version for upgrade readiness checks (e.g., 2.25.0, 3.0.0)"
 	flagDescOutput        = "output format (table|json|yaml)"
-	flagDescFailCritical  = "exit with error if critical findings are detected"
-	flagDescFailWarning   = "exit with error if warning or critical findings are detected"
 	flagDescVerbose       = "show impacted objects and summary information"
 	flagDescDebug         = "show detailed diagnostic logs for troubleshooting"
 	flagDescTimeout       = "operation timeout (e.g., 10m, 30m)"


### PR DESCRIPTION
Add Environment section (OpenShift AI and OpenShift versions) and a
color-coded Result verdict to the lint table output. Detect the
OpenShift platform version alongside the existing RHOAI detection
and include it in both table and JSON/YAML output formats. Remove
the fail-on-critical/fail-on-warning flags so findings are always
informational and never cause a non-zero exit code.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and displays OpenShift platform version alongside cluster/version info.
  * Environment section added to outputs showing OpenShift AI and platform version details.

* **Removed Features**
  * Removed CLI flags for failing on critical/warning checks.

* **Tests**
  * Added tests validating VersionInfo is rendered correctly in table outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->