### PR TITLE
feat: add spec-based image lookup for disconnected cluster support

### DIFF
--- a/pkg/lint/checks/workloads/notebook/impacted.go
+++ b/pkg/lint/checks/workloads/notebook/impacted.go
@@ -424,6 +424,7 @@ func (c *ImpactedWorkloadsCheck) analyzeNotebook(
 // 1. dockerImageReference: Exact match against .status.tags[*].items[*].dockerImageReference
 // 2. SHA lookup: Match SHA against .status.tags[*].items[*].image
 // 3. dockerImageRepository: Match path against .status.dockerImageRepository (internal registry)
+// 4. spec from.name: Exact match against .spec.tags[*].from.name (disconnected clusters)
 // If none match, the image is classified as CUSTOM (user-provided image requiring manual verification).
 func (c *ImpactedWorkloadsCheck) analyzeImage(
 	ctx context.Context,
@@ -499,6 +500,29 @@ func (c *ImpactedWorkloadsCheck) analyzeImage(
 	}
 
 	log.logf("[notebook]     Strategy 3 (dockerImageRepo): no match for path=%s", ref.FullPath)
+
+	// Strategy 4: spec from.name lookup - exact match against source image references.
+	// Handles disconnected clusters where .status.tags[*].items is null (import failed)
+	// but .spec.tags[*].from.name still contains the operator-configured references.
+	lookup = c.findImageStreamBySpecRef(image, imageStreamData)
+	if lookup.Found {
+		ootbIS, isOOTB := ootbImages[lookup.ImageStreamName]
+		if isOOTB {
+			log.logf("[notebook]     Strategy 4 (specRef) matched: is=%s tag=%s type=%s",
+				lookup.ImageStreamName, lookup.Tag, ootbIS.Type)
+
+			return c.analyzeOOTBImage(ctx, reader, ootbImageInput{
+				ImageStreamName: lookup.ImageStreamName,
+				Tag:             lookup.Tag,
+				SHA:             ref.SHA,
+				Type:            ootbIS.Type,
+			}, imageStreamData, appNS, log)
+		}
+
+		log.logf("[notebook]     Strategy 4 matched is=%s but not in OOTB map", lookup.ImageStreamName)
+	}
+
+	log.logf("[notebook]     Strategy 4 (specRef): no match for image=%s", image)
 
 	// No OOTB correlation found - mark as custom image requiring user verification.
 	// We intentionally do NOT use name-based matching as a fallback because an image
@@ -667,6 +691,55 @@ func (c *ImpactedWorkloadsCheck) findImageStreamByDockerRepo(
 	}
 
 	return ootbImageStream{}, false
+}
+
+// findImageStreamBySpecRef searches all ImageStreams for an exact match of the
+// container image against .spec.tags[*].from.name (the source DockerImage reference).
+// This handles disconnected clusters where .status.tags[*].items may be null due to
+// failed imports, but .spec always contains the operator-configured source references.
+func (c *ImpactedWorkloadsCheck) findImageStreamBySpecRef(
+	imageRef string,
+	imageStreams []*unstructured.Unstructured,
+) imageLookupResult {
+	if imageRef == "" {
+		return imageLookupResult{}
+	}
+
+	for _, is := range imageStreams {
+		isName := is.GetName()
+
+		specTags, err := jq.Query[[]any](is, ".spec.tags")
+		if err != nil {
+			continue
+		}
+
+		for _, tagData := range specTags {
+			tagMap, ok := tagData.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			tagName, _ := tagMap["name"].(string)
+
+			fromMap, ok := tagMap["from"].(map[string]any)
+			if !ok {
+				continue
+			}
+
+			fromKind, _ := fromMap["kind"].(string)
+			fromName, _ := fromMap["name"].(string)
+
+			if fromKind == "DockerImage" && fromName == imageRef {
+				return imageLookupResult{
+					ImageStreamName: isName,
+					Tag:             tagName,
+					Found:           true,
+				}
+			}
+		}
+	}
+
+	return imageLookupResult{}
 }
 
 // aggregateImageAnalyses combines individual image analyses into a notebook analysis.

--- a/pkg/lint/checks/workloads/notebook/impacted_test.go
+++ b/pkg/lint/checks/workloads/notebook/impacted_test.go
@@ -83,6 +83,11 @@ const (
 	jupyterExternalCompatible      = externalRegistry + "/odh-" + isJupyterDatascience + "@" + shaCompatible
 	codeserverExternalIncompatible = externalRegistry + "/odh-" + isCodeserverDatascience + "@" + shaIncompatible
 
+	// Strategy 4: Spec from.name exact match (disconnected cluster).
+	// These are the source references stored in .spec.tags[*].from.name.
+	specRefJupyterCompatible      = externalRegistry + "/odh-" + isJupyterDatascience + "@" + shaCompatible
+	specRefCodeserverIncompatible = externalRegistry + "/odh-" + isCodeserverDatascience + "@" + shaIncompatible
+
 	// Custom images - should NOT match any OOTB ImageStream.
 	customImageTag = "quay.io/myorg/custom-image:v1.0"
 	customImageSHA = "quay.io/myorg/custom-image@" + shaCustom
@@ -159,6 +164,21 @@ func newImageStream(name string, nbType string) *unstructured.Unstructured {
 				"tags": []any{
 					map[string]any{
 						"name": tagCurrent,
+						"from": map[string]any{
+							"kind": "DockerImage",
+							"name": externalImageBase + "@" + shaCompatible,
+						},
+						"annotations": map[string]any{
+							"opendatahub.io/notebook-python-dependencies": pythonDeps,
+							"opendatahub.io/notebook-software":            software,
+						},
+					},
+					map[string]any{
+						"name": tagPrevious,
+						"from": map[string]any{
+							"kind": "DockerImage",
+							"name": externalImageBase + "@" + shaIncompatible,
+						},
 						"annotations": map[string]any{
 							"opendatahub.io/notebook-python-dependencies": pythonDeps,
 							"opendatahub.io/notebook-software":            software,
@@ -224,6 +244,82 @@ func newUserContributedImageStream(name string) *unstructured.Unstructured {
 								"dockerImageReference": "quay.io/user/" + name + "@" + shaUserContributed,
 							},
 						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newDisconnectedImageStream creates an ImageStream simulating a disconnected cluster.
+// - Has OOTB metadata (labels, platform.opendatahub.io/version annotation)
+// - Has spec.tags with from: {kind: "DockerImage", name: "<full-ref>"} entries
+// - Has status.dockerImageRepository: "" (empty - internal registry disabled)
+// - Has status.tags with items: null (import failed on disconnected cluster).
+func newDisconnectedImageStream(name string, nbType string) *unstructured.Unstructured {
+	var pythonDeps, software string
+
+	switch nbType {
+	case "jupyter":
+		pythonDeps = `[{"name":"jupyterlab","version":"4.0"}]`
+	case "codeserver":
+		software = `[{"name":"code-server","version":"4.0"}]`
+	case "rstudio":
+		software = `[{"name":"R","version":"4.0"}]`
+	}
+
+	externalImageBase := externalRegistry + "/odh-" + name
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.ImageStream.APIVersion(),
+			"kind":       resources.ImageStream.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "redhat-ods-applications",
+				"labels": map[string]any{
+					"app.kubernetes.io/part-of": "workbenches",
+				},
+				"annotations": map[string]any{
+					"platform.opendatahub.io/version": "2.25.1",
+				},
+			},
+			"spec": map[string]any{
+				"tags": []any{
+					map[string]any{
+						"name": tagCurrent,
+						"from": map[string]any{
+							"kind": "DockerImage",
+							"name": externalImageBase + "@" + shaCompatible,
+						},
+						"annotations": map[string]any{
+							"opendatahub.io/notebook-python-dependencies": pythonDeps,
+							"opendatahub.io/notebook-software":            software,
+						},
+					},
+					map[string]any{
+						"name": tagPrevious,
+						"from": map[string]any{
+							"kind": "DockerImage",
+							"name": externalImageBase + "@" + shaIncompatible,
+						},
+						"annotations": map[string]any{
+							"opendatahub.io/notebook-python-dependencies": pythonDeps,
+							"opendatahub.io/notebook-software":            software,
+						},
+					},
+				},
+			},
+			"status": map[string]any{
+				"dockerImageRepository": "",
+				"tags": []any{
+					map[string]any{
+						"tag":   tagCurrent,
+						"items": nil,
+					},
+					map[string]any{
+						"tag":   tagPrevious,
+						"items": nil,
 					},
 				},
 			},
@@ -636,10 +732,11 @@ func TestImpactedWorkloadsCheck_AnnotationTargetVersion(t *testing.T) {
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationCheckTargetVersion, "3.0.0"))
 }
 
-// TestImpactedWorkloadsCheck_LookupStrategies tests all three image lookup strategies:
+// TestImpactedWorkloadsCheck_LookupStrategies tests all five image lookup strategies:
 // 1. dockerImageReference - exact match against .status.tags[*].items[*].dockerImageReference
 // 2. SHA lookup - match SHA against .status.tags[*].items[*].image
-// 3. dockerImageRepository - match path against .status.dockerImageRepository.
+// 3. dockerImageRepository - match path against .status.dockerImageRepository
+// 4. spec from.name - exact match against .spec.tags[*].from.name (disconnected clusters).
 func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -732,6 +829,47 @@ func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: check.ReasonWorkloadsImpacted,
 			expectedImpact: resultpkg.ImpactBlocking,
+		},
+
+		// Strategy 4: spec from.name - exact match against .spec.tags[*].from.name (disconnected clusters)
+		{
+			name:        "Strategy4_SpecRef_Compliant",
+			description: "Disconnected cluster: spec from.name match (Jupyter compatible)",
+			image:       specRefJupyterCompatible,
+			objects: func() []*unstructured.Unstructured {
+				return []*unstructured.Unstructured{
+					newDisconnectedImageStream(isJupyterDatascience, "jupyter"),
+				}
+			},
+			expectedStatus: metav1.ConditionTrue,
+			expectedReason: check.ReasonVersionCompatible,
+			expectedImpact: resultpkg.ImpactNone,
+		},
+		{
+			name:        "Strategy4_SpecRef_NonCompliant",
+			description: "Disconnected cluster: spec from.name match (CodeServer old tag)",
+			image:       specRefCodeserverIncompatible,
+			objects: func() []*unstructured.Unstructured {
+				return []*unstructured.Unstructured{
+					newDisconnectedImageStream(isCodeserverDatascience, "codeserver"),
+				}
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: check.ReasonWorkloadsImpacted,
+			expectedImpact: resultpkg.ImpactBlocking,
+		},
+		{
+			name:        "Strategy4_SpecRef_NoMatch",
+			description: "Disconnected cluster: image not in spec from.name - falls through to CUSTOM",
+			image:       externalRegistry + "/odh-" + isJupyterDatascience + "@" + shaUnknown,
+			objects: func() []*unstructured.Unstructured {
+				return []*unstructured.Unstructured{
+					newDisconnectedImageStream(isJupyterDatascience, "jupyter"),
+				}
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: check.ReasonWorkloadsImpacted,
+			expectedImpact: resultpkg.ImpactAdvisory, // Falls through to CUSTOM
 		},
 
 		// Non-OOTB images - should be classified as CUSTOM


### PR DESCRIPTION
## Description

On disconnected clusters with the internal image registry disabled, the existing image lookup strategies can all fail:

- Strategies 1-2 (status dockerImageReference / SHA match) depend on .status.tags[*].items, which is null when ImageStream imports fail.
- Strategy 3 (status dockerImageRepository path match) depends on .status.dockerImageRepository, which is empty when the internal registry is disabled.

This causes OOTB notebook images to be misclassified as CUSTOM, producing false positives in the impacted workloads check.

Add Strategy 4: match the container image against
.spec.tags[*].from.name (the source DockerImage reference). Unlike status fields, spec.tags are always populated by the operator regardless of import or registry state.

Note: the notebooks.opendatahub.io/last-image-selection annotation was considered as an additional fallback strategy but intentionally excluded. The annotation is a point-in-time record set by the Dashboard when a notebook is created. If the image is later changed programmatically (e.g. via GitOps or kubectl), the annotation becomes stale while still referencing the original ImageStream. This would produce false compatibility results — reporting an image as compatible when the actual running image may not be — which is the exact class of false positive this check must avoid.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## How Has This Been Tested?

executed `./bin/kubectl-odh lint --checks "*notebook*" --target-version 3.3 --debug` against a variety of clusters and verified correct/expected classifications of notebooks.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved image reference detection in Notebook workload analysis for disconnected cluster environments. The tool now includes an additional lookup strategy for images referenced in specifications, enabling proper identification when standard registry-based lookups are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->