### PR TITLE
feat: distinguish kueue in-use vs not-in-use for management state check

### DIFF
--- a/pkg/lint/checks/components/kueue/kueue.go
+++ b/pkg/lint/checks/components/kueue/kueue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -20,13 +21,20 @@ const (
 	checkTypeManagementState = "management-state"
 
 	// Deferred: parameterize hardcoded version references using ComponentRequest.TargetVersion.
-	msgManagedProhibited   = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release will allow an upgrade when you have migrated to the Red Hat build of Kueue Operator and the Kueue managementState is Unmanaged."
-	msgUnmanagedProhibited = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release will allow an upgrade when the Kueue managementState is Unmanaged."
+	msgManagedProhibited   = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when you have migrated to the Red Hat build of Kueue Operator and the Kueue managementState is Unmanaged."
+	msgUnmanagedProhibited = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when the Kueue managementState is Unmanaged."
+	msgManagedBlocking     = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Managed but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
+	msgUnmanagedBlocking   = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Unmanaged but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
 )
 
 // ManagementStateCheck validates that Kueue managementState is Removed before upgrading to 3.x.
 // In RHOAI 3.3.1, only the Removed state is supported. A future 3.3.x release will support
 // Unmanaged with the Red Hat build of Kueue Operator.
+//
+// The check distinguishes between clusters that are actively using Kueue (namespaces or workloads
+// labeled for Kueue) and those that have Kueue enabled but are not actually using it:
+//   - Managed/Unmanaged + in use: prohibited (upgrade not possible)
+//   - Managed/Unmanaged + not in use: blocking (recoverable — set managementState to Removed)
 type ManagementStateCheck struct {
 	check.BaseCheck
 }
@@ -64,28 +72,55 @@ func (c *ManagementStateCheck) CanApply(ctx context.Context, target check.Target
 
 func (c *ManagementStateCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	return validate.Component(c, target).
-		Run(ctx, func(_ context.Context, req *validate.ComponentRequest) error {
-			switch req.ManagementState {
-			case constants.ManagementStateManaged:
+		Run(ctx, func(ctx context.Context, req *validate.ComponentRequest) error {
+			kueueInUse, err := isKueueInUse(ctx, req.Client)
+			if err != nil {
+				return fmt.Errorf("checking kueue usage: %w", err)
+			}
+
+			setCondition := func(msg string, impact result.Impact) {
 				req.Result.SetCondition(check.NewCondition(
 					check.ConditionTypeCompatible,
 					metav1.ConditionFalse,
 					check.WithReason(check.ReasonVersionIncompatible),
-					check.WithMessage(msgManagedProhibited),
-					check.WithImpact(result.ImpactProhibited),
+					check.WithMessage("%s", msg),
+					check.WithImpact(impact),
 				))
-			case constants.ManagementStateUnmanaged:
-				req.Result.SetCondition(check.NewCondition(
-					check.ConditionTypeCompatible,
-					metav1.ConditionFalse,
-					check.WithReason(check.ReasonVersionIncompatible),
-					check.WithMessage(msgUnmanagedProhibited),
-					check.WithImpact(result.ImpactProhibited),
-				))
+			}
+
+			switch {
+			case req.ManagementState == constants.ManagementStateManaged && kueueInUse:
+				setCondition(msgManagedProhibited, result.ImpactProhibited)
+			case req.ManagementState == constants.ManagementStateManaged && !kueueInUse:
+				setCondition(msgManagedBlocking, result.ImpactBlocking)
+			case req.ManagementState == constants.ManagementStateUnmanaged && kueueInUse:
+				setCondition(msgUnmanagedProhibited, result.ImpactProhibited)
+			case req.ManagementState == constants.ManagementStateUnmanaged && !kueueInUse:
+				setCondition(msgUnmanagedBlocking, result.ImpactBlocking)
 			default:
 				return fmt.Errorf("unexpected management state %q for kueue", req.ManagementState)
 			}
 
 			return nil
 		})
+}
+
+// isKueueInUse returns true if at least one namespace is labeled for Kueue management
+// or at least one monitored workload has the kueue.x-k8s.io/queue-name label.
+func isKueueInUse(ctx context.Context, r client.Reader) (bool, error) {
+	kueueNamespaces, err := kueuediscovery.KueueEnabledNamespaces(ctx, r)
+	if err != nil {
+		return false, fmt.Errorf("finding kueue-enabled namespaces: %w", err)
+	}
+
+	if kueueNamespaces.Len() > 0 {
+		return true, nil
+	}
+
+	workloadNamespaces, err := kueuediscovery.WorkloadLabeledNamespaces(ctx, r)
+	if err != nil {
+		return false, fmt.Errorf("finding workload-labeled namespaces: %w", err)
+	}
+
+	return workloadNamespaces.Len() > 0, nil
 }

--- a/pkg/lint/checks/components/kueue/kueue_test.go
+++ b/pkg/lint/checks/components/kueue/kueue_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -19,7 +20,63 @@ import (
 
 //nolint:gochecknoglobals // Test fixture - shared across test functions
 var listKinds = map[schema.GroupVersionResource]string{
-	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+	resources.DataScienceCluster.GVR():  resources.DataScienceCluster.ListKind(),
+	resources.Namespace.GVR():           resources.Namespace.ListKind(),
+	resources.Notebook.GVR():            resources.Notebook.ListKind(),
+	resources.InferenceService.GVR():    resources.InferenceService.ListKind(),
+	resources.LLMInferenceService.GVR(): resources.LLMInferenceService.ListKind(),
+	resources.RayCluster.GVR():          resources.RayCluster.ListKind(),
+	resources.RayJob.GVR():              resources.RayJob.ListKind(),
+	resources.PyTorchJob.GVR():          resources.PyTorchJob.ListKind(),
+}
+
+func newNamespace(name string, labels map[string]string) *unstructured.Unstructured {
+	meta := map[string]any{
+		"name": name,
+	}
+	if labels != nil {
+		anyLabels := make(map[string]any, len(labels))
+		for k, v := range labels {
+			anyLabels[k] = v
+		}
+
+		meta["labels"] = anyLabels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Namespace.APIVersion(),
+			"kind":       resources.Namespace.Kind,
+			"metadata":   meta,
+		},
+	}
+}
+
+func newWorkload(
+	rt resources.ResourceType,
+	namespace, name string,
+	labels map[string]string,
+) *unstructured.Unstructured {
+	meta := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+	if labels != nil {
+		anyLabels := make(map[string]any, len(labels))
+		for k, v := range labels {
+			anyLabels[k] = v
+		}
+
+		meta["labels"] = anyLabels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": rt.APIVersion(),
+			"kind":       rt.Kind,
+			"metadata":   meta,
+		},
+	}
 }
 
 func TestManagementStateCheck_CanApply_NoDSC(t *testing.T) {
@@ -27,8 +84,8 @@ func TestManagementStateCheck_CanApply_NoDSC(t *testing.T) {
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.0.0",
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -46,8 +103,8 @@ func TestManagementStateCheck_CanApply_NotConfigured(t *testing.T) {
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{dsc},
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.0.0",
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -61,11 +118,16 @@ func TestManagementStateCheck_ManagedProhibited(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
+	// Kueue is Managed AND there is a kueue-labeled namespace with a workload.
+	ns := newNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+	nb := newWorkload(resources.Notebook, "team-a", "my-notebook",
+		map[string]string{constants.LabelKueueQueueName: "default-queue"})
+
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"})},
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.0.0",
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns, nb},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -82,19 +144,51 @@ func TestManagementStateCheck_ManagedProhibited(t *testing.T) {
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
 	g.Expect(result.Annotations).To(And(
 		HaveKeyWithValue("component.opendatahub.io/management-state", "Managed"),
-		HaveKeyWithValue("check.opendatahub.io/target-version", "3.0.0"),
+		HaveKeyWithValue("check.opendatahub.io/target-version", "3.3.1"),
 	))
+}
+
+func TestManagementStateCheck_ManagedBlocking(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Kueue is Managed but NO namespaces or workloads are labeled for kueue.
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"})},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(
+		HaveKeyWithValue("component.opendatahub.io/management-state", "Managed"),
+	)
 }
 
 func TestManagementStateCheck_UnmanagedProhibited(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
+	// Kueue is Unmanaged AND there is a workload labeled for kueue.
+	nb := newWorkload(resources.Notebook, "team-b", "my-notebook",
+		map[string]string{constants.LabelKueueQueueName: "default-queue"})
+
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
-		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"})},
-		CurrentVersion: "2.17.0",
-		TargetVersion:  "3.1.0",
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"}), nb},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -109,6 +203,31 @@ func TestManagementStateCheck_UnmanagedProhibited(t *testing.T) {
 		"Message": And(ContainSubstring("only supports the Kueue managementState of Removed"), Not(ContainSubstring("migrated to the Red Hat build of Kueue Operator"))),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+}
+
+func TestManagementStateCheck_UnmanagedBlocking(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Kueue is Unmanaged but NO namespaces or workloads are labeled for kueue.
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"})},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
 func TestManagementStateCheck_CanApply_ManagementState(t *testing.T) {
@@ -132,8 +251,8 @@ func TestManagementStateCheck_CanApply_ManagementState(t *testing.T) {
 			target := testutil.NewTarget(t, testutil.TargetConfig{
 				ListKinds:      listKinds,
 				Objects:        []*unstructured.Unstructured{dsc},
-				CurrentVersion: "2.17.0",
-				TargetVersion:  "3.0.0",
+				CurrentVersion: "2.25.0",
+				TargetVersion:  "3.3.1",
 			})
 
 			canApply, err := chk.CanApply(t.Context(), target)
@@ -152,4 +271,70 @@ func TestManagementStateCheck_Metadata(t *testing.T) {
 	g.Expect(chk.Name()).To(Equal("Components :: Kueue :: Management State (3.x)"))
 	g.Expect(chk.Group()).To(Equal(check.GroupComponent))
 	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestManagementStateCheck_KueueUsageViaNamespaceLabel(t *testing.T) {
+	t.Run("kueue-managed label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// Kueue-managed namespace exists but no workloads with queue-name label — still "in use".
+		ns := newNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+
+		target := testutil.NewTarget(t, testutil.TargetConfig{
+			ListKinds:      listKinds,
+			Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns},
+			CurrentVersion: "2.25.0",
+			TargetVersion:  "3.3.1",
+		})
+
+		chk := kueue.NewManagementStateCheck()
+		result, err := chk.Validate(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+	})
+
+	t.Run("kueue.openshift.io/managed label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// Namespace with OpenShift kueue-managed label — still counts as "in use".
+		ns := newNamespace("team-a", map[string]string{constants.LabelKueueOpenshiftManaged: "true"})
+
+		target := testutil.NewTarget(t, testutil.TargetConfig{
+			ListKinds:      listKinds,
+			Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns},
+			CurrentVersion: "2.25.0",
+			TargetVersion:  "3.3.1",
+		})
+
+		chk := kueue.NewManagementStateCheck()
+		result, err := chk.Validate(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+	})
+}
+
+func TestManagementStateCheck_KueueUsageViaWorkloadLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// No kueue-managed namespace, but a workload has the queue-name label — still "in use".
+	nb := newWorkload(resources.Notebook, "team-b", "my-notebook",
+		map[string]string{constants.LabelKueueQueueName: "default-queue"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), nb},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.1",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
 }

--- a/pkg/lint/checks/kueue/discovery/discovery.go
+++ b/pkg/lint/checks/kueue/discovery/discovery.go
@@ -1,0 +1,79 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// MonitoredWorkloadTypes lists the top-level CR types monitored for kueue label consistency.
+// These are the only resource types that appear in ImpactedObjects.
+//
+//nolint:gochecknoglobals // Static configuration for monitored workload types.
+var MonitoredWorkloadTypes = []resources.ResourceType{
+	resources.Notebook,
+	resources.InferenceService,
+	resources.LLMInferenceService,
+	resources.RayCluster,
+	resources.RayJob,
+	resources.PyTorchJob,
+}
+
+// KueueEnabledNamespaces returns the set of namespaces that have a kueue-managed label.
+// Uses two ListMetadata calls with label selectors for server-side filtering,
+// giving a fixed cost regardless of how many namespaces exist.
+func KueueEnabledNamespaces(
+	ctx context.Context,
+	r client.Reader,
+) (sets.Set[string], error) {
+	enabled := sets.New[string]()
+
+	for _, selector := range []string{
+		constants.LabelKueueManaged + "=true",
+		constants.LabelKueueOpenshiftManaged + "=true",
+	} {
+		items, err := r.ListMetadata(ctx, resources.Namespace,
+			client.WithLabelSelector(selector))
+		if err != nil {
+			return nil, fmt.Errorf("listing kueue-enabled namespaces: %w", err)
+		}
+
+		for _, ns := range items {
+			enabled.Insert(ns.GetName())
+		}
+	}
+
+	return enabled, nil
+}
+
+// WorkloadLabeledNamespaces returns the set of namespaces that contain at least one
+// monitored workload with the kueue.x-k8s.io/queue-name label.
+func WorkloadLabeledNamespaces(
+	ctx context.Context,
+	r client.Reader,
+) (sets.Set[string], error) {
+	namespaces := sets.New[string]()
+	selector := constants.LabelKueueQueueName
+
+	for _, rt := range MonitoredWorkloadTypes {
+		items, err := r.ListMetadata(ctx, rt, client.WithLabelSelector(selector))
+		if err != nil {
+			if client.IsResourceTypeNotFound(err) {
+				continue
+			}
+
+			return nil, fmt.Errorf("listing %s with kueue label: %w", rt.Kind, err)
+		}
+
+		for _, item := range items {
+			namespaces.Insert(item.GetNamespace())
+		}
+	}
+
+	return namespaces, nil
+}

--- a/pkg/lint/checks/workloads/kueue/check.go
+++ b/pkg/lint/checks/workloads/kueue/check.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
@@ -63,12 +64,12 @@ func (c *DataIntegrityCheck) Validate(
 	}
 
 	// Phase 1: determine relevant namespaces.
-	kueueNamespaces, err := kueueEnabledNamespaces(ctx, target.Client)
+	kueueNamespaces, err := kueuediscovery.KueueEnabledNamespaces(ctx, target.Client)
 	if err != nil {
 		return nil, fmt.Errorf("finding kueue-enabled namespaces: %w", err)
 	}
 
-	workloadNamespaces, err := workloadLabeledNamespaces(ctx, target.Client)
+	workloadNamespaces, err := kueuediscovery.WorkloadLabeledNamespaces(ctx, target.Client)
 	if err != nil {
 		return nil, fmt.Errorf("finding workload-labeled namespaces: %w", err)
 	}
@@ -186,7 +187,7 @@ func listWorkloadsInNamespace(
 ) ([]*metav1.PartialObjectMetadata, error) {
 	var all []*metav1.PartialObjectMetadata
 
-	for _, rt := range monitoredWorkloadTypes {
+	for _, rt := range kueuediscovery.MonitoredWorkloadTypes {
 		items, err := r.ListMetadata(ctx, rt, client.WithNamespace(namespace))
 		if err != nil {
 			// A missing CRD means the resource type is not installed on this cluster,
@@ -304,11 +305,11 @@ func populateImpactedObjects(
 }
 
 // buildCRDFQNLookup builds a map from "apiVersion/kind" to CRD FQN
-// using the authoritative ResourceType definitions from monitoredWorkloadTypes.
+// using the authoritative ResourceType definitions from kueuediscovery.MonitoredWorkloadTypes.
 func buildCRDFQNLookup() map[string]string {
-	lookup := make(map[string]string, len(monitoredWorkloadTypes))
+	lookup := make(map[string]string, len(kueuediscovery.MonitoredWorkloadTypes))
 
-	for _, rt := range monitoredWorkloadTypes {
+	for _, rt := range kueuediscovery.MonitoredWorkloadTypes {
 		key := rt.APIVersion() + "/" + rt.Kind
 		lookup[key] = rt.CRDFQN()
 	}

--- a/pkg/lint/checks/workloads/kueue/support.go
+++ b/pkg/lint/checks/workloads/kueue/support.go
@@ -4,27 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 )
-
-// Top-level CR types that we monitor for kueue label consistency.
-// These are the only resource types that appear in ImpactedObjects.
-//
-//nolint:gochecknoglobals // Static configuration for monitored workload types.
-var monitoredWorkloadTypes = []resources.ResourceType{
-	resources.Notebook,
-	resources.InferenceService,
-	resources.LLMInferenceService,
-	resources.RayCluster,
-	resources.RayJob,
-	resources.PyTorchJob,
-}
 
 // Intermediate resource types used to build the ownership graph.
 // These appear in ownership chains between top-level CRs and Pods.
@@ -88,61 +73,4 @@ func IsKueueUnmanaged(
 		dsc, constants.ComponentKueue,
 		constants.ManagementStateUnmanaged,
 	), nil
-}
-
-// kueueEnabledNamespaces returns the set of namespaces that have a kueue-managed label.
-// Uses two ListMetadata calls with label selectors for server-side filtering,
-// giving a fixed cost regardless of how many namespaces exist.
-func kueueEnabledNamespaces(
-	ctx context.Context,
-	r client.Reader,
-) (sets.Set[string], error) {
-	enabled := sets.New[string]()
-
-	for _, selector := range []string{
-		constants.LabelKueueManaged + "=true",
-		constants.LabelKueueOpenshiftManaged + "=true",
-	} {
-		items, err := r.ListMetadata(ctx, resources.Namespace,
-			client.WithLabelSelector(selector))
-		if err != nil {
-			return nil, fmt.Errorf("listing kueue-enabled namespaces: %w", err)
-		}
-
-		for _, ns := range items {
-			enabled.Insert(ns.GetName())
-		}
-	}
-
-	return enabled, nil
-}
-
-// workloadLabeledNamespaces returns the set of namespaces that contain at least one
-// monitored workload with the kueue.x-k8s.io/queue-name label.
-func workloadLabeledNamespaces(
-	ctx context.Context,
-	r client.Reader,
-) (sets.Set[string], error) {
-	namespaces := sets.New[string]()
-	selector := constants.LabelKueueQueueName
-
-	for _, rt := range monitoredWorkloadTypes {
-		items, err := r.ListMetadata(ctx, rt, client.WithLabelSelector(selector))
-		if err != nil {
-			// A missing CRD means the resource type is not installed on this cluster,
-			// so there are zero instances. Ideally ListMetadata would handle this
-			// the same way it handles permission errors (return empty list).
-			if client.IsResourceTypeNotFound(err) {
-				continue
-			}
-
-			return nil, fmt.Errorf("listing %s with kueue label: %w", rt.Kind, err)
-		}
-
-		for _, item := range items {
-			namespaces.Insert(item.GetNamespace())
-		}
-	}
-
-	return namespaces, nil
 }


### PR DESCRIPTION
## Description

Customers may have kueue managementState set to Managed or Unmanaged without actually using kueue (no labeled namespaces or workloads). The previous check treated all Managed/Unmanaged states as prohibited, blocking upgrades unnecessarily.

Now the check detects whether kueue is actively in use by looking for kueue-managed namespace labels and workload queue-name labels:

- Managed/Unmanaged + in use: prohibited (unchanged)
- Managed/Unmanaged + not in use: blocking (recoverable by setting managementState to Removed)

Blocking messages use a <TODO> placeholder pending documentation review.

Also exports KueueEnabledNamespaces and WorkloadLabeledNamespaces from the workloads package so the component check can reuse the detection logic without duplication.


## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade/management validation now detects whether Kueue is actually in use and gives clearer, context-aware guidance.
  * When Kueue is in use the validator reports a prohibitive impact with updated messaging; when not in use it reports a blocking impact and instructs to set managementState to Removed and re-run.
  * Improved error reporting around detection failures for clearer troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->