### PR TITLE
refactor: update impact messaging for notebook checks

### DIFF
--- a/pkg/lint/checks/workloads/notebook/constants.go
+++ b/pkg/lint/checks/workloads/notebook/constants.go
@@ -49,7 +49,7 @@ const (
 	MsgNotebookImageSummary   = "Found %d Notebook(s) using %d unique images:"
 	MsgCompatibleCount        = "  - %d compatible (%d images, OOTB ready for %s)"
 	MsgCustomCount            = "  - %d custom (%d images, user verification needed)"
-	MsgIncompatibleCount      = "  - %d incompatible (%d images, must update before upgrade)"
+	MsgIncompatibleCount      = "  - %d incompatible (%d images, update recommended before upgrade)"
 	MsgPostUpgradeCount       = "  - %d incompatible (%d images, must rebuild after upgrade to 3.x)"
 	MsgUnverifiedCount        = "  - %d unverified (%d images, could not determine status)"
 	MsgVerifyCustomImages     = "Verify custom images are compatible with RHOAI %s before upgrading"

--- a/pkg/lint/checks/workloads/notebook/impacted.go
+++ b/pkg/lint/checks/workloads/notebook/impacted.go
@@ -1233,13 +1233,13 @@ func (c *ImpactedWorkloadsCheck) setConditions(
 
 	switch {
 	case counters[ImageStatusPreUpgradeActionRequired].count > 0:
-		// Notebooks with pre-upgrade incompatible images block the upgrade.
+		// Notebooks with pre-upgrade incompatible images — advisory, users may choose to update later.
 		dr.SetCondition(check.NewCondition(
 			ConditionTypeNotebooksCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonWorkloadsImpacted),
 			check.WithMessage("%s", message),
-			check.WithImpact(result.ImpactBlocking),
+			check.WithImpact(result.ImpactAdvisory),
 			check.WithRemediation(c.CheckRemediation),
 		))
 

--- a/pkg/lint/checks/workloads/notebook/impacted_test.go
+++ b/pkg/lint/checks/workloads/notebook/impacted_test.go
@@ -452,7 +452,7 @@ func TestImpactedWorkloadsCheck_SingleNotebook(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: check.ReasonWorkloadsImpacted,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 			expectImpacted: true,
 		},
 		{
@@ -539,7 +539,7 @@ func TestImpactedWorkloadsCheck_MultiContainer(t *testing.T) {
 				"sidecar":  codeserverIncompatibleSHA,
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 		},
 		{
 			name: "OneCustom",
@@ -567,7 +567,7 @@ func TestImpactedWorkloadsCheck_MultiContainer(t *testing.T) {
 				"sidecar":  codeserverIncompatibleSHA,
 			},
 			expectedStatus: metav1.ConditionFalse,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 		},
 	}
 
@@ -764,7 +764,7 @@ func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: check.ReasonWorkloadsImpacted,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 		},
 
 		// Strategy 2: SHA lookup - match by SHA digest
@@ -792,7 +792,7 @@ func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: check.ReasonWorkloadsImpacted,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 		},
 
 		// Strategy 3: dockerImageRepository with tag
@@ -820,7 +820,7 @@ func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: check.ReasonWorkloadsImpacted,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 		},
 
 		// Strategy 4: spec from.name - exact match against .spec.tags[*].from.name (disconnected clusters)
@@ -848,7 +848,7 @@ func TestImpactedWorkloadsCheck_LookupStrategies(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionFalse,
 			expectedReason: check.ReasonWorkloadsImpacted,
-			expectedImpact: resultpkg.ImpactBlocking,
+			expectedImpact: resultpkg.ImpactAdvisory,
 		},
 		{
 			name:        "Strategy4_SpecRef_NoMatch",


### PR DESCRIPTION
## Description
The upgrade documentation explicitly accounts for users choosing to leave notebooks running with older images and updating them later. Therefore, odh-cli  should not flag incompatible notebook images as ImpactBlocking (which means "upgrade CANNOT proceed"). Instead, they should be ImpactAdvisory ("upgrade CAN  proceed with warning"), since this is an informed choice users can make — not a hard blocker.

Revised the impact messaging for notebooks in the lint checks to clarify that problematic images are advisory rather than blocking. This change includes updates to the constants and test cases to reflect the new advisory impact status, enhancing user understanding of upgrade recommendations.

- Updated MsgIncompatibleCount to recommend updates before upgrades.
- Changed expected impact in tests from ImpactBlocking to ImpactAdvisory for clarity on user actions required.

## How Has This Been Tested?
executed `./bin/kubectl-odh lint --target-version 3.3 --verbose --debug` against a variety of clusters and verified correct/expected classifications of notebooks.



## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook compatibility validation severity lowered from blocking to advisory. Incompatible notebooks no longer halt upgrades; users receive non-blocking recommendations instead of mandatory language.
  * Upgrade flow now proceeds while showing advisory guidance, and messaging updated to recommend updating notebooks for best compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->