### PR TITLE
RHOAIENG-50105 - AI Core Platform: pre-checks and scripts

### DIFF
--- a/.claude/skills/lint-check/SKILL.md
+++ b/.claude/skills/lint-check/SKILL.md
@@ -12,7 +12,7 @@ This skill streamlines creating new lint checks for `kubectl odh lint`.
 Before implementing, gather the following from the user:
 
 ### 1. Check Classification
-- **Group**: component | service | workload | dependency
+- **Group**: component | service | platform | workload | dependency
 - **Kind**: The specific target (e.g., kserve, dashboard, certmanager, ray)
 - **Check Type**: Use a constant from `check.CheckType*` when applicable, or a package-level string constant for custom types
 

--- a/docs/lint/architecture.md
+++ b/docs/lint/architecture.md
@@ -29,7 +29,7 @@ type Check interface {
 
 **Key methods:**
 - `ID()` - Unique identifier for the lint check
-- `Group()` - Returns `CheckGroup` type: `GroupComponent`, `GroupService`, `GroupWorkload`, or `GroupDependency`
+- `Group()` - Returns `CheckGroup` type: `GroupComponent`, `GroupDependency`, `GroupPlatform`, `GroupService`, or `GroupWorkload`
 - `CheckKind()` - Returns the kind of resource being checked (e.g., "kserve", "codeflare"). Used by validation builders to construct diagnostic results
 - `CheckType()` - Returns the type of check (e.g., "removal", "deprecation"). Used by validation builders to construct diagnostic results
 - `CanApply()` - Determines if lint check is applicable based on version context
@@ -86,6 +86,10 @@ func NewCommand(
     registry := check.NewRegistry()
 
     // Explicitly register all checks (no global state, full test isolation)
+    // Platform (2)
+    registry.MustRegister(dscinitialization.NewDSCInitializationReadinessCheck())
+    registry.MustRegister(datasciencecluster.NewDataScienceClusterReadinessCheck())
+
     // Components (13)
     registry.MustRegister(codeflare.NewRemovalCheck())
     registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
@@ -139,7 +143,7 @@ The DiagnosticResult uses a flattened structure (not nested Metadata):
 ```go
 type DiagnosticResult struct {
     // Flattened metadata fields (not nested in a Metadata struct)
-    Group       string            // "component", "service", "workload", "dependency"
+    Group       string            // "component", "dependency", "platform", "service", "workload"
     Kind        string            // Target: "kserve", "dashboard", etc.
     Name        string            // Check type identifier (e.g., "removal", "deprecation")
     Annotations map[string]string // Version metadata with domain-qualified keys

--- a/docs/lint/writing-checks.md
+++ b/docs/lint/writing-checks.md
@@ -133,7 +133,11 @@ func NewCommand(
     registry := check.NewRegistry()
 
     // Explicitly register all checks
-    // Components (11)
+    // Platform (2)
+    registry.MustRegister(dscinitialization.NewDSCInitializationReadinessCheck())
+    registry.MustRegister(datasciencecluster.NewDataScienceClusterReadinessCheck())
+
+    // Components (13)
     registry.MustRegister(codeflare.NewRemovalCheck())
     registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
     registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
@@ -144,7 +148,7 @@ func NewCommand(
     registry.MustRegister(certmanager.NewCheck())
     // ... additional dependency checks
 
-    // Workloads (7)
+    // Workloads (8)
     registry.MustRegister(guardrails.NewOtelMigrationCheck())
     registry.MustRegister(kserveworkloads.NewAcceleratorMigrationCheck())
     registry.MustRegister(notebook.NewImpactedWorkloadsCheck())

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -7,6 +7,12 @@ const (
 	ManagementStateRemoved   = "Removed"
 )
 
+// Platform names for DSC and DSCI check kind identifiers.
+const (
+	PlatformDSCI = "dsci"
+	PlatformDSC  = "dsc"
+)
+
 // Component names used across multiple package groups.
 const (
 	ComponentDashboard        = "dashboard"

--- a/pkg/lint/check/base_test.go
+++ b/pkg/lint/check/base_test.go
@@ -86,6 +86,7 @@ func TestBaseCheck(t *testing.T) {
 			{"service", check.GroupService},
 			{"workload", check.GroupWorkload},
 			{"dependency", check.GroupDependency},
+			{"platform", check.GroupPlatform},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/lint/check/check.go
+++ b/pkg/lint/check/check.go
@@ -6,24 +6,26 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 )
 
-// CheckGroup classifies checks into logical groups (component, service, workload, dependency).
+// CheckGroup classifies checks into logical groups (component, dependency, platform, service, workload).
 type CheckGroup string
 
 const (
 	GroupComponent  CheckGroup = "component"
+	GroupDependency CheckGroup = "dependency"
+	GroupPlatform   CheckGroup = "platform"
 	GroupService    CheckGroup = "service"
 	GroupWorkload   CheckGroup = "workload"
-	GroupDependency CheckGroup = "dependency"
 )
 
 // CanonicalGroupOrder defines the execution order for check groups.
 // Dependencies run first to validate platform prerequisites, followed by
-// services, components, and finally workloads.
+// services, the core platform CRs (DSC/DSCI), components, and finally workloads.
 //
 //nolint:gochecknoglobals // Canonical ordering must be accessible across packages
 var CanonicalGroupOrder = []CheckGroup{
 	GroupDependency,
 	GroupService,
+	GroupPlatform,
 	GroupComponent,
 	GroupWorkload,
 }
@@ -90,7 +92,7 @@ type Check interface {
 	// Description returns what this check validates
 	Description() string
 
-	// Group returns the check group (component, service, workload, dependency)
+	// Group returns the check group (component, dependency, platform, service, workload)
 	Group() CheckGroup
 
 	// CheckKind returns the kind of resource being checked (e.g., "kserve", "codeflare").

--- a/pkg/lint/check/constants.go
+++ b/pkg/lint/check/constants.go
@@ -5,6 +5,7 @@ type CheckType string
 
 // Check type names used across multiple packages.
 const (
+	CheckTypeReadiness                   CheckType = "readiness"
 	CheckTypeRemoval                     CheckType = "removal"
 	CheckTypeInstalled                   CheckType = "installed"
 	CheckTypeImpactedWorkloads           CheckType = "impacted-workloads"

--- a/pkg/lint/check/executor_bench_test.go
+++ b/pkg/lint/check/executor_bench_test.go
@@ -119,6 +119,11 @@ func setupBenchmarkRegistry() *check.CheckRegistry {
 		_ = registry.Register(newBenchmarkCheck("workloads", i))
 	}
 
+	// Platform (5 checks)
+	for i := range 5 {
+		_ = registry.Register(newBenchmarkCheck("platform", i))
+	}
+
 	return registry
 }
 
@@ -137,6 +142,8 @@ func newBenchmarkCheck(categoryStr string, index int) *benchmarkCheck {
 		group = check.GroupService
 	case "workloads":
 		group = check.GroupWorkload
+	case "platform":
+		group = check.GroupPlatform
 	}
 
 	return &benchmarkCheck{

--- a/pkg/lint/check/registry.go
+++ b/pkg/lint/check/registry.go
@@ -102,7 +102,7 @@ func (r *CheckRegistry) ListAll() []Check {
 // ListByPatterns returns checks matching any of the selector patterns and group.
 // Each pattern can be:
 //   - Wildcard: "*" matches all checks
-//   - Group shortcut: "components", "services", "workloads", "dependencies"
+//   - Group shortcut: "components", "dependencies", "platform", "services", "workloads"
 //   - Exact ID: "components.dashboard"
 //   - Glob pattern: "components.*", "*dashboard*", "*.dashboard"
 //

--- a/pkg/lint/check/registry_test.go
+++ b/pkg/lint/check/registry_test.go
@@ -24,6 +24,7 @@ func TestCheckRegistry_ListByPattern(t *testing.T) {
 		{id: "components.workbench", name: "Workbench Component", group: check.GroupComponent},
 		{id: "services.oauth", name: "OAuth Service", group: check.GroupService},
 		{id: "workloads.limits", name: "Resource Limits", group: check.GroupWorkload},
+		{id: "platform.dsc", name: "DSC Readiness", group: check.GroupPlatform},
 	}
 
 	for _, mc := range mockChecks {
@@ -44,7 +45,7 @@ func TestCheckRegistry_ListByPattern(t *testing.T) {
 			name:    "wildcard all checks",
 			pattern: "*",
 			group:   "",
-			wantIDs: []string{"components.dashboard", "components.workbench", "services.oauth", "workloads.limits"},
+			wantIDs: []string{"components.dashboard", "components.workbench", "services.oauth", "workloads.limits", "platform.dsc"},
 		},
 		{
 			name:    "group shortcut components",
@@ -63,6 +64,12 @@ func TestCheckRegistry_ListByPattern(t *testing.T) {
 			pattern: "workloads",
 			group:   "",
 			wantIDs: []string{"workloads.limits"},
+		},
+		{
+			name:    "group shortcut platform",
+			pattern: "platform",
+			group:   "",
+			wantIDs: []string{"platform.dsc"},
 		},
 		{
 			name:    "glob components.*",

--- a/pkg/lint/check/selector.go
+++ b/pkg/lint/check/selector.go
@@ -6,18 +6,19 @@ import (
 )
 
 // Selector shortcut names used in CLI --checks flag.
-// These are plural user-facing names that map to internal CheckGroup values.
+// These are plural user-facing names (except for platform) that map to internal CheckGroup values.
 const (
 	SelectorComponents   = "components"
+	SelectorDependencies = "dependencies"
+	SelectorPlatform     = "platform"
 	SelectorServices     = "services"
 	SelectorWorkloads    = "workloads"
-	SelectorDependencies = "dependencies"
 )
 
 // matchesPattern returns true if the check matches the selector pattern
 // Pattern can be:
 //   - Wildcard: "*" matches all checks
-//   - Group shortcut: "components", "services", "workloads", "dependencies"
+//   - Group shortcut: "components", "services", "workloads", "dependencies", "platform"
 //   - Exact ID: "components.dashboard"
 //   - Glob pattern: "components.*", "*dashboard*", "*.dashboard"
 func matchesPattern(check Check, pattern string) (bool, error) {
@@ -30,12 +31,14 @@ func matchesPattern(check Check, pattern string) (bool, error) {
 	switch pattern {
 	case SelectorComponents:
 		return check.Group() == GroupComponent, nil
+	case SelectorDependencies:
+		return check.Group() == GroupDependency, nil
+	case SelectorPlatform:
+		return check.Group() == GroupPlatform, nil
 	case SelectorServices:
 		return check.Group() == GroupService, nil
 	case SelectorWorkloads:
 		return check.Group() == GroupWorkload, nil
-	case SelectorDependencies:
-		return check.Group() == GroupDependency, nil
 	}
 
 	// Exact ID match

--- a/pkg/lint/check/selector_test.go
+++ b/pkg/lint/check/selector_test.go
@@ -131,6 +131,20 @@ func TestMatchesPattern_GroupShortcuts(t *testing.T) {
 			pattern: "dependencies",
 			want:    false,
 		},
+		{
+			name:    "platform shortcut matches platform check",
+			checkID: "platform.dsc.readiness",
+			group:   check.GroupPlatform,
+			pattern: "platform",
+			want:    true,
+		},
+		{
+			name:    "platform shortcut does not match component check",
+			checkID: "components.dashboard",
+			group:   check.GroupComponent,
+			pattern: "platform",
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lint/check/validate/dsc.go
+++ b/pkg/lint/check/validate/dsc.go
@@ -1,4 +1,4 @@
-package validate //nolint:dupl // DSCIBuilder mirrors DSCBuilder pattern for the DSCInitialization resource
+package validate //nolint:dupl // DSCBuilder mirrors DSCIBuilder pattern for the DataScienceCluster resource
 
 import (
 	"context"
@@ -13,45 +13,45 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
-// DSCIBuilder provides a fluent API for DSCInitialization-based validation.
-// It handles DSCI fetching and annotation population automatically.
-type DSCIBuilder struct {
+// DSCBuilder provides a fluent API for DataScienceCluster-based validation.
+// It handles DSC fetching and annotation population automatically.
+type DSCBuilder struct {
 	check  check.Check
 	target check.Target
 }
 
-// DSCI creates a builder for DSCInitialization-based validation.
-// This is used by service checks that need to read platform configuration from DSCI.
+// DSC creates a builder for DataScienceCluster-based validation.
+// This is used by checks that need to read platform configuration from DSC.
 //
 // Example:
 //
-//	validate.DSCI(c, target).
-//	    Run(ctx, func(dr *result.DiagnosticResult, dsci *unstructured.Unstructured) error {
+//	validate.DSC(c, target).
+//	    Run(ctx, func(dr *result.DiagnosticResult, dsc *unstructured.Unstructured) error {
 //	        // Validation logic here
 //	        return nil
 //	    })
-func DSCI(c check.Check, target check.Target) *DSCIBuilder {
-	return &DSCIBuilder{check: c, target: target}
+func DSC(c check.Check, target check.Target) *DSCBuilder {
+	return &DSCBuilder{check: c, target: target}
 }
 
-// DSCIValidateFn is the validation function called after DSCI is fetched.
-// It receives an auto-created DiagnosticResult with pre-populated annotations and the fetched DSCI.
-type DSCIValidateFn func(dr *result.DiagnosticResult, dsci *unstructured.Unstructured) error
+// DSCValidateFn is the validation function called after DSC is fetched.
+// It receives an auto-created DiagnosticResult with pre-populated annotations and the fetched DSC.
+type DSCValidateFn func(dr *result.DiagnosticResult, dsc *unstructured.Unstructured) error
 
-// Run fetches the DSCI, auto-populates annotations, and executes validation.
+// Run fetches the DSC, auto-populates annotations, and executes validation.
 //
 // The builder handles:
-//   - DSCI not found: returns a standard "not found" diagnostic result (not an error)
-//   - DSCI fetch error: returns wrapped error
+//   - DSC not found: returns a standard "not found" diagnostic result (not an error)
+//   - DSC fetch error: returns wrapped error
 //   - Annotation population: target version is automatically added
 //
 // Returns (*result.DiagnosticResult, error) following the standard lint check signature.
-func (b *DSCIBuilder) Run(
+func (b *DSCBuilder) Run(
 	ctx context.Context,
-	fn DSCIValidateFn,
+	fn DSCValidateFn,
 ) (*result.DiagnosticResult, error) {
-	// Fetch the DSCInitialization singleton
-	dsci, err := client.GetDSCInitialization(ctx, b.target.Client)
+	// Fetch the DataScienceCluster singleton
+	dsc, err := client.GetDataScienceCluster(ctx, b.target.Client)
 	switch {
 	case apierrors.IsNotFound(err):
 		dr := result.New(string(b.check.Group()), b.check.CheckKind(), b.check.CheckType(), b.check.Description())
@@ -60,13 +60,13 @@ func (b *DSCIBuilder) Run(
 				check.ConditionTypeAvailable,
 				metav1.ConditionFalse,
 				check.WithReason(check.ReasonResourceNotFound),
-				check.WithMessage("No DSCInitialization found"),
+				check.WithMessage("No DataScienceCluster found"),
 			),
 		}
 
 		return dr, nil
 	case err != nil:
-		return nil, fmt.Errorf("getting DSCInitialization: %w", err)
+		return nil, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
 	// Create result with auto-populated annotations
@@ -82,7 +82,7 @@ func (b *DSCIBuilder) Run(
 	}
 
 	// Execute the validation function
-	if err := fn(dr, dsci); err != nil {
+	if err := fn(dr, dsc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/lint/checks/platform/datasciencecluster/datasciencecluster_readiness.go
+++ b/pkg/lint/checks/platform/datasciencecluster/datasciencecluster_readiness.go
@@ -1,0 +1,44 @@
+package datasciencecluster
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+)
+
+// DataScienceClusterReadinessCheck validates that DataScienceCluster is in Ready state.
+type DataScienceClusterReadinessCheck struct {
+	check.BaseCheck
+}
+
+// NewDataScienceClusterReadinessCheck creates a new DataScienceClusterReadinessCheck.
+func NewDataScienceClusterReadinessCheck() *DataScienceClusterReadinessCheck {
+	return &DataScienceClusterReadinessCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupPlatform,
+			Kind:             constants.PlatformDSC,
+			Type:             check.CheckTypeReadiness,
+			CheckID:          "platform.dsc.readiness",
+			CheckName:        "Platform :: DSC :: Readiness Check",
+			CheckDescription: "Validates that DataScienceCluster is in Ready state",
+		},
+	}
+}
+
+// CanApply returns true for all targets since DSC readiness is always relevant.
+func (c DataScienceClusterReadinessCheck) CanApply(_ context.Context, _ check.Target) (bool, error) {
+	return true, nil
+}
+
+// Validate executes the check against the provided target.
+func (c DataScienceClusterReadinessCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	return validate.DSC(c, target).Run(ctx, func(dr *result.DiagnosticResult, dsc *unstructured.Unstructured) error {
+		return validateReadyCondition(dr, dsc, "DataScienceCluster", metav1.ConditionTrue)
+	})
+}

--- a/pkg/lint/checks/platform/datasciencecluster/datasciencecluster_readiness_test.go
+++ b/pkg/lint/checks/platform/datasciencecluster/datasciencecluster_readiness_test.go
@@ -1,0 +1,156 @@
+package datasciencecluster_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/datasciencecluster"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+// Test fixtures for DataScienceCluster readiness check.
+//
+//nolint:gochecknoglobals // Test fixtures shared across test functions in this file.
+var dscReadinessListKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newDSCWithoutConditions() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"status": map[string]any{},
+		},
+	}
+}
+
+func newDSCWithReadyCondition(status string, message string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":    "Ready",
+						"status":  status,
+						"reason":  "ReconcileCompleted",
+						"message": message,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDataScienceClusterReadinessCheck_NoDSC(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dscReadinessListKinds,
+	})
+
+	chk := datasciencecluster.NewDataScienceClusterReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+}
+
+func TestDataScienceClusterReadinessCheck_NoReadyCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dscReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCWithoutConditions()},
+	})
+
+	chk := datasciencecluster.NewDataScienceClusterReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonInsufficientData),
+		"Message": ContainSubstring("Ready condition is missing"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDataScienceClusterReadinessCheck_NotReady(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dscReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCWithReadyCondition("False", "reconcile failed")},
+	})
+
+	chk := datasciencecluster.NewDataScienceClusterReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonResourceUnavailable),
+		"Message": And(ContainSubstring("DataScienceCluster"), ContainSubstring("reconcile failed")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDataScienceClusterReadinessCheck_Ready(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dscReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCWithReadyCondition("True", "Reconcile completed successfully")},
+	})
+
+	chk := datasciencecluster.NewDataScienceClusterReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonResourceAvailable),
+		"Message": ContainSubstring("DataScienceCluster is ready"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+}
+
+func TestDataScienceClusterReadinessCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := datasciencecluster.NewDataScienceClusterReadinessCheck()
+
+	g.Expect(chk.ID()).To(Equal("platform.dsc.readiness"))
+	g.Expect(chk.Name()).To(Equal("Platform :: DSC :: Readiness Check"))
+	g.Expect(chk.Group()).To(Equal(check.GroupPlatform))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/platform/datasciencecluster/support.go
+++ b/pkg/lint/checks/platform/datasciencecluster/support.go
@@ -1,0 +1,56 @@
+package datasciencecluster
+
+import (
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+// validateReadyCondition checks that the Ready condition is True on a resource.
+func validateReadyCondition(
+	dr *result.DiagnosticResult,
+	obj *unstructured.Unstructured,
+	resourceName string,
+	expectedStatus metav1.ConditionStatus,
+) error {
+	// Use // [] so that a missing conditions field yields an empty array rather than
+	// a gojq "cannot iterate over: null" error.
+	readyCondition, err := jq.Query[metav1.Condition](obj, `.status.conditions // [] | .[] | select(.type == "Ready")`)
+
+	switch {
+	case err != nil && !errors.Is(err, jq.ErrNotFound):
+		return fmt.Errorf("querying %s ready condition: %w", resourceName, err)
+	case errors.Is(err, jq.ErrNotFound), readyCondition.Type == "":
+		// Either the query returned null or select found no matching condition.
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeReady,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonInsufficientData),
+			check.WithMessage("%s resource found but Ready condition is missing", resourceName),
+			check.WithImpact(result.ImpactBlocking),
+		))
+	case readyCondition.Status != expectedStatus:
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeReady,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonResourceUnavailable),
+			check.WithMessage("%s is not ready (status: %s) due to '%s'. %s must be ready before upgrading", resourceName, readyCondition.Status, readyCondition.Message, resourceName),
+			check.WithImpact(result.ImpactBlocking),
+		))
+	default:
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeReady,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceAvailable),
+			check.WithMessage("%s is ready", resourceName),
+		))
+	}
+
+	return nil
+}

--- a/pkg/lint/checks/platform/dscinitialization/dscinitialization_readiness.go
+++ b/pkg/lint/checks/platform/dscinitialization/dscinitialization_readiness.go
@@ -1,0 +1,40 @@
+package dscinitialization
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+)
+
+// DSCInitializationReadinessCheck validates that DSCInitialization is in Ready state before upgrading to RHOAI 3.x.
+type DSCInitializationReadinessCheck struct {
+	check.BaseCheck
+}
+
+func NewDSCInitializationReadinessCheck() *DSCInitializationReadinessCheck {
+	return &DSCInitializationReadinessCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupPlatform,
+			Kind:             constants.PlatformDSCI,
+			Type:             check.CheckTypeReadiness,
+			CheckID:          "platform.dsci.readiness",
+			CheckName:        "Platform :: DSCI :: Readiness Check",
+			CheckDescription: "Validates that DSCInitialization is in Ready state before upgrading to RHOAI 3.x",
+		},
+	}
+}
+
+func (c DSCInitializationReadinessCheck) CanApply(_ context.Context, _ check.Target) (bool, error) {
+	return true, nil
+}
+
+func (c DSCInitializationReadinessCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	return validate.DSCI(c, target).Run(ctx, func(dr *result.DiagnosticResult, dsci *unstructured.Unstructured) error {
+		return validatePhaseReady(dr, dsci, "DSCInitialization")
+	})
+}

--- a/pkg/lint/checks/platform/dscinitialization/dscinitialization_readiness_test.go
+++ b/pkg/lint/checks/platform/dscinitialization/dscinitialization_readiness_test.go
@@ -1,0 +1,353 @@
+package dscinitialization_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/dscinitialization"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+// Test constants for DSCInitialization readiness check.
+//
+//nolint:gochecknoglobals // Test fixtures shared across test functions in this file.
+var dsciReadinessListKinds = map[schema.GroupVersionResource]string{
+	resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+}
+
+func newDSCIWithPhase(phase string) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": resources.DSCInitialization.APIVersion(),
+		"kind":       resources.DSCInitialization.Kind,
+		"metadata": map[string]any{
+			"name": "default-dsci",
+		},
+	}
+	if phase != "" {
+		obj["status"] = map[string]any{
+			"phase": phase,
+		}
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newDSCIWithEmptyPhase() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{
+				"phase": "",
+			},
+		},
+	}
+}
+
+func newDSCIWithoutPhase() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{},
+		},
+	}
+}
+
+func TestDSCInitializationReadinessCheck_NoDSCI(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+}
+
+func TestDSCInitializationReadinessCheck_PhaseMissing(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCIWithoutPhase()},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonInsufficientData),
+		"Message": ContainSubstring("phase field is missing"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDSCInitializationReadinessCheck_PhaseEmpty(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCIWithEmptyPhase()},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonInsufficientData),
+		"Message": ContainSubstring("phase is empty"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDSCInitializationReadinessCheck_NotReady(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCIWithPhase("Degraded")},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonResourceUnavailable),
+		"Message": And(ContainSubstring("DSCInitialization"), ContainSubstring("Degraded")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDSCInitializationReadinessCheck_NotReadyWithUnknownCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{
+				"phase": "Ready",
+				"conditions": []any{
+					map[string]any{"type": "ReconcileComplete", "status": "Unknown", "message": "reconcile state unknown"},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{dsci},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonResourceUnavailable),
+		"Message": ContainSubstring("ReconcileComplete: reconcile state unknown"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDSCInitializationReadinessCheck_NotReadyWithUnhappyConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{
+				"phase": "Degraded",
+				"conditions": []any{
+					map[string]any{"type": "ReconcileComplete", "status": "False", "message": "reconcile failed: some error"},
+					map[string]any{"type": "Degraded", "status": "True", "message": "operator is degraded"},
+					map[string]any{"type": "Progressing", "status": "False", "message": "Reconcile completed successfully"},
+					map[string]any{"type": "Available", "status": "True", "message": "Reconcile completed successfully"},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{dsci},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeReady),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceUnavailable),
+		"Message": And(
+			ContainSubstring("DSCInitialization"),
+			ContainSubstring("Degraded"),
+			ContainSubstring("ReconcileComplete: reconcile failed: some error"),
+			ContainSubstring("Degraded: operator is degraded"),
+		),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDSCInitializationReadinessCheck_ReadyWithRemovedCapabilities(t *testing.T) {
+	g := NewWithT(t)
+
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{
+				"phase": "Ready",
+				"conditions": []any{
+					map[string]any{"type": "ReconcileComplete", "status": "True", "reason": "ReconcileCompleted", "message": "reconcile completed"},
+					map[string]any{"type": "CapabilityServiceMesh", "status": "False", "reason": "Removed", "message": "service mesh removed"},
+					map[string]any{"type": "CapabilityServiceMeshAuthorization", "status": "False", "reason": "Removed", "message": "service mesh authorization removed"},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{dsci},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonResourceAvailable),
+		"Message": ContainSubstring("DSCInitialization is ready"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+}
+
+func TestDSCInitializationReadinessCheck_Ready(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{newDSCIWithPhase("Ready")},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonResourceAvailable),
+		"Message": ContainSubstring("DSCInitialization is ready"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+}
+
+func TestDSCInitializationReadinessCheck_ReadyWithUnhappyConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{
+				"phase": "Ready",
+				"conditions": []any{
+					map[string]any{"type": "ReconcileComplete", "status": "False", "message": "reconcile failed: some error"},
+					map[string]any{"type": "Degraded", "status": "False", "message": "not degraded"},
+					map[string]any{"type": "Progressing", "status": "False", "message": "not progressing"},
+					map[string]any{"type": "Available", "status": "True", "message": "available"},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dsciReadinessListKinds,
+		Objects:   []*unstructured.Unstructured{dsci},
+	})
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+	result, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeReady),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonResourceUnavailable),
+		"Message": And(ContainSubstring("phase is Ready"), ContainSubstring("ReconcileComplete: reconcile failed: some error")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestDSCInitializationReadinessCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := dscinitialization.NewDSCInitializationReadinessCheck()
+
+	g.Expect(chk.ID()).To(Equal("platform.dsci.readiness"))
+	g.Expect(chk.Name()).To(Equal("Platform :: DSCI :: Readiness Check"))
+	g.Expect(chk.Group()).To(Equal(check.GroupPlatform))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/platform/dscinitialization/support.go
+++ b/pkg/lint/checks/platform/dscinitialization/support.go
@@ -1,0 +1,143 @@
+package dscinitialization
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+// dsciStatusCondition is a minimal representation of a DSCI status condition used for
+// collecting unhappy condition messages regardless of phase.
+type dsciStatusCondition struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+// collectUnhappyDSCIConditionMessages returns messages from DSCI status conditions that
+// deviate from their expected state. Progressing and Degraded conditions are expected to
+// be False when healthy; all other condition types are expected to be True.
+// CapabilityServiceMesh and CapabilityServiceMeshAuthorization are exceptions: when False
+// with reason Removed they represent a healthy disabled state, not a problem.
+// Returns nil if no conditions field exists or no conditions are unhappy.
+func collectUnhappyDSCIConditionMessages(obj *unstructured.Unstructured) ([]string, error) {
+	conditions, err := jq.Query[[]dsciStatusCondition](obj, ".status.conditions")
+	if errors.Is(err, jq.ErrNotFound) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("querying DSCI conditions: %w", err)
+	}
+
+	var messages []string
+
+	for _, cond := range conditions {
+		// Progressing and Degraded follow negative semantics: only False is healthy.
+		// All other conditions expect True. Any value other than the expected one is unhappy.
+		expectFalse := cond.Type == "Progressing" || cond.Type == "Degraded"
+		unhappy := (expectFalse && cond.Status != string(metav1.ConditionFalse)) ||
+			(!expectFalse && cond.Status != string(metav1.ConditionTrue))
+
+		// CapabilityServiceMesh and CapabilityServiceMeshAuthorization with reason Removed
+		// indicate the capability is intentionally disabled, which is a valid healthy state.
+		if isRemovedCapabilityServiceMesh(cond) {
+			unhappy = false
+		}
+
+		if unhappy && cond.Message != "" {
+			messages = append(messages, fmt.Sprintf("%s: %s", cond.Type, cond.Message))
+		}
+	}
+
+	return messages, nil
+}
+
+// isRemovedCapabilityServiceMesh returns true for capability conditions that are False because the
+// capability was explicitly removed, which is an expected healthy state.
+func isRemovedCapabilityServiceMesh(cond dsciStatusCondition) bool {
+	isCapabilityServiceMesh := cond.Type == "CapabilityServiceMesh" || cond.Type == "CapabilityServiceMeshAuthorization"
+
+	return isCapabilityServiceMesh && cond.Status == string(metav1.ConditionFalse) && cond.Reason == "Removed"
+}
+
+// validatePhaseReady checks that the status.phase field is "Ready" on a resource and there are no unexpected conditions.
+func validatePhaseReady(
+	dr *result.DiagnosticResult,
+	obj *unstructured.Unstructured,
+	resourceName string,
+) error {
+	phaseStatus, err := jq.Query[string](obj, `.status.phase`)
+
+	switch {
+	case errors.Is(err, jq.ErrNotFound):
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeReady,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonInsufficientData),
+			check.WithMessage("%s resource found but phase field is missing", resourceName),
+			check.WithImpact(result.ImpactBlocking),
+		))
+	case err != nil:
+		return fmt.Errorf("querying %s phase: %w", resourceName, err)
+	case phaseStatus == "":
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeReady,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonInsufficientData),
+			check.WithMessage("%s resource found but phase is empty", resourceName),
+			check.WithImpact(result.ImpactBlocking),
+		))
+	case phaseStatus != "Ready":
+		condMessages, msgErr := collectUnhappyDSCIConditionMessages(obj)
+		if msgErr != nil {
+			return fmt.Errorf("collecting conditions from %s: %w", resourceName, msgErr)
+		}
+
+		msg := fmt.Sprintf("%s is not ready (phase: %s). %s must be ready before upgrading", resourceName, phaseStatus, resourceName)
+		if len(condMessages) > 0 {
+			msg += ". Conditions: " + strings.Join(condMessages, "; ")
+		}
+
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeReady,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonResourceUnavailable),
+			check.WithMessage("%s", msg),
+			check.WithImpact(result.ImpactBlocking),
+		))
+	default:
+		// Phase is Ready, but conditions may still signal problems.
+		condMessages, msgErr := collectUnhappyDSCIConditionMessages(obj)
+		if msgErr != nil {
+			return fmt.Errorf("collecting conditions from %s: %w", resourceName, msgErr)
+		}
+
+		if len(condMessages) > 0 {
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeReady,
+				metav1.ConditionFalse,
+				check.WithReason(check.ReasonResourceUnavailable),
+				check.WithMessage("%s phase is Ready but some conditions are not expected. Conditions: %s", resourceName, strings.Join(condMessages, "; ")),
+				check.WithImpact(result.ImpactBlocking),
+			))
+		} else {
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeReady,
+				metav1.ConditionTrue,
+				check.WithReason(check.ReasonResourceAvailable),
+				check.WithMessage("%s is ready", resourceName),
+			))
+		}
+	}
+
+	return nil
+}

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -23,6 +23,8 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/datasciencecluster"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/dscinitialization"
 	datasciencepipelinesworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/guardrails"
 	kserveworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/kserve"
@@ -79,6 +81,10 @@ func NewCommand(
 	registry := check.NewRegistry()
 
 	// Explicitly register all checks (no global state, full test isolation)
+	// Platform (2)
+	registry.MustRegister(dscinitialization.NewDSCInitializationReadinessCheck())
+	registry.MustRegister(datasciencecluster.NewDataScienceClusterReadinessCheck())
+
 	// Components (13)
 	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
 	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
@@ -290,7 +296,7 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 		Debug:          c.Debug,
 	}
 
-	// Execute checks in canonical order: dependencies → services → components → workloads
+	// Execute checks in canonical order: dependencies → services → platform → components → workloads
 	resultsByGroup := make(map[check.CheckGroup][]check.CheckExecution)
 
 	for _, group := range check.CanonicalGroupOrder {

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -179,16 +179,6 @@ func ValidateCheckSelector(selector string) error {
 		return errors.New("check selector cannot be empty")
 	}
 
-	// Allow category shortcuts
-	if selector == "components" || selector == "services" || selector == "workloads" || selector == "dependencies" {
-		return nil
-	}
-
-	// Allow wildcard (default)
-	if selector == "*" {
-		return nil
-	}
-
 	// Validate glob pattern
 	_, err := path.Match(selector, "test.check")
 	if err != nil {
@@ -243,9 +233,10 @@ type CheckResultTableRow struct {
 type LintOutput struct {
 	ClusterVersion *string             `json:"clusterVersion,omitempty" yaml:"clusterVersion,omitempty"`
 	TargetVersion  *string             `json:"targetVersion,omitempty"  yaml:"targetVersion,omitempty"`
-	Components     []CheckResultOutput `json:"components"               yaml:"components"`
-	Services       []CheckResultOutput `json:"services"                 yaml:"services"`
 	Dependencies   []CheckResultOutput `json:"dependencies"             yaml:"dependencies"`
+	Services       []CheckResultOutput `json:"services"                 yaml:"services"`
+	Platform       []CheckResultOutput `json:"platform"                 yaml:"platform"`
+	Components     []CheckResultOutput `json:"components"               yaml:"components"`
 	Workloads      []CheckResultOutput `json:"workloads"                yaml:"workloads"`
 	Summary        struct {
 		Total  int `json:"total"  yaml:"total"`
@@ -256,7 +247,7 @@ type LintOutput struct {
 
 // FlattenResults converts a map of results by group to a flat sorted array.
 // Results are sorted by:
-// 1. Group (canonical order: Dependency, Service, Component, Workload)
+// 1. Group (canonical order: Dependency, Service, Platform, Component, Workload)
 // 2. Kind (alphabetically within each group)
 // 3. Name (alphabetically within each kind).
 func FlattenResults(resultsByGroup map[check.CheckGroup][]check.CheckExecution) []check.CheckExecution {
@@ -394,7 +385,7 @@ func impactSortPriority(impact result.Impact) int {
 }
 
 // groupSortPriority returns a numeric priority that follows the canonical
-// group order: dependency -> service -> component -> workload.
+// group order: dependency -> service -> platform -> component -> workload.
 func groupSortPriority(group string) int {
 	for i, g := range check.CanonicalGroupOrder {
 		if string(g) == group {

--- a/pkg/lint/command_options_test.go
+++ b/pkg/lint/command_options_test.go
@@ -104,6 +104,11 @@ func TestValidateCheckSelector(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "category platform valid",
+			selector: "platform",
+			wantErr:  false,
+		},
+		{
 			name:     "glob pattern components.* valid",
 			selector: "components.*",
 			wantErr:  false,

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -16,9 +16,10 @@ const (
 const flagDescChecks = `check selector patterns (glob patterns or categories):
   - '*'             : all checks
   - 'components.*'  : all component checks
+  - 'dependencies.*': all dependency checks
+  - 'platform.*'    : all platform checks
   - 'services.*'    : all service checks
   - 'workloads.*'   : all workload checks
-  - 'dependencies.*': all dependency checks
   - '*dashboard*'   : all checks with 'dashboard' in ID
   - 'exact.id'      : exact check ID
 Can be specified multiple times`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[RHOAIENG-50105](https://issues.redhat.com/browse/RHOAIENG-50105)
## Description
Adding phase check for DSC and DSCI.

This will allow to catch any issues surfaced by operator on DSC/DSCI that are not caught by odh-cli.

## How Has This Been Tested?
make test & local testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<img width="1468" height="804" alt="image" src="https://github.com/user-attachments/assets/4659fb51-9378-4b77-ad54-81e2a36928c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-level readiness checks for DataScienceCluster and DSCInitialization; new platform check group and readiness check type included in canonical order
  * Added platform and dependencies selector shortcuts and category patterns for linting

* **Behavior**
  * Readiness now inspects Ready condition/phase and surfaces blocking diagnostics when resources are not ready

* **Tests**
  * Added comprehensive unit tests covering readiness scenarios for both resources
<!-- end of auto-generated comment: release notes by coderabbit.ai -->