### PR TITLE
Adding output of impacted isvcs when --verbose flag is set. 

### DIFF
--- a/pkg/lint/checks/workloads/kserve/impacted.go
+++ b/pkg/lint/checks/workloads/kserve/impacted.go
@@ -51,6 +51,10 @@ const (
 // ImpactedWorkloadsCheck lists InferenceServices and ServingRuntimes using deprecated deployment modes.
 type ImpactedWorkloadsCheck struct {
 	check.BaseCheck
+
+	// deploymentModeFilter filters InferenceServices by deployment mode in verbose output.
+	// Valid values: "all" (default), "serverless", "modelmesh".
+	deploymentModeFilter string
 }
 
 func NewImpactedWorkloadsCheck() *ImpactedWorkloadsCheck {
@@ -64,7 +68,14 @@ func NewImpactedWorkloadsCheck() *ImpactedWorkloadsCheck {
 			CheckDescription: "Lists InferenceServices and ServingRuntimes using deprecated deployment modes (ModelMesh, Serverless), removed ServingRuntimes, or ServingRuntimes referencing deprecated AcceleratorProfiles that will be impacted in RHOAI 3.x",
 			CheckRemediation: "Migrate InferenceServices from Serverless/ModelMesh to RawDeployment mode, update ServingRuntimes to supported versions, and review AcceleratorProfile references before upgrading",
 		},
+		deploymentModeFilter: "all", // Default to showing all deployment modes
 	}
+}
+
+// SetDeploymentModeFilter sets the filter for InferenceService display by deployment mode.
+// Valid values: "all", "serverless", "modelmesh".
+func (c *ImpactedWorkloadsCheck) SetDeploymentModeFilter(filter string) {
+	c.deploymentModeFilter = filter
 }
 
 // CanApply returns whether this check should run for the given target.
@@ -177,6 +188,7 @@ type inferenceServiceRow struct {
 
 // FormatVerboseOutput provides custom formatting for InferenceServices in verbose mode.
 // Displays a detailed table showing Name, Namespace, and DeploymentMode for each InferenceService.
+// Filters InferenceServices based on the deploymentModeFilter setting.
 func (c *ImpactedWorkloadsCheck) FormatVerboseOutput(out io.Writer, dr *result.DiagnosticResult) {
 	// Collect InferenceServices from impacted objects
 	var isvcs []inferenceServiceRow
@@ -193,6 +205,21 @@ func (c *ImpactedWorkloadsCheck) FormatVerboseOutput(out io.Writer, dr *result.D
 				deploymentMode = "RawDeployment"
 			} else {
 				deploymentMode = "Unknown"
+			}
+		}
+
+		// Apply deployment mode filter
+		if c.deploymentModeFilter != "all" {
+			filterMode := ""
+			switch c.deploymentModeFilter {
+			case "serverless":
+				filterMode = deploymentModeServerless
+			case "modelmesh":
+				filterMode = deploymentModeModelMesh
+			}
+
+			if deploymentMode != filterMode {
+				continue
 			}
 		}
 

--- a/pkg/lint/checks/workloads/kserve/impacted.go
+++ b/pkg/lint/checks/workloads/kserve/impacted.go
@@ -3,6 +3,8 @@ package kserve
 import (
 	"context"
 	"fmt"
+	"io"
+	"sort"
 	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,6 +13,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
@@ -163,4 +166,72 @@ func (c *ImpactedWorkloadsCheck) Validate(
 	dr.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(len(dr.ImpactedObjects))
 
 	return dr, nil
+}
+
+// inferenceServiceRow represents a row in the InferenceService detail table.
+type inferenceServiceRow struct {
+	Name           string `mapstructure:"NAME"`
+	Namespace      string `mapstructure:"NAMESPACE"`
+	DeploymentMode string `mapstructure:"DEPLOYMENT MODE"`
+}
+
+// FormatVerboseOutput provides custom formatting for InferenceServices in verbose mode.
+// Displays a detailed table showing Name, Namespace, and DeploymentMode for each InferenceService.
+func (c *ImpactedWorkloadsCheck) FormatVerboseOutput(out io.Writer, dr *result.DiagnosticResult) {
+	// Collect InferenceServices from impacted objects
+	var isvcs []inferenceServiceRow
+
+	for _, obj := range dr.ImpactedObjects {
+		if obj.Kind != "InferenceService" {
+			continue
+		}
+
+		deploymentMode := obj.Annotations[annotationDeploymentMode]
+		if deploymentMode == "" {
+			// Check for runtime annotation (for removed runtime ISVCs)
+			if runtime := obj.Annotations["serving.kserve.io/runtime"]; runtime != "" {
+				deploymentMode = "RawDeployment"
+			} else {
+				deploymentMode = "Unknown"
+			}
+		}
+
+		isvcs = append(isvcs, inferenceServiceRow{
+			Name:           obj.Name,
+			Namespace:      obj.Namespace,
+			DeploymentMode: deploymentMode,
+		})
+	}
+
+	if len(isvcs) == 0 {
+		return
+	}
+
+	// Sort by namespace, then by name
+	sort.Slice(isvcs, func(i, j int) bool {
+		if isvcs[i].Namespace != isvcs[j].Namespace {
+			return isvcs[i].Namespace < isvcs[j].Namespace
+		}
+
+		return isvcs[i].Name < isvcs[j].Name
+	})
+
+	// Render table with InferenceService details
+	renderer := table.NewRenderer[inferenceServiceRow](
+		table.WithWriter[inferenceServiceRow](out),
+		table.WithHeaders[inferenceServiceRow]("NAME", "NAMESPACE", "DEPLOYMENT MODE"),
+		table.WithTableOptions[inferenceServiceRow](table.DefaultTableOptions...),
+	)
+
+	for _, isvc := range isvcs {
+		if err := renderer.Append(isvc); err != nil {
+			_, _ = fmt.Fprintf(out, "    Error rendering InferenceService: %v\n", err)
+
+			return
+		}
+	}
+
+	if err := renderer.Render(); err != nil {
+		_, _ = fmt.Fprintf(out, "    Error rendering table: %v\n", err)
+	}
 }

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -120,8 +120,9 @@ func NewCommand(
 	registry.MustRegister(trainingoperatorworkloads.NewImpactedWorkloadsCheck())
 
 	c := &Command{
-		SharedOptions: shared,
-		registry:      registry,
+		SharedOptions:      shared,
+		registry:           registry,
+		ISVCDeploymentMode: "all",
 	}
 
 	// Apply functional options

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/pflag"
@@ -46,6 +47,10 @@ type Command struct {
 	// If empty, runs in lint mode (validates current state).
 	// If set, runs in upgrade mode (assesses upgrade readiness to target version).
 	TargetVersion string
+
+	// ISVCDeploymentMode filters InferenceService display by deployment mode.
+	// Valid values: "all" (default), "serverless", "modelmesh".
+	ISVCDeploymentMode string
 
 	// parsedTargetVersion is the parsed semver version (upgrade mode only)
 	parsedTargetVersion *semver.Version
@@ -135,6 +140,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.BoolVar(&c.Debug, "debug", false, flagDescDebug)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
+	fs.StringVar(&c.ISVCDeploymentMode, "isvc-deployment-mode", "all", flagDescISVCDeploymentMode)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, flagDescQPS)
@@ -172,6 +178,12 @@ func (c *Command) Validate() error {
 	// Validate shared options
 	if err := c.SharedOptions.Validate(); err != nil {
 		return fmt.Errorf("validating shared options: %w", err)
+	}
+
+	// Validate ISVC deployment mode filter
+	validModes := []string{"all", "serverless", "modelmesh"}
+	if !slices.Contains(validModes, c.ISVCDeploymentMode) {
+		return fmt.Errorf("invalid isvc-deployment-mode: %s (must be one of: all, serverless, modelmesh)", c.ISVCDeploymentMode)
 	}
 
 	return nil
@@ -222,6 +234,16 @@ func (c *Command) Run(ctx context.Context) error {
 	return c.runUpgradeMode(ctx, currentVersion)
 }
 
+// configureCheckSettings applies command-level settings to specific checks.
+func (c *Command) configureCheckSettings() {
+	// Apply ISVC deployment mode filter to the KServe impacted workloads check
+	for _, chk := range c.registry.ListAll() {
+		if isvcCheck, ok := chk.(*kserveworkloads.ImpactedWorkloadsCheck); ok {
+			isvcCheck.SetDeploymentModeFilter(c.ISVCDeploymentMode)
+		}
+	}
+}
+
 // runLintMode validates current cluster state.
 //
 //nolint:unparam // keep explicit error return value
@@ -242,6 +264,9 @@ func (c *Command) runLintMode(_ context.Context, currentVersion *semver.Version)
 // runUpgradeMode assesses upgrade readiness for a target version.
 func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Version) error {
 	c.IO.Errorf("Assessing upgrade readiness: %s → %s\n", currentVersion.String(), c.TargetVersion)
+
+	// Configure check-specific settings
+	c.configureCheckSettings()
 
 	// Execute checks using target version for applicability filtering
 	c.IO.Errorf("Running upgrade compatibility checks...")

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -2,13 +2,14 @@ package lint
 
 // Flag descriptions for the lint command.
 const (
-	flagDescTargetVersion = "target version for upgrade readiness checks (e.g., 2.25.0, 3.0.0)"
-	flagDescOutput        = "output format (table|json|yaml)"
-	flagDescVerbose       = "show impacted objects and summary information"
-	flagDescDebug         = "show detailed diagnostic logs for troubleshooting"
-	flagDescTimeout       = "operation timeout (e.g., 10m, 30m)"
-	flagDescQPS           = "Kubernetes API QPS limit (queries per second)"
-	flagDescBurst         = "Kubernetes API burst capacity"
+	flagDescTargetVersion      = "target version for upgrade readiness checks (e.g., 2.25.0, 3.0.0)"
+	flagDescOutput             = "output format (table|json|yaml)"
+	flagDescVerbose            = "show impacted objects and summary information"
+	flagDescDebug              = "show detailed diagnostic logs for troubleshooting"
+	flagDescTimeout            = "operation timeout (e.g., 10m, 30m)"
+	flagDescQPS                = "Kubernetes API QPS limit (queries per second)"
+	flagDescBurst              = "Kubernetes API burst capacity"
+	flagDescISVCDeploymentMode = "filter InferenceService display by deployment mode (all|serverless|modelmesh)"
 )
 
 const flagDescChecks = `check selector patterns (glob patterns or categories):


### PR DESCRIPTION
Name, Namespace, and Deployment mode is printed out. Also added --isvc-deployment-mode flag. New flag allows users to filter for only serverless or modelmesh ISVCs when using the --verbose flag. 

New output:
<img width="1698" height="776" alt="image" src="https://github.com/user-attachments/assets/a49f111c-b0e7-4aa8-9ad4-59f2209e4b45" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verbose view now shows impacted InferenceServices in a sorted, tabular list with Name, Namespace and Deployment Mode, and supports filtering by deployment mode (all/serverless/modelmesh).
  * Added a CLI flag to set the deployment-mode filter and validation for allowed values.

* **Tests**
  * Added tests for verbose formatting including multi-item and empty-result cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->