### PR TITLE
feat: add kueue labels lint checks for all workload types

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,7 +11,21 @@ const (
 const (
 	ComponentDashboard        = "dashboard"
 	ComponentKServe           = "kserve"
+	ComponentRay              = "ray"
 	ComponentTrainingOperator = "trainingoperator"
+	ComponentWorkbenches      = "workbenches"
+)
+
+// Component names for Kueue integration.
+const (
+	ComponentKueue = "kueue"
+)
+
+// Kueue-specific label keys used across workload check packages.
+const (
+	LabelKueueManaged          = "kueue-managed"
+	LabelKueueOpenshiftManaged = "kueue.openshift.io/managed"
+	LabelKueueQueueName        = "kueue.x-k8s.io/queue-name"
 )
 
 // Workload annotations used across multiple check packages.

--- a/pkg/lint/checks/workloads/kserve/kueue_labels_isvc.go
+++ b/pkg/lint/checks/workloads/kserve/kueue_labels_isvc.go
@@ -1,0 +1,25 @@
+package kserve
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	ConditionTypeISVCKueueLabels        = "ISVCKueueLabels"
+	ConditionTypeISVCKueueMissingLabels = "ISVCKueueMissingLabels"
+)
+
+func NewKueueLabelsISVCCheck() *kueue.KueueLabelCheck {
+	return kueue.NewCheck(kueue.CheckConfig{
+		Kind:                      constants.ComponentKServe,
+		Component:                 constants.ComponentKServe,
+		Resource:                  resources.InferenceService,
+		ConditionType:             ConditionTypeISVCKueueLabels,
+		MissingLabelConditionType: ConditionTypeISVCKueueMissingLabels,
+		KindLabel:                 "InferenceService",
+		CheckID:                   "workloads.kserve.kueue-labels-isvc",
+		CheckName:                 "Workloads :: KServe :: InferenceService Kueue Labels",
+	})
+}

--- a/pkg/lint/checks/workloads/kserve/kueue_labels_isvc_test.go
+++ b/pkg/lint/checks/workloads/kserve/kueue_labels_isvc_test.go
@@ -1,4 +1,4 @@
-package notebook_test
+package kserve_test
 
 import (
 	"fmt"
@@ -12,8 +12,8 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/notebook"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
@@ -21,13 +21,13 @@ import (
 )
 
 //nolint:gochecknoglobals
-var kueueLabelsListKinds = map[schema.GroupVersionResource]string{
-	resources.Notebook.GVR():           resources.Notebook.ListKind(),
+var kueueLabelsISVCListKinds = map[schema.GroupVersionResource]string{
+	resources.InferenceService.GVR():   resources.InferenceService.ListKind(),
 	resources.Namespace.GVR():          resources.Namespace.ListKind(),
 	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
 }
 
-func newNamespace(name string, labels map[string]any) *unstructured.Unstructured {
+func newKueueNamespace(name string, labels map[string]any) *unstructured.Unstructured {
 	metadata := map[string]any{
 		"name": name,
 	}
@@ -45,369 +45,376 @@ func newNamespace(name string, labels map[string]any) *unstructured.Unstructured
 	}
 }
 
-func TestKueueLabelsCheck_Metadata(t *testing.T) {
+func newISVC(name string, namespace string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.InferenceService.APIVersion(),
+			"kind":       resources.InferenceService.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestKueueLabelsISVCCheck_Metadata(t *testing.T) {
 	g := NewWithT(t)
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 
-	g.Expect(chk.ID()).To(Equal("workloads.notebook.kueue-labels"))
-	g.Expect(chk.Name()).To(Equal("Workloads :: Notebook :: Kueue Labels"))
+	g.Expect(chk.ID()).To(Equal("workloads.kserve.kueue-labels-isvc"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: KServe :: InferenceService Kueue Labels"))
 	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
-	g.Expect(chk.CheckKind()).To(Equal("notebook"))
+	g.Expect(chk.CheckKind()).To(Equal("kserve"))
 	g.Expect(chk.CheckType()).To(Equal(string(check.CheckTypeDataIntegrity)))
 	g.Expect(chk.Description()).ToNot(BeEmpty())
 	g.Expect(chk.Remediation()).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
 }
 
-func TestKueueLabelsCheck_CanApply_WorkbenchesManagedKueueManaged(t *testing.T) {
+func TestKueueLabelsISVCCheck_CanApply_KServeManagedKueueManaged(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed", "kueue": "Managed"})},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed", "kueue": "Managed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeTrue())
 }
 
-func TestKueueLabelsCheck_CanApply_WorkbenchesManagedKueueUnmanaged(t *testing.T) {
+func TestKueueLabelsISVCCheck_CanApply_KServeManagedKueueUnmanaged(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed", "kueue": "Unmanaged"})},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed", "kueue": "Unmanaged"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeTrue())
 }
 
-func TestKueueLabelsCheck_CanApply_WorkbenchesManagedKueueRemoved(t *testing.T) {
+func TestKueueLabelsISVCCheck_CanApply_KServeManagedKueueRemoved(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed", "kueue": "Removed"})},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed", "kueue": "Removed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeFalse())
 }
 
-func TestKueueLabelsCheck_CanApply_WorkbenchesRemoved(t *testing.T) {
+func TestKueueLabelsISVCCheck_CanApply_KServeRemoved(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed", "kueue": "Managed"})},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Removed", "kueue": "Managed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeFalse())
 }
 
-func TestKueueLabelsCheck_NoNotebooks(t *testing.T) {
+func TestKueueLabelsISVCCheck_NoInferenceServices(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
+		ListKinds:      kueueLabelsISVCListKinds,
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(2))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(notebook.ConditionTypeKueueLabels),
+		"Type":    Equal(kserve.ConditionTypeISVCKueueLabels),
 		"Status":  Equal(metav1.ConditionTrue),
 		"Reason":  Equal(check.ReasonRequirementsMet),
-		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloads, "Notebook")),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloads, "InferenceService")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
 	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(notebook.ConditionTypeKueueMissingLabels),
+		"Type":    Equal(kserve.ConditionTypeISVCKueueMissingLabels),
 		"Status":  Equal(metav1.ConditionTrue),
-		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "Notebook")),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "InferenceService")),
 	}))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
 	g.Expect(result.ImpactedObjects).To(BeEmpty())
 }
 
-func TestKueueLabelsCheck_NotebookWithoutQueueLabel(t *testing.T) {
+func TestKueueLabelsISVCCheck_WithoutQueueLabel(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := newNamespace("user-ns", nil)
-	nb := newNotebook("my-notebook", "user-ns", notebookOptions{})
+	ns := newKueueNamespace("user-ns", nil)
+	isvc := newISVC("my-isvc", "user-ns", nil)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{ns, isvc},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "Notebook")))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "InferenceService")))
 	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "Notebook")))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "InferenceService")))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
 	g.Expect(result.ImpactedObjects).To(BeEmpty())
 }
 
-func TestKueueLabelsCheck_NotebookWithQueueLabelInKueueNamespace(t *testing.T) {
+func TestKueueLabelsISVCCheck_WithQueueLabelInKueueNamespace(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := newNamespace("kueue-ns", map[string]any{
+	ns := newKueueNamespace("kueue-ns", map[string]any{
 		constants.LabelKueueManaged: "true",
 	})
 
-	nb := newNotebook("good-notebook", "kueue-ns", notebookOptions{
-		Labels: map[string]any{
-			constants.LabelKueueQueueName: "default",
-		},
+	isvc := newISVC("good-isvc", "kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
 	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{ns, isvc},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "InferenceService")))
 	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "InferenceService")))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
 	g.Expect(result.ImpactedObjects).To(BeEmpty())
 }
 
-func TestKueueLabelsCheck_NotebookWithoutQueueLabelInKueueNamespace(t *testing.T) {
+func TestKueueLabelsISVCCheck_WithoutQueueLabelInKueueNamespace(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := newNamespace("kueue-ns", map[string]any{
+	ns := newKueueNamespace("kueue-ns", map[string]any{
 		constants.LabelKueueManaged: "true",
 	})
 
-	nb := newNotebook("unlabeled-notebook", "kueue-ns", notebookOptions{})
+	isvc := newISVC("unlabeled-isvc", "kueue-ns", nil)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{ns, isvc},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(2))
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "Notebook")))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "InferenceService")))
 	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(notebook.ConditionTypeKueueMissingLabels),
+		"Type":    Equal(kserve.ConditionTypeISVCKueueMissingLabels),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonConfigurationInvalid),
-		"Message": Equal(fmt.Sprintf(kueue.MsgMissingLabelInKueueNs, 1, "Notebook")),
+		"Message": Equal(fmt.Sprintf(kueue.MsgMissingLabelInKueueNs, 1, "InferenceService")),
 	}))
 	g.Expect(result.Status.Conditions[1].Impact).To(Equal(resultpkg.ImpactBlocking))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
 	g.Expect(result.ImpactedObjects).To(HaveLen(1))
-	g.Expect(result.ImpactedObjects[0].Name).To(Equal("unlabeled-notebook"))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("unlabeled-isvc"))
 	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("kueue-ns"))
 }
 
-func TestKueueLabelsCheck_LabeledNotebookInNonKueueNamespace(t *testing.T) {
+func TestKueueLabelsISVCCheck_LabeledInNonKueueNamespace(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := newNamespace("plain-ns", nil)
+	ns := newKueueNamespace("plain-ns", nil)
 
-	nb := newNotebook("bad-notebook", "plain-ns", notebookOptions{
-		Labels: map[string]any{
-			constants.LabelKueueQueueName: "default",
-		},
+	isvc := newISVC("bad-isvc", "plain-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
 	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{ns, isvc},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(2))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(notebook.ConditionTypeKueueLabels),
+		"Type":    Equal(kserve.ConditionTypeISVCKueueLabels),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonConfigurationInvalid),
-		"Message": Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "Notebook")),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "InferenceService")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 	g.Expect(result.Status.Conditions[0].Remediation).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
 	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "Notebook")))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "InferenceService")))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
 	g.Expect(result.ImpactedObjects).To(HaveLen(1))
-	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-notebook"))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-isvc"))
 	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("plain-ns"))
 }
 
-func TestKueueLabelsCheck_MixedLabeledNotebooks(t *testing.T) {
+func TestKueueLabelsISVCCheck_MixedLabeledInferenceServices(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	nsKueue := newNamespace("kueue-ns", map[string]any{
+	nsKueue := newKueueNamespace("kueue-ns", map[string]any{
 		constants.LabelKueueManaged: "true",
 	})
-	nsPlain := newNamespace("plain-ns", nil)
+	nsPlain := newKueueNamespace("plain-ns", nil)
 
-	nbGood := newNotebook("good-notebook", "kueue-ns", notebookOptions{
-		Labels: map[string]any{
-			constants.LabelKueueQueueName: "default",
-		},
+	isvcGood := newISVC("good-isvc", "kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
 	})
-	nbBad := newNotebook("bad-notebook", "plain-ns", notebookOptions{
-		Labels: map[string]any{
-			constants.LabelKueueQueueName: "default",
-		},
+	isvcBad := newISVC("bad-isvc", "plain-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
 	})
-	nbPlain := newNotebook("plain-notebook", "plain-ns", notebookOptions{})
+	isvcPlain := newISVC("plain-isvc", "plain-ns", nil)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{nsKueue, nsPlain, nbGood, nbBad, nbPlain},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{nsKueue, nsPlain, isvcGood, isvcBad, isvcPlain},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "InferenceService")))
 	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "InferenceService")))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
 	g.Expect(result.ImpactedObjects).To(HaveLen(1))
-	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-notebook"))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-isvc"))
 }
 
-func TestKueueLabelsCheck_OpenshiftKueueNamespaceLabel(t *testing.T) {
+func TestKueueLabelsISVCCheck_OpenshiftKueueLabel(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := newNamespace("ocp-kueue-ns", map[string]any{
+	ns := newKueueNamespace("ocp-kueue-ns", map[string]any{
 		constants.LabelKueueOpenshiftManaged: "true",
 	})
 
-	nb := newNotebook("good-notebook", "ocp-kueue-ns", notebookOptions{
-		Labels: map[string]any{
-			constants.LabelKueueQueueName: "default",
-		},
+	isvc := newISVC("good-isvc", "ocp-kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
 	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{ns, isvc},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "InferenceService")))
 	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "InferenceService")))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
 	g.Expect(result.ImpactedObjects).To(BeEmpty())
 }
 
-func TestKueueLabelsCheck_NotebookWithCustomQueueName(t *testing.T) {
+func TestKueueLabelsISVCCheck_CustomQueueName(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	ns := newNamespace("kueue-ns", map[string]any{
+	ns := newKueueNamespace("kueue-ns", map[string]any{
 		constants.LabelKueueManaged: "true",
 	})
 
-	nb := newNotebook("custom-queue-notebook", "kueue-ns", notebookOptions{
-		Labels: map[string]any{
-			constants.LabelKueueQueueName: "team-queue",
-		},
+	isvc := newISVC("custom-queue-isvc", "kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "team-queue",
 	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		ListKinds:      kueueLabelsISVCListKinds,
+		Objects:        []*unstructured.Unstructured{ns, isvc},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "InferenceService")))
 	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "Notebook")))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "InferenceService")))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
 	g.Expect(result.ImpactedObjects).To(BeEmpty())
 }
 
-func TestKueueLabelsCheck_AnnotationTargetVersion(t *testing.T) {
+func TestKueueLabelsISVCCheck_AnnotationTargetVersion(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      kueueLabelsListKinds,
+		ListKinds:      kueueLabelsISVCListKinds,
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
 
-	chk := notebook.NewKueueLabelsCheck()
+	chk := kserve.NewKueueLabelsISVCCheck()
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())

--- a/pkg/lint/checks/workloads/kserve/kueue_labels_llmisvc.go
+++ b/pkg/lint/checks/workloads/kserve/kueue_labels_llmisvc.go
@@ -1,0 +1,25 @@
+package kserve
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	ConditionTypeLLMISVCKueueLabels        = "LLMISVCKueueLabels"
+	ConditionTypeLLMISVCKueueMissingLabels = "LLMISVCKueueMissingLabels"
+)
+
+func NewKueueLabelsLLMCheck() *kueue.KueueLabelCheck {
+	return kueue.NewCheck(kueue.CheckConfig{
+		Kind:                      constants.ComponentKServe,
+		Component:                 constants.ComponentKServe,
+		Resource:                  resources.LLMInferenceService,
+		ConditionType:             ConditionTypeLLMISVCKueueLabels,
+		MissingLabelConditionType: ConditionTypeLLMISVCKueueMissingLabels,
+		KindLabel:                 "LLMInferenceService",
+		CheckID:                   "workloads.kserve.kueue-labels-llm",
+		CheckName:                 "Workloads :: KServe :: LLMInferenceService Kueue Labels",
+	})
+}

--- a/pkg/lint/checks/workloads/kserve/kueue_labels_llmisvc_test.go
+++ b/pkg/lint/checks/workloads/kserve/kueue_labels_llmisvc_test.go
@@ -1,0 +1,314 @@
+package kserve_test
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var kueueLabelsLLMListKinds = map[schema.GroupVersionResource]string{
+	resources.LLMInferenceService.GVR(): resources.LLMInferenceService.ListKind(),
+	resources.Namespace.GVR():           resources.Namespace.ListKind(),
+	resources.DataScienceCluster.GVR():  resources.DataScienceCluster.ListKind(),
+}
+
+func newLLMISVC(name string, namespace string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.LLMInferenceService.APIVersion(),
+			"kind":       resources.LLMInferenceService.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestKueueLabelsLLMCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.kserve.kueue-labels-llm"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: KServe :: LLMInferenceService Kueue Labels"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.CheckKind()).To(Equal("kserve"))
+	g.Expect(chk.CheckType()).To(Equal(string(check.CheckTypeDataIntegrity)))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+	g.Expect(chk.Remediation()).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+}
+
+func TestKueueLabelsLLMCheck_CanApply_KServeManagedKueueManaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestKueueLabelsLLMCheck_CanApply_KServeManagedKueueRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed", "kueue": "Removed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsLLMCheck_CanApply_KServeRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Removed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsLLMCheck_NoLLMInferenceServices(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(kserve.ConditionTypeLLMISVCKueueLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonRequirementsMet),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloads, "LLMInferenceService")),
+	}))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(kserve.ConditionTypeLLMISVCKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "LLMInferenceService")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsLLMCheck_WithoutQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("kueue-ns", map[string]any{
+		constants.LabelKueueManaged: "true",
+	})
+
+	llm := newLLMISVC("unlabeled-llm", "kueue-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{ns, llm},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "LLMInferenceService")))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(kserve.ConditionTypeLLMISVCKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonConfigurationInvalid),
+		"Message": Equal(fmt.Sprintf(kueue.MsgMissingLabelInKueueNs, 1, "LLMInferenceService")),
+	}))
+	g.Expect(result.Status.Conditions[1].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("unlabeled-llm"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("kueue-ns"))
+}
+
+func TestKueueLabelsLLMCheck_LabeledInNonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("plain-ns", nil)
+
+	llm := newLLMISVC("bad-llm", "plain-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{ns, llm},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(kserve.ConditionTypeLLMISVCKueueLabels),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonConfigurationInvalid),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "LLMInferenceService")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Remediation).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "LLMInferenceService")))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-llm"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("plain-ns"))
+}
+
+func TestKueueLabelsLLMCheck_WithQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("kueue-ns", map[string]any{
+		constants.LabelKueueManaged: "true",
+	})
+
+	llm := newLLMISVC("good-llm", "kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{ns, llm},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "LLMInferenceService")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "LLMInferenceService")))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsLLMCheck_MixedLabeledLLMInferenceServices(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nsKueue := newKueueNamespace("kueue-ns", map[string]any{
+		constants.LabelKueueManaged: "true",
+	})
+	nsPlain := newKueueNamespace("plain-ns", nil)
+
+	llmGood := newLLMISVC("good-llm", "kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
+	})
+	llmBad := newLLMISVC("bad-llm", "plain-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
+	})
+	llmPlain := newLLMISVC("plain-llm", "plain-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{nsKueue, nsPlain, llmGood, llmBad, llmPlain},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "LLMInferenceService")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "LLMInferenceService")))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-llm"))
+}
+
+func TestKueueLabelsLLMCheck_OpenshiftKueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("ocp-kueue-ns", map[string]any{
+		constants.LabelKueueOpenshiftManaged: "true",
+	})
+
+	llm := newLLMISVC("good-llm", "ocp-kueue-ns", map[string]any{
+		constants.LabelKueueQueueName: "default",
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsLLMListKinds,
+		Objects:        []*unstructured.Unstructured{ns, llm},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := kserve.NewKueueLabelsLLMCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "LLMInferenceService")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "LLMInferenceService")))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}

--- a/pkg/lint/checks/workloads/kueue/check.go
+++ b/pkg/lint/checks/workloads/kueue/check.go
@@ -1,0 +1,85 @@
+package kueue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	remediationLabeledInNonKueueNs = "Add the kueue-managed or kueue.openshift.io/managed label to the affected namespaces, " +
+		"or remove the kueue.x-k8s.io/queue-name label from the workloads if kueue integration is not intended"
+
+	remediationMissingLabelInKueueNs = "Add the kueue.x-k8s.io/queue-name label to the workloads in kueue-enabled namespaces, " +
+		"or remove the kueue-managed or kueue.openshift.io/managed label from the namespaces if kueue integration is not intended for those workloads"
+)
+
+// CheckConfig holds the per-resource parameters that differentiate each kueue label check.
+type CheckConfig struct {
+	Kind                      string
+	Component                 string
+	Resource                  resources.ResourceType
+	ConditionType             string
+	MissingLabelConditionType string
+	KindLabel                 string
+	CheckID                   string
+	CheckName                 string
+}
+
+// KueueLabelCheck verifies that workloads with the kueue queue label are in
+// kueue-enabled namespaces, and that workloads in kueue-enabled namespaces
+// have the kueue queue label.
+type KueueLabelCheck struct {
+	check.BaseCheck
+
+	component                 string
+	resource                  resources.ResourceType
+	conditionType             string
+	missingLabelConditionType string
+	kindLabel                 string
+}
+
+func NewCheck(cfg CheckConfig) *KueueLabelCheck {
+	return &KueueLabelCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             cfg.Kind,
+			Type:             check.CheckTypeDataIntegrity,
+			CheckID:          cfg.CheckID,
+			CheckName:        cfg.CheckName,
+			CheckDescription: fmt.Sprintf("Verifies that %ss with the kueue queue label are in kueue-enabled namespaces", cfg.KindLabel),
+			CheckRemediation: remediationLabeledInNonKueueNs,
+		},
+		component:                 cfg.Component,
+		resource:                  cfg.Resource,
+		conditionType:             cfg.ConditionType,
+		missingLabelConditionType: cfg.MissingLabelConditionType,
+		kindLabel:                 cfg.KindLabel,
+	}
+}
+
+func (c *KueueLabelCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	ok, err := IsComponentAndKueueActive(ctx, target, c.component)
+	if err != nil {
+		return false, fmt.Errorf("checking %s and kueue state: %w", c.component, err)
+	}
+
+	return ok, nil
+}
+
+func (c *KueueLabelCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.WorkloadsMetadata(c, target, c.resource).
+		Run(ctx, ValidateFn(
+			c.resource,
+			c.conditionType,
+			c.missingLabelConditionType,
+			c.kindLabel,
+		))
+}

--- a/pkg/lint/checks/workloads/kueue/support.go
+++ b/pkg/lint/checks/workloads/kueue/support.go
@@ -1,0 +1,248 @@
+package kueue
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
+)
+
+// Messages for the "labeled in non-kueue namespace" condition.
+const (
+	MsgNoWorkloads        = "No %s instances found"
+	MsgNoLabeledWorkloads = "No %s(s) found with the kueue.x-k8s.io/queue-name label"
+	MsgAllValid           = "All %d %s(s) with the kueue.x-k8s.io/queue-name label are in kueue-enabled namespaces"
+	MsgNsNotKueueEnabled  = "Found %d %s(s) with the kueue.x-k8s.io/queue-name label in namespaces not enabled for kueue"
+)
+
+// Messages for the "missing label in kueue namespace" condition.
+const (
+	MsgNoWorkloadsInKueueNs  = "No %s(s) found in kueue-enabled namespaces"
+	MsgAllInKueueNsLabeled   = "All %d %s(s) in kueue-enabled namespaces have the kueue.x-k8s.io/queue-name label"
+	MsgMissingLabelInKueueNs = "Found %d %s(s) in kueue-enabled namespaces without the kueue.x-k8s.io/queue-name label"
+)
+
+// IsComponentAndKueueActive returns true when the given component is Managed AND Kueue is active
+// (Managed or Unmanaged) on the DSC.
+func IsComponentAndKueueActive(
+	ctx context.Context,
+	target check.Target,
+	componentName string,
+) (bool, error) {
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	if !components.HasManagementState(
+		dsc, componentName,
+		constants.ManagementStateManaged,
+	) {
+		return false, nil
+	}
+
+	if !components.HasManagementState(
+		dsc, constants.ComponentKueue,
+		constants.ManagementStateManaged, constants.ManagementStateUnmanaged,
+	) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// ValidateFn returns a validation function that classifies workloads into four categories
+// based on kueue label presence and namespace enablement, then emits two conditions:
+//   - labeled workloads in non-kueue namespaces (conditionType)
+//   - unlabeled workloads in kueue-enabled namespaces (missingLabelConditionType)
+func ValidateFn(
+	resourceType resources.ResourceType,
+	conditionType string,
+	missingLabelConditionType string,
+	kindLabel string,
+) validate.WorkloadValidateFn[*metav1.PartialObjectMetadata] {
+	return func(ctx context.Context, req *validate.WorkloadRequest[*metav1.PartialObjectMetadata]) error {
+		dr := req.Result
+
+		if len(req.Items) == 0 {
+			dr.Annotations[check.AnnotationImpactedWorkloadCount] = "0"
+			dr.SetCondition(newLabeledInNonKueueCondition(conditionType, kindLabel, len(req.Items), 0, 0))
+			dr.SetCondition(newMissingLabelCondition(missingLabelConditionType, kindLabel, 0, 0))
+			dr.SetImpactedObjects(resourceType, nil)
+
+			return nil
+		}
+
+		allKueueNs, err := kueueEnabledNamespaces(ctx, req.Client)
+		if err != nil {
+			return err
+		}
+
+		// Classify workloads into four categories based on label presence and namespace.
+		var (
+			labeled             []types.NamespacedName
+			labeledInNonKueueNs []types.NamespacedName
+			inKueueNs           []types.NamespacedName
+			unlabeledInKueueNs  []types.NamespacedName
+		)
+
+		for _, item := range req.Items {
+			nn := types.NamespacedName{
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
+			}
+
+			hasLabel := kube.ContainsLabel(item, constants.LabelKueueQueueName)
+			inKueue := allKueueNs.Has(item.GetNamespace())
+
+			if hasLabel {
+				labeled = append(labeled, nn)
+			}
+
+			if inKueue {
+				inKueueNs = append(inKueueNs, nn)
+			}
+
+			switch {
+			case hasLabel && !inKueue:
+				labeledInNonKueueNs = append(labeledInNonKueueNs, nn)
+			case !hasLabel && inKueue:
+				unlabeledInKueueNs = append(unlabeledInKueueNs, nn)
+			}
+		}
+
+		totalImpacted := len(labeledInNonKueueNs) + len(unlabeledInKueueNs)
+		dr.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(totalImpacted)
+
+		dr.SetCondition(newLabeledInNonKueueCondition(
+			conditionType, kindLabel,
+			len(req.Items), len(labeled), len(labeledInNonKueueNs),
+		))
+		dr.SetCondition(newMissingLabelCondition(
+			missingLabelConditionType, kindLabel,
+			len(inKueueNs), len(unlabeledInKueueNs),
+		))
+
+		dr.SetImpactedObjects(resourceType, labeledInNonKueueNs)
+		dr.AddImpactedObjects(resourceType, unlabeledInKueueNs)
+
+		return nil
+	}
+}
+
+// newLabeledInNonKueueCondition builds the condition for workloads that have the
+// kueue queue label but are in namespaces not enabled for kueue.
+func newLabeledInNonKueueCondition(
+	conditionType string,
+	kindLabel string,
+	totalWorkloads int,
+	labeledCount int,
+	impactedCount int,
+) result.Condition {
+	switch {
+	case totalWorkloads == 0:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage(MsgNoWorkloads, kindLabel),
+		)
+	case labeledCount == 0:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage(MsgNoLabeledWorkloads, kindLabel),
+		)
+	case impactedCount == 0:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage(MsgAllValid, labeledCount, kindLabel),
+		)
+	default:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonConfigurationInvalid),
+			check.WithMessage(MsgNsNotKueueEnabled, impactedCount, kindLabel),
+			check.WithImpact(result.ImpactBlocking),
+			check.WithRemediation(remediationLabeledInNonKueueNs),
+		)
+	}
+}
+
+// newMissingLabelCondition builds the condition for workloads in kueue-enabled
+// namespaces that are missing the kueue queue label.
+func newMissingLabelCondition(
+	conditionType string,
+	kindLabel string,
+	totalInKueueNs int,
+	missingCount int,
+) result.Condition {
+	switch {
+	case totalInKueueNs == 0:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage(MsgNoWorkloadsInKueueNs, kindLabel),
+		)
+	case missingCount == 0:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage(MsgAllInKueueNsLabeled, totalInKueueNs, kindLabel),
+		)
+	default:
+		return check.NewCondition(
+			conditionType,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonConfigurationInvalid),
+			check.WithMessage(MsgMissingLabelInKueueNs, missingCount, kindLabel),
+			check.WithImpact(result.ImpactBlocking),
+			check.WithRemediation(remediationMissingLabelInKueueNs),
+		)
+	}
+}
+
+// kueueEnabledNamespaces returns the set of namespaces that have a kueue-managed label.
+// Uses two ListMetadata calls with label selectors for server-side filtering,
+// giving a fixed cost regardless of how many namespaces exist.
+func kueueEnabledNamespaces(
+	ctx context.Context,
+	r client.Reader,
+) (sets.Set[string], error) {
+	enabled := sets.New[string]()
+
+	for _, selector := range []string{
+		constants.LabelKueueManaged + "=true",
+		constants.LabelKueueOpenshiftManaged + "=true",
+	} {
+		items, err := r.ListMetadata(ctx, resources.Namespace,
+			client.WithLabelSelector(selector))
+		if err != nil {
+			return nil, fmt.Errorf("listing kueue-enabled namespaces: %w", err)
+		}
+
+		for _, ns := range items {
+			enabled.Insert(ns.GetName())
+		}
+	}
+
+	return enabled, nil
+}

--- a/pkg/lint/checks/workloads/notebook/constants.go
+++ b/pkg/lint/checks/workloads/notebook/constants.go
@@ -3,9 +3,6 @@ package notebook
 const (
 	// kind is the check kind for all notebook checks.
 	kind = "notebook"
-
-	// componentWorkbenches is the DSC component name used to check management state.
-	componentWorkbenches = "workbenches"
 )
 
 // Condition types reported by notebook checks.
@@ -17,6 +14,7 @@ const (
 	ConditionTypeHardwareProfileIntegrity     = "HardwareProfileIntegrity"
 	ConditionTypeNotebooksCompatible          = "NotebooksCompatible"
 	ConditionTypeKueueLabels                  = "KueueLabels"
+	ConditionTypeKueueMissingLabels           = "KueueMissingLabels"
 	ConditionTypeRunningWorkloads             = "RunningWorkloads"
 )
 
@@ -79,12 +77,6 @@ const (
 const (
 	MsgAllConnectionsValid = "All Notebook connections reference existing Secrets"
 	MsgConnectionsMissing  = "Found %d Notebook(s) referencing connection Secrets that do not exist on the cluster"
-)
-
-// Messages for KueueLabels check.
-const (
-	MsgAllKueueLabelsValid = "All Notebooks in kueue-enabled namespaces have the required queue label"
-	MsgKueueLabelsMissing  = "Found %d Notebook(s) in kueue-enabled namespaces missing the kueue.x-k8s.io/queue-name label"
 )
 
 // Messages for ContainerName check.

--- a/pkg/lint/checks/workloads/notebook/kueue_labels.go
+++ b/pkg/lint/checks/workloads/notebook/kueue_labels.go
@@ -1,144 +1,20 @@
 package notebook
 
 import (
-	"context"
-	"fmt"
-	"strconv"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
-// Kueue-specific label keys.
-const (
-	LabelKueueManaged          = "kueue-managed"
-	LabelKueueOpenshiftManaged = "kueue.openshift.io/managed"
-	LabelKueueQueueName        = "kueue.x-k8s.io/queue-name"
-)
-
-// KueueLabelsCheck verifies that Notebooks in kueue-enabled namespaces have the
-// required kueue queue label for workload scheduling.
-type KueueLabelsCheck struct {
-	check.BaseCheck
-}
-
-func NewKueueLabelsCheck() *KueueLabelsCheck {
-	return &KueueLabelsCheck{
-		BaseCheck: check.BaseCheck{
-			CheckGroup:       check.GroupWorkload,
-			Kind:             kind,
-			Type:             check.CheckTypeDataIntegrity,
-			CheckID:          "workloads.notebook.kueue-labels",
-			CheckName:        "Workloads :: Notebook :: Kueue Labels",
-			CheckDescription: "Verifies that Notebooks in kueue-enabled namespaces have the required kueue queue label for workload scheduling",
-			CheckRemediation: "Add the label kueue.x-k8s.io/queue-name: default to the affected Notebooks, or remove kueue labels from the namespace if kueue integration is not intended",
-		},
-	}
-}
-
-// CanApply returns whether this check should run for the given target.
-// Applies whenever Workbenches is Managed, regardless of version.
-func (c *KueueLabelsCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	return isWorkbenchesManaged(ctx, target)
-}
-
-// Validate lists Notebooks and checks that those in kueue-enabled namespaces have
-// the required kueue queue label.
-func (c *KueueLabelsCheck) Validate(
-	ctx context.Context,
-	target check.Target,
-) (*result.DiagnosticResult, error) {
-	return validate.WorkloadsMetadata(c, target, resources.Notebook).
-		Run(ctx, c.checkKueueLabels)
-}
-
-// checkKueueLabels cross-references notebook namespaces against kueue-enabled namespaces
-// and verifies that notebooks in those namespaces have the required queue label.
-func (c *KueueLabelsCheck) checkKueueLabels(
-	ctx context.Context,
-	req *validate.WorkloadRequest[*metav1.PartialObjectMetadata],
-) error {
-	dr := req.Result
-
-	// Collect unique namespaces from notebooks.
-	notebookNamespaces := sets.New[string]()
-	for _, nb := range req.Items {
-		notebookNamespaces.Insert(nb.GetNamespace())
-	}
-
-	// Build kueue-enabled namespace set by fetching metadata for each namespace.
-	kueueNamespaces := sets.New[string]()
-
-	for ns := range notebookNamespaces {
-		nsMeta, err := req.Client.GetResourceMetadata(ctx, resources.Namespace, ns)
-		if err != nil {
-			if client.IsResourceTypeNotFound(err) {
-				continue
-			}
-
-			return fmt.Errorf("getting namespace %s metadata: %w", ns, err)
-		}
-
-		if nsMeta == nil {
-			continue
-		}
-
-		labels := nsMeta.GetLabels()
-		if labels[LabelKueueManaged] == "true" || labels[LabelKueueOpenshiftManaged] == "true" {
-			kueueNamespaces.Insert(ns)
-		}
-	}
-
-	// Check notebooks in kueue-enabled namespaces for the required queue label.
-	impacted := make([]types.NamespacedName, 0)
-
-	for _, nb := range req.Items {
-		if !kueueNamespaces.Has(nb.GetNamespace()) {
-			continue
-		}
-
-		labels := nb.GetLabels()
-		queueName, ok := labels[LabelKueueQueueName]
-		if !ok || queueName == "" {
-			impacted = append(impacted, types.NamespacedName{
-				Namespace: nb.GetNamespace(),
-				Name:      nb.GetName(),
-			})
-		}
-	}
-
-	totalImpacted := len(impacted)
-	dr.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(totalImpacted)
-
-	dr.Status.Conditions = append(dr.Status.Conditions, c.newCondition(totalImpacted))
-	dr.SetImpactedObjects(resources.Notebook, impacted)
-
-	return nil
-}
-
-func (c *KueueLabelsCheck) newCondition(totalImpacted int) result.Condition {
-	if totalImpacted == 0 {
-		return check.NewCondition(
-			ConditionTypeKueueLabels,
-			metav1.ConditionTrue,
-			check.WithReason(check.ReasonRequirementsMet),
-			check.WithMessage(MsgAllKueueLabelsValid),
-		)
-	}
-
-	return check.NewCondition(
-		ConditionTypeKueueLabels,
-		metav1.ConditionFalse,
-		check.WithReason(check.ReasonConfigurationInvalid),
-		check.WithMessage(MsgKueueLabelsMissing, totalImpacted),
-		check.WithImpact(result.ImpactBlocking),
-		check.WithRemediation(c.CheckRemediation),
-	)
+func NewKueueLabelsCheck() *kueue.KueueLabelCheck {
+	return kueue.NewCheck(kueue.CheckConfig{
+		Kind:                      kind,
+		Component:                 constants.ComponentWorkbenches,
+		Resource:                  resources.Notebook,
+		ConditionType:             ConditionTypeKueueLabels,
+		MissingLabelConditionType: ConditionTypeKueueMissingLabels,
+		KindLabel:                 "Notebook",
+		CheckID:                   "workloads.notebook.kueue-labels",
+		CheckName:                 "Workloads :: Notebook :: Kueue Labels",
+	})
 }

--- a/pkg/lint/checks/workloads/notebook/utils.go
+++ b/pkg/lint/checks/workloads/notebook/utils.go
@@ -22,7 +22,7 @@ func isWorkbenchesManaged(ctx context.Context, target check.Target) (bool, error
 		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
-	return components.HasManagementState(dsc, componentWorkbenches, constants.ManagementStateManaged), nil
+	return components.HasManagementState(dsc, constants.ComponentWorkbenches, constants.ManagementStateManaged), nil
 }
 
 // NotebookContainer holds the parsed name and image of a container from a notebook spec.

--- a/pkg/lint/checks/workloads/ray/kueue_labels_raycluster.go
+++ b/pkg/lint/checks/workloads/ray/kueue_labels_raycluster.go
@@ -1,0 +1,25 @@
+package ray
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	ConditionTypeRayClusterKueueLabels        = "RayClusterKueueLabels"
+	ConditionTypeRayClusterKueueMissingLabels = "RayClusterKueueMissingLabels"
+)
+
+func NewKueueLabelsRayClusterCheck() *kueue.KueueLabelCheck {
+	return kueue.NewCheck(kueue.CheckConfig{
+		Kind:                      kind,
+		Component:                 constants.ComponentRay,
+		Resource:                  resources.RayCluster,
+		ConditionType:             ConditionTypeRayClusterKueueLabels,
+		MissingLabelConditionType: ConditionTypeRayClusterKueueMissingLabels,
+		KindLabel:                 "RayCluster",
+		CheckID:                   "workloads.ray.kueue-labels-raycluster",
+		CheckName:                 "Workloads :: Ray :: RayCluster Kueue Labels",
+	})
+}

--- a/pkg/lint/checks/workloads/ray/kueue_labels_raycluster_test.go
+++ b/pkg/lint/checks/workloads/ray/kueue_labels_raycluster_test.go
@@ -1,0 +1,264 @@
+package ray_test
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/ray"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var kueueLabelsRayClusterListKinds = map[schema.GroupVersionResource]string{
+	resources.RayCluster.GVR():         resources.RayCluster.ListKind(),
+	resources.Namespace.GVR():          resources.Namespace.ListKind(),
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newKueueNs(name string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{"name": name}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Namespace.APIVersion(),
+			"kind":       resources.Namespace.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func newRayCluster(name string, namespace string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.RayCluster.APIVersion(),
+			"kind":       resources.RayCluster.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestKueueLabelsRayClusterCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.ray.kueue-labels-raycluster"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: Ray :: RayCluster Kueue Labels"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.CheckKind()).To(Equal("ray"))
+	g.Expect(chk.CheckType()).To(Equal(string(check.CheckTypeDataIntegrity)))
+	g.Expect(chk.Remediation()).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+}
+
+func TestKueueLabelsRayClusterCheck_CanApply_RayManagedKueueManaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"ray": "Managed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestKueueLabelsRayClusterCheck_CanApply_RayManagedKueueRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"ray": "Managed", "kueue": "Removed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsRayClusterCheck_CanApply_RayRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"ray": "Removed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsRayClusterCheck_NoRayClusters(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(ray.ConditionTypeRayClusterKueueLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonRequirementsMet),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloads, "RayCluster")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(ray.ConditionTypeRayClusterKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "RayCluster")),
+	}))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsRayClusterCheck_WithoutQueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("plain-ns", nil)
+	rc := newRayCluster("my-rc", "plain-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rc},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "RayCluster")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "RayCluster")))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsRayClusterCheck_WithoutQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("kueue-ns", map[string]any{constants.LabelKueueManaged: "true"})
+	rc := newRayCluster("unlabeled-rc", "kueue-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rc},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "RayCluster")))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(ray.ConditionTypeRayClusterKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonConfigurationInvalid),
+		"Message": Equal(fmt.Sprintf(kueue.MsgMissingLabelInKueueNs, 1, "RayCluster")),
+	}))
+	g.Expect(result.Status.Conditions[1].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("unlabeled-rc"))
+}
+
+func TestKueueLabelsRayClusterCheck_WithQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("kueue-ns", map[string]any{constants.LabelKueueManaged: "true"})
+	rc := newRayCluster("good-rc", "kueue-ns", map[string]any{constants.LabelKueueQueueName: "default"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rc},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "RayCluster")))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsRayClusterCheck_LabeledInNonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("plain-ns", nil)
+	rc := newRayCluster("bad-rc", "plain-ns", map[string]any{constants.LabelKueueQueueName: "default"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayClusterListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rc},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayClusterCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "RayCluster")))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-rc"))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "RayCluster")))
+}

--- a/pkg/lint/checks/workloads/ray/kueue_labels_rayjob.go
+++ b/pkg/lint/checks/workloads/ray/kueue_labels_rayjob.go
@@ -1,0 +1,25 @@
+package ray
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	ConditionTypeRayJobKueueLabels        = "RayJobKueueLabels"
+	ConditionTypeRayJobKueueMissingLabels = "RayJobKueueMissingLabels"
+)
+
+func NewKueueLabelsRayJobCheck() *kueue.KueueLabelCheck {
+	return kueue.NewCheck(kueue.CheckConfig{
+		Kind:                      kind,
+		Component:                 constants.ComponentRay,
+		Resource:                  resources.RayJob,
+		ConditionType:             ConditionTypeRayJobKueueLabels,
+		MissingLabelConditionType: ConditionTypeRayJobKueueMissingLabels,
+		KindLabel:                 "RayJob",
+		CheckID:                   "workloads.ray.kueue-labels-rayjob",
+		CheckName:                 "Workloads :: Ray :: RayJob Kueue Labels",
+	})
+}

--- a/pkg/lint/checks/workloads/ray/kueue_labels_rayjob_test.go
+++ b/pkg/lint/checks/workloads/ray/kueue_labels_rayjob_test.go
@@ -1,0 +1,196 @@
+package ray_test
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/ray"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var kueueLabelsRayJobListKinds = map[schema.GroupVersionResource]string{
+	resources.RayJob.GVR():             resources.RayJob.ListKind(),
+	resources.Namespace.GVR():          resources.Namespace.ListKind(),
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newRayJob(name string, namespace string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.RayJob.APIVersion(),
+			"kind":       resources.RayJob.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestKueueLabelsRayJobCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.ray.kueue-labels-rayjob"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: Ray :: RayJob Kueue Labels"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.CheckKind()).To(Equal("ray"))
+	g.Expect(chk.Remediation()).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+}
+
+func TestKueueLabelsRayJobCheck_CanApply_RayManagedKueueManaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayJobListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"ray": "Managed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestKueueLabelsRayJobCheck_CanApply_RayRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayJobListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"ray": "Removed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsRayJobCheck_NoRayJobs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayJobListKinds,
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(ray.ConditionTypeRayJobKueueLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloads, "RayJob")),
+	}))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(ray.ConditionTypeRayJobKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "RayJob")),
+	}))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsRayJobCheck_WithQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("kueue-ns", map[string]any{constants.LabelKueueManaged: "true"})
+	rj := newRayJob("good-rj", "kueue-ns", map[string]any{constants.LabelKueueQueueName: "default"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rj},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "RayJob")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "RayJob")))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsRayJobCheck_LabeledInNonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("plain-ns", nil)
+	rj := newRayJob("bad-rj", "plain-ns", map[string]any{constants.LabelKueueQueueName: "default"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rj},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-rj"))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "RayJob")))
+}
+
+func TestKueueLabelsRayJobCheck_WithoutQueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNs("plain-ns", nil)
+	rj := newRayJob("unlabeled-rj", "plain-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsRayJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, rj},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := ray.NewKueueLabelsRayJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "RayJob")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "RayJob")))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}

--- a/pkg/lint/checks/workloads/trainingoperator/kueue_labels.go
+++ b/pkg/lint/checks/workloads/trainingoperator/kueue_labels.go
@@ -1,0 +1,25 @@
+package trainingoperator
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	ConditionTypePyTorchJobKueueLabels        = "PyTorchJobKueueLabels"
+	ConditionTypePyTorchJobKueueMissingLabels = "PyTorchJobKueueMissingLabels"
+)
+
+func NewKueueLabelsPyTorchJobCheck() *kueue.KueueLabelCheck {
+	return kueue.NewCheck(kueue.CheckConfig{
+		Kind:                      constants.ComponentTrainingOperator,
+		Component:                 constants.ComponentTrainingOperator,
+		Resource:                  resources.PyTorchJob,
+		ConditionType:             ConditionTypePyTorchJobKueueLabels,
+		MissingLabelConditionType: ConditionTypePyTorchJobKueueMissingLabels,
+		KindLabel:                 "PyTorchJob",
+		CheckID:                   "workloads.trainingoperator.kueue-labels-pytorchjob",
+		CheckName:                 "Workloads :: TrainingOperator :: PyTorchJob Kueue Labels",
+	})
+}

--- a/pkg/lint/checks/workloads/trainingoperator/kueue_labels_test.go
+++ b/pkg/lint/checks/workloads/trainingoperator/kueue_labels_test.go
@@ -1,0 +1,267 @@
+package trainingoperator_test
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kueue"
+	trainingoperator "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainingoperator"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var kueueLabelsPyTorchJobListKinds = map[schema.GroupVersionResource]string{
+	resources.PyTorchJob.GVR():         resources.PyTorchJob.ListKind(),
+	resources.Namespace.GVR():          resources.Namespace.ListKind(),
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newKueueNamespace(name string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{"name": name}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Namespace.APIVersion(),
+			"kind":       resources.Namespace.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func newPyTorchJob(name string, namespace string, labels map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(labels) > 0 {
+		metadata["labels"] = labels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.PyTorchJob.APIVersion(),
+			"kind":       resources.PyTorchJob.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestKueueLabelsPyTorchJobCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.trainingoperator.kueue-labels-pytorchjob"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: TrainingOperator :: PyTorchJob Kueue Labels"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.CheckKind()).To(Equal("trainingoperator"))
+	g.Expect(chk.CheckType()).To(Equal(string(check.CheckTypeDataIntegrity)))
+	g.Expect(chk.Remediation()).To(ContainSubstring("kueue.x-k8s.io/queue-name"))
+}
+
+func TestKueueLabelsPyTorchJobCheck_CanApply_TrainingOperatorManagedKueueManaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestKueueLabelsPyTorchJobCheck_CanApply_TrainingOperatorManagedKueueRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed", "kueue": "Removed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsPyTorchJobCheck_CanApply_TrainingOperatorRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Removed", "kueue": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestKueueLabelsPyTorchJobCheck_NoPyTorchJobs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainingoperator.ConditionTypePyTorchJobKueueLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonRequirementsMet),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloads, "PyTorchJob")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainingoperator.ConditionTypePyTorchJobKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Message": Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "PyTorchJob")),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsPyTorchJobCheck_WithoutQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("kueue-ns", map[string]any{constants.LabelKueueManaged: "true"})
+	job := newPyTorchJob("unlabeled-job", "kueue-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, job},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "PyTorchJob")))
+	g.Expect(result.Status.Conditions[1].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainingoperator.ConditionTypePyTorchJobKueueMissingLabels),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonConfigurationInvalid),
+		"Message": Equal(fmt.Sprintf(kueue.MsgMissingLabelInKueueNs, 1, "PyTorchJob")),
+	}))
+	g.Expect(result.Status.Conditions[1].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("unlabeled-job"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("kueue-ns"))
+}
+
+func TestKueueLabelsPyTorchJobCheck_LabeledInNonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("plain-ns", nil)
+	job := newPyTorchJob("bad-job", "plain-ns", map[string]any{constants.LabelKueueQueueName: "default"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, job},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNsNotKueueEnabled, 1, "PyTorchJob")))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "PyTorchJob")))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("bad-job"))
+}
+
+func TestKueueLabelsPyTorchJobCheck_WithQueueLabelInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("kueue-ns", map[string]any{constants.LabelKueueManaged: "true"})
+	job := newPyTorchJob("good-job", "kueue-ns", map[string]any{constants.LabelKueueQueueName: "default"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, job},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgAllValid, 1, "PyTorchJob")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgAllInKueueNsLabeled, 1, "PyTorchJob")))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestKueueLabelsPyTorchJobCheck_WithoutQueueLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newKueueNamespace("plain-ns", nil)
+	job := newPyTorchJob("my-job", "plain-ns", nil)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      kueueLabelsPyTorchJobListKinds,
+		Objects:        []*unstructured.Unstructured{ns, job},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trainingoperator.NewKueueLabelsPyTorchJobCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[0].Message).To(Equal(fmt.Sprintf(kueue.MsgNoLabeledWorkloads, "PyTorchJob")))
+	g.Expect(result.Status.Conditions[1].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Status.Conditions[1].Message).To(Equal(fmt.Sprintf(kueue.MsgNoWorkloadsInKueueNs, "PyTorchJob")))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -98,7 +98,7 @@ func NewCommand(
 	registry.MustRegister(certmanager.NewCheck())
 	registry.MustRegister(openshift.NewCheck())
 
-	// Workloads (20)
+	// Workloads (25)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
@@ -108,6 +108,8 @@ func NewCommand(
 	registry.MustRegister(kserveworkloads.NewAcceleratorMigrationCheck())
 	registry.MustRegister(kserveworkloads.NewHardwareProfileMigrationCheck())
 	registry.MustRegister(kserveworkloads.NewImpactedWorkloadsCheck())
+	registry.MustRegister(kserveworkloads.NewKueueLabelsISVCCheck())
+	registry.MustRegister(kserveworkloads.NewKueueLabelsLLMCheck())
 	registry.MustRegister(llamastackworkloads.NewConfigCheck())
 	registry.MustRegister(notebook.NewAcceleratorMigrationCheck())
 	registry.MustRegister(notebook.NewContainerNameCheck())
@@ -117,7 +119,10 @@ func NewCommand(
 	registry.MustRegister(notebook.NewKueueLabelsCheck())
 	registry.MustRegister(notebook.NewImpactedWorkloadsCheck())
 	registry.MustRegister(notebook.NewRunningWorkloadsCheck())
+	registry.MustRegister(ray.NewKueueLabelsRayClusterCheck())
+	registry.MustRegister(ray.NewKueueLabelsRayJobCheck())
 	registry.MustRegister(ray.NewImpactedWorkloadsCheck())
+	registry.MustRegister(trainingoperatorworkloads.NewKueueLabelsPyTorchJobCheck())
 	registry.MustRegister(trainingoperatorworkloads.NewImpactedWorkloadsCheck())
 
 	c := &Command{

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -227,6 +227,14 @@ var (
 		Resource: "rayclusters",
 	}
 
+	// RayJob is the Ray RayJob resource.
+	RayJob = ResourceType{
+		Group:    "ray.io",
+		Version:  "v1",
+		Kind:     "RayJob",
+		Resource: "rayjobs",
+	}
+
 	// PyTorchJob is the Kubeflow Training PyTorchJob resource.
 	PyTorchJob = ResourceType{
 		Group:    "kubeflow.org",

--- a/pkg/util/kube/annotations.go
+++ b/pkg/util/kube/annotations.go
@@ -33,7 +33,28 @@ func GetAnnotation(obj client.Object, key string) string {
 	return annotations[key]
 }
 
-// HasAnnotation checks if a Kubernetes object has a specific annotation matching the given value.
+// HasAnnotation checks if a Kubernetes object has a specific annotation with the given key
+// and that its value matches the expected value.
 func HasAnnotation(obj client.Object, key string, value string) bool {
-	return GetAnnotation(obj, key) == value
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	v, ok := annotations[key]
+
+	return ok && v == value
+}
+
+// ContainsAnnotation checks if a Kubernetes object has an annotation with the given key,
+// regardless of its value (including empty string).
+func ContainsAnnotation(obj client.Object, key string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, ok := annotations[key]
+
+	return ok
 }

--- a/pkg/util/kube/annotations_test.go
+++ b/pkg/util/kube/annotations_test.go
@@ -196,6 +196,15 @@ func TestHasAnnotation(t *testing.T) {
 			value:    "",
 			expected: true,
 		},
+		{
+			name: "key absent checking for empty value returns false",
+			annotations: map[string]string{
+				"other.key": "value",
+			},
+			key:      "test.key",
+			value:    "",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/kube/labels.go
+++ b/pkg/util/kube/labels.go
@@ -1,0 +1,40 @@
+package kube
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// GetLabel returns the value of a label on a Kubernetes object.
+// Returns empty string if the label doesn't exist or labels map is nil.
+func GetLabel(obj client.Object, key string) string {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return ""
+	}
+
+	return labels[key]
+}
+
+// HasLabel checks if a Kubernetes object has a specific label with the given key
+// and that its value matches the expected value.
+func HasLabel(obj client.Object, key string, value string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+
+	v, ok := labels[key]
+
+	return ok && v == value
+}
+
+// ContainsLabel checks if a Kubernetes object has a label with the given key,
+// regardless of its value (including empty string).
+func ContainsLabel(obj client.Object, key string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+
+	_, ok := labels[key]
+
+	return ok
+}

--- a/pkg/util/kube/labels_test.go
+++ b/pkg/util/kube/labels_test.go
@@ -1,0 +1,64 @@
+package kube_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHasLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("label present with matching value", func(t *testing.T) {
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app": "test"},
+			},
+		}
+
+		g.Expect(kube.HasLabel(obj, "app", "test")).To(BeTrue())
+	})
+
+	t.Run("label present with non-matching value", func(t *testing.T) {
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app": "other"},
+			},
+		}
+
+		g.Expect(kube.HasLabel(obj, "app", "test")).To(BeFalse())
+	})
+
+	t.Run("label present with empty value checking for empty", func(t *testing.T) {
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app": ""},
+			},
+		}
+
+		g.Expect(kube.HasLabel(obj, "app", "")).To(BeTrue())
+	})
+
+	t.Run("label absent checking for empty value", func(t *testing.T) {
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"other": "value"},
+			},
+		}
+
+		g.Expect(kube.HasLabel(obj, "app", "")).To(BeFalse())
+	})
+
+	t.Run("nil labels map", func(t *testing.T) {
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{},
+		}
+
+		g.Expect(kube.HasLabel(obj, "app", "")).To(BeFalse())
+	})
+}


### PR DESCRIPTION
Extend the kueue queue-name label validation to InferenceService,
LLMInferenceService, RayCluster, RayJob, and PyTorchJob workloads.
Checks verify that workloads with the kueue.x-k8s.io/queue-name label
are in kueue-enabled namespaces, and are only active when both the
owning component and Kueue are enabled on the DSC.

Also introduces shared validation logic in workloads/kueue/support.go,
AddCondition/SetConditions helpers on DiagnosticResult, and
GetLabel/HasLabel utilities in pkg/util/kube.

<img width="1197" height="373" alt="image" src="https://github.com/user-attachments/assets/4f666c69-e4fb-47fd-a880-1d4494208eb3" />
