### PR TITLE
feat: add --severity flag to filter lint output by minimum severity level

### DIFF
--- a/pkg/lint/check/result/result.go
+++ b/pkg/lint/check/result/result.go
@@ -248,39 +248,22 @@ func (r *DiagnosticResult) GetMessage() string {
 }
 
 // GetImpact returns the highest impact level across all conditions.
-// Returns nil if there are no conditions.
-// Impact is always explicit (set during condition creation), never derived.
-func (r *DiagnosticResult) GetImpact() *string {
-	if len(r.Status.Conditions) == 0 {
-		return nil
-	}
-
-	var hasBlocking bool
-	var hasAdvisory bool
+// Returns ImpactNone if there are no conditions.
+func (r *DiagnosticResult) GetImpact() Impact {
+	maxImpact := ImpactNone
 
 	for _, cond := range r.Status.Conditions {
 		switch cond.Impact {
 		case ImpactBlocking:
-			hasBlocking = true
+			return ImpactBlocking
 		case ImpactAdvisory:
-			hasAdvisory = true
+			maxImpact = ImpactAdvisory
 		case ImpactNone:
 			// No impact - continue checking other conditions
 		}
 	}
 
-	var result Impact
-	if hasBlocking {
-		result = ImpactBlocking
-	} else if hasAdvisory {
-		result = ImpactAdvisory
-	} else {
-		result = ImpactNone
-	}
-
-	resultStr := string(result)
-
-	return &resultStr
+	return maxImpact
 }
 
 // GetRemediation returns remediation guidance from the first condition that has it set.

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -143,6 +143,7 @@ func NewCommand(
 func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescTargetVersion)
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescOutput)
+	fs.StringVar((*string)(&c.SeverityLevel), "severity", string(SeverityLevelInfo), flagDescSeverity)
 	fs.StringArrayVar(&c.CheckSelectors, "checks", []string{"*"}, flagDescChecks)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.BoolVar(&c.Debug, "debug", false, flagDescDebug)
@@ -301,33 +302,39 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 		resultsByGroup[group] = results
 	}
 
+	// Flatten, strip nil results, and apply severity filter
+	flatResults := FlattenResults(resultsByGroup)
+	flatResults = slices.DeleteFunc(flatResults, func(exec check.CheckExecution) bool {
+		return exec.Result == nil
+	})
+	flatResults = FilterBySeverity(flatResults, c.SeverityLevel)
+
 	// Format and output results
-	if err := c.formatAndOutputUpgradeResults(ctx, currentVersion.String(), resultsByGroup); err != nil {
+	if err := c.formatAndOutputUpgradeResults(ctx, currentVersion.String(), flatResults); err != nil {
 		return err
 	}
 
 	// Print verdict and determine exit code
-	return c.printVerdictAndExit(resultsByGroup)
+	return c.printVerdictAndExit(flatResults)
 }
 
 // printVerdictAndExit prints a prominent result verdict for table output and returns
 // an error if fail-on conditions are met (to control exit code).
-func (c *Command) printVerdictAndExit(resultsByGroup map[check.CheckGroup][]check.CheckExecution) error {
+func (c *Command) printVerdictAndExit(results []check.CheckExecution) error {
 	var hasBlocking, hasAdvisory bool
 
-	for _, results := range resultsByGroup {
-		for _, exec := range results {
-			impact := exec.Result.GetImpact()
-			if impact != nil {
-				switch *impact {
-				case string(resultpkg.ImpactBlocking):
-					hasBlocking = true
-				case string(resultpkg.ImpactAdvisory):
-					hasAdvisory = true
-				default:
-					// ImpactNone and unknown impacts don't affect exit code
-				}
-			}
+	for _, exec := range results {
+		if exec.Result == nil {
+			continue
+		}
+
+		switch exec.Result.GetImpact() {
+		case resultpkg.ImpactBlocking:
+			hasBlocking = true
+		case resultpkg.ImpactAdvisory:
+			hasAdvisory = true
+		case resultpkg.ImpactNone:
+			// No impact on exit code
 		}
 	}
 
@@ -351,26 +358,23 @@ func (c *Command) openShiftVersionPtr() *string {
 func (c *Command) formatAndOutputUpgradeResults(
 	ctx context.Context,
 	currentVer string,
-	resultsByGroup map[check.CheckGroup][]check.CheckExecution,
+	results []check.CheckExecution,
 ) error {
 	clusterVer := &c.currentClusterVersion
 	targetVer := &c.TargetVersion
 	ocpVer := c.openShiftVersionPtr()
 
-	// Flatten results to sorted array
-	flatResults := FlattenResults(resultsByGroup)
-
 	switch c.OutputFormat {
 	case OutputFormatTable:
-		return c.outputUpgradeTable(ctx, currentVer, flatResults)
+		return c.outputUpgradeTable(ctx, currentVer, results)
 	case OutputFormatJSON:
-		if err := OutputJSON(c.IO.Out(), flatResults, clusterVer, targetVer, ocpVer); err != nil {
+		if err := OutputJSON(c.IO.Out(), results, clusterVer, targetVer, ocpVer); err != nil {
 			return fmt.Errorf("outputting JSON: %w", err)
 		}
 
 		return nil
 	case OutputFormatYAML:
-		if err := OutputYAML(c.IO.Out(), flatResults, clusterVer, targetVer, ocpVer); err != nil {
+		if err := OutputYAML(c.IO.Out(), results, clusterVer, targetVer, ocpVer); err != nil {
 			return fmt.Errorf("outputting YAML: %w", err)
 		}
 

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -31,6 +31,16 @@ const (
 	DefaultTimeout = 5 * time.Minute
 )
 
+// SeverityLevel represents the minimum severity threshold for display filtering.
+// Only conditions at or above this level are shown in the output.
+type SeverityLevel string
+
+const (
+	SeverityLevelCritical SeverityLevel = "critical" // Show only blocking (critical) conditions
+	SeverityLevelWarning  SeverityLevel = "warning"  // Show blocking and advisory conditions
+	SeverityLevelInfo     SeverityLevel = "info"     // Show all conditions (default)
+)
+
 // Validate checks if the output format is valid.
 func (o OutputFormat) Validate() error {
 	switch o {
@@ -38,6 +48,16 @@ func (o OutputFormat) Validate() error {
 		return nil
 	default:
 		return fmt.Errorf("invalid output format: %s (must be one of: table, json, yaml)", o)
+	}
+}
+
+// Validate checks if the severity level is valid.
+func (s SeverityLevel) Validate() error {
+	switch s {
+	case SeverityLevelCritical, SeverityLevelWarning, SeverityLevelInfo:
+		return nil
+	default:
+		return fmt.Errorf("invalid severity level: %s (must be one of: critical, warning, info)", s)
 	}
 }
 
@@ -54,6 +74,10 @@ type SharedOptions struct {
 
 	// CheckSelectors filters which checks to run (glob patterns, repeatable)
 	CheckSelectors []string
+
+	// SeverityLevel sets the minimum severity threshold for display filtering.
+	// Conditions below this level are excluded from all output formats.
+	SeverityLevel SeverityLevel
 
 	// Verbose enables progress messages (default: false, quiet by default)
 	Verbose bool
@@ -81,8 +105,9 @@ func NewSharedOptions(
 	return &SharedOptions{
 		ConfigFlags:    configFlags,
 		OutputFormat:   OutputFormatTable,
-		CheckSelectors: []string{"*"},  // Run all checks by default
-		Timeout:        DefaultTimeout, // Default timeout to prevent hanging on slow clusters
+		CheckSelectors: []string{"*"},     // Run all checks by default
+		SeverityLevel:  SeverityLevelInfo, // Show all severity levels by default
+		Timeout:        DefaultTimeout,    // Default timeout to prevent hanging on slow clusters
 		IO:             iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
 		QPS:            client.DefaultQPS,
 		Burst:          client.DefaultBurst,
@@ -112,6 +137,11 @@ func (o *SharedOptions) Complete() error {
 func (o *SharedOptions) Validate() error {
 	// Validate output format
 	if err := o.OutputFormat.Validate(); err != nil {
+		return err
+	}
+
+	// Validate severity level
+	if err := o.SeverityLevel.Validate(); err != nil {
 		return err
 	}
 
@@ -251,6 +281,60 @@ func FlattenResults(resultsByGroup map[check.CheckGroup][]check.CheckExecution) 
 	}
 
 	return flattened
+}
+
+// FilterBySeverity returns a filtered copy of results containing only conditions
+// that meet the minimum severity threshold. Results with no remaining conditions
+// are excluded entirely. The original slice is not modified.
+func FilterBySeverity(results []check.CheckExecution, minLevel SeverityLevel) []check.CheckExecution {
+	if minLevel == SeverityLevelInfo {
+		return results
+	}
+
+	filtered := make([]check.CheckExecution, 0, len(results))
+
+	for _, exec := range results {
+		if exec.Result == nil {
+			continue
+		}
+
+		var kept []result.Condition
+		for _, cond := range exec.Result.Status.Conditions {
+			if meetsMinSeverity(cond.Impact, minLevel) {
+				kept = append(kept, cond)
+			}
+		}
+
+		if len(kept) == 0 {
+			continue
+		}
+
+		filteredResult := *exec.Result
+		filteredResult.Status.Conditions = kept
+
+		filtered = append(filtered, check.CheckExecution{
+			Check:  exec.Check,
+			Result: &filteredResult,
+			Error:  exec.Error,
+		})
+	}
+
+	return filtered
+}
+
+// meetsMinSeverity returns true if the given impact level is at or above the
+// minimum severity threshold.
+func meetsMinSeverity(impact result.Impact, minLevel SeverityLevel) bool {
+	switch minLevel {
+	case SeverityLevelCritical:
+		return impact == result.ImpactBlocking
+	case SeverityLevelWarning:
+		return impact == result.ImpactBlocking || impact == result.ImpactAdvisory
+	case SeverityLevelInfo:
+		return true
+	}
+
+	return true
 }
 
 // checkMaxImpact returns the highest-severity impact across all conditions

--- a/pkg/lint/command_options_test.go
+++ b/pkg/lint/command_options_test.go
@@ -3,7 +3,11 @@ package lint_test
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/opendatahub-io/odh-cli/pkg/lint"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 
 	. "github.com/onsi/gomega"
 )
@@ -152,4 +156,173 @@ func TestValidateCheckSelector(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSeverityLevelValidate(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name    string
+		level   lint.SeverityLevel
+		wantErr bool
+	}{
+		{name: "critical valid", level: lint.SeverityLevelCritical, wantErr: false},
+		{name: "warning valid", level: lint.SeverityLevelWarning, wantErr: false},
+		{name: "info valid", level: lint.SeverityLevelInfo, wantErr: false},
+		{name: "empty invalid", level: "", wantErr: true},
+		{name: "unknown invalid", level: "high", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.level.Validate()
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func makeCondition(impact result.Impact, msg string) result.Condition {
+	status := metav1.ConditionTrue
+	switch impact {
+	case result.ImpactBlocking:
+		status = metav1.ConditionFalse
+	case result.ImpactAdvisory:
+		status = metav1.ConditionFalse
+	case result.ImpactNone:
+		// status stays ConditionTrue
+	}
+
+	return result.Condition{
+		Condition: metav1.Condition{
+			Type:    "Validated",
+			Status:  status,
+			Reason:  "TestReason",
+			Message: msg,
+		},
+		Impact: impact,
+	}
+}
+
+func makeExec(kind string, conditions ...result.Condition) check.CheckExecution {
+	return check.CheckExecution{
+		Result: &result.DiagnosticResult{
+			Group: "components",
+			Kind:  kind,
+			Name:  "test-check",
+			Status: result.DiagnosticStatus{
+				Conditions: conditions,
+			},
+		},
+	}
+}
+
+func TestFilterBySeverity_InfoReturnsAll(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		makeExec("kserve", makeCondition(result.ImpactBlocking, "crit")),
+		makeExec("dashboard", makeCondition(result.ImpactAdvisory, "warn")),
+		makeExec("notebook", makeCondition(result.ImpactNone, "info")),
+	}
+
+	filtered := lint.FilterBySeverity(results, lint.SeverityLevelInfo)
+
+	g.Expect(filtered).To(HaveLen(3))
+}
+
+func TestFilterBySeverity_WarningHidesInfo(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		makeExec("kserve", makeCondition(result.ImpactBlocking, "crit")),
+		makeExec("dashboard", makeCondition(result.ImpactAdvisory, "warn")),
+		makeExec("notebook", makeCondition(result.ImpactNone, "info")),
+	}
+
+	filtered := lint.FilterBySeverity(results, lint.SeverityLevelWarning)
+
+	g.Expect(filtered).To(HaveLen(2))
+	g.Expect(filtered[0].Result.Kind).To(Equal("kserve"))
+	g.Expect(filtered[1].Result.Kind).To(Equal("dashboard"))
+}
+
+func TestFilterBySeverity_CriticalHidesWarningAndInfo(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		makeExec("kserve", makeCondition(result.ImpactBlocking, "crit")),
+		makeExec("dashboard", makeCondition(result.ImpactAdvisory, "warn")),
+		makeExec("notebook", makeCondition(result.ImpactNone, "info")),
+	}
+
+	filtered := lint.FilterBySeverity(results, lint.SeverityLevelCritical)
+
+	g.Expect(filtered).To(HaveLen(1))
+	g.Expect(filtered[0].Result.Kind).To(Equal("kserve"))
+}
+
+func TestFilterBySeverity_MixedConditionsPartiallyFiltered(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		makeExec("kserve",
+			makeCondition(result.ImpactBlocking, "crit-condition"),
+			makeCondition(result.ImpactNone, "info-condition"),
+		),
+	}
+
+	filtered := lint.FilterBySeverity(results, lint.SeverityLevelWarning)
+
+	g.Expect(filtered).To(HaveLen(1))
+	g.Expect(filtered[0].Result.Status.Conditions).To(HaveLen(1))
+	g.Expect(filtered[0].Result.Status.Conditions[0].Message).To(Equal("crit-condition"))
+}
+
+func TestFilterBySeverity_AllConditionsFilteredDropsResult(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		makeExec("dashboard",
+			makeCondition(result.ImpactNone, "info-1"),
+			makeCondition(result.ImpactNone, "info-2"),
+		),
+	}
+
+	filtered := lint.FilterBySeverity(results, lint.SeverityLevelWarning)
+
+	g.Expect(filtered).To(BeEmpty())
+}
+
+func TestFilterBySeverity_DoesNotMutateOriginal(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		makeExec("kserve",
+			makeCondition(result.ImpactBlocking, "crit"),
+			makeCondition(result.ImpactNone, "info"),
+		),
+	}
+
+	_ = lint.FilterBySeverity(results, lint.SeverityLevelCritical)
+
+	g.Expect(results[0].Result.Status.Conditions).To(HaveLen(2))
+}
+
+func TestFilterBySeverity_NilResultSkipped(t *testing.T) {
+	g := NewWithT(t)
+
+	results := []check.CheckExecution{
+		{Result: nil},
+		makeExec("kserve", makeCondition(result.ImpactBlocking, "crit")),
+	}
+
+	filtered := lint.FilterBySeverity(results, lint.SeverityLevelCritical)
+
+	g.Expect(filtered).To(HaveLen(1))
+	g.Expect(filtered[0].Result.Kind).To(Equal("kserve"))
 }

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -4,6 +4,7 @@ package lint
 const (
 	flagDescTargetVersion      = "target version for upgrade readiness checks (e.g., 2.25.0, 3.0.0)"
 	flagDescOutput             = "output format (table|json|yaml)"
+	flagDescSeverity           = "minimum severity level to display (critical|warning|info)"
 	flagDescVerbose            = "show impacted objects and summary information"
 	flagDescDebug              = "show detailed diagnostic logs for troubleshooting"
 	flagDescTimeout            = "operation timeout (e.g., 10m, 30m)"


### PR DESCRIPTION
Allow users to control which conditions are displayed by setting a minimum
severity threshold (critical, warning, info). Defaults to info (show all).
Also refactors GetImpact() to return Impact directly instead of *string.

Made-with: Cursor

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --severity flag to filter lint results by minimum severity (critical, warning, info).

* **Improvements**
  * Impact computation now returns a concrete severity value, reporting the highest severity across conditions and short-circuiting/blocking more deterministically.

* **Tests**
  * Added comprehensive tests for severity validation and filtering, ordering, non-mutation, and nil handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->