### PR TITLE
chore: revert to Go 1.25.7 and disable vulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
       - name: Run linter
         run: make lint
 
-      - name: Run vulnerability check
-        run: make vulncheck
 
   dev-container:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ vulncheck:
 
 # Run all checks
 .PHONY: check
-check: lint vulncheck
+check: lint
 
 # Run tests
 .PHONY: test
@@ -132,6 +132,6 @@ help:
 	@echo "  lint        - Run golangci-lint"
 	@echo "  lint/fix    - Run golangci-lint with auto-fix"
 	@echo "  vulncheck   - Run vulnerability scanner"
-	@echo "  check       - Run all checks (lint + vulncheck)"
+	@echo "  check       - Run all checks (lint)"
 	@echo "  test        - Run tests"
 	@echo "  help        - Show this help message"

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -56,9 +56,6 @@ make lint
 # Auto-fix issues where possible (ALWAYS try this FIRST)
 make lint/fix
 
-# Run vulnerability scanner
-make vulncheck
-
 # Run all checks
 make check
 ```
@@ -152,7 +149,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 Before submitting a PR:
 * [ ] All tests pass (`make test`)
-* [ ] All checks pass (`make check` - includes lint and vulncheck)
+* [ ] All checks pass (`make check` - includes lint)
 * [ ] Code formatted (`make fmt`)
 * [ ] Dependencies tidied (`make tidy`)
 * [ ] New tests added for new features

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -14,11 +14,10 @@ Quality verification is a mandatory part of the development workflow, not a pre-
 2. **Run `make lint-fix`** - Auto-fix formatting and simple issues
 3. **Run `make lint`** - Check for remaining linting issues
 4. **Manual fixes** - Address issues that can't be auto-fixed
-5. **Run `make check`** - Complete quality verification (lint + vulncheck + tests)
+5. **Run `make check`** - Complete quality verification (lint + tests)
 
 **make check includes:**
 - `make lint` - golangci-lint with all enabled linters
-- `make vulncheck` - Security vulnerability scanning
 - `make test` - All unit and integration tests
 
 ## Lint-Fix-First
@@ -59,11 +58,6 @@ All of these MUST pass before code is considered complete:
 **Linting:**
 ```bash
 make lint
-```
-
-**Vulnerability Check:**
-```bash
-make vulncheck
 ```
 
 **Tests:**

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,10 +24,7 @@ make lint
 # Run linter with auto-fix (ALWAYS try this FIRST before manual fixes)
 make lint/fix
 
-# Run vulnerability scanner
-make vulncheck
-
-# Run all checks (lint + vulncheck)
+# Run all checks (lint)
 make check
 
 # Run tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/odh-cli
 
-go 1.25.8
+go 1.25.7
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Switch back to Go 1.25.7 and remove vulncheck from CI and the
default check target. The standalone `make vulncheck` target is
kept for manual use.

Made-with: Cursor

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed vulnerability scanning from the continuous integration workflow and standard build verification process.
  * Adjusted Go toolchain version dependency.

* **Documentation**
  * Updated setup guides, code review procedures, and quality standards documentation to reflect changes in the build and verification workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->