### PR TITLE
feat(RHOAIENG-54609): add --no-color flag and centralized color package

### DIFF
--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/blang/semver/v4"
+	"github.com/fatih/color"
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -151,6 +152,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&c.CheckSelectors, "checks", []string{"*"}, flagDescChecks)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.BoolVar(&c.Debug, "debug", false, flagDescDebug)
+	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
 	fs.StringVar(&c.ISVCDeploymentMode, "isvc-deployment-mode", "all", flagDescISVCDeploymentMode)
 
@@ -165,6 +167,11 @@ func (c *Command) Complete() error {
 	if err := c.SharedOptions.Complete(); err != nil {
 		return fmt.Errorf("completing shared options: %w", err)
 	}
+	// Disable color for structured output; fatih/color handles NO_COLOR env and non-TTY detection.
+	if c.OutputFormat == OutputFormatJSON || c.OutputFormat == OutputFormatYAML {
+		c.NoColor = true
+	}
+	color.NoColor = c.NoColor
 
 	// Wrap IO with QuietWrapper if NOT in verbose or debug mode (default is quiet)
 	if !c.Verbose && !c.Debug {

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -86,6 +86,9 @@ type SharedOptions struct {
 	// Debug enables detailed diagnostic logging for troubleshooting (default: false)
 	Debug bool
 
+	// NoColor disables color output (default: false)
+	NoColor bool
+
 	// Timeout is the maximum duration for command execution
 	Timeout time.Duration
 

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -188,6 +188,7 @@ func TestCommand_AddFlags(t *testing.T) {
 		g.Expect(fs.Lookup("output")).ToNot(BeNil())
 		g.Expect(fs.Lookup("checks")).ToNot(BeNil())
 		g.Expect(fs.Lookup("timeout")).ToNot(BeNil())
+		g.Expect(fs.Lookup("no-color")).ToNot(BeNil())
 	})
 }
 

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -11,6 +11,7 @@ const (
 	flagDescQPS                = "Kubernetes API QPS limit (queries per second)"
 	flagDescBurst              = "Kubernetes API burst capacity"
 	flagDescISVCDeploymentMode = "filter InferenceService display by deployment mode (all|serverless|modelmesh)"
+	flagDescNoColor            = "disable colored output (also respects NO_COLOR env var)"
 )
 
 const flagDescChecks = `check selector patterns (glob patterns or categories):

--- a/pkg/lint/output_table.go
+++ b/pkg/lint/output_table.go
@@ -9,27 +9,14 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/fatih/color"
-
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
+	utilcolor "github.com/opendatahub-io/odh-cli/pkg/util/color"
 )
 
 //nolint:gochecknoglobals
 var (
-	// Table output symbols.
-	statusPass       = color.New(color.FgGreen).Sprint("✓")
-	statusWarn       = color.New(color.FgYellow).Sprint("⚠")
-	statusFail       = color.New(color.FgRed).Sprint("✗")
-	statusProhibited = color.New(color.FgRed, color.Bold).Sprint("‼")
-
-	// Severity level formatting.
-	severityProhibited = color.New(color.FgRed, color.Bold).Sprint("prohibited")
-	severityCrit       = color.New(color.FgRed).Sprint("critical")
-	severityWarn       = color.New(color.FgYellow).Sprint("warning")
-	severityInfo       = color.New(color.FgCyan).Sprint("info")
-
 	// Table headers.
 	tableHeaders        = []string{"STATUS", "KIND", "GROUP", "CHECK", "IMPACT", "MESSAGE"}
 	verboseTableHeaders = []string{"STATUS", "KIND", "GROUP", "CHECK", "IMPACT"}
@@ -45,16 +32,16 @@ func printVerdict(out io.Writer, hasProhibited bool, hasBlocking bool, hasAdviso
 
 	switch {
 	case hasProhibited:
-		verdict := color.New(color.FgRed, color.Bold).Sprint("PROHIBITED")
+		verdict := utilcolor.VerdictProhibited()
 		_, _ = fmt.Fprintf(out, "  %s - upgrade is not possible\n", verdict)
 	case hasBlocking:
-		verdict := color.New(color.FgRed, color.Bold).Sprint("FAIL")
+		verdict := utilcolor.VerdictFail()
 		_, _ = fmt.Fprintf(out, "  %s - blocking findings detected\n", verdict)
 	case hasAdvisory:
-		verdict := color.New(color.FgYellow, color.Bold).Sprint("WARNING")
+		verdict := utilcolor.VerdictWarning()
 		_, _ = fmt.Fprintf(out, "  %s - advisory findings detected\n", verdict)
 	default:
-		verdict := color.New(color.FgGreen, color.Bold).Sprint("PASS")
+		verdict := utilcolor.VerdictPass()
 		_, _ = fmt.Fprintf(out, "  %s - all checks passed\n", verdict)
 	}
 }
@@ -63,20 +50,18 @@ func printVerdict(out io.Writer, hasProhibited bool, hasBlocking bool, hasAdviso
 // listing all prohibited findings. Each prohibited condition is shown so that none
 // can be overlooked when multiple checks report prohibited-level impact.
 func outputProhibitedBanner(out io.Writer, findings []sortableRow) {
-	bold := color.New(color.FgRed, color.Bold)
-
 	_, _ = fmt.Fprintln(out)
 	bannerText := "  Prohibited Violations Detected: Upgrade is NOT POSSIBLE  "
 	bannerWidth := visibleLen(bannerText)
 	hLine := strings.Repeat("═", bannerWidth)
 
-	_, _ = fmt.Fprintln(out, bold.Sprintf("╔%s╗", hLine))
-	_, _ = fmt.Fprintln(out, bold.Sprintf("║%s║", bannerText))
-	_, _ = fmt.Fprintln(out, bold.Sprintf("╚%s╝", hLine))
+	_, _ = fmt.Fprintln(out, utilcolor.BannerProhibited("╔%s╗", hLine))
+	_, _ = fmt.Fprintln(out, utilcolor.BannerProhibited("║%s║", bannerText))
+	_, _ = fmt.Fprintln(out, utilcolor.BannerProhibited("╚%s╝", hLine))
 
 	for _, f := range findings {
 		_, _ = fmt.Fprintf(out, "  %s  [%s / %s] %s\n",
-			statusProhibited, f.row.Group, f.row.Check, f.row.Message)
+			utilcolor.StatusProhibited(), f.row.Group, f.row.Check, f.row.Message)
 	}
 
 	_, _ = fmt.Fprintln(out)
@@ -114,7 +99,7 @@ func collectSortedRows(results []check.CheckExecution) []sortableRow {
 					Kind:        exec.Result.Kind,
 					Group:       exec.Result.Group,
 					Check:       exec.Result.Name,
-					Impact:      getImpactString(&condition, severityProhibited, severityCrit, severityWarn, severityInfo),
+					Impact:      getImpactString(&condition, utilcolor.SeverityProhibited(), utilcolor.SeverityCritical(), utilcolor.SeverityWarning(), utilcolor.SeverityInfo()),
 					Message:     condition.Message,
 					Description: exec.Result.Spec.Description,
 				},
@@ -148,16 +133,16 @@ func collectSortedRows(results []check.CheckExecution) []sortableRow {
 func statusSymbol(impact result.Impact) string {
 	switch impact {
 	case result.ImpactProhibited:
-		return statusProhibited
+		return utilcolor.StatusProhibited()
 	case result.ImpactBlocking:
-		return statusFail
+		return utilcolor.StatusFail()
 	case result.ImpactAdvisory:
-		return statusWarn
+		return utilcolor.StatusWarn()
 	case result.ImpactNone:
-		return statusPass
+		return utilcolor.StatusPass()
 	}
 
-	return statusPass
+	return utilcolor.StatusPass()
 }
 
 // visibleLen returns the display width (rune count) of a string after stripping
@@ -304,7 +289,7 @@ func buildVerboseRows(
 			check:  exec.Result.Name,
 			impact: getImpactString(
 				&result.Condition{Impact: maxImpact},
-				severityProhibited, severityCrit, severityWarn, severityInfo,
+				utilcolor.SeverityProhibited(), utilcolor.SeverityCritical(), utilcolor.SeverityWarning(), utilcolor.SeverityInfo(),
 			),
 			exec: exec,
 		}

--- a/pkg/util/color/symbols.go
+++ b/pkg/util/color/symbols.go
@@ -1,0 +1,85 @@
+package color
+
+import "github.com/fatih/color"
+
+// Pre-allocated Color objects. Created once at package level; Sprint/Sprintf
+// is deferred to call time so that color.NoColor (set during Complete) is
+// respected.
+//
+//nolint:gochecknoglobals
+var (
+	green      = color.New(color.FgGreen)
+	yellow     = color.New(color.FgYellow)
+	red        = color.New(color.FgRed)
+	cyan       = color.New(color.FgCyan)
+	redBold    = color.New(color.FgRed, color.Bold)
+	greenBold  = color.New(color.FgGreen, color.Bold)
+	yellowBold = color.New(color.FgYellow, color.Bold)
+)
+
+// StatusPass returns a green checkmark symbol.
+func StatusPass() string {
+	return green.Sprint("✓")
+}
+
+// StatusWarn returns a yellow warning symbol.
+func StatusWarn() string {
+	return yellow.Sprint("⚠")
+}
+
+// StatusFail returns a red cross symbol.
+func StatusFail() string {
+	return red.Sprint("✗")
+}
+
+// Severity level formatting.
+
+// SeverityCritical returns "critical" in red.
+func SeverityCritical() string {
+	return red.Sprint("critical")
+}
+
+// SeverityWarning returns "warning" in yellow.
+func SeverityWarning() string {
+	return yellow.Sprint("warning")
+}
+
+// SeverityInfo returns "info" in cyan.
+func SeverityInfo() string {
+	return cyan.Sprint("info")
+}
+
+// VerdictFail returns "FAIL" in bold red.
+func VerdictFail() string {
+	return redBold.Sprint("FAIL")
+}
+
+// VerdictWarning returns "WARNING" in bold yellow.
+func VerdictWarning() string {
+	return yellowBold.Sprint("WARNING")
+}
+
+// VerdictPass returns "PASS" in bold green.
+func VerdictPass() string {
+	return greenBold.Sprint("PASS")
+}
+
+// StatusProhibited returns a bold red double-exclamation symbol.
+func StatusProhibited() string {
+	return redBold.Sprint("‼")
+}
+
+// SeverityProhibited returns "prohibited" in bold red.
+func SeverityProhibited() string {
+	return redBold.Sprint("prohibited")
+}
+
+// VerdictProhibited returns "PROHIBITED" in bold red.
+func VerdictProhibited() string {
+	return redBold.Sprint("PROHIBITED")
+}
+
+// BannerProhibited returns a bold red formatted string for prohibited banners.
+func BannerProhibited(format string, a ...any) string {
+	return redBold.Sprintf(format, a...)
+}


### PR DESCRIPTION
## Description

Add `--no-color` flag to the `lint` command with automatic color detection following the [NO_COLOR standard](https://no-color.org/).

Color is disabled automatically with the following priority chain:
1. **Structured output formats** (JSON/YAML) always force `NoColor=true` to prevent ANSI codes from corrupting machine-readable output
2. **`--no-color` flag** explicitly disables color when set
3. **`NO_COLOR` environment variable** disables color when set to any non-empty value
4. **TTY detection** disables color when stdout is not a terminal (e.g., piped or redirected)

Additionally, this PR refactors color formatting by extracting inline `color.New(...)` calls from `output_table.go` into a centralized `pkg/util/color/symbols.go` package. This ensures symbols and severity labels are generated at render time (respecting the `color.NoColor` global), rather than at init time when the color state is not yet determined.

### Changes
- **`pkg/lint/command.go`**: Add `--no-color` flag registration, color detection logic in `Complete()`, and `IsTerminal()` method using `golang.org/x/term`
- **`pkg/lint/command_options.go`**: Add `NoColor` field to `SharedOptions`, add `WithOutputFormat` and `WithIO` functional options
- **`pkg/lint/constants.go`**: Add `flagDescNoColor` constant
- **`pkg/lint/output_table.go`**: Replace inline color symbols with centralized `utilcolor` package calls
- **`pkg/util/color/symbols.go`**: New package providing status symbols, severity labels, and verdict strings as functions
- **`go.mod`**: Promote `golang.org/x/term` from indirect to direct dependency

## JIRA ISSUE 
RHOAIENG-54609 


## How Has This Been Tested?

**Unit tests:**
- Updated `TestCommand_AddFlags` to verify `--no-color` flag registration

**Manual testing against a live OpenShift cluster with odh-operator installed**
- `./bin/kubectl-odh lint --target-version 3.0.0` -- colors rendered on TTY
- `./bin/kubectl-odh lint --target-version 3.0.0 --no-color` -- colors stripped
- `NO_COLOR=1 ./bin/kubectl-odh lint --target-version 3.0.0` -- colors stripped via env var
- `unset NO_COLOR && ./bin/kubectl-odh lint --target-version 3.0.0` -- colors restored
- `./bin/kubectl-odh lint --target-version 3.0.0 -o json` -- no ANSI codes in JSON output
- `make lint` -- 0 issues
- `make build` -- builds successfully
#### Without no color flag 
<img width="1076" height="555" alt="Screenshot From 2026-03-23 16-05-38" src="https://github.com/user-attachments/assets/cf3f1477-ea2d-4836-a141-29d4b3159a94" />

#### With no color flag 
<img width="1066" height="312" alt="Screenshot From 2026-03-23 15-55-30" src="https://github.com/user-attachments/assets/5201d165-592e-4631-86cd-00783201f229" />

#### with NO_COLOR env set 
<img width="1076" height="555" alt="Screenshot From 2026-03-23 16-14-35" src="https://github.com/user-attachments/assets/dc82b34a-3ddc-416b-a3b4-81ba5bfb1d97" />

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--no-color` CLI flag to disable colored output in lint results. The flag respects the `NO_COLOR` environment variable and is automatically enabled for JSON and YAML structured output formats.

* **Refactor**
  * Reorganized color output handling into centralized utility functions for improved code maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->