### PR TITLE
feat: add kueue labels lint check for notebooks

### DIFF
--- a/pkg/lint/checks/workloads/notebook/constants.go
+++ b/pkg/lint/checks/workloads/notebook/constants.go
@@ -16,6 +16,7 @@ const (
 	ConditionTypeHardwareProfileCompatible    = "HardwareProfileCompatible"
 	ConditionTypeHardwareProfileIntegrity     = "HardwareProfileIntegrity"
 	ConditionTypeNotebooksCompatible          = "NotebooksCompatible"
+	ConditionTypeKueueLabels                  = "KueueLabels"
 	ConditionTypeRunningWorkloads             = "RunningWorkloads"
 )
 
@@ -78,6 +79,12 @@ const (
 const (
 	MsgAllConnectionsValid = "All Notebook connections reference existing Secrets"
 	MsgConnectionsMissing  = "Found %d Notebook(s) referencing connection Secrets that do not exist on the cluster"
+)
+
+// Messages for KueueLabels check.
+const (
+	MsgAllKueueLabelsValid = "All Notebooks in kueue-enabled namespaces have the required queue label"
+	MsgKueueLabelsMissing  = "Found %d Notebook(s) in kueue-enabled namespaces missing the kueue.x-k8s.io/queue-name label"
 )
 
 // Messages for ContainerName check.

--- a/pkg/lint/checks/workloads/notebook/kueue_labels.go
+++ b/pkg/lint/checks/workloads/notebook/kueue_labels.go
@@ -1,0 +1,144 @@
+package notebook
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// Kueue-specific label keys.
+const (
+	LabelKueueManaged          = "kueue-managed"
+	LabelKueueOpenshiftManaged = "kueue.openshift.io/managed"
+	LabelKueueQueueName        = "kueue.x-k8s.io/queue-name"
+)
+
+// KueueLabelsCheck verifies that Notebooks in kueue-enabled namespaces have the
+// required kueue queue label for workload scheduling.
+type KueueLabelsCheck struct {
+	check.BaseCheck
+}
+
+func NewKueueLabelsCheck() *KueueLabelsCheck {
+	return &KueueLabelsCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             check.CheckTypeDataIntegrity,
+			CheckID:          "workloads.notebook.kueue-labels",
+			CheckName:        "Workloads :: Notebook :: Kueue Labels",
+			CheckDescription: "Verifies that Notebooks in kueue-enabled namespaces have the required kueue queue label for workload scheduling",
+			CheckRemediation: "Add the label kueue.x-k8s.io/queue-name: default to the affected Notebooks, or remove kueue labels from the namespace if kueue integration is not intended",
+		},
+	}
+}
+
+// CanApply returns whether this check should run for the given target.
+// Applies whenever Workbenches is Managed, regardless of version.
+func (c *KueueLabelsCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	return isWorkbenchesManaged(ctx, target)
+}
+
+// Validate lists Notebooks and checks that those in kueue-enabled namespaces have
+// the required kueue queue label.
+func (c *KueueLabelsCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.WorkloadsMetadata(c, target, resources.Notebook).
+		Run(ctx, c.checkKueueLabels)
+}
+
+// checkKueueLabels cross-references notebook namespaces against kueue-enabled namespaces
+// and verifies that notebooks in those namespaces have the required queue label.
+func (c *KueueLabelsCheck) checkKueueLabels(
+	ctx context.Context,
+	req *validate.WorkloadRequest[*metav1.PartialObjectMetadata],
+) error {
+	dr := req.Result
+
+	// Collect unique namespaces from notebooks.
+	notebookNamespaces := sets.New[string]()
+	for _, nb := range req.Items {
+		notebookNamespaces.Insert(nb.GetNamespace())
+	}
+
+	// Build kueue-enabled namespace set by fetching metadata for each namespace.
+	kueueNamespaces := sets.New[string]()
+
+	for ns := range notebookNamespaces {
+		nsMeta, err := req.Client.GetResourceMetadata(ctx, resources.Namespace, ns)
+		if err != nil {
+			if client.IsResourceTypeNotFound(err) {
+				continue
+			}
+
+			return fmt.Errorf("getting namespace %s metadata: %w", ns, err)
+		}
+
+		if nsMeta == nil {
+			continue
+		}
+
+		labels := nsMeta.GetLabels()
+		if labels[LabelKueueManaged] == "true" || labels[LabelKueueOpenshiftManaged] == "true" {
+			kueueNamespaces.Insert(ns)
+		}
+	}
+
+	// Check notebooks in kueue-enabled namespaces for the required queue label.
+	impacted := make([]types.NamespacedName, 0)
+
+	for _, nb := range req.Items {
+		if !kueueNamespaces.Has(nb.GetNamespace()) {
+			continue
+		}
+
+		labels := nb.GetLabels()
+		queueName, ok := labels[LabelKueueQueueName]
+		if !ok || queueName == "" {
+			impacted = append(impacted, types.NamespacedName{
+				Namespace: nb.GetNamespace(),
+				Name:      nb.GetName(),
+			})
+		}
+	}
+
+	totalImpacted := len(impacted)
+	dr.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(totalImpacted)
+
+	dr.Status.Conditions = append(dr.Status.Conditions, c.newCondition(totalImpacted))
+	dr.SetImpactedObjects(resources.Notebook, impacted)
+
+	return nil
+}
+
+func (c *KueueLabelsCheck) newCondition(totalImpacted int) result.Condition {
+	if totalImpacted == 0 {
+		return check.NewCondition(
+			ConditionTypeKueueLabels,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage(MsgAllKueueLabelsValid),
+		)
+	}
+
+	return check.NewCondition(
+		ConditionTypeKueueLabels,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonConfigurationInvalid),
+		check.WithMessage(MsgKueueLabelsMissing, totalImpacted),
+		check.WithImpact(result.ImpactBlocking),
+		check.WithRemediation(c.CheckRemediation),
+	)
+}

--- a/pkg/lint/checks/workloads/notebook/kueue_labels_test.go
+++ b/pkg/lint/checks/workloads/notebook/kueue_labels_test.go
@@ -1,0 +1,319 @@
+package notebook_test
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/notebook"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var kueueLabelsListKinds = map[schema.GroupVersionResource]string{
+	resources.Notebook.GVR():           resources.Notebook.ListKind(),
+	resources.Namespace.GVR():          resources.Namespace.ListKind(),
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newNamespace(name string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name": name,
+	}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Namespace.APIVersion(),
+			"kind":       resources.Namespace.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestKueueLabelsCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := notebook.NewKueueLabelsCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.notebook.kueue-labels"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: Notebook :: Kueue Labels"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.CheckKind()).To(Equal("notebook"))
+	g.Expect(chk.CheckType()).To(Equal(string(check.CheckTypeDataIntegrity)))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+	g.Expect(chk.Remediation()).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+}
+
+func TestKueueLabelsCheck_CanApply_WorkbenchesManaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestKueueLabelsCheck_CanApply_WorkbenchesRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsCheck_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(notebook.ConditionTypeKueueLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonRequirementsMet),
+		"Message": Equal(notebook.MsgAllKueueLabelsValid),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsCheck_NamespaceWithoutKueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("user-ns", nil)
+	nb := newNotebook("my-notebook", "user-ns", notebookOptions{})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{ns, nb},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsCheck_NotebookWithKueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("kueue-ns", map[string]any{
+		notebook.LabelKueueManaged: "true",
+	})
+
+	nb := newNotebook("good-notebook", "kueue-ns", notebookOptions{
+		Labels: map[string]any{
+			notebook.LabelKueueQueueName: "default",
+		},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{ns, nb},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsCheck_NotebookMissingKueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("kueue-ns", map[string]any{
+		notebook.LabelKueueManaged: "true",
+	})
+
+	nb := newNotebook("bad-notebook", "kueue-ns", notebookOptions{})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{ns, nb},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(notebook.ConditionTypeKueueLabels),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonConfigurationInvalid),
+		"Message": Equal(fmt.Sprintf(notebook.MsgKueueLabelsMissing, 1)),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Remediation).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-notebook"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("kueue-ns"))
+}
+
+func TestKueueLabelsCheck_MixedNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("kueue-ns", map[string]any{
+		notebook.LabelKueueManaged: "true",
+	})
+	nsPlain := newNamespace("plain-ns", nil)
+
+	// Notebook with kueue label in kueue namespace — compliant
+	nbGood := newNotebook("good-notebook", "kueue-ns", notebookOptions{
+		Labels: map[string]any{
+			notebook.LabelKueueQueueName: "default",
+		},
+	})
+
+	// Notebook without kueue label in kueue namespace — non-compliant
+	nbBad := newNotebook("bad-notebook", "kueue-ns", notebookOptions{})
+
+	// Notebook in non-kueue namespace — should not be flagged
+	nbPlain := newNotebook("plain-notebook", "plain-ns", notebookOptions{})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{ns, nsPlain, nbGood, nbBad, nbPlain},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-notebook"))
+}
+
+func TestKueueLabelsCheck_BothKueueNamespaceLabels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Namespace with the OpenShift-specific kueue label
+	ns := newNamespace("ocp-kueue-ns", map[string]any{
+		notebook.LabelKueueOpenshiftManaged: "true",
+	})
+
+	nb := newNotebook("unlabeled-notebook", "ocp-kueue-ns", notebookOptions{})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{ns, nb},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("unlabeled-notebook"))
+}
+
+func TestKueueLabelsCheck_NotebookWithCustomQueueName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("kueue-ns", map[string]any{
+		notebook.LabelKueueManaged: "true",
+	})
+
+	nb := newNotebook("custom-queue-notebook", "kueue-ns", notebookOptions{
+		Labels: map[string]any{
+			notebook.LabelKueueQueueName: "team-queue",
+		},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{ns, nb},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsCheck_AnnotationTargetVersion(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsListKinds,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewKueueLabelsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationCheckTargetVersion, "3.0.0"))
+}

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -93,7 +93,7 @@ func NewCommand(
 	registry.MustRegister(certmanager.NewCheck())
 	registry.MustRegister(openshift.NewCheck())
 
-	// Workloads (16)
+	// Workloads (20)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
@@ -109,6 +109,7 @@ func NewCommand(
 	registry.MustRegister(notebook.NewHardwareProfileMigrationCheck())
 	registry.MustRegister(notebook.NewConnectionIntegrityCheck())
 	registry.MustRegister(notebook.NewHardwareProfileIntegrityCheck())
+	registry.MustRegister(notebook.NewKueueLabelsCheck())
 	registry.MustRegister(notebook.NewImpactedWorkloadsCheck())
 	registry.MustRegister(notebook.NewRunningWorkloadsCheck())
 	registry.MustRegister(ray.NewImpactedWorkloadsCheck())


### PR DESCRIPTION
Detect Notebooks in kueue-enabled namespaces that are missing the required kueue.x-k8s.io/queue-name label. Without this label, notebooks that attempt to be modified will end up failing with this error:

```
Error from server (Forbidden): admission webhook
"kubeflow-kueuelabels-validator.opendatahub.io" denied the request: Kueue
label validation failed: missing required label "kueue.x-k8s.io/queue-name"
```

This is a critical misconfiguration that must be flagged and addressed in order for subsequent migration to be successful.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a notebook validation that checks Kueue label configuration in Kueue-enabled namespaces, providing diagnostics, impact severity, and remediation guidance when labels are missing or invalid.
* **Tests**
  * Added comprehensive tests covering applicability, validation scenarios, annotations, impacted-object reporting, and remediation messaging.
* **Chores**
  * Registered the new notebook validation in the workload checks list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->