### PR TITLE
feat: add --no-color flag with TTY detection and NO_COLOR env var support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
+	golang.org/x/term v0.39.0
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -3,10 +3,13 @@ package lint
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/blang/semver/v4"
+	"github.com/fatih/color"
 	"github.com/spf13/pflag"
+	"golang.org/x/term"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -154,6 +157,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&c.CheckSelectors, "checks", []string{"*"}, flagDescChecks)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.BoolVar(&c.Debug, "debug", false, flagDescDebug)
+	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
 	fs.StringVar(&c.ISVCDeploymentMode, "isvc-deployment-mode", "all", flagDescISVCDeploymentMode)
 
@@ -168,6 +172,16 @@ func (c *Command) Complete() error {
 	if err := c.SharedOptions.Complete(); err != nil {
 		return fmt.Errorf("completing shared options: %w", err)
 	}
+	// Set global color state with priority: --no-color flag > NO_COLOR env > TTY detection
+	//nolint:revive // Both branches set NoColor=true but for different reasons (intentional)
+	if c.OutputFormat == OutputFormatJSON || c.OutputFormat == OutputFormatYAML {
+		// Force NoColor for structured output formats (prevents data corruption)
+		c.NoColor = true
+	} else if !c.NoColor && (os.Getenv("NO_COLOR") != "" || !c.IsTerminal()) {
+		// Disable colors if NO_COLOR env var is set OR stdout is not a TTY
+		c.NoColor = true
+	}
+	color.NoColor = c.NoColor
 
 	// Wrap IO with QuietWrapper if NOT in verbose or debug mode (default is quiet)
 	if !c.Verbose && !c.Debug {
@@ -452,4 +466,15 @@ func collectNamespaceRequesters(
 	}
 
 	return requesters
+}
+
+// IsTerminal returns true if stdout is a terminal (TTY).
+// Returns false if stdout is piped, redirected, or not a file descriptor.
+func (c *Command) IsTerminal() bool {
+	// Check if IO.Out() is a *os.File with a valid file descriptor
+	if file, ok := c.IO.Out().(*os.File); ok {
+		return term.IsTerminal(int(file.Fd()))
+	}
+	// If not a file (e.g., buffer in tests), assume not a terminal
+	return false
 }

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -85,6 +85,8 @@ type SharedOptions struct {
 	// Debug enables detailed diagnostic logging for troubleshooting (default: false)
 	Debug bool
 
+	// NoColor disables color output (default: false)
+	NoColor bool
 	// Timeout is the maximum duration for command execution
 	Timeout time.Duration
 
@@ -202,6 +204,20 @@ type CommandOption func(*Command)
 func WithTargetVersion(version string) CommandOption {
 	return func(c *Command) {
 		c.TargetVersion = version
+	}
+}
+
+// WithOutputFormat returns a CommandOption that sets the output format.
+func WithOutputFormat(format OutputFormat) CommandOption {
+	return func(c *Command) {
+		c.OutputFormat = format
+	}
+}
+
+// WithIO returns a CommandOption that sets the IOStreams.
+func WithIO(streams iostreams.Interface) CommandOption {
+	return func(c *Command) {
+		c.IO = streams
 	}
 }
 

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -255,3 +255,336 @@ func TestCommand_FunctionalOptions(t *testing.T) {
 		g.Expect(command.IO).ToNot(BeNil())
 	})
 }
+
+// TestColorDetection_DefaultBehavior tests that colors are disabled for non-TTY output.
+func TestColorDetection_DefaultBehavior(t *testing.T) {
+	t.Run("should disable colors when output is not a TTY (buffer)", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		// Buffers are not TTY, so TTY detection should disable colors
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_NoColorFlag tests --no-color flag behavior.
+func TestColorDetection_NoColorFlag(t *testing.T) {
+	t.Run("should disable colors when --no-color flag is set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.NoColor = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_NOColorEnv tests NO_COLOR environment variable.
+func TestColorDetection_NOColorEnv(t *testing.T) {
+	t.Run("should disable colors when NO_COLOR env var is set", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Set NO_COLOR environment variable
+		t.Setenv("NO_COLOR", "1")
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_NOColorEnvValues tests NO_COLOR with various values.
+func TestColorDetection_NOColorEnvValues(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{"value=1", "1", true},
+		{"value=true", "true", true},
+		{"value=yes", "yes", true},
+		{"value=anything", "anything", true},
+		{"empty string", "", true}, // Still true because buffer is non-TTY
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			t.Setenv("NO_COLOR", tc.value)
+
+			var out, errOut bytes.Buffer
+			streams := genericiooptions.IOStreams{
+				In:     &bytes.Buffer{},
+				Out:    &out,
+				ErrOut: &errOut,
+			}
+
+			command := lint.NewCommand(streams, testConfigFlags())
+
+			err := command.Complete()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(command.NoColor).To(Equal(tc.expected))
+		})
+	}
+}
+
+// TestColorDetection_JSONFormat tests JSON output forces NoColor.
+func TestColorDetection_JSONFormat(t *testing.T) {
+	t.Run("should force no colors for JSON output format", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags(),
+			lint.WithOutputFormat(lint.OutputFormatJSON),
+		)
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_YAMLFormat tests YAML output forces NoColor.
+func TestColorDetection_YAMLFormat(t *testing.T) {
+	t.Run("should force no colors for YAML output format", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags(),
+			lint.WithOutputFormat(lint.OutputFormatYAML),
+		)
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_PriorityFlagOverridesDefault tests flag priority.
+func TestColorDetection_PriorityFlagOverridesDefault(t *testing.T) {
+	t.Run("priority: --no-color flag overrides default", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.NoColor = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_PriorityJSONOverridesFlag tests JSON format has highest priority.
+func TestColorDetection_PriorityJSONOverridesFlag(t *testing.T) {
+	t.Run("priority: JSON format overrides --no-color=false", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		// Even if NoColor is false, JSON should force it to true
+		command := lint.NewCommand(streams, testConfigFlags(),
+			lint.WithOutputFormat(lint.OutputFormatJSON),
+		)
+		command.NoColor = false
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_PriorityJSONOverridesEnv tests JSON format overrides NO_COLOR env.
+func TestColorDetection_PriorityJSONOverridesEnv(t *testing.T) {
+	t.Run("priority: JSON format overrides NO_COLOR unset", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// NO_COLOR is not set (colors would be enabled)
+		// But JSON format should force NoColor=true
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags(),
+			lint.WithOutputFormat(lint.OutputFormatJSON),
+		)
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestIsTerminal_BufferOutput tests IsTerminal returns false for buffer output.
+func TestIsTerminal_BufferOutput(t *testing.T) {
+	t.Run("should return false for buffer (non-TTY)", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Create command with buffer output (not a real file/terminal)
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+
+		// Buffer is not a TTY
+		g.Expect(command.IsTerminal()).To(BeFalse())
+	})
+}
+
+// TestColorDetection_PriorityEnvOverridesDefault tests NO_COLOR env overrides default.
+func TestColorDetection_PriorityEnvOverridesDefault(t *testing.T) {
+	t.Run("priority: NO_COLOR env overrides default", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Set NO_COLOR env var
+		t.Setenv("NO_COLOR", "1")
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		// NoColor flag not set (would default to false)
+		// But NO_COLOR env should force it to true
+		command := lint.NewCommand(streams, testConfigFlags())
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(command.NoColor).To(BeTrue())
+	})
+}
+
+// TestColorDetection_CompletePriorityChain tests full priority chain.
+func TestColorDetection_CompletePriorityChain(t *testing.T) {
+	t.Run("priority chain: JSON > Flag > Env > TTY > Default", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			format    lint.OutputFormat
+			flagValue bool
+			envValue  string
+			expected  bool
+			reason    string
+		}{
+			{
+				name:      "JSON forces NoColor",
+				format:    lint.OutputFormatJSON,
+				flagValue: false,
+				envValue:  "",
+				expected:  true,
+				reason:    "JSON format has highest priority",
+			},
+			{
+				name:      "Flag overrides env",
+				format:    lint.OutputFormatTable,
+				flagValue: true,
+				envValue:  "",
+				expected:  true,
+				reason:    "Flag set to true",
+			},
+			{
+				name:      "Env works when flag not set",
+				format:    lint.OutputFormatTable,
+				flagValue: false,
+				envValue:  "1",
+				expected:  true,
+				reason:    "NO_COLOR env set",
+			},
+			{
+				name:      "Default to true (TTY detection with buffer)",
+				format:    lint.OutputFormatTable,
+				flagValue: false,
+				envValue:  "",
+				expected:  true,
+				reason:    "No overrides, but buffer is non-TTY so colors disabled",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				g := NewWithT(t)
+
+				if tc.envValue != "" {
+					t.Setenv("NO_COLOR", tc.envValue)
+				}
+
+				var out, errOut bytes.Buffer
+				streams := genericiooptions.IOStreams{
+					In:     &bytes.Buffer{},
+					Out:    &out,
+					ErrOut: &errOut,
+				}
+
+				command := lint.NewCommand(streams, testConfigFlags(),
+					lint.WithOutputFormat(tc.format),
+				)
+				command.NoColor = tc.flagValue
+
+				err := command.Complete()
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(command.NoColor).To(Equal(tc.expected), tc.reason)
+			})
+		}
+	})
+}

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -11,6 +11,7 @@ const (
 	flagDescQPS                = "Kubernetes API QPS limit (queries per second)"
 	flagDescBurst              = "Kubernetes API burst capacity"
 	flagDescISVCDeploymentMode = "filter InferenceService display by deployment mode (all|serverless|modelmesh)"
+	flagDescNoColor            = "disable colored output (also respects NO_COLOR env var)"
 )
 
 const flagDescChecks = `check selector patterns (glob patterns or categories):

--- a/pkg/lint/output_table.go
+++ b/pkg/lint/output_table.go
@@ -9,25 +9,14 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/fatih/color"
-
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
+	utilcolor "github.com/opendatahub-io/odh-cli/pkg/util/color"
 )
 
 //nolint:gochecknoglobals
 var (
-	// Table output symbols.
-	statusPass = color.New(color.FgGreen).Sprint("✓")
-	statusWarn = color.New(color.FgYellow).Sprint("⚠")
-	statusFail = color.New(color.FgRed).Sprint("✗")
-
-	// Severity level formatting.
-	severityCrit = color.New(color.FgRed).Sprint("critical")
-	severityWarn = color.New(color.FgYellow).Add(color.Bold).Sprint("warning") // Bold yellow (orange-ish)
-	severityInfo = color.New(color.FgCyan).Sprint("info")
-
 	// Table headers.
 	tableHeaders        = []string{"STATUS", "KIND", "GROUP", "CHECK", "IMPACT", "MESSAGE"}
 	verboseTableHeaders = []string{"STATUS", "KIND", "GROUP", "CHECK", "IMPACT"}
@@ -43,13 +32,13 @@ func printVerdict(out io.Writer, hasBlocking bool, hasAdvisory bool) {
 
 	switch {
 	case hasBlocking:
-		verdict := color.New(color.FgRed, color.Bold).Sprint("FAIL")
+		verdict := utilcolor.VerdictFail()
 		_, _ = fmt.Fprintf(out, "  %s - blocking findings detected\n", verdict)
 	case hasAdvisory:
-		verdict := color.New(color.FgYellow, color.Bold).Sprint("WARNING")
+		verdict := utilcolor.VerdictWarning()
 		_, _ = fmt.Fprintf(out, "  %s - advisory findings detected\n", verdict)
 	default:
-		verdict := color.New(color.FgGreen, color.Bold).Sprint("PASS")
+		verdict := utilcolor.VerdictPass()
 		_, _ = fmt.Fprintf(out, "  %s - all checks passed\n", verdict)
 	}
 }
@@ -86,7 +75,7 @@ func collectSortedRows(results []check.CheckExecution) []sortableRow {
 					Kind:        exec.Result.Kind,
 					Group:       exec.Result.Group,
 					Check:       exec.Result.Name,
-					Impact:      getImpactString(&condition, severityCrit, severityWarn, severityInfo),
+					Impact:      getImpactString(&condition, utilcolor.SeverityCritical(), utilcolor.SeverityWarning(), utilcolor.SeverityInfo()),
 					Message:     condition.Message,
 					Description: exec.Result.Spec.Description,
 				},
@@ -120,14 +109,14 @@ func collectSortedRows(results []check.CheckExecution) []sortableRow {
 func statusSymbol(impact result.Impact) string {
 	switch impact {
 	case result.ImpactBlocking:
-		return statusFail
+		return utilcolor.StatusFail()
 	case result.ImpactAdvisory:
-		return statusWarn
+		return utilcolor.StatusWarn()
 	case result.ImpactNone:
-		return statusPass
+		return utilcolor.StatusPass()
 	}
 
-	return statusPass
+	return utilcolor.StatusPass()
 }
 
 // visibleLen returns the display width (rune count) of a string after stripping
@@ -259,7 +248,7 @@ func buildVerboseRows(
 			check:  exec.Result.Name,
 			impact: getImpactString(
 				&result.Condition{Impact: maxImpact},
-				severityCrit, severityWarn, severityInfo,
+				utilcolor.SeverityCritical(), utilcolor.SeverityWarning(), utilcolor.SeverityInfo(),
 			),
 			exec: exec,
 		}

--- a/pkg/util/color/symbols.go
+++ b/pkg/util/color/symbols.go
@@ -1,0 +1,50 @@
+package color
+
+import "github.com/fatih/color"
+
+// StatusPass returns a green checkmark symbol.
+func StatusPass() string {
+	return color.New(color.FgGreen).Sprint("✓")
+}
+
+// StatusWarn returns a yellow warning symbol.
+func StatusWarn() string {
+	return color.New(color.FgYellow).Sprint("⚠")
+}
+
+// StatusFail returns a red cross symbol.
+func StatusFail() string {
+	return color.New(color.FgRed).Sprint("✗")
+}
+
+// Severity level formatting.
+
+// SeverityCritical returns "critical" in red.
+func SeverityCritical() string {
+	return color.New(color.FgRed).Sprint("critical")
+}
+
+// SeverityWarning returns "warning" in bold yellow.
+func SeverityWarning() string {
+	return color.New(color.FgYellow).Add(color.Bold).Sprint("warning")
+}
+
+// SeverityInfo returns "info" in cyan.
+func SeverityInfo() string {
+	return color.New(color.FgCyan).Sprint("info")
+}
+
+// VerdictFail returns "FAIL" in bold red.
+func VerdictFail() string {
+	return color.New(color.FgRed, color.Bold).Sprint("FAIL")
+}
+
+// VerdictWarning returns "WARNING" in bold yellow.
+func VerdictWarning() string {
+	return color.New(color.FgYellow, color.Bold).Sprint("WARNING")
+}
+
+// VerdictPass returns "PASS" in bold green.
+func VerdictPass() string {
+	return color.New(color.FgGreen, color.Bold).Sprint("PASS")
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Problem Statement 
The CLI uses github.com/fatih/color for colored table output but lacks TTY detection and NO_COLOR support. When agents pipe CLI output (which they always do), ANSI escape sequences contaminate the data — including JSON output if colored strings leak into structured fields.

This is a data corruption issue for agents and automation tools that parse CLI output.

## Description
Implements comprehensive color output control to prevent ANSI escape sequences from contaminating piped output and structured data formats.

#### Changes:

- Added --no-color flag for explicit user control
- Implemented NO_COLOR environment variable support (de facto standard: https://no-color.org/)
- Added automatic TTY detection using golang.org/x/term to disable colors when output is piped/redirected
- Force colors disabled for JSON/YAML output formats to prevent data corruption
- Created centralized color package pkg/util/color/symbols.go with runtime functions
- Refactored output_table.go to use centralized functions instead of pre-colored global variables


#### Priority Logic:

1. JSON/YAML format → Force NoColor (data integrity)
2. --no-color flag → User explicit choice
3. NO_COLOR env var → User preference
4. TTY detection → Automatic (non-TTY = no colors)
5. Default → Colors enabled (TTY only)

#### Files Modified

| File | Changes |
|------|---------|
| `pkg/lint/command_options.go` | Added `NoColor` field + functional options |
| `pkg/lint/command.go` | Flag registration, detection logic, `IsTerminal()` method |
| `pkg/lint/constants.go` | Flag description constant |
| `pkg/util/color/symbols.go` | **NEW** - Centralized color functions |
| `pkg/lint/output_table.go` | Refactored to use centralized functions |
| `pkg/lint/command_test.go` | Comprehensive test coverage (12 tests) |

## How Has This Been Tested?


#### Manual testing
#### Test Steps

**1. Build the binary**
```bash
make build
```
- Gets Colored Output 
```bash
./bin/kubectl-odh lint --target-version 3.3.0
```
- Test --no-color flag
```bash
./bin/kubectl-odh lint --target-version 3.3.0 --no-color
```
- Test NO_COLOR environment variable
```bash
export NO_COLOR=1
./bin/kubectl-odh lint --target-version 3.3.0
```
- Unset NO_COLOR and verify colors return
```bash
unset NO_COLOR or export NO_COLOR=0
```
- Test piped output (TTY auto-detection)
```bash
 ./bin/kubectl-odh lint --target-version 3.3.0 -o json

```
```bash
   ./bin/kubectl-odh lint --target-version 3.3.0 -o yaml

```

#### Unit Tests

Added 12 comprehensive tests in `pkg/lint/command_test.go`:

```bash
go test -v ./pkg/lint -run TestColorDetection
```
#### Test Coverage

- TTY detection (buffers correctly identified as non-TTY)
- `--no-color` flag disables colors
- `NO_COLOR` environment variable support
- Multiple `NO_COLOR` values (`"1"`, `"true"`, `"yes"`, `""` - empty string)
- JSON format forces no colors
- YAML format forces no colors
- Priority: Flag overrides default
- Priority: JSON format overrides flag
- Priority: JSON format overrides env var
- Priority: Env var overrides default
- Complete priority chain integration
- `IsTerminal()` method returns false for buffers


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
