### PR TITLE
lint: skip checks when current and target versions match (major.minor)

### DIFF
--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -35,7 +35,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube/discovery"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -178,149 +177,56 @@ func (c *Command) Validate() error {
 
 // Run executes the lint command in either lint or upgrade mode.
 func (c *Command) Run(ctx context.Context) error {
-	// Create context with timeout to prevent hanging on slow clusters
 	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
 	defer cancel()
 
-	// Detect current cluster version (needed for both modes)
 	currentVersion, err := version.Detect(ctx, c.Client)
 	if err != nil {
 		return fmt.Errorf("detecting cluster version: %w", err)
 	}
 
-	// Store current version for output formatting
 	c.currentClusterVersion = currentVersion.String()
 
-	// Determine mode: upgrade (with --target-version) or lint (without --target-version)
-	if c.TargetVersion != "" {
-		return c.runUpgradeMode(ctx, currentVersion)
+	// Determine effective target version (defaults to current for lint mode)
+	targetVersion := currentVersion
+	if c.parsedTargetVersion != nil {
+		targetVersion = c.parsedTargetVersion
 	}
 
-	return c.runLintMode(ctx, currentVersion)
-}
+	// Same major.minor means no upgrade checks are needed (checked before
+	// the downgrade guard so that e.g. --target-version 2.25 with current
+	// 2.25.2 is treated as "same version", not as a downgrade).
+	if version.SameMajorMinor(currentVersion, targetVersion) {
+		openshiftVersion, _ := version.DetectOpenShiftVersion(ctx, c.Client)
 
-// runLintMode validates current cluster state.
-func (c *Command) runLintMode(ctx context.Context, clusterVersion *semver.Version) error {
-	c.IO.Errorf("Detected OpenShift AI version: %s\n", clusterVersion.String())
+		c.IO.Fprintln()
+		c.IO.Fprintln("Environment:")
+		c.IO.Fprintf("  OpenShift AI version: %s", currentVersion.String())
 
-	// Discover components and services
-	c.IO.Errorf("Discovering OpenShift AI components and services...")
-	components, err := discovery.DiscoverComponentsAndServices(ctx, c.Client)
-	if err != nil {
-		return fmt.Errorf("discovering components and services: %w", err)
-	}
-	c.IO.Errorf("Found %d API groups", len(components))
-	for _, comp := range components {
-		c.IO.Errorf("  - %s/%s (%d resources)", comp.APIGroup, comp.Version, len(comp.Resources))
-	}
-	c.IO.Fprintln()
-
-	// Discover workloads
-	c.IO.Errorf("Discovering workload custom resources...")
-	workloads, err := discovery.DiscoverWorkloads(ctx, c.Client)
-	if err != nil {
-		return fmt.Errorf("discovering workloads: %w", err)
-	}
-	c.IO.Errorf("Found %d workload types", len(workloads))
-	for _, gvr := range workloads {
-		c.IO.Errorf("  - %s/%s %s", gvr.Group, gvr.Version, gvr.Resource)
-	}
-	c.IO.Fprintln()
-
-	// Execute component and service checks (Resource: nil)
-	c.IO.Errorf("Running component and service checks...")
-	componentTarget := check.Target{
-		Client:         c.Client,
-		CurrentVersion: clusterVersion, // For lint mode, current = target
-		TargetVersion:  clusterVersion,
-		Resource:       nil, // No specific resource for component/service checks
-		IO:             c.IO,
-		Debug:          c.Debug,
-	}
-
-	executor := check.NewExecutor(c.registry, c.IO)
-
-	// Execute checks in canonical order: dependencies → services → components → workloads
-	// Store results by group for later organization
-	resultsByGroup := make(map[check.CheckGroup][]check.CheckExecution)
-
-	for _, group := range check.CanonicalGroupOrder {
-		if group == check.GroupWorkload {
-			continue // Workloads handled separately below
+		if openshiftVersion != nil {
+			c.IO.Fprintf("  OpenShift version:    %s", openshiftVersion.String())
 		}
 
-		results, err := executor.ExecuteSelective(ctx, componentTarget, c.CheckSelectors, group)
-		if err != nil {
-			// Log error but continue with other checks
-			c.IO.Errorf("Warning: Failed to execute %s checks: %v", group, err)
-			resultsByGroup[group] = []check.CheckExecution{}
+		c.IO.Fprintln()
+		c.IO.Fprintf("Current and target versions are the same (%s), no checks will be executed.",
+			version.MajorMinorLabel(currentVersion))
 
-			continue
-		}
-
-		resultsByGroup[group] = results
+		return nil
 	}
 
-	// Execute workload checks for each discovered workload instance
-	c.IO.Errorf("Running workload checks...")
-	var workloadResults []check.CheckExecution
-
-	for _, gvr := range workloads {
-		// List all instances of this workload type
-		instances, err := c.Client.ListResources(ctx, gvr)
-		if err != nil {
-			// Skip workloads we can't access
-			c.IO.Errorf("Warning: Failed to list %s: %v", gvr.Resource, err)
-
-			continue
-		}
-
-		// Run workload checks for each instance
-		for i := range instances {
-			workloadTarget := check.Target{
-				Client:         c.Client,
-				CurrentVersion: clusterVersion, // For lint mode, current = target
-				TargetVersion:  clusterVersion,
-				Resource:       instances[i],
-				IO:             c.IO,
-				Debug:          c.Debug,
-			}
-
-			results, err := executor.ExecuteSelective(ctx, workloadTarget, c.CheckSelectors, check.GroupWorkload)
-			if err != nil {
-				return fmt.Errorf("executing workload checks: %w", err)
-			}
-
-			workloadResults = append(workloadResults, results...)
-		}
-	}
-
-	// Add workload results to the results map
-	resultsByGroup[check.GroupWorkload] = workloadResults
-
-	// Format and output results based on output format
-	if err := c.formatAndOutputResults(ctx, resultsByGroup); err != nil {
-		return err
-	}
-
-	// Determine exit code based on fail-on flags
-	return c.determineExitCode(resultsByGroup)
-}
-
-// runUpgradeMode assesses upgrade readiness for a target version.
-func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Version) error {
-	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
-	c.IO.Errorf("Target OpenShift AI version: %s\n", c.TargetVersion)
-
-	// Check if target version is greater than or equal to current
-	if c.parsedTargetVersion.LT(*currentVersion) {
+	// Reject downgrades when explicit --target-version is provided
+	if c.parsedTargetVersion != nil && c.parsedTargetVersion.LT(*currentVersion) {
 		return fmt.Errorf("target version %s is older than current version %s (downgrades not supported)",
 			c.TargetVersion, currentVersion.String())
 	}
 
-	c.IO.Errorf("Assessing upgrade readiness: %s → %s\n", currentVersion.String(), c.TargetVersion)
+	return c.runUpgradeMode(ctx, currentVersion)
+}
 
-	// Execute checks using target version for applicability filtering
+// runUpgradeMode assesses upgrade readiness for a target version.
+// Downgrade and same-version guards are handled by Run() before calling this method.
+func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Version) error {
+	c.IO.Errorf("Assessing upgrade readiness: %s → %s\n", currentVersion.String(), c.TargetVersion)
 	c.IO.Errorf("Running upgrade compatibility checks...")
 	executor := check.NewExecutor(c.registry, c.IO)
 
@@ -398,59 +304,6 @@ func (c *Command) determineExitCode(resultsByGroup map[check.CheckGroup][]check.
 
 	if c.FailOnWarning && hasAdvisory {
 		return errors.New("advisory findings detected")
-	}
-
-	return nil
-}
-
-// formatAndOutputResults formats and outputs check results based on the output format.
-func (c *Command) formatAndOutputResults(
-	ctx context.Context,
-	resultsByGroup map[check.CheckGroup][]check.CheckExecution,
-) error {
-	clusterVer := &c.currentClusterVersion
-	var targetVer *string
-	if c.TargetVersion != "" {
-		targetVer = &c.TargetVersion
-	}
-
-	// Flatten results to sorted array
-	flatResults := FlattenResults(resultsByGroup)
-
-	switch c.OutputFormat {
-	case OutputFormatTable:
-		return c.outputTable(ctx, flatResults)
-	case OutputFormatJSON:
-		if err := OutputJSON(c.IO.Out(), flatResults, clusterVer, targetVer); err != nil {
-			return fmt.Errorf("outputting JSON: %w", err)
-		}
-
-		return nil
-	case OutputFormatYAML:
-		if err := OutputYAML(c.IO.Out(), flatResults, clusterVer, targetVer); err != nil {
-			return fmt.Errorf("outputting YAML: %w", err)
-		}
-
-		return nil
-	default:
-		return fmt.Errorf("unsupported output format: %s", c.OutputFormat)
-	}
-}
-
-// outputTable outputs results in table format.
-func (c *Command) outputTable(ctx context.Context, results []check.CheckExecution) error {
-	c.IO.Fprintln()
-	c.IO.Fprintln("Check Results:")
-	c.IO.Fprintln("==============")
-
-	opts := TableOutputOptions{ShowImpactedObjects: c.Verbose}
-
-	if c.Verbose {
-		opts.NamespaceRequesters = collectNamespaceRequesters(ctx, c.Client, results)
-	}
-
-	if err := OutputTable(c.IO.Out(), results, opts); err != nil {
-		return fmt.Errorf("outputting table: %w", err)
 	}
 
 	return nil

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -22,7 +22,7 @@ func testConfigFlags() *genericclioptions.ConfigFlags {
 
 // T022: Test lint mode (no --target-version flag).
 func TestLintMode_NoVersionFlag(t *testing.T) {
-	t.Run("lint mode should validate current state only", func(t *testing.T) {
+	t.Run("lint mode should skip checks when no target version provided", func(t *testing.T) {
 		g := NewWithT(t)
 
 		var out, errOut bytes.Buffer
@@ -32,13 +32,12 @@ func TestLintMode_NoVersionFlag(t *testing.T) {
 			ErrOut: &errOut,
 		}
 
-		// Use current non-deprecated constructor
 		cmd := lint.NewCommand(streams, testConfigFlags())
 
-		// No --target-version flag set (lint mode)
 		g.Expect(cmd.TargetVersion).To(BeEmpty())
 
-		// In lint mode, target version should default to current version
+		// Without --target-version, Run() will short-circuit when
+		// current and target versions share the same major.minor
 		err := cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
@@ -87,11 +86,8 @@ func TestLintMode_CheckTargetVersionMatches(t *testing.T) {
 		// Verify no --target-version flag set (lint mode)
 		g.Expect(command.TargetVersion).To(BeEmpty())
 
-		// In lint mode, when Run() executes, it should create CheckTarget
-		// with CurrentVersion == TargetVersion (both pointing to detected cluster version)
-		// This is architectural verification - the actual Run() implementation
-		// already does this at lint.go:169-170
-		// We verify the logic path exists without requiring a real cluster
+		// In lint mode, Run() detects that current == target (same major.minor)
+		// and short-circuits with a "no checks will be executed" message
 	})
 }
 
@@ -118,11 +114,8 @@ func TestUpgradeMode_CheckTargetVersionDiffers(t *testing.T) {
 		err := command.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 
-		// In upgrade mode, when Run() executes, it should create CheckTarget
-		// with CurrentVersion != TargetVersion (current vs target)
-		// This is architectural verification - the actual Run() implementation
-		// already does this at lint.go:297-298
-		// We verify the command is properly configured for upgrade mode
+		// In upgrade mode, Run() delegates to runUpgradeMode() when
+		// current and target differ at the major.minor level
 	})
 }
 
@@ -163,9 +156,8 @@ func TestIntegration_LintAndUpgradeModes(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// Note: Full end-to-end Run() testing requires k3s-envtest infrastructure
-		// The Run() logic is verified through the implementation at lint.go:115-132
-		// - Lint mode: calls runLintMode() when TargetVersion is empty
-		// - Upgrade mode: calls runUpgradeMode() when TargetVersion is set
+		// Run() prints environment, then either short-circuits (same major.minor)
+		// or delegates to runUpgradeMode() (different major.minor)
 	})
 }
 

--- a/pkg/util/version/helpers.go
+++ b/pkg/util/version/helpers.go
@@ -37,6 +37,16 @@ func IsVersion3x(v *semver.Version) bool {
 	return v.Major == 3 //nolint:mnd
 }
 
+// SameMajorMinor checks if two versions share the same major and minor version.
+// Patch version is ignored. Returns false if either version is nil.
+func SameMajorMinor(a *semver.Version, b *semver.Version) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	return a.Major == b.Major && a.Minor == b.Minor
+}
+
 // IsVersionAtLeast checks if the given version is at least the specified major.minor version.
 // Patch version is ignored in the comparison.
 // Returns false if version is nil.

--- a/pkg/util/version/helpers_test.go
+++ b/pkg/util/version/helpers_test.go
@@ -199,6 +199,80 @@ func TestIsVersionAtLeast(t *testing.T) {
 	}
 }
 
+func TestSameMajorMinor(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *semver.Version
+		b        *semver.Version
+		expected bool
+	}{
+		{
+			name:     "nil a returns false",
+			a:        nil,
+			b:        toVersionPtr("3.0.0"),
+			expected: false,
+		},
+		{
+			name:     "nil b returns false",
+			a:        toVersionPtr("3.0.0"),
+			b:        nil,
+			expected: false,
+		},
+		{
+			name:     "both nil returns false",
+			a:        nil,
+			b:        nil,
+			expected: false,
+		},
+		{
+			name:     "identical versions returns true",
+			a:        toVersionPtr("2.25.2"),
+			b:        toVersionPtr("2.25.2"),
+			expected: true,
+		},
+		{
+			name:     "same major.minor different patch returns true",
+			a:        toVersionPtr("2.25.2"),
+			b:        toVersionPtr("2.25.5"),
+			expected: true,
+		},
+		{
+			name:     "different minor returns false",
+			a:        toVersionPtr("2.25.0"),
+			b:        toVersionPtr("2.26.0"),
+			expected: false,
+		},
+		{
+			name:     "different major returns false",
+			a:        toVersionPtr("2.25.0"),
+			b:        toVersionPtr("3.25.0"),
+			expected: false,
+		},
+		{
+			name:     "3.x to 3.x same minor returns true",
+			a:        toVersionPtr("3.3.0"),
+			b:        toVersionPtr("3.3.1"),
+			expected: true,
+		},
+		{
+			name:     "3.x to 3.x different minor returns false",
+			a:        toVersionPtr("3.0.0"),
+			b:        toVersionPtr("3.1.0"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := version.SameMajorMinor(tt.a, tt.b)
+
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
 func TestMajorMinorLabel(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
When running without --target-version or with a target that shares the
same major.minor as the detected cluster version, print an environment
summary and exit early instead of running checks that would all be
filtered out by CanApply.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lint command now displays environment information (OpenShift AI and OpenShift versions) and exits early when no explicit target version is provided or when the target matches the current version's major/minor.
  * Downgrade protection remains enforced when an explicit target version is provided.

* **Tests**
  * Updated test cases to reflect lint command behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->