### PR TITLE
update: cli name, documentation for usage, github image push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
           username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
+      - name: Set container repo for red-hat-data-services
+        if: github.repository_owner == 'red-hat-data-services'
+        run: echo "CONTAINER_REPO=quay.io/rhoai/odh-cli-rhel9" >> $GITHUB_ENV
+
       - name: Build and push dev image
         env:
           VERSION: dev
@@ -96,6 +100,10 @@ jobs:
           registry: ${{ secrets.CONTAINER_REGISTRY }}
           username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
           password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+
+      - name: Set container repo for red-hat-data-services
+        if: github.repository_owner == 'red-hat-data-services'
+        run: echo "CONTAINER_REPO=quay.io/rhoai/odh-cli-rhel9" >> $GITHUB_ENV
 
       - name: Build and push image
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,15 +1,15 @@
 version: 2
 
-project_name: kubectl-odh
+project_name: odh-cli
 
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - id: kubectl-odh
+  - id: odh-cli
     main: ./cmd/main.go
-    binary: kubectl-odh
+    binary: odh-cli
     env:
       - CGO_ENABLED=0
     goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,20 +67,7 @@ RUN python3 -m pip install --no-cache-dir \
     'kubernetes>=28.1.0' \
     'PyYAML>=6.0'
 
-# Install kubectl with multi-arch support (latest stable version)
-RUN set -e; \
-    ARCH=${TARGETARCH:-amd64}; \
-    case "$ARCH" in \
-        amd64) KUBE_ARCH="amd64" ;; \
-        arm64) KUBE_ARCH="arm64" ;; \
-        *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
-    esac; \
-    echo "Installing kubectl for architecture: $KUBE_ARCH"; \
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl"; \
-    chmod +x kubectl; \
-    mv kubectl /usr/local/bin/kubectl
-
-# Install OpenShift CLI (oc) with multi-arch support (stable version)
+# Install OpenShift CLI (oc) and kubectl with multi-arch support
 RUN set -e; \
     ARCH=${TARGETARCH:-amd64}; \
     case "$ARCH" in \
@@ -88,13 +75,14 @@ RUN set -e; \
         arm64) OC_ARCH="arm64" ;; \
         *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
-    echo "Installing oc for architecture: $OC_ARCH"; \
+    echo "Installing oc and kubectl for architecture: $OC_ARCH"; \
     curl -fsSL -o openshift-client.tar.gz \
-        "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.17/openshift-client-linux-${OC_ARCH}-rhel9.tar.gz"; \
+        "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.19/openshift-client-linux-${OC_ARCH}-rhel9.tar.gz"; \
     tar -xzf openshift-client.tar.gz; \
-    chmod +x oc; \
+    chmod +x oc kubectl; \
     mv oc /usr/local/bin/oc; \
-    rm -f openshift-client.tar.gz kubectl README.md
+    mv kubectl /usr/local/bin/kubectl; \
+    rm -f openshift-client.tar.gz README.md
 
 # Install yq with multi-arch support (stable version)
 RUN set -e; \
@@ -111,18 +99,19 @@ RUN set -e; \
     chmod +x /usr/local/bin/yq
 
 # Copy binary from builder (cross-compiled for target platform)
-COPY --from=builder /workspace/bin/kubectl-odh /opt/rhai-cli/bin/rhai-cli
+COPY --from=builder /workspace/bin/odh-cli /opt/odh-cli/bin/odh-cli
 
-# Add rhai-cli to PATH
-ENV PATH="/opt/rhai-cli/bin:${PATH}"
+# Add odh-cli to PATH
+ENV PATH="/opt/odh-cli/bin:${PATH}"
 
 # Copy upgrade helpers from builder
 COPY --from=builder /opt/rhai-upgrade-helpers /opt/rhai-upgrade-helpers
 
 # Create backup directory for upgrade artifacts (world-writable with sticky bit
 # so arbitrary UIDs can create subdirectories without permission errors)
+# This is path is created by https://github.com/red-hat-data-services/rhoai-upgrade-helpers
 RUN mkdir -p /tmp/rhoai-upgrade-backup && chmod 1777 /tmp/rhoai-upgrade-backup
 
-# Set entrypoint to rhai-cli binary
+# Set entrypoint to odh-cli binary
 # Users can override with --entrypoint /bin/bash for interactive debugging
-ENTRYPOINT ["/opt/rhai-cli/bin/rhai-cli"]
+ENTRYPOINT ["/opt/odh-cli/bin/odh-cli"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# kubectl-odh CLI Makefile
+# odh-cli Makefile
 
 # Binary name
-BINARY_NAME=bin/kubectl-odh
+BINARY_NAME=bin/odh-cli
 
 # Version information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -18,7 +18,7 @@ LINT_TIMEOUT := 10m
 
 # Container registry configuration
 CONTAINER_REGISTRY ?= quay.io
-CONTAINER_REPO ?= $(CONTAINER_REGISTRY)/rhoai/rhoai-upgrade-helpers-rhel9
+CONTAINER_REPO ?= $(CONTAINER_REGISTRY)/opendatahub-io/odh-cli-rhel9
 CONTAINER_PLATFORMS ?= linux/amd64,linux/arm64
 CONTAINER_TAGS ?= $(VERSION)
 
@@ -122,7 +122,7 @@ publish: build-image
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  build       - Build the kubectl-odh binary"
+	@echo "  build       - Build the odh-cli binary"
 	@echo "  build-image - Build container image without pushing (creates local manifest)"
 	@echo "  publish     - Build and push container image using Podman manifest"
 	@echo "  run         - Run the doctor command"

--- a/README.md
+++ b/README.md
@@ -1,113 +1,165 @@
 # odh-cli
 
-CLI tool for RHOAI (Red Hat OpenShift AI) for interacting with RHOAI deployments on Kubernetes.
+CLI tool for ODH/RHOAI (Red Hat OpenShift AI) for interacting with ODH/RHOAI deployments on Kubernetes.
+
+## Available Subcommands
+
+- **`odh-cli lint`** - Validate cluster configuration and assess upgrade readiness
+- **`odh-cli version`** - Display CLI version information
 
 ## Quick Start
 
 ### Using Containers
 
-Run the CLI using the pre-built container image:
+Run the CLI using the pre-built container image. Set your container runtime (podman or docker):
 
-**Podman:**
 ```bash
-podman run --rm -ti \
-  -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
-```
+# Use podman or docker
+CONTAINER_TOOL=podman  # or 'docker'
 
-**Docker:**
-```bash
-docker run --rm -ti \
+# Run lint command
+$CONTAINER_TOOL run --rm -ti \
   -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
+  quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0
 ```
 
 The container has `KUBECONFIG=/kubeconfig` set by default, so you just need to mount your kubeconfig to that path.
 
-> **SELinux:** On systems with SELinux enabled (Fedora, RHEL, CentOS), add `:Z` to the volume mount:
+> **Note:** If `KUBECONFIG` is not set, use the default path:
 > ```bash
-> # Podman
-> podman run --rm -ti \
->   -v $KUBECONFIG:/kubeconfig:Z \
->   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
->
-> # Docker
-> docker run --rm -ti \
->   -v $KUBECONFIG:/kubeconfig:Z \
->   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
+> $CONTAINER_TOOL run --rm -ti \
+>   -v ~/.kube/config:/kubeconfig \
+>   quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0
 > ```
 
+> **SELinux:** On SELinux systems (Fedora, RHEL, CentOS), add `:Z` to volume mounts:
+> ```bash
+> # With KUBECONFIG set
+> $CONTAINER_TOOL run --rm -ti \
+>   -v $KUBECONFIG:/kubeconfig:Z \
+>   quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0
+>
+> # With default kubeconfig path
+> $CONTAINER_TOOL run --rm -ti \
+>   -v ~/.kube/config:/kubeconfig:Z \
+>   quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0
+> ```
+
+**Working with Multiple Clusters:**
+
+If your kubeconfig contains multiple cluster contexts, the CLI uses the `current-context`. You have two options:
+
+**Option 1: Switch context before running (Recommended)**
+
+```bash
+# Switch to desired cluster
+kubectl config use-context <context-name>
+
+# Run the CLI (uses new context-name)
+$CONTAINER_TOOL run --rm -ti \
+  -v ~/.kube/config:/kubeconfig \
+  quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0
+```
+
+**Option 2: Set context with --context flag**
+
+```bash
+$CONTAINER_TOOL run --rm -ti \
+  -v ~/.kube/config:/kubeconfig:Z \
+  quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0 \
+  --context <context-name>
+```
+
 **Available Tags:**
-- `:latest` - Latest stable release
-- `:dev` - Latest development build from main branch (updated on every push)
-- `:vX.Y.Z` - Specific version (e.g., `:v1.2.3`)
+- `:dev` - Latest development build from main branch
+- `:rhoai-X.Y-ea.Z` - Specific version (e.g., `:rhoai-3.4-ea.1`)
 
-> **Note:** The images are OCI-compliant and work with both Podman and Docker. Examples for both are provided below.
+> **Note:** The images are OCI-compliant and work with both Podman and Docker.
 
-**Shell Access:**
+**Interactive Shell Access:**
 
-The container also bundles migration tools and CLI utilities that can be used directly from a shell session:
+For interactive debugging and running upgrade helper scripts:
 
-**Podman:**
+**Step 1: Login to cluster (on your host)**
 ```bash
-podman run -it --rm \
-  -v $KUBECONFIG:/kubeconfig \
-  --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
+# Login on your cluster which should  update ~/.kube/config
+oc login --token=sha256~xxxx --server=https://api.my-cluster.example.com:6443
 ```
 
-**Docker:**
+**Step 2: Shell into container**
 ```bash
-docker run -it --rm \
-  -v $KUBECONFIG:/kubeconfig \
+# Mount the kubeconfig that was created by oc login
+$CONTAINER_TOOL run -it --rm \
+  -v ~/.kube/config:/kubeconfig \
   --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
+  quay.io/rhoai/odh-cli-rhel9:dev
 ```
+
+**Step 3: Inside container - you're already authenticated**
 
 Available tools:
-- `rhai-cli`
-- `kubectl` (latest stable)
-- `oc` (latest stable)
-- `jq`
-- `wget`
-- `curl`
-- `tar`
-- `gzip`
-- `bash`
+- `odh-cli` - The CLI tool (at `/opt/odh-cli/bin/odh-cli`)
+- `kubectl` / `oc` - Kubernetes/OpenShift client tools from OCP 4.19
+- Upgrade helper scripts at `/opt/rhai-upgrade-helpers`
+- Standard utilities: `jq`, `yq`, `python3`, `wget`, `curl`, `tar`, `gzip`, `bash`
 
-Example usage:
+Example workflow:
 ```bash
-oc login --token=sha256~xxxx --server=https://api.my-cluster.p3.openshiftapps.com:6443
-
-kubectl get pods -n opendatahub
+# Verify connection
 oc get dsci
 
-rhai-cli lint --target-version 3.3.0
+# Run lint command
+odh-cli lint --target-version 3.3.0
+
+# Example: Run upgrade helper script
+cd /opt/rhai-upgrade-helpers
+./ray/ray_cluster_migration.py backup
 ```
 
-The `rhai-cli` binary is located at `/opt/rhai-cli/bin/rhai-cli` (already on `PATH`).
-Upgrade helper scripts are located at `/opt/rhai-upgrade-helpers`.
+**Using Upgrade Helper Scripts:**
+
+The lint command identifies upgrade issues and provides remediation steps that reference upgrade helper scripts. Follow this workflow:
+
+**Step 1: Run lint to identify issues**
+```bash
+$CONTAINER_TOOL run --rm -ti \
+  -v ~/.kube/config:/kubeconfig \
+  quay.io/rhoai/odh-cli-rhel9:dev lint --target-version 3.3.0
+```
+
+**Step 2: Review remediation guidance**
+
+Lint output shows which helper scripts to run:
+```
+CHECK: Ray workloads migration
+REMEDIATION: Run ray_cluster_migration.py from rhoai-upgrade-helpers repository
+```
+
+**Step 3: Run helper scripts in shell mode**
+
+Shell into the container with backup directory mounted:
+```bash
+$CONTAINER_TOOL run -it --rm \
+  -v ~/.kube/config:/kubeconfig:Z \
+  -v ./backup:/tmp/rhoai-upgrade-backup:Z \
+  --entrypoint /bin/bash quay.io/rhoai/odh-cli-rhel9:dev
+
+# Inside container - run the recommended script
+cd /opt/rhai-upgrade-helpers
+./ray/ray_cluster_migration.py backup
+./trustyai/backup-metrics.sh
+```
+
+Scripts write backups to `/tmp/rhoai-upgrade-backup/<component>/` which persists to `./backup/` on your localhost via the volume mount.
 
 **Token Authentication:**
 
-For environments where you have a token and server URL instead of a kubeconfig file:
+For environments with token and server URL (no kubeconfig file):
 
-**Podman:**
 ```bash
-podman run --rm -ti \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev \
-  lint \
-  --target-version 3.3.0 \
-  --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
-  --server=https://api.my-cluster.p3.openshiftapps.com:6443
-```
-
-**Docker:**
-```bash
-docker run --rm -ti \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev \
-  lint \
-  --target-version 3.3.0 \
+$CONTAINER_TOOL run --rm -ti \
+  quay.io/rhoai/odh-cli-rhel9:dev \
+  lint --target-version 3.3.0 \
   --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
   --server=https://api.my-cluster.p3.openshiftapps.com:6443
 ```
@@ -120,4 +172,3 @@ For detailed documentation, see:
 - [Development Guide](docs/development.md)
 - [Lint Architecture](docs/lint/architecture.md)
 - [Writing Lint Checks](docs/lint/writing-checks.md)
-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,40 @@ CLI tool for ODH/RHOAI (Red Hat OpenShift AI) for interacting with ODH/RHOAI dep
 
 ## Quick Start
 
+### Using Pre-built Binary
+
+Download the latest release from [GitHub Releases](https://github.com/opendatahub-io/odh-cli/releases):
+
+```bash
+# Download and extract (example for Linux amd64)
+curl -LO https://github.com/opendatahub-io/odh-cli/releases/latest/download/odh-cli_linux_amd64.tar.gz
+tar -xzf odh-cli_linux_amd64.tar.gz
+
+# Make it avaiable on PATH
+sudo mv odh-cli /usr/local/bin/
+
+# Verify installation
+odh-cli version
+
+# Run commands
+odh-cli lint --target-version 3.3.0
+```
+
+**As kubectl Plugin (optional):**
+
+To use as `kubectl odh`, rename or symlink the binary after download it:
+
+```bash
+# Option 1: Rename
+sudo mv odh-cli /usr/local/bin/kubectl-odh
+
+# Option 2: Symlink (keeps both names available)
+sudo ln -s /usr/local/bin/odh-cli /usr/local/bin/kubectl-odh
+
+# Now use with kubectl
+kubectl odh lint --target-version 3.3.0
+```
+
 ### Using Containers
 
 Run the CLI using the pre-built container image. Set your container runtime (podman or docker):

--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -20,6 +20,12 @@ const cmdLong = `
 Backs up OpenShift AI workloads (notebooks, etc.) and their dependencies
 (ConfigMaps, Secrets, PVCs) to a directory structure.
 
+INVOCATION:
+  The examples below use 'odh-cli'. Depending on your setup, substitute with:
+    - Container:       podman|docker run <image> backup ...
+    - kubectl plugin:  kubectl odh backup ...
+    - Direct binary:   odh-cli backup ...
+
 The backup command:
   - Discovers workload resources based on --includes/--exclude filters
   - For each workload, identifies and backs up referenced dependencies

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -19,6 +19,12 @@ const (
 const cmdLong = `
 Validates the current OpenShift AI installation or assesses upgrade readiness.
 
+INVOCATION:
+  The examples below use 'odh-cli'. Depending on your setup, substitute with:
+    - Container:       podman|docker run <image> lint ...
+    - kubectl plugin:  kubectl odh lint ...
+    - Direct binary:   odh-cli lint ...
+
 LINT MODE (without --target-version):
   Validates the current cluster state and reports configuration issues.
 
@@ -38,32 +44,32 @@ Each issue is reported with:
 
 Examples:
   # Validate current cluster state
-  kubectl odh lint
+  odh-cli lint
 
   # Assess upgrade readiness for version 3.0
-  kubectl odh lint --target-version 3.0
+  odh-cli lint --target-version 3.0
 
   # Validate with JSON output
-  kubectl odh lint -o json
+  odh-cli lint -o json
 
   # Validate only component checks
-  kubectl odh lint --checks "components"
+  odh-cli lint --checks "components"
 `
 const cmdExample = `
   # Validate current cluster state
-  kubectl odh lint
+  odh-cli lint
 
   # Assess upgrade readiness for version 3.0
-  kubectl odh lint --target-version 3.0
+  odh-cli lint --target-version 3.0
 
   # Output results in JSON format
-  kubectl odh lint -o json
+  odh-cli lint -o json
 
   # Run only dashboard-related checks
-  kubectl odh lint --checks "*dashboard*"
+  odh-cli lint --checks "*dashboard*"
 
   # Check upgrade readiness to version 3.1
-  kubectl odh lint --target-version 3.1
+  odh-cli lint --target-version 3.1
 `
 
 // AddCommand adds the lint command to the root command.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ func main() {
 	flags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 
 	cmd := &cobra.Command{
-		Use:   "kubectl-odh",
+		Use:   "odh-cli",
 		Short: "kubectl plugin for ODH/RHOAI",
 	}
 

--- a/cmd/migrate/list/list.go
+++ b/cmd/migrate/list/list.go
@@ -26,13 +26,13 @@ migrations without version filtering, or --target-version to filter by applicabi
 
 const cmdExample = `
   # List applicable migrations for version 3.0
-  kubectl odh migrate list --target-version 3.0.0
+  odh-cli migrate list --target-version 3.0.0
 
   # List all migrations without version filtering
-  kubectl odh migrate list --all
+  odh-cli migrate list --all
 
   # List with JSON output
-  kubectl odh migrate list --target-version 3.0.0 -o json
+  odh-cli migrate list --target-version 3.0.0 -o json
 `
 
 // AddCommand adds the list subcommand to the migrate command.

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -19,6 +19,12 @@ const (
 const cmdLong = `
 The migrate command manages cluster migrations for OpenShift AI components.
 
+INVOCATION:
+  The examples below use 'odh-cli'. Depending on your setup, substitute with:
+    - Container:       podman|docker run <image> migrate ...
+    - kubectl plugin:  kubectl odh migrate ...
+    - Direct binary:   odh-cli migrate ...
+
 Use 'migrate list' to see available migrations filtered by version compatibility.
 Use 'migrate prepare' to backup resources before migration.
 Use 'migrate run' to execute one or more migrations sequentially.
@@ -35,22 +41,22 @@ Available subcommands:
 
 const cmdExample = `
   # List available migrations for version 3.0
-  kubectl odh migrate list --target-version 3.0.0
+  odh-cli migrate list --target-version 3.0.0
 
   # List all migrations including non-applicable ones
-  kubectl odh migrate list --all
+  odh-cli migrate list --all
 
   # Prepare for migration (creates backups)
-  kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
+  odh-cli migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
 
   # Run a migration with confirmation prompts
-  kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0
+  odh-cli migrate run --migration kueue.rhbok.migrate --target-version 3.0.0
 
   # Run migration in dry-run mode (preview changes only)
-  kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run
+  odh-cli migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run
 
   # Run multiple migrations sequentially
-  kubectl odh migrate run --migration kueue.rhbok.migrate --migration other.migration --target-version 3.0.0 --yes
+  odh-cli migrate run --migration kueue.rhbok.migrate --migration other.migration --target-version 3.0.0 --yes
 `
 
 // AddCommand adds the migrate command to the root command.

--- a/cmd/migrate/prepare/prepare.go
+++ b/cmd/migrate/prepare/prepare.go
@@ -30,19 +30,19 @@ Use --output-dir to specify where backups should be written.
 
 const cmdExample = `
   # Prepare for a single migration (creates timestamped backup directory)
-  kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
+  odh-cli migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
 
   # Prepare with custom backup directory
-  kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --output-dir /path/to/backups
+  odh-cli migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --output-dir /path/to/backups
 
   # Preview what would be backed up (dry-run mode)
-  kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run
+  odh-cli migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run
 
   # Prepare without confirmation prompts
-  kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
+  odh-cli migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
 
   # Prepare multiple migrations sequentially
-  kubectl odh migrate prepare -m kueue.rhbok.migrate -m other.migration --target-version 3.0.0
+  odh-cli migrate prepare -m kueue.rhbok.migrate -m other.migration --target-version 3.0.0
 `
 
 // AddCommand adds the prepare subcommand to the migrate command.

--- a/cmd/migrate/run/run.go
+++ b/cmd/migrate/run/run.go
@@ -26,20 +26,20 @@ Use 'migrate prepare' to backup resources before running migrations.
 
 const cmdExample = `
   # Run a single migration with confirmation prompts
-  kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0
+  odh-cli migrate run --migration kueue.rhbok.migrate --target-version 3.0.0
 
   # Run migration in dry-run mode (verbose is automatically enabled)
-  kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run
+  odh-cli migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run
 
   # Run migration without confirmation prompts
-  kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
+  odh-cli migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
 
   # Run multiple migrations sequentially
-  kubectl odh migrate run -m kueue.rhbok.migrate -m other.migration --target-version 3.0.0
+  odh-cli migrate run -m kueue.rhbok.migrate -m other.migration --target-version 3.0.0
 
   # Typical workflow: prepare first, then run
-  kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
-  kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
+  odh-cli migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
+  odh-cli migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
 `
 
 // AddCommand adds the run subcommand to the migrate command.

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -44,7 +44,7 @@ func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
 			default:
 				_, err := fmt.Fprintf(
 					cmd.OutOrStdout(),
-					"kubectl-odh version %s (commit: %s, built: %s)\n",
+					"odh-cli version %s (commit: %s, built: %s)\n",
 					version.GetVersion(),
 					version.GetCommit(),
 					version.GetDate(),

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,12 +35,23 @@ go run github.com/opendatahub-io/odh-cli/cmd@latest \
 
 ## As kubectl Plugin
 
-Install the `kubectl-odh` binary to your PATH:
+To use as a kubectl plugin, rename or symlink the `odh-cli` binary:
 
 ```bash
-# Download from releases
-# Place in PATH as kubectl-odh
+# Download from GitHub releases
+curl -LO https://github.com/opendatahub-io/odh-cli/releases/latest/download/odh-cli_linux_amd64.tar.gz
+tar -xzf odh-cli_linux_amd64.tar.gz
+
+# Option 1: Rename to kubectl-odh for kubectl to auto discovery
+sudo mv odh-cli /usr/local/bin/kubectl-odh
+
+# Option 2: Symlink (keeps both names available)
+sudo mv odh-cli /usr/local/bin/
+sudo ln -s /usr/local/bin/odh-cli /usr/local/bin/kubectl-odh
+
 # Use with kubectl
 kubectl odh lint --target-version 3.3.0
-kubectl odh version
+
+# or just use directly
+odh-cli lint --target-version 3.3.0
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
we have out-of-date info in the repo for image, usage, name of the main cli etc
- update Makefile for the final image
- update README with usage and image
- update Dockerfile, download kubectl and oc both by "oc" from 4.19

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI renamed to odh-cli (binary name, entrypoint and version output updated).
  * odh-cli now ships/install guidance for both oc and kubectl included.

* **Chores**
  * CI updated to conditionally set container repo during dev/release flows.
  * Build embeds commit and build date into the binary.

* **Documentation**
  * README and docs updated with new CLI names, install/run examples, container usage, and multi-cluster guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->