### PR TITLE
chore: leverage ForComponent in notebooks checks

### DIFF
--- a/pkg/lint/check/executor.go
+++ b/pkg/lint/check/executor.go
@@ -132,66 +132,7 @@ func (e *Executor) executeCheck(ctx context.Context, target Target, check Check)
 
 	// If check returned an error, create a diagnostic result with error condition
 	if err != nil {
-		var message string
-		var reason string
-
-		// Handle specific error types
-		switch {
-		case apierrors.IsForbidden(err):
-			reason = ReasonAPIAccessDenied
-			message = "Insufficient permissions to access cluster resources"
-			// Log to stderr if verbose
-			if e.io != nil {
-				e.io.Errorf("Permission denied: %s - Check: %s", message, check.Name())
-			}
-		case apierrors.IsUnauthorized(err):
-			reason = ReasonAPIAccessDenied
-			message = "Authentication required to access cluster resources"
-			// Log to stderr if verbose
-			if e.io != nil {
-				e.io.Errorf("Unauthorized: %s - Check: %s", message, check.Name())
-			}
-		case apierrors.IsTimeout(err):
-			reason = ReasonCheckExecutionFailed
-			message = "Request timed out"
-		case apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err):
-			reason = ReasonCheckExecutionFailed
-			message = "API server is unavailable or overloaded"
-		default:
-			reason = ReasonCheckExecutionFailed
-		}
-
-		errorResult := result.New(
-			string(check.Group()),
-			check.CheckKind(),
-			check.CheckType(),
-			check.Description(),
-		)
-
-		var condition result.Condition
-		if reason == ReasonCheckExecutionFailed && message == "" {
-			condition = NewCondition(
-				ConditionTypeValidated,
-				metav1.ConditionUnknown,
-				WithReason(reason),
-				WithMessage("Check execution failed: %v", err),
-			)
-		} else {
-			condition = NewCondition(
-				ConditionTypeValidated,
-				metav1.ConditionUnknown,
-				WithReason(reason),
-				WithMessage("%s", message),
-			)
-		}
-
-		errorResult.Status.Conditions = []result.Condition{condition}
-
-		return CheckExecution{
-			Check:  check,
-			Result: errorResult,
-			Error:  err,
-		}
+		return e.buildValidateError(check, err)
 	}
 
 	// Validate the result
@@ -222,5 +163,70 @@ func (e *Executor) executeCheck(ctx context.Context, target Target, check Check)
 		Check:  check,
 		Result: checkResult,
 		Error:  nil,
+	}
+}
+
+// buildValidateError creates a CheckExecution for a Validate error,
+// classifying the error into an appropriate reason and message.
+func (e *Executor) buildValidateError(check Check, err error) CheckExecution {
+	var message string
+	var reason string
+
+	// Handle specific error types
+	switch {
+	case apierrors.IsForbidden(err):
+		reason = ReasonAPIAccessDenied
+		message = "Insufficient permissions to access cluster resources"
+
+		if e.io != nil {
+			e.io.Errorf("Permission denied: %s - Check: %s", message, check.Name())
+		}
+	case apierrors.IsUnauthorized(err):
+		reason = ReasonAPIAccessDenied
+		message = "Authentication required to access cluster resources"
+
+		if e.io != nil {
+			e.io.Errorf("Unauthorized: %s - Check: %s", message, check.Name())
+		}
+	case apierrors.IsTimeout(err):
+		reason = ReasonCheckExecutionFailed
+		message = "Request timed out"
+	case apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err):
+		reason = ReasonCheckExecutionFailed
+		message = "API server is unavailable or overloaded"
+	default:
+		reason = ReasonCheckExecutionFailed
+	}
+
+	errorResult := result.New(
+		string(check.Group()),
+		check.CheckKind(),
+		check.CheckType(),
+		check.Description(),
+	)
+
+	var condition result.Condition
+	if reason == ReasonCheckExecutionFailed && message == "" {
+		condition = NewCondition(
+			ConditionTypeValidated,
+			metav1.ConditionUnknown,
+			WithReason(reason),
+			WithMessage("Check execution failed: %v", err),
+		)
+	} else {
+		condition = NewCondition(
+			ConditionTypeValidated,
+			metav1.ConditionUnknown,
+			WithReason(reason),
+			WithMessage("%s", message),
+		)
+	}
+
+	errorResult.Status.Conditions = []result.Condition{condition}
+
+	return CheckExecution{
+		Check:  check,
+		Result: errorResult,
+		Error:  err,
 	}
 }

--- a/pkg/lint/check/executor.go
+++ b/pkg/lint/check/executor.go
@@ -218,7 +218,7 @@ func (e *Executor) buildValidateError(check Check, err error) CheckExecution {
 			ConditionTypeValidated,
 			metav1.ConditionUnknown,
 			WithReason(reason),
-			WithMessage("%s", message),
+			WithMessage("%s: %v", message, err),
 		)
 	}
 

--- a/pkg/lint/check/executor.go
+++ b/pkg/lint/check/executor.go
@@ -83,7 +83,9 @@ func (e *Executor) executeChecks(ctx context.Context, target Target, checks []Ch
 
 		// Execute check sequentially
 		exec := e.executeCheck(ctx, target, check)
-		results = append(results, exec)
+		if exec.Result != nil {
+			results = append(results, exec)
+		}
 	}
 
 	return results
@@ -122,6 +124,11 @@ func (e *Executor) executeCheck(ctx context.Context, target Target, check Check)
 	}
 
 	checkResult, err := check.Validate(ctx, target)
+
+	// Nil result signals the check should be silently skipped.
+	if err == nil && checkResult == nil {
+		return CheckExecution{Check: check}
+	}
 
 	// If check returned an error, create a diagnostic result with error condition
 	if err != nil {

--- a/pkg/lint/check/validate/workload.go
+++ b/pkg/lint/check/validate/workload.go
@@ -97,7 +97,7 @@ func (b *WorkloadBuilder[T]) Filter(fn func(T) (bool, error)) *WorkloadBuilder[T
 // ForComponent specifies the DSC component(s) this workload check requires.
 // If set, Run() verifies at least one component is not in "Removed" state
 // before listing resources. If all components are Removed (or DSC is not found),
-// a passing result is returned indicating no validation is needed.
+// Run returns nil, causing the check to be silently skipped in output.
 // Multiple names use OR semantics (at least one must be active).
 func (b *WorkloadBuilder[T]) ForComponent(names ...string) *WorkloadBuilder[T] {
 	b.componentNames = names
@@ -124,13 +124,13 @@ func (b *WorkloadBuilder[T]) Run(
 
 	// Check component state precondition if ForComponent was called.
 	if len(b.componentNames) > 0 {
-		earlyResult, err := b.checkComponentState(ctx, dr)
+		active, err := b.checkComponentState(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		if earlyResult != nil {
-			return earlyResult, nil
+		if !active {
+			return nil, nil
 		}
 	}
 
@@ -180,41 +180,26 @@ func (b *WorkloadBuilder[T]) Run(
 }
 
 // checkComponentState verifies at least one component is not in Removed state.
-// Returns (result, nil) if validation should short-circuit, or (nil, nil) to continue.
-func (b *WorkloadBuilder[T]) checkComponentState(
-	ctx context.Context,
-	dr *result.DiagnosticResult,
-) (*result.DiagnosticResult, error) {
+// Returns (true, nil) if at least one component is active, or (false, nil) if
+// all components are Removed or the DSC is not found.
+func (b *WorkloadBuilder[T]) checkComponentState(ctx context.Context) (bool, error) {
 	dsc, err := client.GetDataScienceCluster(ctx, b.target.Client)
 	switch {
 	case apierrors.IsNotFound(err):
-		dr.SetCondition(check.NewCondition(
-			check.ConditionTypeAvailable,
-			metav1.ConditionFalse,
-			check.WithReason(check.ReasonResourceNotFound),
-			check.WithMessage("No DataScienceCluster found"),
-		))
-
-		return dr, nil
+		return false, nil
 	case err != nil:
-		return nil, fmt.Errorf("getting DataScienceCluster: %w", err)
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
-	// Check if at least one component is active (not Removed).
+	// At least one component must be active (not Removed).
 	for _, name := range b.componentNames {
 		if !components.HasManagementState(dsc, name, constants.ManagementStateRemoved) {
-			return nil, nil
+			return true, nil
 		}
 	}
 
-	// All components are Removed - skip workload validation.
-	dr.SetCondition(check.NewCondition(
-		check.ConditionTypeConfigured,
-		metav1.ConditionTrue,
-		check.WithReason(check.ReasonRequirementsMet),
-	))
-
-	return dr, nil
+	// All components are Removed.
+	return false, nil
 }
 
 // Complete is a convenience alternative to Run for checks that only need to set conditions.

--- a/pkg/lint/check/validate/workload_test.go
+++ b/pkg/lint/check/validate/workload_test.go
@@ -585,7 +585,7 @@ func TestWorkloadBuilder_Complete_ErrorPropagated(t *testing.T) {
 	g.Expect(err).To(MatchError(expectedErr))
 }
 
-func TestWorkloadBuilder_ForComponent_RemovedReturnsPassingResult(t *testing.T) {
+func TestWorkloadBuilder_ForComponent_RemovedSkips(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
@@ -621,13 +621,8 @@ func TestWorkloadBuilder_ForComponent_RemovedReturnsPassingResult(t *testing.T) 
 		})
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(dr).ToNot(BeNil())
+	g.Expect(dr).To(BeNil())
 	g.Expect(validationCalled).To(BeFalse())
-	g.Expect(dr.Status.Conditions).To(HaveLen(1))
-	g.Expect(dr.Status.Conditions[0].Type).To(Equal(check.ConditionTypeConfigured))
-	g.Expect(dr.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-	g.Expect(dr.Status.Conditions[0].Reason).To(Equal(check.ReasonRequirementsMet))
-	g.Expect(dr.Annotations).To(HaveKeyWithValue(check.AnnotationCheckTargetVersion, "3.0.0"))
 }
 
 func TestWorkloadBuilder_ForComponent_ManagedProceedsNormally(t *testing.T) {
@@ -719,12 +714,8 @@ func TestWorkloadBuilder_ForComponent_DSCNotFound(t *testing.T) {
 		})
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(dr).ToNot(BeNil())
+	g.Expect(dr).To(BeNil())
 	g.Expect(validationCalled).To(BeFalse())
-	g.Expect(dr.Status.Conditions).To(HaveLen(1))
-	g.Expect(dr.Status.Conditions[0].Type).To(Equal(check.ConditionTypeAvailable))
-	g.Expect(dr.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-	g.Expect(dr.Status.Conditions[0].Reason).To(Equal(check.ReasonResourceNotFound))
 }
 
 func TestWorkloadBuilder_ForComponent_MultipleComponentsORSemantics(t *testing.T) {

--- a/pkg/lint/checks/workloads/notebook/accelerator_migration.go
+++ b/pkg/lint/checks/workloads/notebook/accelerator_migration.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
@@ -34,13 +35,9 @@ func NewAcceleratorMigrationCheck() *AcceleratorMigrationCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Only applies when upgrading from 2.x to 3.x and Workbenches is Managed.
-func (c *AcceleratorMigrationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
-		return false, nil
-	}
-
-	return isWorkbenchesManaged(ctx, target)
+// Only applies when upgrading from 2.x to 3.x; component state is checked via ForComponent in Validate.
+func (c *AcceleratorMigrationCheck) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
 }
 
 // Validate executes the check against the provided target.
@@ -49,6 +46,7 @@ func (c *AcceleratorMigrationCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.WorkloadsMetadata(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Run(ctx, c.checkAcceleratorRefs)
 }
 

--- a/pkg/lint/checks/workloads/notebook/accelerator_migration_test.go
+++ b/pkg/lint/checks/workloads/notebook/accelerator_migration_test.go
@@ -32,7 +32,7 @@ func TestAcceleratorMigrationCheck_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications")},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications")},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -61,7 +61,7 @@ func TestAcceleratorMigrationCheck_NotebookWithoutAcceleratorProfile(t *testing.
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications"), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -106,7 +106,7 @@ func TestAcceleratorMigrationCheck_NotebookWithExistingAcceleratorProfile(t *tes
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), nb, profile},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications"), nb, profile},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -145,7 +145,7 @@ func TestAcceleratorMigrationCheck_NotebookWithMissingAcceleratorProfile(t *test
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications"), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -204,7 +204,7 @@ func TestAcceleratorMigrationCheck_MixedNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), nb1, nb2, nb3, profile},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications"), nb1, nb2, nb3, profile},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -247,12 +247,11 @@ func TestAcceleratorMigrationCheck_CanApply_NilVersions(t *testing.T) {
 	g.Expect(canApply).To(BeFalse())
 }
 
-func TestAcceleratorMigrationCheck_CanApply_LintMode2x(t *testing.T) {
+func TestAcceleratorMigrationCheck_CanApply_SameVersion(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "2.17.0",
 	})
@@ -263,12 +262,11 @@ func TestAcceleratorMigrationCheck_CanApply_LintMode2x(t *testing.T) {
 	g.Expect(canApply).To(BeFalse())
 }
 
-func TestAcceleratorMigrationCheck_CanApply_UpgradeTo3x_Managed(t *testing.T) {
+func TestAcceleratorMigrationCheck_CanApply_UpgradeTo3x(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -279,45 +277,13 @@ func TestAcceleratorMigrationCheck_CanApply_UpgradeTo3x_Managed(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
-func TestAcceleratorMigrationCheck_CanApply_UpgradeTo3x_Removed(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewAcceleratorMigrationCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
-}
-
-func TestAcceleratorMigrationCheck_CanApply_LintMode3x(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
-		CurrentVersion: "3.0.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewAcceleratorMigrationCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
-}
-
 func TestAcceleratorMigrationCheck_AnnotationTargetVersion(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications")},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications")},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -355,7 +321,7 @@ func TestAcceleratorMigrationCheck_DefaultNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      acceleratorListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), nb, profile},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI("redhat-ods-applications"), nb, profile},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/connection_integrity.go
+++ b/pkg/lint/checks/workloads/notebook/connection_integrity.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
@@ -40,9 +41,9 @@ func NewConnectionIntegrityCheck() *ConnectionIntegrityCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Applies whenever Workbenches is Managed, regardless of version.
-func (c *ConnectionIntegrityCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	return isWorkbenchesManaged(ctx, target)
+// Applies regardless of version; component state is checked via ForComponent in Validate.
+func (c *ConnectionIntegrityCheck) CanApply(_ context.Context, _ check.Target) (bool, error) {
+	return true, nil
 }
 
 // Validate lists Notebooks with the connections annotation and verifies that each
@@ -52,6 +53,7 @@ func (c *ConnectionIntegrityCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.WorkloadsMetadata(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Run(ctx, c.checkConnections)
 }
 

--- a/pkg/lint/checks/workloads/notebook/connection_integrity_test.go
+++ b/pkg/lint/checks/workloads/notebook/connection_integrity_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -23,6 +24,10 @@ var connIntegrityListKinds = map[schema.GroupVersionResource]string{
 	resources.Notebook.GVR():           resources.Notebook.ListKind(),
 	resources.Secret.GVR():             resources.Secret.ListKind(),
 	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func workbenchesDSC(state string) *unstructured.Unstructured {
+	return testutil.NewDSC(map[string]string{"workbenches": state})
 }
 
 func newSecret(name, namespace string) *unstructured.Unstructured {
@@ -67,13 +72,46 @@ func TestConnectionIntegrityCheck_CanApply(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
+func TestConnectionIntegrityCheck_Validate_SkipWhenDSCMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      connIntegrityListKinds,
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewConnectionIntegrityCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
+}
+
+func TestConnectionIntegrityCheck_Validate_SkipWhenWorkbenchesRemoved(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      connIntegrityListKinds,
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateRemoved)},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewConnectionIntegrityCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
+}
+
 func TestConnectionIntegrityCheck_NoNotebooks(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged)},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -102,7 +140,7 @@ func TestConnectionIntegrityCheck_NotebookWithoutConnectionAnnotation(t *testing
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -131,7 +169,7 @@ func TestConnectionIntegrityCheck_AllSecretsExist(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb, secret1, secret2},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb, secret1, secret2},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -157,7 +195,7 @@ func TestConnectionIntegrityCheck_SecretMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -196,7 +234,7 @@ func TestConnectionIntegrityCheck_OneOfMultipleSecretsMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb, secret},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb, secret},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -236,7 +274,7 @@ func TestConnectionIntegrityCheck_MixedNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), secret, nbGood, nbPlain, nbBroken},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), secret, nbGood, nbPlain, nbBroken},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -266,7 +304,7 @@ func TestConnectionIntegrityCheck_SecretInWrongNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), secret, nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), secret, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -293,7 +331,7 @@ func TestConnectionIntegrityCheck_NotebookFlaggedOnlyOnce(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -312,7 +350,7 @@ func TestConnectionIntegrityCheck_AnnotationTargetVersion(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged)},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/connection_integrity_test.go
+++ b/pkg/lint/checks/workloads/notebook/connection_integrity_test.go
@@ -52,12 +52,11 @@ func TestConnectionIntegrityCheck_Metadata(t *testing.T) {
 	g.Expect(chk.Remediation()).To(ContainSubstring("missing connection Secret"))
 }
 
-func TestConnectionIntegrityCheck_CanApply_WorkbenchesManaged(t *testing.T) {
+func TestConnectionIntegrityCheck_CanApply(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -68,28 +67,13 @@ func TestConnectionIntegrityCheck_CanApply_WorkbenchesManaged(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
-func TestConnectionIntegrityCheck_CanApply_WorkbenchesRemoved(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
-		CurrentVersion: "3.0.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewConnectionIntegrityCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
-}
-
 func TestConnectionIntegrityCheck_NoNotebooks(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -118,7 +102,7 @@ func TestConnectionIntegrityCheck_NotebookWithoutConnectionAnnotation(t *testing
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -147,7 +131,7 @@ func TestConnectionIntegrityCheck_AllSecretsExist(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb, secret1, secret2},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb, secret1, secret2},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -173,7 +157,7 @@ func TestConnectionIntegrityCheck_SecretMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -212,7 +196,7 @@ func TestConnectionIntegrityCheck_OneOfMultipleSecretsMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb, secret},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb, secret},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -252,7 +236,7 @@ func TestConnectionIntegrityCheck_MixedNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{secret, nbGood, nbPlain, nbBroken},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), secret, nbGood, nbPlain, nbBroken},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -282,7 +266,7 @@ func TestConnectionIntegrityCheck_SecretInWrongNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{secret, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), secret, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -309,7 +293,7 @@ func TestConnectionIntegrityCheck_NotebookFlaggedOnlyOnce(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -328,6 +312,7 @@ func TestConnectionIntegrityCheck_AnnotationTargetVersion(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      connIntegrityListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/container_name.go
+++ b/pkg/lint/checks/workloads/notebook/container_name.go
@@ -3,6 +3,7 @@ package notebook
 import (
 	"context"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
@@ -33,9 +34,9 @@ func NewContainerNameCheck() *ContainerNameCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Applies in all modes when Workbenches is Managed.
-func (c *ContainerNameCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	return isWorkbenchesManaged(ctx, target)
+// Applies regardless of version; component state is checked via ForComponent in Validate.
+func (c *ContainerNameCheck) CanApply(_ context.Context, _ check.Target) (bool, error) {
+	return true, nil
 }
 
 // Validate executes the check against the provided target.
@@ -44,6 +45,7 @@ func (c *ContainerNameCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.Workloads(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Filter(hasDashboardAnnotationAndNameMismatch).
 		Complete(ctx, c.newContainerNameCondition)
 }

--- a/pkg/lint/checks/workloads/notebook/container_name_test.go
+++ b/pkg/lint/checks/workloads/notebook/container_name_test.go
@@ -76,7 +76,7 @@ func TestContainerNameCheck_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        nil,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -106,7 +106,7 @@ func TestContainerNameCheck_MatchingContainerName(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -136,7 +136,7 @@ func TestContainerNameCheck_MismatchedContainerName(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -168,7 +168,7 @@ func TestContainerNameCheck_NoDashboardAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -198,7 +198,7 @@ func TestContainerNameCheck_SizeSelectionAnnotationMismatch(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -230,7 +230,7 @@ func TestContainerNameCheck_SizeSelectionAnnotationMatching(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -272,7 +272,7 @@ func TestContainerNameCheck_MixedNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nbMatching, nbMismatched, nbSizeOnly, nbNoDashboard},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nbMatching, nbMismatched, nbSizeOnly, nbNoDashboard},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -305,7 +305,7 @@ func TestContainerNameCheck_WithOAuthProxy(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -325,12 +325,11 @@ func TestContainerNameCheck_WithOAuthProxy(t *testing.T) {
 	g.Expect(result.ImpactedObjects).To(HaveLen(1))
 }
 
-func TestContainerNameCheck_CanApply_Managed(t *testing.T) {
+func TestContainerNameCheck_CanApply(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -339,22 +338,6 @@ func TestContainerNameCheck_CanApply_Managed(t *testing.T) {
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeTrue())
-}
-
-func TestContainerNameCheck_CanApply_Removed(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      containerNameListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewContainerNameCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
 }
 
 func TestContainerNameCheck_Metadata(t *testing.T) {

--- a/pkg/lint/checks/workloads/notebook/hardware_profile_integrity.go
+++ b/pkg/lint/checks/workloads/notebook/hardware_profile_integrity.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
@@ -39,9 +40,9 @@ func NewHardwareProfileIntegrityCheck() *HardwareProfileIntegrityCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Applies whenever Workbenches is Managed, regardless of version.
-func (c *HardwareProfileIntegrityCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	return isWorkbenchesManaged(ctx, target)
+// Applies regardless of version; component state is checked via ForComponent in Validate.
+func (c *HardwareProfileIntegrityCheck) CanApply(_ context.Context, _ check.Target) (bool, error) {
+	return true, nil
 }
 
 // Validate lists Notebooks with hardware profile annotations and checks that each
@@ -51,6 +52,7 @@ func (c *HardwareProfileIntegrityCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.WorkloadsMetadata(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Run(ctx, c.checkHardwareProfiles)
 }
 

--- a/pkg/lint/checks/workloads/notebook/hardware_profile_integrity_test.go
+++ b/pkg/lint/checks/workloads/notebook/hardware_profile_integrity_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -77,13 +78,30 @@ func TestHardwareProfileIntegrityCheck_CanApply(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
+func TestHardwareProfileIntegrityCheck_Validate_SkipWhenWorkbenchesRemoved(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      hwpIntegrityListKinds,
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateRemoved)},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewHardwareProfileIntegrityCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
+}
+
 func TestHardwareProfileIntegrityCheck_NoNotebooks(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged)},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -112,7 +130,7 @@ func TestHardwareProfileIntegrityCheck_NotebookWithoutHWPAnnotation(t *testing.T
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -153,7 +171,7 @@ func TestHardwareProfileIntegrityCheck_ProfileExists(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, nb, profile},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), crd, nb, profile},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -183,7 +201,7 @@ func TestHardwareProfileIntegrityCheck_ProfileMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), crd, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -245,7 +263,7 @@ func TestHardwareProfileIntegrityCheck_MixedExistingAndMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, profile, nbGood, nbPlain, nbBroken},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), crd, profile, nbGood, nbPlain, nbBroken},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -294,7 +312,7 @@ func TestHardwareProfileIntegrityCheck_WrongNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, profile, nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), crd, profile, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -349,7 +367,7 @@ func TestHardwareProfileIntegrityCheck_ProfileExistsV1Alpha1(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, nb, profile},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), crd, nb, profile},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -370,7 +388,7 @@ func TestHardwareProfileIntegrityCheck_AnnotationTargetVersion(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged)},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/hardware_profile_integrity_test.go
+++ b/pkg/lint/checks/workloads/notebook/hardware_profile_integrity_test.go
@@ -62,45 +62,12 @@ func TestHardwareProfileIntegrityCheck_Metadata(t *testing.T) {
 	g.Expect(chk.Remediation()).To(ContainSubstring("missing HardwareProfile"))
 }
 
-func TestHardwareProfileIntegrityCheck_CanApply_WorkbenchesManaged(t *testing.T) {
+func TestHardwareProfileIntegrityCheck_CanApply(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "3.0.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewHardwareProfileIntegrityCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeTrue())
-}
-
-func TestHardwareProfileIntegrityCheck_CanApply_WorkbenchesRemoved(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
-		CurrentVersion: "3.0.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewHardwareProfileIntegrityCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
-}
-
-func TestHardwareProfileIntegrityCheck_CanApply_UpgradeMode(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
-		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
 
@@ -116,6 +83,7 @@ func TestHardwareProfileIntegrityCheck_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -144,7 +112,7 @@ func TestHardwareProfileIntegrityCheck_NotebookWithoutHWPAnnotation(t *testing.T
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -185,7 +153,7 @@ func TestHardwareProfileIntegrityCheck_ProfileExists(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{crd, nb, profile},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, nb, profile},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -215,7 +183,7 @@ func TestHardwareProfileIntegrityCheck_ProfileMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{crd, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -277,7 +245,7 @@ func TestHardwareProfileIntegrityCheck_MixedExistingAndMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{crd, profile, nbGood, nbPlain, nbBroken},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, profile, nbGood, nbPlain, nbBroken},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -326,7 +294,7 @@ func TestHardwareProfileIntegrityCheck_WrongNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{crd, profile, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, profile, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -381,7 +349,7 @@ func TestHardwareProfileIntegrityCheck_ProfileExistsV1Alpha1(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
-		Objects:        []*unstructured.Unstructured{crd, nb, profile},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), crd, nb, profile},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -402,6 +370,7 @@ func TestHardwareProfileIntegrityCheck_AnnotationTargetVersion(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/hardwareprofile_migration.go
+++ b/pkg/lint/checks/workloads/notebook/hardwareprofile_migration.go
@@ -35,9 +35,9 @@ func NewHardwareProfileMigrationCheck() *HardwareProfileMigrationCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Applies whenever Workbenches is Managed.
-func (c *HardwareProfileMigrationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	return isWorkbenchesManaged(ctx, target)
+// Applies regardless of version; component state is checked via ForComponent in Validate.
+func (c *HardwareProfileMigrationCheck) CanApply(_ context.Context, _ check.Target) (bool, error) {
+	return true, nil
 }
 
 // Validate executes the check against the provided target.
@@ -46,6 +46,7 @@ func (c *HardwareProfileMigrationCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.WorkloadsMetadata(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Filter(hasLegacyHardwareProfileAnnotation).
 		Complete(ctx, c.newCondition)
 }

--- a/pkg/lint/checks/workloads/notebook/hardwareprofile_migration_test.go
+++ b/pkg/lint/checks/workloads/notebook/hardwareprofile_migration_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -29,7 +30,7 @@ func TestHardwareProfileMigration_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged)},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -57,7 +58,7 @@ func TestHardwareProfileMigration_NotebookWithoutAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -88,7 +89,7 @@ func TestHardwareProfileMigration_NotebookWithEmptyAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -119,7 +120,7 @@ func TestHardwareProfileMigration_NotebookWithAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -166,7 +167,7 @@ func TestHardwareProfileMigration_MixedNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb1, nb2, nb3},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb1, nb2, nb3},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -199,6 +200,39 @@ func TestHardwareProfileMigration_CanApply(t *testing.T) {
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeTrue())
+}
+
+func TestHardwareProfileMigration_Validate_SkipWhenDSCMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      hardwareProfileListKinds,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewHardwareProfileMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
+}
+
+func TestHardwareProfileMigration_Validate_SkipWhenWorkbenchesRemoved(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      hardwareProfileListKinds,
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateRemoved)},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewHardwareProfileMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
 }
 
 func TestHardwareProfileMigration_Metadata(t *testing.T) {

--- a/pkg/lint/checks/workloads/notebook/hardwareprofile_migration_test.go
+++ b/pkg/lint/checks/workloads/notebook/hardwareprofile_migration_test.go
@@ -29,6 +29,7 @@ func TestHardwareProfileMigration_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -56,7 +57,7 @@ func TestHardwareProfileMigration_NotebookWithoutAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -87,7 +88,7 @@ func TestHardwareProfileMigration_NotebookWithEmptyAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -118,7 +119,7 @@ func TestHardwareProfileMigration_NotebookWithAnnotation(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -165,7 +166,7 @@ func TestHardwareProfileMigration_MixedNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hardwareProfileListKinds,
-		Objects:        []*unstructured.Unstructured{nb1, nb2, nb3},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb1, nb2, nb3},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -187,32 +188,17 @@ func TestHardwareProfileMigration_MixedNotebooks(t *testing.T) {
 	g.Expect(result.ImpactedObjects).To(HaveLen(2))
 }
 
-func TestHardwareProfileMigration_CanApply_Managed(t *testing.T) {
+func TestHardwareProfileMigration_CanApply(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds: hardwareProfileListKinds,
-		Objects:   []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 	})
 
 	chk := notebook.NewHardwareProfileMigrationCheck()
 	canApply, err := chk.CanApply(t.Context(), target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeTrue())
-}
-
-func TestHardwareProfileMigration_CanApply_Removed(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds: hardwareProfileListKinds,
-		Objects:   []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
-	})
-
-	chk := notebook.NewHardwareProfileMigrationCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
 }
 
 func TestHardwareProfileMigration_Metadata(t *testing.T) {

--- a/pkg/lint/checks/workloads/notebook/impacted.go
+++ b/pkg/lint/checks/workloads/notebook/impacted.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
@@ -191,13 +192,9 @@ func imageStatusLabel(status string) string {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Only applies when upgrading FROM 2.x TO 3.x and Workbenches is Managed.
-func (c *ImpactedWorkloadsCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
-		return false, nil
-	}
-
-	return isWorkbenchesManaged(ctx, target)
+// Only applies when upgrading FROM 2.x TO 3.x; component state is checked via ForComponent in Validate.
+func (c *ImpactedWorkloadsCheck) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
 }
 
 // Validate executes the check against the provided target.
@@ -206,6 +203,7 @@ func (c *ImpactedWorkloadsCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.Workloads(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Run(ctx, func(ctx context.Context, req *validate.WorkloadRequest[*unstructured.Unstructured]) error {
 			return c.analyzeNotebooks(ctx, req)
 		})

--- a/pkg/lint/checks/workloads/notebook/impacted_test.go
+++ b/pkg/lint/checks/workloads/notebook/impacted_test.go
@@ -359,6 +359,7 @@ func TestImpactedWorkloadsCheck_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -473,7 +474,7 @@ func TestImpactedWorkloadsCheck_SingleNotebook(t *testing.T) {
 			g := NewWithT(t)
 			ctx := t.Context()
 
-			objects := append(tc.objects(), testutil.NewDSCI(applicationsNS))
+			objects := append(tc.objects(), testutil.NewDSC(map[string]string{"workbenches": "Managed"}), testutil.NewDSCI(applicationsNS))
 
 			target := testutil.NewTarget(t, testutil.TargetConfig{
 				ListKinds:      listKinds,
@@ -577,6 +578,7 @@ func TestImpactedWorkloadsCheck_MultiContainer(t *testing.T) {
 
 			objects := tc.objects()
 			objects = append(objects,
+				testutil.NewDSC(map[string]string{"workbenches": "Managed"}),
 				newNotebookWithContainers("multi-nb", "test-ns", tc.containers),
 				testutil.NewDSCI(applicationsNS),
 			)
@@ -622,6 +624,7 @@ func TestImpactedWorkloadsCheck_MixedNotebooks(t *testing.T) {
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds: listKinds,
 		Objects: []*unstructured.Unstructured{
+			testutil.NewDSC(map[string]string{"workbenches": "Managed"}),
 			testutil.NewDSCI(applicationsNS),
 			jupyterIS, rstudioIS, rstudioISTBad, jupyterNb, rstudioNb,
 		},
@@ -663,35 +666,24 @@ func TestImpactedWorkloadsCheck_CanApply(t *testing.T) {
 		name           string
 		currentVersion string
 		targetVersion  string
-		workbenches    string
 		expected       bool
 	}{
 		{
 			name:           "LintMode_SameVersion",
 			currentVersion: "2.17.0",
 			targetVersion:  "2.17.0",
-			workbenches:    "Managed",
 			expected:       false,
 		},
 		{
-			name:           "Upgrade2xTo3x_Managed",
+			name:           "Upgrade2xTo3x",
 			currentVersion: "2.17.0",
 			targetVersion:  "3.0.0",
-			workbenches:    "Managed",
 			expected:       true,
-		},
-		{
-			name:           "Upgrade2xTo3x_Removed",
-			currentVersion: "2.17.0",
-			targetVersion:  "3.0.0",
-			workbenches:    "Removed",
-			expected:       false,
 		},
 		{
 			name:           "Upgrade3xTo3x",
 			currentVersion: "3.0.0",
 			targetVersion:  "3.1.0",
-			workbenches:    "Managed",
 			expected:       false,
 		},
 	}
@@ -702,7 +694,6 @@ func TestImpactedWorkloadsCheck_CanApply(t *testing.T) {
 
 			target := testutil.NewTarget(t, testutil.TargetConfig{
 				ListKinds:      listKinds,
-				Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": tc.workbenches})},
 				CurrentVersion: tc.currentVersion,
 				TargetVersion:  tc.targetVersion,
 			})
@@ -721,6 +712,7 @@ func TestImpactedWorkloadsCheck_AnnotationTargetVersion(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -954,6 +946,7 @@ func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 
 			objects := tc.objects()
 			objects = append(objects,
+				testutil.NewDSC(map[string]string{"workbenches": "Managed"}),
 				newNotebookWithImage("test-nb", "test-ns", tc.image),
 				testutil.NewDSCI(applicationsNS),
 			)
@@ -1038,6 +1031,7 @@ func TestImpactedWorkloadsCheck_InfrastructureContainerFiltering(t *testing.T) {
 			ctx := t.Context()
 
 			objects := []*unstructured.Unstructured{
+				testutil.NewDSC(map[string]string{"workbenches": "Managed"}),
 				testutil.NewDSCI(applicationsNS),
 				newImageStream(isJupyterDatascience, "jupyter"),
 				newNotebookWithContainers("test-nb", "test-ns", tc.containers),

--- a/pkg/lint/checks/workloads/notebook/kueue_labels_test.go
+++ b/pkg/lint/checks/workloads/notebook/kueue_labels_test.go
@@ -129,6 +129,7 @@ func TestKueueLabelsCheck_NoNotebooks(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -163,7 +164,7 @@ func TestKueueLabelsCheck_NotebookWithoutQueueLabel(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), ns, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -196,7 +197,7 @@ func TestKueueLabelsCheck_NotebookWithQueueLabelInKueueNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), ns, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -225,7 +226,7 @@ func TestKueueLabelsCheck_NotebookWithoutQueueLabelInKueueNamespace(t *testing.T
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), ns, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -347,7 +348,7 @@ func TestKueueLabelsCheck_OpenshiftKueueNamespaceLabel(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), ns, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -380,7 +381,7 @@ func TestKueueLabelsCheck_NotebookWithCustomQueueName(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
-		Objects:        []*unstructured.Unstructured{ns, nb},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), ns, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -403,6 +404,7 @@ func TestKueueLabelsCheck_AnnotationTargetVersion(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      kueueLabelsListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/running_workloads.go
+++ b/pkg/lint/checks/workloads/notebook/running_workloads.go
@@ -5,6 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
@@ -33,13 +34,9 @@ func NewRunningWorkloadsCheck() *RunningWorkloadsCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// Only applies when upgrading from 2.x to 3.x and Workbenches is Managed.
-func (c *RunningWorkloadsCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
-		return false, nil
-	}
-
-	return isWorkbenchesManaged(ctx, target)
+// Only applies when upgrading from 2.x to 3.x; component state is checked via ForComponent in Validate.
+func (c *RunningWorkloadsCheck) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
 }
 
 // Validate lists all Notebooks and reports an advisory for any that are not stopped.
@@ -48,6 +45,7 @@ func (c *RunningWorkloadsCheck) Validate(
 	target check.Target,
 ) (*result.DiagnosticResult, error) {
 	return validate.WorkloadsMetadata(c, target, resources.Notebook).
+		ForComponent(constants.ComponentWorkbenches).
 		Filter(isRunning).
 		Complete(ctx, c.newRunningWorkloadsCondition)
 }

--- a/pkg/lint/checks/workloads/notebook/running_workloads_test.go
+++ b/pkg/lint/checks/workloads/notebook/running_workloads_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -78,13 +79,46 @@ func TestRunningWorkloadsCheck_CanApply_UpgradeTo3x(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
+func TestRunningWorkloadsCheck_Validate_SkipWhenDSCMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      runningWorkloadsListKinds,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewRunningWorkloadsCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
+}
+
+func TestRunningWorkloadsCheck_Validate_SkipWhenWorkbenchesRemoved(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      runningWorkloadsListKinds,
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateRemoved)},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewRunningWorkloadsCheck()
+	result, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(BeNil())
+}
+
 func TestRunningWorkloadsCheck_NoNotebooks(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged)},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -123,7 +157,7 @@ func TestRunningWorkloadsCheck_AllStopped(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb1, nb2},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb1, nb2},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -152,7 +186,7 @@ func TestRunningWorkloadsCheck_OneRunning(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nbRunning},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nbRunning},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -199,7 +233,7 @@ func TestRunningWorkloadsCheck_MixedRunningAndStopped(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nbStopped, nbRunning1, nbRunning2},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nbStopped, nbRunning1, nbRunning2},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -230,7 +264,7 @@ func TestRunningWorkloadsCheck_AllRunning(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb1, nb2, nb3},
+		Objects:        []*unstructured.Unstructured{workbenchesDSC(constants.ManagementStateManaged), nb1, nb2, nb3},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/running_workloads_test.go
+++ b/pkg/lint/checks/workloads/notebook/running_workloads_test.go
@@ -48,12 +48,11 @@ func TestRunningWorkloadsCheck_CanApply_NilVersions(t *testing.T) {
 	g.Expect(canApply).To(BeFalse())
 }
 
-func TestRunningWorkloadsCheck_CanApply_LintMode2x(t *testing.T) {
+func TestRunningWorkloadsCheck_CanApply_SameVersion(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "2.17.0",
 	})
@@ -64,12 +63,11 @@ func TestRunningWorkloadsCheck_CanApply_LintMode2x(t *testing.T) {
 	g.Expect(canApply).To(BeFalse())
 }
 
-func TestRunningWorkloadsCheck_CanApply_UpgradeTo3x_Managed(t *testing.T) {
+func TestRunningWorkloadsCheck_CanApply_UpgradeTo3x(t *testing.T) {
 	g := NewWithT(t)
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -80,44 +78,13 @@ func TestRunningWorkloadsCheck_CanApply_UpgradeTo3x_Managed(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
-func TestRunningWorkloadsCheck_CanApply_UpgradeTo3x_Removed(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Removed"})},
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewRunningWorkloadsCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
-}
-
-func TestRunningWorkloadsCheck_CanApply_LintMode3x(t *testing.T) {
-	g := NewWithT(t)
-
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
-		CurrentVersion: "3.0.0",
-		TargetVersion:  "3.0.0",
-	})
-
-	chk := notebook.NewRunningWorkloadsCheck()
-	canApply, err := chk.CanApply(t.Context(), target)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(canApply).To(BeFalse())
-}
-
 func TestRunningWorkloadsCheck_NoNotebooks(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"})},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -156,7 +123,7 @@ func TestRunningWorkloadsCheck_AllStopped(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{nb1, nb2},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb1, nb2},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -185,7 +152,7 @@ func TestRunningWorkloadsCheck_OneRunning(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{nbRunning},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nbRunning},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -232,7 +199,7 @@ func TestRunningWorkloadsCheck_MixedRunningAndStopped(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{nbStopped, nbRunning1, nbRunning2},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nbStopped, nbRunning1, nbRunning2},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -263,7 +230,7 @@ func TestRunningWorkloadsCheck_AllRunning(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      runningWorkloadsListKinds,
-		Objects:        []*unstructured.Unstructured{nb1, nb2, nb3},
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"workbenches": "Managed"}), nb1, nb2, nb3},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/workloads/notebook/utils.go
+++ b/pkg/lint/checks/workloads/notebook/utils.go
@@ -7,24 +7,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/opendatahub-io/odh-cli/pkg/constants"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
-
-// isWorkbenchesManaged returns true when the Workbenches component is set to Managed on the DSC.
-// Used as the common precondition for all notebook checks.
-func isWorkbenchesManaged(ctx context.Context, target check.Target) (bool, error) {
-	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
-	if err != nil {
-		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
-	}
-
-	return components.HasManagementState(dsc, constants.ComponentWorkbenches, constants.ManagementStateManaged), nil
-}
 
 // NotebookContainer holds the parsed name and image of a container from a notebook spec.
 type NotebookContainer struct {


### PR DESCRIPTION
## Description

#29 introduced a nice abstraction to remove some boilerplate logic required of each component
- DSC lookup
- Component managementState check

This PR updates all notebooks checks to now define 'ForComponent` on its WorkloadBuilder chain and, as a result, removes the now-dead code that was previously handled at the component level.

Additionally, based on talks in a [private slack channel](https://redhat-internal.slack.com/archives/C09TK95JP4M/p1772113075397909), we want to revise the logic behind ForComponent to not emit any output when a component is Removed. Previously, when ForComponent detected all specified components in Removed state (or DSC not found), it emitted a passing result with a Configured=True condition. This meant checks still appeared in output, adding noise for components the user has explicitly disabled.

Change ForComponent's short-circuit to return nil instead of a passing result, and teach the executor to treat a nil Validate result as a silent skip — the same behavior as when CanApply() returns false.

## How Has This Been Tested?
executed `./bin/kubectl-odh lint --checks "*notebook*" --target-version 3.3 --verbose --debug` against a variety of clusters and verified correct/expected classifications of notebooks.


## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checks now silently skip when related components are missing or removed; API errors are classified with clearer diagnostic messages (timeouts, auth, service errors).

* **Refactor**
  * Centralized validation/error handling and moved component gating into validation flow for more consistent behavior.

* **Tests**
  * Updated and consolidated tests and test data to reflect new validation and skip semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->