### PR TITLE
add directory for component backups to be stored and mounted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,10 @@ ENV PATH="/opt/rhai-cli/bin:${PATH}"
 # Copy upgrade helpers from builder
 COPY --from=builder /opt/rhai-upgrade-helpers /opt/rhai-upgrade-helpers
 
+# Create backup directory for upgrade artifacts (world-writable with sticky bit
+# so arbitrary UIDs can create subdirectories without permission errors)
+RUN mkdir -p /tmp/rhoai-upgrade-backup && chmod 1777 /tmp/rhoai-upgrade-backup
+
 # Set entrypoint to rhai-cli binary
 # Users can override with --entrypoint /bin/bash for interactive debugging
 ENTRYPOINT ["/opt/rhai-cli/bin/rhai-cli"]


### PR DESCRIPTION
Create /tmp/rhoai-upgrade-backup directory in the container image with world-writable permissions (sticky bit) so upgrade helper scripts can write backup artifacts under arbitrary OpenShift UIDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upgrade failures on restricted/containerized platforms by ensuring a temporary backup directory is created with world-writable, sticky-bit permissions so containers running with arbitrary UIDs can create required subdirectories during upgrades, preventing permission-related errors and improving upgrade reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->