### PR TITLE
fix: reduce false positives for ServiceMesh capability conditions in DSCI check

### DIFF
--- a/pkg/lint/checks/platform/dscinitialization/dscinitialization_readiness_test.go
+++ b/pkg/lint/checks/platform/dscinitialization/dscinitialization_readiness_test.go
@@ -238,44 +238,139 @@ func TestDSCInitializationReadinessCheck_NotReadyWithUnhappyConditions(t *testin
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
-func TestDSCInitializationReadinessCheck_ReadyWithRemovedCapabilities(t *testing.T) {
-	g := NewWithT(t)
-
-	dsci := &unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": resources.DSCInitialization.APIVersion(),
-			"kind":       resources.DSCInitialization.Kind,
-			"metadata": map[string]any{
-				"name": "default-dsci",
-			},
-			"status": map[string]any{
-				"phase": "Ready",
-				"conditions": []any{
-					map[string]any{"type": "ReconcileComplete", "status": "True", "reason": "ReconcileCompleted", "message": "reconcile completed"},
-					map[string]any{"type": "CapabilityServiceMesh", "status": "False", "reason": "Removed", "message": "service mesh removed"},
-					map[string]any{"type": "CapabilityServiceMeshAuthorization", "status": "False", "reason": "Removed", "message": "service mesh authorization removed"},
-				},
-			},
+func TestDSCInitializationReadinessCheck_CapabilityConditions(t *testing.T) {
+	tests := []struct {
+		name            string
+		conditionType   string
+		reason          string
+		message         string
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+		expectedImpact  resultpkg.Impact
+		expectedMessage string
+	}{
+		{
+			name:            "ServiceMesh/Removed",
+			conditionType:   "CapabilityServiceMesh",
+			reason:          "Removed",
+			message:         "ServiceMesh removed",
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  check.ReasonResourceAvailable,
+			expectedImpact:  resultpkg.ImpactNone,
+			expectedMessage: "DSCInitialization is ready",
+		},
+		{
+			name:            "ServiceMesh/Unmanaged",
+			conditionType:   "CapabilityServiceMesh",
+			reason:          "Unmanaged",
+			message:         "ServiceMesh is set to Unmanaged",
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  check.ReasonResourceAvailable,
+			expectedImpact:  resultpkg.ImpactNone,
+			expectedMessage: "DSCInitialization is ready",
+		},
+		{
+			name:            "ServiceMesh/NotReady",
+			conditionType:   "CapabilityServiceMesh",
+			reason:          "NotReady",
+			message:         "ServiceMeshControlPlane is not ready",
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  check.ReasonResourceUnavailable,
+			expectedImpact:  resultpkg.ImpactBlocking,
+			expectedMessage: "CapabilityServiceMesh: ServiceMeshControlPlane is not ready",
+		},
+		{
+			name:            "ServiceMesh/MissingOperator",
+			conditionType:   "CapabilityServiceMesh",
+			reason:          "MissingOperator",
+			message:         "ServiceMesh operator not found",
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  check.ReasonResourceUnavailable,
+			expectedImpact:  resultpkg.ImpactBlocking,
+			expectedMessage: "CapabilityServiceMesh: ServiceMesh operator not found",
+		},
+		{
+			name:            "ServiceMeshAuth/Unmanaged",
+			conditionType:   "CapabilityServiceMeshAuthorization",
+			reason:          "Unmanaged",
+			message:         "ServiceMesh is set to Unmanaged",
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  check.ReasonResourceAvailable,
+			expectedImpact:  resultpkg.ImpactNone,
+			expectedMessage: "DSCInitialization is ready",
+		},
+		{
+			name:            "ServiceMeshAuth/Removed",
+			conditionType:   "CapabilityServiceMeshAuthorization",
+			reason:          "Removed",
+			message:         "ServiceMesh authorization removed",
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  check.ReasonResourceAvailable,
+			expectedImpact:  resultpkg.ImpactNone,
+			expectedMessage: "DSCInitialization is ready",
+		},
+		{
+			name:            "ServiceMeshAuth/MissingOperator",
+			conditionType:   "CapabilityServiceMeshAuthorization",
+			reason:          "MissingOperator",
+			message:         "Authorino operator not found",
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  check.ReasonResourceAvailable,
+			expectedImpact:  resultpkg.ImpactNone,
+			expectedMessage: "DSCInitialization is ready",
+		},
+		{
+			name:            "ServiceMeshAuth/NotReady",
+			conditionType:   "CapabilityServiceMeshAuthorization",
+			reason:          "NotReady",
+			message:         "Authorino resource not ready",
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  check.ReasonResourceUnavailable,
+			expectedImpact:  resultpkg.ImpactBlocking,
+			expectedMessage: "CapabilityServiceMeshAuthorization: Authorino resource not ready",
 		},
 	}
 
-	target := testutil.NewTarget(t, testutil.TargetConfig{
-		ListKinds: dsciReadinessListKinds,
-		Objects:   []*unstructured.Unstructured{dsci},
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	chk := dscinitialization.NewDSCInitializationReadinessCheck()
-	result, err := chk.Validate(t.Context(), target)
+			dsci := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": resources.DSCInitialization.APIVersion(),
+					"kind":       resources.DSCInitialization.Kind,
+					"metadata": map[string]any{
+						"name": "default-dsci",
+					},
+					"status": map[string]any{
+						"phase": "Ready",
+						"conditions": []any{
+							map[string]any{"type": "ReconcileComplete", "status": "True", "reason": "ReconcileCompleted", "message": "reconcile completed"},
+							map[string]any{"type": tc.conditionType, "status": "False", "reason": tc.reason, "message": tc.message},
+						},
+					},
+				},
+			}
 
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Conditions).To(HaveLen(1))
-	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeReady),
-		"Status":  Equal(metav1.ConditionTrue),
-		"Reason":  Equal(check.ReasonResourceAvailable),
-		"Message": ContainSubstring("DSCInitialization is ready"),
-	}))
-	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+			target := testutil.NewTarget(t, testutil.TargetConfig{
+				ListKinds: dsciReadinessListKinds,
+				Objects:   []*unstructured.Unstructured{dsci},
+			})
+
+			chk := dscinitialization.NewDSCInitializationReadinessCheck()
+			result, err := chk.Validate(t.Context(), target)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result.Status.Conditions).To(HaveLen(1))
+			g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+				"Type":    Equal(check.ConditionTypeReady),
+				"Status":  Equal(tc.expectedStatus),
+				"Reason":  Equal(tc.expectedReason),
+				"Message": ContainSubstring(tc.expectedMessage),
+			}))
+			g.Expect(result.Status.Conditions[0].Impact).To(Equal(tc.expectedImpact))
+		})
+	}
 }
 
 func TestDSCInitializationReadinessCheck_Ready(t *testing.T) {

--- a/pkg/lint/checks/platform/dscinitialization/support.go
+++ b/pkg/lint/checks/platform/dscinitialization/support.go
@@ -25,8 +25,12 @@ type dsciStatusCondition struct {
 // collectUnhappyDSCIConditionMessages returns messages from DSCI status conditions that
 // deviate from their expected state. Progressing and Degraded conditions are expected to
 // be False when healthy; all other condition types are expected to be True.
-// CapabilityServiceMesh and CapabilityServiceMeshAuthorization are exceptions: when False
-// with reason Removed they represent a healthy disabled state, not a problem.
+//
+// ServiceMesh capability conditions receive special handling:
+//   - CapabilityServiceMesh: False with reason Removed or Unmanaged is a healthy state.
+//   - CapabilityServiceMeshAuthorization: only False with reason NotReady is a genuine
+//     problem; all other False reasons (Removed, Unmanaged, MissingOperator) are non-blocking.
+//
 // Returns nil if no conditions field exists or no conditions are unhappy.
 func collectUnhappyDSCIConditionMessages(obj *unstructured.Unstructured) ([]string, error) {
 	conditions, err := jq.Query[[]dsciStatusCondition](obj, ".status.conditions")
@@ -47,9 +51,7 @@ func collectUnhappyDSCIConditionMessages(obj *unstructured.Unstructured) ([]stri
 		unhappy := (expectFalse && cond.Status != string(metav1.ConditionFalse)) ||
 			(!expectFalse && cond.Status != string(metav1.ConditionTrue))
 
-		// CapabilityServiceMesh and CapabilityServiceMeshAuthorization with reason Removed
-		// indicate the capability is intentionally disabled, which is a valid healthy state.
-		if isRemovedCapabilityServiceMesh(cond) {
+		if isExpectedCapabilityServiceMeshFalse(cond) || isExpectedCapabilityServiceMeshAuthFalse(cond) {
 			unhappy = false
 		}
 
@@ -61,12 +63,26 @@ func collectUnhappyDSCIConditionMessages(obj *unstructured.Unstructured) ([]stri
 	return messages, nil
 }
 
-// isRemovedCapabilityServiceMesh returns true for capability conditions that are False because the
-// capability was explicitly removed, which is an expected healthy state.
-func isRemovedCapabilityServiceMesh(cond dsciStatusCondition) bool {
-	isCapabilityServiceMesh := cond.Type == "CapabilityServiceMesh" || cond.Type == "CapabilityServiceMeshAuthorization"
+// isExpectedCapabilityServiceMeshFalse returns true when the CapabilityServiceMesh condition
+// is False because the capability was explicitly removed or set to unmanaged, both of which
+// are intentional user choices and expected healthy states.
+func isExpectedCapabilityServiceMeshFalse(cond dsciStatusCondition) bool {
+	return cond.Type == "CapabilityServiceMesh" &&
+		cond.Status == string(metav1.ConditionFalse) &&
+		(cond.Reason == "Removed" || cond.Reason == "Unmanaged")
+}
 
-	return isCapabilityServiceMesh && cond.Status == string(metav1.ConditionFalse) && cond.Reason == "Removed"
+// isExpectedCapabilityServiceMeshAuthFalse returns true when the CapabilityServiceMeshAuthorization
+// condition is False for a non-blocking reason. Only NotReady indicates a genuine problem; all
+// other False reasons (Removed, Unmanaged, MissingOperator) represent intentional or environmental
+// states that are not upgrade blockers.
+//
+// A denylist (reason != NotReady) is used intentionally over an explicit allowlist so that new
+// benign reasons added upstream are automatically treated as non-blocking without a code change.
+func isExpectedCapabilityServiceMeshAuthFalse(cond dsciStatusCondition) bool {
+	return cond.Type == "CapabilityServiceMeshAuthorization" &&
+		cond.Status == string(metav1.ConditionFalse) &&
+		cond.Reason != "NotReady"
 }
 
 // validatePhaseReady checks that the status.phase field is "Ready" on a resource and there are no unexpected conditions.


### PR DESCRIPTION
Split the single isRemovedCapabilityServiceMesh helper into two separate
functions with different exemption logic per condition type:

- CapabilityServiceMesh: False with reason Removed or Unmanaged is treated
  as a healthy intentional state (not flagged).
- CapabilityServiceMeshAuthorization: only False with reason NotReady is a
  genuine problem; all other False reasons (Removed, Unmanaged,
  MissingOperator) are non-blocking and no longer flagged.

Made-with: Cursor

## Description

<!-- What does this PR do? -->

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined readiness detection: Service Mesh False with reasons Removed or Unmanaged is treated non-blocking; Service Mesh Authorization False is considered blocking only when reason is NotReady, yielding clearer readiness/impact results.
* **Tests**
  * Added parameterized readiness tests covering capability types and reason combinations, validating readiness condition, message prefixes, and impact classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->