### PR TITLE
fix: skip checks when current and target versions match (major.minor)

### DIFF
--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -32,7 +32,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube/discovery"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -198,152 +197,47 @@ func (c *Command) Run(ctx context.Context) error {
 		c.currentOpenShiftVersion = ocpVersion.String()
 	}
 
-	// Determine mode: upgrade (with --target-version) or lint (without --target-version)
-	if c.TargetVersion != "" {
-		return c.runUpgradeMode(ctx, currentVersion)
+	// Determine effective target version (defaults to current for lint mode)
+	targetVersion := currentVersion
+	if c.parsedTargetVersion != nil {
+		targetVersion = c.parsedTargetVersion
 	}
-
-	return c.runLintMode(ctx, currentVersion)
-}
-
-// runLintMode validates current cluster state.
-func (c *Command) runLintMode(ctx context.Context, clusterVersion *semver.Version) error {
-	c.IO.Errorf("Detected OpenShift AI version: %s\n", clusterVersion.String())
-
-	// Discover components and services
-	c.IO.Errorf("Discovering OpenShift AI components and services...")
-	components, err := discovery.DiscoverComponentsAndServices(ctx, c.Client)
-	if err != nil {
-		return fmt.Errorf("discovering components and services: %w", err)
-	}
-	c.IO.Errorf("Found %d API groups", len(components))
-	for _, comp := range components {
-		c.IO.Errorf("  - %s/%s (%d resources)", comp.APIGroup, comp.Version, len(comp.Resources))
-	}
-	c.IO.Fprintln()
-
-	// Discover workloads
-	c.IO.Errorf("Discovering workload custom resources...")
-	workloads, err := discovery.DiscoverWorkloads(ctx, c.Client)
-	if err != nil {
-		return fmt.Errorf("discovering workloads: %w", err)
-	}
-	c.IO.Errorf("Found %d workload types", len(workloads))
-	for _, gvr := range workloads {
-		c.IO.Errorf("  - %s/%s %s", gvr.Group, gvr.Version, gvr.Resource)
-	}
-	c.IO.Fprintln()
-
-	// Execute component and service checks (Resource: nil)
-	c.IO.Errorf("Running component and service checks...")
-	componentTarget := check.Target{
-		Client:         c.Client,
-		CurrentVersion: clusterVersion, // For lint mode, current = target
-		TargetVersion:  clusterVersion,
-		Resource:       nil, // No specific resource for component/service checks
-		IO:             c.IO,
-		Debug:          c.Debug,
-	}
-
-	executor := check.NewExecutor(c.registry, c.IO)
-
-	// Execute checks in canonical order: dependencies → services → components → workloads
-	// Store results by group for later organization
-	resultsByGroup := make(map[check.CheckGroup][]check.CheckExecution)
-
-	for _, group := range check.CanonicalGroupOrder {
-		if group == check.GroupWorkload {
-			continue // Workloads handled separately below
-		}
-
-		results, err := executor.ExecuteSelective(ctx, componentTarget, c.CheckSelectors, group)
-		if err != nil {
-			// Log error but continue with other checks
-			c.IO.Errorf("Warning: Failed to execute %s checks: %v", group, err)
-			resultsByGroup[group] = []check.CheckExecution{}
-
-			continue
-		}
-
-		resultsByGroup[group] = results
-	}
-
-	// Execute workload checks for each discovered workload instance
-	c.IO.Errorf("Running workload checks...")
-	var workloadResults []check.CheckExecution
-
-	for _, gvr := range workloads {
-		// List all instances of this workload type
-		instances, err := c.Client.ListResources(ctx, gvr)
-		if err != nil {
-			// Skip workloads we can't access
-			c.IO.Errorf("Warning: Failed to list %s: %v", gvr.Resource, err)
-
-			continue
-		}
-
-		// Run workload checks for each instance
-		for i := range instances {
-			workloadTarget := check.Target{
-				Client:         c.Client,
-				CurrentVersion: clusterVersion, // For lint mode, current = target
-				TargetVersion:  clusterVersion,
-				Resource:       instances[i],
-				IO:             c.IO,
-				Debug:          c.Debug,
-			}
-
-			results, err := executor.ExecuteSelective(ctx, workloadTarget, c.CheckSelectors, check.GroupWorkload)
-			if err != nil {
-				return fmt.Errorf("executing workload checks: %w", err)
-			}
-
-			workloadResults = append(workloadResults, results...)
-		}
-	}
-
-	// Add workload results to the results map
-	resultsByGroup[check.GroupWorkload] = workloadResults
-
-	// Format and output results based on output format
-	if err := c.formatAndOutputResults(ctx, resultsByGroup); err != nil {
-		return err
-	}
-
-	// Print verdict and determine exit code
-	return c.printVerdictAndExit(resultsByGroup)
-}
-
-// runUpgradeMode assesses upgrade readiness for a target version.
-func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Version) error {
-	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
-	c.IO.Errorf("Target OpenShift AI version: %s\n", c.TargetVersion)
 
 	// Same major.minor means no upgrade checks are needed (checked before
 	// the downgrade guard so that e.g. --target-version 2.25 with current
 	// 2.25.2 is treated as "same version", not as a downgrade).
-	if version.SameMajorMinor(currentVersion, c.parsedTargetVersion) {
-		c.IO.Fprintln()
-		c.IO.Fprintln("Environment:")
-		c.IO.Fprintf("  OpenShift AI version: %s", currentVersion.String())
-
-		if c.currentOpenShiftVersion != "" {
-			c.IO.Fprintf("  OpenShift version:    %s", c.currentOpenShiftVersion)
-		}
-
-		c.IO.Fprintln()
-		c.IO.Fprintf("Current and target versions are the same (%s), no checks will be executed.",
-			version.MajorMinorLabel(currentVersion))
-
-		return nil
+	if version.SameMajorMinor(currentVersion, targetVersion) {
+		return c.runLintMode(ctx, currentVersion)
 	}
 
-	// Check if target version is older than current
-	if c.parsedTargetVersion.LT(*currentVersion) {
+	// Reject downgrades when explicit --target-version is provided
+	if targetVersion.LT(*currentVersion) {
 		return fmt.Errorf("target version %s is older than current version %s (downgrades not supported)",
 			c.TargetVersion, currentVersion.String())
 	}
 
+	return c.runUpgradeMode(ctx, currentVersion)
+}
+
+// runLintMode validates current cluster state.
+//
+//nolint:unparam // keep explicit error return value
+func (c *Command) runLintMode(_ context.Context, currentVersion *semver.Version) error {
+	c.IO.Fprintln()
+	outputVersionInfo(c.IO.Out(), &VersionInfo{
+		RHOAICurrentVersion: currentVersion.String(),
+		OpenShiftVersion:    c.currentOpenShiftVersion,
+	})
+
+	c.IO.Fprintln()
+	c.IO.Fprintf("Current and target versions are the same (%s), no checks will be executed.",
+		version.MajorMinorLabel(currentVersion))
+
+	return nil
+}
+
+// runUpgradeMode assesses upgrade readiness for a target version.
+func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Version) error {
 	c.IO.Errorf("Assessing upgrade readiness: %s → %s\n", currentVersion.String(), c.TargetVersion)
 
 	// Execute checks using target version for applicability filtering
@@ -416,65 +310,6 @@ func (c *Command) openShiftVersionPtr() *string {
 	}
 
 	return &c.currentOpenShiftVersion
-}
-
-// formatAndOutputResults formats and outputs check results based on the output format.
-func (c *Command) formatAndOutputResults(
-	ctx context.Context,
-	resultsByGroup map[check.CheckGroup][]check.CheckExecution,
-) error {
-	clusterVer := &c.currentClusterVersion
-	var targetVer *string
-	if c.TargetVersion != "" {
-		targetVer = &c.TargetVersion
-	}
-
-	ocpVer := c.openShiftVersionPtr()
-
-	// Flatten results to sorted array
-	flatResults := FlattenResults(resultsByGroup)
-
-	switch c.OutputFormat {
-	case OutputFormatTable:
-		return c.outputTable(ctx, flatResults)
-	case OutputFormatJSON:
-		if err := OutputJSON(c.IO.Out(), flatResults, clusterVer, targetVer, ocpVer); err != nil {
-			return fmt.Errorf("outputting JSON: %w", err)
-		}
-
-		return nil
-	case OutputFormatYAML:
-		if err := OutputYAML(c.IO.Out(), flatResults, clusterVer, targetVer, ocpVer); err != nil {
-			return fmt.Errorf("outputting YAML: %w", err)
-		}
-
-		return nil
-	default:
-		return fmt.Errorf("unsupported output format: %s", c.OutputFormat)
-	}
-}
-
-// outputTable outputs results in table format.
-func (c *Command) outputTable(ctx context.Context, results []check.CheckExecution) error {
-	c.IO.Fprintln()
-
-	opts := TableOutputOptions{
-		ShowImpactedObjects: c.Verbose,
-		VersionInfo: &VersionInfo{
-			RHOAICurrentVersion: c.currentClusterVersion,
-			OpenShiftVersion:    c.currentOpenShiftVersion,
-		},
-	}
-
-	if c.Verbose {
-		opts.NamespaceRequesters = collectNamespaceRequesters(ctx, c.Client, results)
-	}
-
-	if err := OutputTable(c.IO.Out(), results, opts); err != nil {
-		return fmt.Errorf("outputting table: %w", err)
-	}
-
-	return nil
 }
 
 // formatAndOutputUpgradeResults formats upgrade assessment results.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://github.com/opendatahub-io/odh-cli/pull/26 added result verdict in the status report.

https://github.com/opendatahub-io/odh-cli/pull/27 introduced the change to skip checks when current version equals to target version or target version option is not provided at all.

#27 was merged earlier which resulted in #26 overwriting the changes from #27, so the checks are still run even if no target version is specified.

This PR fixes that by "applying" (with many changes) #27 on top of #26.




## How Has This Been Tested?
Locally.

```bash
$ ./bin/kubectl-odh lint                                                                  

Environment:
  OpenShift AI version: 3.3.0
  OpenShift version:    4.20.14

Current and target versions are the same (3.3), no checks will be executed.

$ ./bin/kubectl-odh lint --target-version=3.3

Environment:
  OpenShift AI version: 3.3.0
  OpenShift version:    4.20.14

Current and target versions are the same (3.3), no checks will be executed.


$ ./bin/kubectl-odh lint --target-version=3.2
running command: target version 3.2 is older than current version 3.3.0 (downgrades not supported)
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents downgrades by rejecting operations where a specified target version is older than the current version.

* **Improvements**
  * Explicit target-version handling that cleanly separates lint and upgrade flows.
  * Lint mode now computes an effective target version and provides concise status output.
  * Short-circuits when versions are the same major/minor to streamline checks and upgrade output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->