### PR TITLE
fix: resolve HardwareProfile API version from CRD storage version

### DIFF
--- a/pkg/lint/checks/workloads/notebook/hardware_profile_integrity.go
+++ b/pkg/lint/checks/workloads/notebook/hardware_profile_integrity.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -94,23 +95,23 @@ func (c *HardwareProfileIntegrityCheck) checkHardwareProfiles(
 	}
 
 	// Build HardwareProfile cache scoped to only the namespaces referenced by notebooks.
+	// Skip CRD resolution entirely when no notebooks reference a HardwareProfile,
+	// avoiding unnecessary API calls that may fail for RBAC-limited users.
 	profileCache := sets.New[types.NamespacedName]()
 
-	for ns := range targetNamespaces {
-		profiles, err := req.Client.ListMetadata(ctx, resources.InfrastructureHardwareProfile, client.WithNamespace(ns))
-		if err != nil {
-			if client.IsResourceTypeNotFound(err) {
-				continue
-			}
-
-			return fmt.Errorf("listing HardwareProfiles in namespace %s: %w", ns, err)
+	if len(referenced) > 0 {
+		// Resolve the HardwareProfile API version from the CRD's storage version.
+		hwpResource, resolveErr := resolveResourceType(ctx, req.Client, resources.InfrastructureHardwareProfile)
+		if resolveErr != nil && !apierrors.IsNotFound(resolveErr) {
+			return fmt.Errorf("resolving HardwareProfile version: %w", resolveErr)
 		}
 
-		for _, p := range profiles {
-			profileCache.Insert(types.NamespacedName{
-				Namespace: p.GetNamespace(),
-				Name:      p.GetName(),
-			})
+		// If CRD not found (IsNotFound): hwpResource is zero, skip listing below.
+		// profileCache stays empty → all HWP references flagged as missing (correct).
+		if resolveErr == nil {
+			if err := populateProfileCache(ctx, req.Client, hwpResource, targetNamespaces, profileCache); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -131,6 +132,35 @@ func (c *HardwareProfileIntegrityCheck) checkHardwareProfiles(
 
 	dr.Status.Conditions = append(dr.Status.Conditions, c.newCondition(totalImpacted))
 	dr.SetImpactedObjects(resources.Notebook, impacted)
+
+	return nil
+}
+
+// populateProfileCache lists HardwareProfiles in each target namespace and inserts them into the cache.
+func populateProfileCache(
+	ctx context.Context,
+	reader client.Reader,
+	hwpResource resources.ResourceType,
+	targetNamespaces sets.Set[string],
+	profileCache sets.Set[types.NamespacedName],
+) error {
+	for ns := range targetNamespaces {
+		profiles, err := reader.ListMetadata(ctx, hwpResource, client.WithNamespace(ns))
+		if err != nil {
+			if client.IsResourceTypeNotFound(err) {
+				continue
+			}
+
+			return fmt.Errorf("listing HardwareProfiles in namespace %s: %w", ns, err)
+		}
+
+		for _, p := range profiles {
+			profileCache.Insert(types.NamespacedName{
+				Namespace: p.GetNamespace(),
+				Name:      p.GetName(),
+			})
+		}
+	}
 
 	return nil
 }

--- a/pkg/lint/checks/workloads/notebook/hardware_profile_integrity_test.go
+++ b/pkg/lint/checks/workloads/notebook/hardware_profile_integrity_test.go
@@ -23,6 +23,29 @@ var hwpIntegrityListKinds = map[schema.GroupVersionResource]string{
 	resources.Notebook.GVR():                      resources.Notebook.ListKind(),
 	resources.InfrastructureHardwareProfile.GVR(): resources.InfrastructureHardwareProfile.ListKind(),
 	resources.DataScienceCluster.GVR():            resources.DataScienceCluster.ListKind(),
+	resources.CustomResourceDefinition.GVR():      resources.CustomResourceDefinition.ListKind(),
+}
+
+func newHardwareProfileCRD(storageVersion string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.CustomResourceDefinition.APIVersion(),
+			"kind":       resources.CustomResourceDefinition.Kind,
+			"metadata": map[string]any{
+				"name": "hardwareprofiles.infrastructure.opendatahub.io",
+			},
+			"spec": map[string]any{
+				"group": "infrastructure.opendatahub.io",
+				"versions": []any{
+					map[string]any{
+						"name":    storageVersion,
+						"served":  true,
+						"storage": true,
+					},
+				},
+			},
+		},
+	}
 }
 
 func TestHardwareProfileIntegrityCheck_Metadata(t *testing.T) {
@@ -140,6 +163,8 @@ func TestHardwareProfileIntegrityCheck_ProfileExists(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
+	crd := newHardwareProfileCRD("v1")
+
 	profile := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resources.InfrastructureHardwareProfile.APIVersion(),
@@ -160,7 +185,7 @@ func TestHardwareProfileIntegrityCheck_ProfileExists(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb, profile},
+		Objects:        []*unstructured.Unstructured{crd, nb, profile},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -179,6 +204,8 @@ func TestHardwareProfileIntegrityCheck_ProfileMissing(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
+	crd := newHardwareProfileCRD("v1")
+
 	nb := newNotebook("broken-notebook", "user-ns", notebookOptions{
 		Annotations: map[string]any{
 			notebook.AnnotationHardwareProfileName:      "missing-profile",
@@ -188,7 +215,7 @@ func TestHardwareProfileIntegrityCheck_ProfileMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{nb},
+		Objects:        []*unstructured.Unstructured{crd, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -215,6 +242,8 @@ func TestHardwareProfileIntegrityCheck_ProfileMissing(t *testing.T) {
 func TestHardwareProfileIntegrityCheck_MixedExistingAndMissing(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
+
+	crd := newHardwareProfileCRD("v1")
 
 	profile := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -248,7 +277,7 @@ func TestHardwareProfileIntegrityCheck_MixedExistingAndMissing(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{profile, nbGood, nbPlain, nbBroken},
+		Objects:        []*unstructured.Unstructured{crd, profile, nbGood, nbPlain, nbBroken},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -274,6 +303,8 @@ func TestHardwareProfileIntegrityCheck_WrongNamespace(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
+	crd := newHardwareProfileCRD("v1")
+
 	// Profile exists but in a different namespace
 	profile := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -295,7 +326,7 @@ func TestHardwareProfileIntegrityCheck_WrongNamespace(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      hwpIntegrityListKinds,
-		Objects:        []*unstructured.Unstructured{profile, nb},
+		Objects:        []*unstructured.Unstructured{crd, profile, nb},
 		CurrentVersion: "3.0.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -307,6 +338,62 @@ func TestHardwareProfileIntegrityCheck_WrongNamespace(t *testing.T) {
 	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
 	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
+func TestHardwareProfileIntegrityCheck_ProfileExistsV1Alpha1(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// CRD reports v1alpha1 as the storage version (RHOAI 2.25.x clusters).
+	crd := newHardwareProfileCRD("v1alpha1")
+
+	hwpV1Alpha1 := resources.ResourceType{
+		Group:    "infrastructure.opendatahub.io",
+		Version:  "v1alpha1",
+		Kind:     "HardwareProfile",
+		Resource: "hardwareprofiles",
+	}
+
+	profile := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": hwpV1Alpha1.APIVersion(),
+			"kind":       hwpV1Alpha1.Kind,
+			"metadata": map[string]any{
+				"name":      "gpu-large",
+				"namespace": "opendatahub",
+			},
+		},
+	}
+
+	nb := newNotebook("gpu-notebook", "user-ns", notebookOptions{
+		Annotations: map[string]any{
+			notebook.AnnotationHardwareProfileName:      "gpu-large",
+			notebook.AnnotationHardwareProfileNamespace: "opendatahub",
+		},
+	})
+
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.Notebook.GVR():                 resources.Notebook.ListKind(),
+		hwpV1Alpha1.GVR():                        hwpV1Alpha1.ListKind(),
+		resources.DataScienceCluster.GVR():       resources.DataScienceCluster.ListKind(),
+		resources.CustomResourceDefinition.GVR(): resources.CustomResourceDefinition.ListKind(),
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{crd, nb, profile},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := notebook.NewHardwareProfileIntegrityCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
 }
 
 func TestHardwareProfileIntegrityCheck_AnnotationTargetVersion(t *testing.T) {

--- a/pkg/lint/checks/workloads/notebook/utils.go
+++ b/pkg/lint/checks/workloads/notebook/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
@@ -78,4 +79,48 @@ func IsInfrastructureContainer(containerName string, image string) bool {
 	}
 
 	return false
+}
+
+// resolveResourceType queries the CRD for the given ResourceType and returns
+// a copy with Version set to the cluster's storage version.
+// Returns an error if the CRD cannot be read or has no storage version.
+func resolveResourceType(
+	ctx context.Context,
+	c client.Reader,
+	rt resources.ResourceType,
+) (resources.ResourceType, error) {
+	crdName := rt.Resource + "." + rt.Group
+
+	crd, err := c.Get(ctx, resources.CustomResourceDefinition.GVR(), crdName)
+	if err != nil {
+		return resources.ResourceType{}, fmt.Errorf("getting CRD %s: %w", crdName, err)
+	}
+
+	if crd == nil {
+		// Reader.Get returns nil (no error) for permission errors
+		return resources.ResourceType{}, fmt.Errorf("unable to read CRD %s: insufficient permissions", crdName)
+	}
+
+	versions, err := jq.Query[[]any](crd, ".spec.versions")
+	if err != nil {
+		return resources.ResourceType{}, fmt.Errorf("reading versions from CRD %s: %w", crdName, err)
+	}
+
+	for _, v := range versions {
+		vm, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if storage, _ := vm["storage"].(bool); storage {
+			if name, _ := vm["name"].(string); name != "" {
+				resolved := rt
+				resolved.Version = name
+
+				return resolved, nil
+			}
+		}
+	}
+
+	return resources.ResourceType{}, fmt.Errorf("no storage version found in CRD %s", crdName)
 }


### PR DESCRIPTION
## Description

The hardware profile integrity check previously hardcoded the API version when listing HardwareProfiles. Clusters running older RHOAI versions (e.g., 2.25.x) use v1alpha1 instead of v1, causing list operations to fail silently. This resolves the correct version dynamically by querying the CRD's storage version before listing profiles.

Summary of changes:
- utils.go — new resolveResourceType() helper that reads a CRD and returns a ResourceType with the cluster's actual storage version
- hardware_profile_integrity.go — calls resolveResourceType() before building the profile cache; gracefully handles CRD-not-found (treats all HWP references as missing)
- hardware_profile_integrity_test.go — all existing tests updated to include a HardwareProfile CRD fixture; new TestHardwareProfileIntegrityCheck_ProfileExistsV1Alpha1 test covering the v1alpha1 scenario

## How Has This Been Tested?
executed `./bin/kubectl-odh lint --checks "*notebook*" --target-version 3.3 --verbose --debug` against a variety of clusters and verified correct/expected classifications of notebooks.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic CRD storage-version detection for hardware profile checks, improving compatibility across Kubernetes setups.

* **Bug Fixes**
  * Skip CRD lookups when no hardware profiles are referenced; avoid unnecessary permission/RBAC calls and gracefully handle CRD absence (treats profiles as missing).

* **Tests**
  * Expanded tests covering v1 and v1alpha1 storage versions and CRD-present/absent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->