### PR TITLE
feat: add Service Mesh v3 dependency check for 2.x to 3.x upgrades

### DIFF
--- a/docs/lint/architecture.md
+++ b/docs/lint/architecture.md
@@ -105,9 +105,10 @@ func NewCommand(
     registry.MustRegister(modelmesh.NewRemovalCheck())
     registry.MustRegister(trainingoperator.NewDeprecationCheck())
 
-    // Dependencies (2)
+    // Dependencies (3)
     registry.MustRegister(certmanager.NewCheck())
     registry.MustRegister(openshift.NewCheck())
+    registry.MustRegister(servicemesh.NewCheck())
 
     // Workloads (8)
     registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,6 +59,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonResourceNotFound),
 			check.WithMessage("ingress-operator deployment not found in openshift-ingress-operator namespace"),
+			check.WithRemediation("Check that the openshift-ingress-operator namespace and the ingress-operator deployment exist in the cluster."),
 			check.WithImpact(result.ImpactBlocking),
 		))
 
@@ -70,6 +72,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonInsufficientData),
 			check.WithMessage("Unable to read ingress-operator deployment (insufficient permissions)"),
+			check.WithRemediation("Grant read access to deployments in the openshift-ingress-operator namespace."),
 			check.WithImpact(result.ImpactBlocking),
 		))
 
@@ -87,6 +90,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonDependencyUnavailable),
 			check.WithMessage("GATEWAY_API_OPERATOR_VERSION env var not found on ingress-operator deployment"),
+			check.WithRemediation("Verify the ingress-operator deployment in the openshift-ingress-operator namespace has the GATEWAY_API_OPERATOR_VERSION environment variable."),
 			check.WithImpact(result.ImpactBlocking),
 		))
 
@@ -99,16 +103,21 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonDependencyUnavailable),
 			check.WithMessage("GATEWAY_API_OPERATOR_VERSION env var is empty on ingress-operator deployment"),
+			check.WithRemediation("Verify the ingress-operator deployment in the openshift-ingress-operator namespace has a non-empty GATEWAY_API_OPERATOR_VERSION environment variable."),
 			check.WithImpact(result.ImpactBlocking),
 		))
 
 		return dr, nil
 	}
 
-	// Step 3: Build the expected CSV name.
-	requiredCSV := "servicemeshoperator3.v" + requiredVersion
+	// Step 3: The env var contains the full CSV name (e.g. "servicemeshoperator3.v3.1.0").
+	requiredCSV := requiredVersion
+	displayVersion := strings.TrimPrefix(requiredCSV, "servicemeshoperator3.v")
 
 	// Step 4: Find the servicemeshoperator3 PackageManifest from redhat-operators in openshift-marketplace.
+	// Multiple catalog sources can produce PackageManifests with the same name, so we list all
+	// PackageManifests and filter by .status.catalogSource. A direct get-by-name would return a
+	// non-deterministic result when multiple catalog sources provide the same package.
 	manifests, err := client.List[*unstructured.Unstructured](ctx, target.Client, resources.PackageManifest,
 		func(pm *unstructured.Unstructured) (bool, error) {
 			if pm.GetName() != "servicemeshoperator3" || pm.GetNamespace() != "openshift-marketplace" {
@@ -132,6 +141,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonResourceNotFound),
 			check.WithMessage("servicemeshoperator3 PackageManifest from redhat-operators not found in openshift-marketplace"),
+			check.WithRemediation("Mirror servicemeshoperator3 into the redhat-operators catalog source in the openshift-marketplace namespace."),
 			check.WithImpact(result.ImpactBlocking),
 		))
 
@@ -141,7 +151,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	pm := manifests[0]
 
 	// Step 5: Extract available CSVs from all channels.
-	availableCSVs, err := jq.Query[[]string](pm, "[.status.channels[]?.currentCSV]")
+	availableCSVs, err := jq.Query[[]string](pm, "[.status.channels[]?.entries[]?.name]")
 	if err != nil {
 		return nil, fmt.Errorf("querying available CSVs: %w", err)
 	}
@@ -152,14 +162,14 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			check.ConditionTypeAvailable,
 			metav1.ConditionTrue,
 			check.WithReason(check.ReasonResourceFound),
-			check.WithMessage("%s version %s is available in the cluster catalog", displayName, requiredVersion),
+			check.WithMessage("%s (%s) is available in the 'redhat-operators' cluster catalog", displayName, requiredCSV),
 		))
 	} else {
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeAvailable,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonDependencyUnavailable),
-			check.WithMessage("%s version %s is not available in the cluster catalog", displayName, requiredVersion),
+			check.WithMessage("%s version %s is not available in the cluster catalog", displayName, displayVersion),
 			check.WithRemediation(fmt.Sprintf("Mirror %s into your environment. It must be available in the redhat-operators catalog source in the openshift-marketplace namespace. See the pre-requisite instructions in the RHOAI 2.x to 3.x upgrade guide.", requiredCSV)),
 			check.WithImpact(result.ImpactBlocking),
 		))

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -1,0 +1,113 @@
+package servicemesh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const kind = "servicemesh-v3"
+
+const displayName = "Red Hat Service Mesh v3"
+
+const disconnectedNote = "If performing a disconnected install, ensure the appropriate images are mirrored into your environment."
+
+//nolint:gochecknoglobals
+var minVersion = semver.MustParse("3.1.0")
+
+// Check validates Red Hat Service Mesh v3 operator installation and version.
+type Check struct {
+	check.BaseCheck
+}
+
+func NewCheck() *Check {
+	return &Check{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupDependency,
+			Kind:             kind,
+			Type:             check.CheckTypeInstalled,
+			CheckID:          "dependencies.servicemesh.installed",
+			CheckName:        "Dependencies :: Service Mesh v3 :: Installed",
+			CheckDescription: "Reports the Red Hat Service Mesh v3 operator installation status and validates minimum version requirement",
+		},
+	}
+}
+
+func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
+}
+
+func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	return validate.Operator(c, target).
+		WithNames("servicemeshoperator3").
+		WithConditionBuilder(func(found bool, installedCSV string) result.Condition {
+			if !found {
+				return check.NewCondition(
+					check.ConditionTypeAvailable,
+					metav1.ConditionFalse,
+					check.WithReason(check.ReasonResourceNotFound),
+					check.WithMessage("%s is not installed. Install the latest 3.x version (minimum required is %s). %s",
+						displayName, minVersion.String(), disconnectedNote),
+					check.WithImpact(result.ImpactBlocking),
+				)
+			}
+
+			ver, err := parseInstalledCSVVersion(installedCSV)
+			if err != nil {
+				return check.NewCondition(
+					check.ConditionTypeAvailable,
+					metav1.ConditionFalse,
+					check.WithReason(check.ReasonVersionIncompatible),
+					check.WithMessage("%s is installed but version could not be determined from %q; minimum required is %s",
+						displayName, installedCSV, minVersion.String()),
+					check.WithImpact(result.ImpactBlocking),
+				)
+			}
+
+			if ver.LT(minVersion) {
+				return check.NewCondition(
+					check.ConditionTypeAvailable,
+					metav1.ConditionFalse,
+					check.WithReason(check.ReasonVersionIncompatible),
+					check.WithMessage("%s version %s is below minimum required version %s. %s",
+						displayName, ver.String(), minVersion.String(), disconnectedNote),
+					check.WithImpact(result.ImpactBlocking),
+				)
+			}
+
+			return check.NewCondition(
+				check.ConditionTypeAvailable,
+				metav1.ConditionTrue,
+				check.WithReason(check.ReasonResourceFound),
+				check.WithMessage("%s installed: %s", displayName, ver.String()),
+			)
+		}).
+		Run(ctx)
+}
+
+// parseInstalledCSVVersion extracts a semver.Version from an InstalledCSV string.
+// The expected format is "<name>.v<semver>", e.g. "servicemeshoperator3.v3.1.0".
+func parseInstalledCSVVersion(csv string) (semver.Version, error) {
+	idx := strings.LastIndex(csv, ".v")
+	if idx < 0 {
+		return semver.Version{}, fmt.Errorf("no version segment found in %q", csv)
+	}
+
+	raw := csv[idx+2:] // skip ".v"
+
+	ver, err := semver.ParseTolerant(raw)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("parsing version %q from %q: %w", raw, csv, err)
+	}
+
+	return ver, nil
+}

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -2,16 +2,19 @@ package servicemesh
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
+	"slices"
 
-	"github.com/blang/semver/v4"
-
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -19,12 +22,7 @@ const kind = "servicemesh-v3"
 
 const displayName = "Red Hat Service Mesh v3"
 
-const disconnectedNote = "If performing a disconnected install, ensure the appropriate images are mirrored into your environment."
-
-//nolint:gochecknoglobals
-var minVersion = semver.MustParse("3.1.0")
-
-// Check validates Red Hat Service Mesh v3 operator installation and version.
+// Check validates that the required Service Mesh v3 version is available in the cluster's operator catalog.
 type Check struct {
 	check.BaseCheck
 }
@@ -37,7 +35,7 @@ func NewCheck() *Check {
 			Type:             check.CheckTypeInstalled,
 			CheckID:          "dependencies.servicemesh.installed",
 			CheckName:        "Dependencies :: Service Mesh v3 :: Installed",
-			CheckDescription: "Reports the Red Hat Service Mesh v3 operator installation status and validates minimum version requirement",
+			CheckDescription: "Validates that the required Service Mesh v3 version is available to install from the cluster's operator catalog",
 		},
 	}
 }
@@ -47,67 +45,125 @@ func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
 }
 
 func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
-	return validate.Operator(c, target).
-		WithNames("servicemeshoperator3").
-		WithConditionBuilder(func(found bool, installedCSV string) result.Condition {
-			if !found {
-				return check.NewCondition(
-					check.ConditionTypeAvailable,
-					metav1.ConditionFalse,
-					check.WithReason(check.ReasonResourceNotFound),
-					check.WithMessage("%s is not installed. Install the latest 3.x version (minimum required is %s). %s",
-						displayName, minVersion.String(), disconnectedNote),
-					check.WithImpact(result.ImpactBlocking),
-				)
+	dr := c.NewResult()
+
+	// Step 1: Get the ingress-operator deployment to determine the required version.
+	deploy, err := target.Client.GetResource(ctx, resources.Deployment, "ingress-operator",
+		client.InNamespace("openshift-ingress-operator"))
+
+	switch {
+	case apierrors.IsNotFound(err):
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("ingress-operator deployment not found in openshift-ingress-operator namespace"),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return dr, nil
+	case err != nil:
+		return nil, fmt.Errorf("getting ingress-operator deployment: %w", err)
+	case deploy == nil:
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonInsufficientData),
+			check.WithMessage("Unable to read ingress-operator deployment (insufficient permissions)"),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return dr, nil
+	}
+
+	// Step 2: Extract the required version from the GATEWAY_API_OPERATOR_VERSION env var.
+	requiredVersion, err := jq.Query[string](deploy,
+		`[.spec.template.spec.containers[].env[]? | select(.name == "GATEWAY_API_OPERATOR_VERSION") | .value] | first`)
+
+	switch {
+	case errors.Is(err, jq.ErrNotFound):
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonDependencyUnavailable),
+			check.WithMessage("GATEWAY_API_OPERATOR_VERSION env var not found on ingress-operator deployment"),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return dr, nil
+	case err != nil:
+		return nil, fmt.Errorf("querying GATEWAY_API_OPERATOR_VERSION: %w", err)
+	case requiredVersion == "":
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonDependencyUnavailable),
+			check.WithMessage("GATEWAY_API_OPERATOR_VERSION env var is empty on ingress-operator deployment"),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return dr, nil
+	}
+
+	// Step 3: Build the expected CSV name.
+	requiredCSV := "servicemeshoperator3.v" + requiredVersion
+
+	// Step 4: Find the servicemeshoperator3 PackageManifest from redhat-operators in openshift-marketplace.
+	manifests, err := client.List[*unstructured.Unstructured](ctx, target.Client, resources.PackageManifest,
+		func(pm *unstructured.Unstructured) (bool, error) {
+			if pm.GetName() != "servicemeshoperator3" || pm.GetNamespace() != "openshift-marketplace" {
+				return false, nil
 			}
 
-			ver, err := parseInstalledCSVVersion(installedCSV)
+			catalogSource, err := jq.Query[string](pm, ".status.catalogSource")
 			if err != nil {
-				return check.NewCondition(
-					check.ConditionTypeAvailable,
-					metav1.ConditionFalse,
-					check.WithReason(check.ReasonVersionIncompatible),
-					check.WithMessage("%s is installed but version could not be determined from %q; minimum required is %s",
-						displayName, installedCSV, minVersion.String()),
-					check.WithImpact(result.ImpactBlocking),
-				)
+				return false, nil
 			}
 
-			if ver.LT(minVersion) {
-				return check.NewCondition(
-					check.ConditionTypeAvailable,
-					metav1.ConditionFalse,
-					check.WithReason(check.ReasonVersionIncompatible),
-					check.WithMessage("%s version %s is below minimum required version %s. %s",
-						displayName, ver.String(), minVersion.String(), disconnectedNote),
-					check.WithImpact(result.ImpactBlocking),
-				)
-			}
-
-			return check.NewCondition(
-				check.ConditionTypeAvailable,
-				metav1.ConditionTrue,
-				check.WithReason(check.ReasonResourceFound),
-				check.WithMessage("%s installed: %s", displayName, ver.String()),
-			)
-		}).
-		Run(ctx)
-}
-
-// parseInstalledCSVVersion extracts a semver.Version from an InstalledCSV string.
-// The expected format is "<name>.v<semver>", e.g. "servicemeshoperator3.v3.1.0".
-func parseInstalledCSVVersion(csv string) (semver.Version, error) {
-	idx := strings.LastIndex(csv, ".v")
-	if idx < 0 {
-		return semver.Version{}, fmt.Errorf("no version segment found in %q", csv)
-	}
-
-	raw := csv[idx+2:] // skip ".v"
-
-	ver, err := semver.ParseTolerant(raw)
+			return catalogSource == "redhat-operators", nil
+		})
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("parsing version %q from %q: %w", raw, csv, err)
+		return nil, fmt.Errorf("listing PackageManifests: %w", err)
 	}
 
-	return ver, nil
+	if len(manifests) == 0 {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("servicemeshoperator3 PackageManifest from redhat-operators not found in openshift-marketplace"),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return dr, nil
+	}
+
+	pm := manifests[0]
+
+	// Step 5: Extract available CSVs from all channels.
+	availableCSVs, err := jq.Query[[]string](pm, "[.status.channels[]?.currentCSV]")
+	if err != nil {
+		return nil, fmt.Errorf("querying available CSVs: %w", err)
+	}
+
+	// Step 6: Check if the required CSV is available.
+	if slices.Contains(availableCSVs, requiredCSV) {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceFound),
+			check.WithMessage("%s version %s is available in the cluster catalog", displayName, requiredVersion),
+		))
+	} else {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonDependencyUnavailable),
+			check.WithMessage("%s version %s is not available in the cluster catalog", displayName, requiredVersion),
+			check.WithRemediation(fmt.Sprintf("Mirror %s into your environment. It must be available in the redhat-operators catalog source in the openshift-marketplace namespace. See the pre-requisite instructions in the RHOAI 2.x to 3.x upgrade guide.", requiredCSV)),
+			check.WithImpact(result.ImpactBlocking),
+		))
+	}
+
+	return dr, nil
 }

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -45,10 +45,47 @@ func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
 	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
 }
 
+// extractEnvVar extracts a named environment variable from the ingress-operator deployment.
+// It returns the value, a diagnostic result if the variable is missing/empty, and an error.
+// When the returned result is non-nil, the caller should return it immediately.
+func extractEnvVar(deploy *unstructured.Unstructured, dr *result.DiagnosticResult, envName string) (string, *result.DiagnosticResult, error) {
+	value, err := jq.Query[string](deploy,
+		fmt.Sprintf(`[.spec.template.spec.containers[].env[]? | select(.name == "%s") | .value] | first`, envName))
+
+	switch {
+	case errors.Is(err, jq.ErrNotFound):
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonDependencyUnavailable),
+			check.WithMessage("%s env var not found on ingress-operator deployment", envName),
+			check.WithRemediation(fmt.Sprintf("Verify the ingress-operator deployment in the openshift-ingress-operator namespace has the %s environment variable.", envName)),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return "", dr, nil
+	case err != nil:
+		return "", nil, fmt.Errorf("querying %s: %w", envName, err)
+	case value == "":
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonDependencyUnavailable),
+			check.WithMessage("%s env var is empty on ingress-operator deployment", envName),
+			check.WithRemediation(fmt.Sprintf("Verify the ingress-operator deployment in the openshift-ingress-operator namespace has a non-empty %s environment variable.", envName)),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return "", dr, nil
+	}
+
+	return value, nil, nil
+}
+
 func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	dr := c.NewResult()
 
-	// Step 1: Get the ingress-operator deployment to determine the required version.
+	// Step 1: Get the ingress-operator deployment to determine the required version and channel.
 	deploy, err := target.Client.GetResource(ctx, resources.Deployment, "ingress-operator",
 		client.InNamespace("openshift-ingress-operator"))
 
@@ -80,41 +117,22 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	}
 
 	// Step 2: Extract the required version from the GATEWAY_API_OPERATOR_VERSION env var.
-	requiredVersion, err := jq.Query[string](deploy,
-		`[.spec.template.spec.containers[].env[]? | select(.name == "GATEWAY_API_OPERATOR_VERSION") | .value] | first`)
-
-	switch {
-	case errors.Is(err, jq.ErrNotFound):
-		dr.SetCondition(check.NewCondition(
-			check.ConditionTypeAvailable,
-			metav1.ConditionFalse,
-			check.WithReason(check.ReasonDependencyUnavailable),
-			check.WithMessage("GATEWAY_API_OPERATOR_VERSION env var not found on ingress-operator deployment"),
-			check.WithRemediation("Verify the ingress-operator deployment in the openshift-ingress-operator namespace has the GATEWAY_API_OPERATOR_VERSION environment variable."),
-			check.WithImpact(result.ImpactBlocking),
-		))
-
-		return dr, nil
-	case err != nil:
-		return nil, fmt.Errorf("querying GATEWAY_API_OPERATOR_VERSION: %w", err)
-	case requiredVersion == "":
-		dr.SetCondition(check.NewCondition(
-			check.ConditionTypeAvailable,
-			metav1.ConditionFalse,
-			check.WithReason(check.ReasonDependencyUnavailable),
-			check.WithMessage("GATEWAY_API_OPERATOR_VERSION env var is empty on ingress-operator deployment"),
-			check.WithRemediation("Verify the ingress-operator deployment in the openshift-ingress-operator namespace has a non-empty GATEWAY_API_OPERATOR_VERSION environment variable."),
-			check.WithImpact(result.ImpactBlocking),
-		))
-
-		return dr, nil
+	requiredVersion, earlyResult, err := extractEnvVar(deploy, dr, "GATEWAY_API_OPERATOR_VERSION")
+	if earlyResult != nil || err != nil {
+		return earlyResult, err
 	}
 
-	// Step 3: The env var contains the full CSV name (e.g. "servicemeshoperator3.v3.1.0").
+	// Step 3: Extract the required channel from the GATEWAY_API_OPERATOR_CHANNEL env var.
+	requiredChannel, earlyResult, err := extractEnvVar(deploy, dr, "GATEWAY_API_OPERATOR_CHANNEL")
+	if earlyResult != nil || err != nil {
+		return earlyResult, err
+	}
+
+	// Step 4: The env var contains the full CSV name (e.g. "servicemeshoperator3.v3.1.0").
 	requiredCSV := requiredVersion
 	displayVersion := strings.TrimPrefix(requiredCSV, "servicemeshoperator3.v")
 
-	// Step 4: Find the servicemeshoperator3 PackageManifest from redhat-operators in openshift-marketplace.
+	// Step 5: Find the servicemeshoperator3 PackageManifest from redhat-operators in openshift-marketplace.
 	// Multiple catalog sources can produce PackageManifests with the same name, so we list all
 	// PackageManifests and filter by .status.catalogSource. A direct get-by-name would return a
 	// non-deterministic result when multiple catalog sources provide the same package.
@@ -150,27 +168,28 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 
 	pm := manifests[0]
 
-	// Step 5: Extract available CSVs from all channels.
-	availableCSVs, err := jq.Query[[]string](pm, "[.status.channels[]?.entries[]?.name]")
+	// Step 6: Extract available CSVs from the required channel.
+	availableCSVs, err := jq.Query[[]string](pm,
+		fmt.Sprintf(`[.status.channels[]? | select(.name == "%s") | .entries[]?.name]`, requiredChannel))
 	if err != nil {
 		return nil, fmt.Errorf("querying available CSVs: %w", err)
 	}
 
-	// Step 6: Check if the required CSV is available.
+	// Step 7: Check if the required CSV is available.
 	if slices.Contains(availableCSVs, requiredCSV) {
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeAvailable,
 			metav1.ConditionTrue,
 			check.WithReason(check.ReasonResourceFound),
-			check.WithMessage("%s (%s) is available in the 'redhat-operators' cluster catalog", displayName, requiredCSV),
+			check.WithMessage("%s (%s) is available in the '%s' channel of the 'redhat-operators' cluster catalog", displayName, requiredCSV, requiredChannel),
 		))
 	} else {
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeAvailable,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonDependencyUnavailable),
-			check.WithMessage("%s version %s is not available in the cluster catalog", displayName, displayVersion),
-			check.WithRemediation(fmt.Sprintf("Mirror %s into your environment. It must be available in the redhat-operators catalog source in the openshift-marketplace namespace. See the pre-requisite instructions in the RHOAI 2.x to 3.x upgrade guide.", requiredCSV)),
+			check.WithMessage("%s version %s is not available in the '%s' channel of the cluster catalog", displayName, displayVersion, requiredChannel),
+			check.WithRemediation(fmt.Sprintf("Mirror %s into the '%s' channel of the redhat-operators catalog source in the openshift-marketplace namespace. See the pre-requisite instructions in the RHOAI 2.x to 3.x upgrade guide.", requiredCSV, requiredChannel)),
 			check.WithImpact(result.ImpactBlocking),
 		))
 	}

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -1,20 +1,25 @@
 package servicemesh_test
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/blang/semver/v4"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemesh"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -60,13 +65,19 @@ func newIngressOperatorDeployment(envVars map[string]string) *unstructured.Unstr
 	return &unstructured.Unstructured{Object: obj}
 }
 
-func newPackageManifest(catalogSource string, currentCSVs []string) *unstructured.Unstructured {
-	channels := make([]any, 0, len(currentCSVs))
-	for i, csv := range currentCSVs {
-		channels = append(channels, map[string]any{
-			"name":       fmt.Sprintf("channel-%d", i),
-			"currentCSV": csv,
+func newPackageManifest(catalogSource string, csvNames []string) *unstructured.Unstructured {
+	entries := make([]any, 0, len(csvNames))
+	for _, csv := range csvNames {
+		entries = append(entries, map[string]any{
+			"name": csv,
 		})
+	}
+
+	channels := []any{
+		map[string]any{
+			"name":    "stable",
+			"entries": entries,
+		},
 	}
 
 	obj := map[string]any{
@@ -90,7 +101,7 @@ func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{
-		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 	})
 	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
 
@@ -111,7 +122,10 @@ func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 		"Status": Equal(metav1.ConditionTrue),
 		"Reason": Equal(check.ReasonResourceFound),
 	}))
-	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3.1.0"))
+	g.Expect(result.Status.Conditions[0].Message).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("redhat-operators"),
+	))
 }
 
 func TestServiceMeshV3Check_DeploymentNotFound(t *testing.T) {
@@ -137,6 +151,52 @@ func TestServiceMeshV3Check_DeploymentNotFound(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_InsufficientPermissions(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// testutil.NewTarget does not support reactor injection, so we construct the client manually.
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		listKinds(),
+	)
+
+	// Simulate a Forbidden error when trying to get the ingress-operator deployment.
+	dynamicClient.PrependReactor("get", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "apps", Resource: "deployments"},
+			"ingress-operator",
+			errors.New("forbidden"),
+		)
+	})
+
+	currentVer := semver.MustParse("2.17.0")
+	targetVer := semver.MustParse("3.0.0")
+
+	target := check.Target{
+		Client:         client.NewForTesting(client.TestClientConfig{Dynamic: dynamicClient}),
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonInsufficientData),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("insufficient permissions"))
+	g.Expect(result.Status.Conditions[0].Remediation).To(ContainSubstring("read access"))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
@@ -172,7 +232,7 @@ func TestServiceMeshV3Check_PackageManifestNotFound(t *testing.T) {
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{
-		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
@@ -200,7 +260,7 @@ func TestServiceMeshV3Check_WrongCatalogSource(t *testing.T) {
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{
-		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 	})
 	// PackageManifest exists but from a non-redhat-operators catalog; the check should not find it.
 	pm := newPackageManifest("custom-operators", []string{"servicemeshoperator3.v3.1.0"})
@@ -231,7 +291,7 @@ func TestServiceMeshV3Check_VersionNotAvailable(t *testing.T) {
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{
-		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 	})
 	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.0.0"})
 
@@ -337,12 +397,12 @@ func TestServiceMeshV3Check_EnvVarEmpty(t *testing.T) {
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
-func TestServiceMeshV3Check_VersionAvailableInMultipleChannels(t *testing.T) {
+func TestServiceMeshV3Check_VersionAvailableAmongMultipleEntries(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{
-		"GATEWAY_API_OPERATOR_VERSION": "3.2.0",
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.2.0",
 	})
 	pm := newPackageManifest("redhat-operators", []string{
 		"servicemeshoperator3.v3.0.0",
@@ -367,7 +427,10 @@ func TestServiceMeshV3Check_VersionAvailableInMultipleChannels(t *testing.T) {
 		"Status": Equal(metav1.ConditionTrue),
 		"Reason": Equal(check.ReasonResourceFound),
 	}))
-	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3.2.0"))
+	g.Expect(result.Status.Conditions[0].Message).To(And(
+		ContainSubstring("servicemeshoperator3.v3.2.0"),
+		ContainSubstring("redhat-operators"),
+	))
 }
 
 func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
@@ -375,7 +438,7 @@ func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{
-		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 	})
 	// PackageManifest with no catalogSource in status — won't match redhat-operators.
 	pm := &unstructured.Unstructured{
@@ -389,8 +452,12 @@ func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
 			"status": map[string]any{
 				"channels": []any{
 					map[string]any{
-						"name":       "stable",
-						"currentCSV": "servicemeshoperator3.v3.1.0",
+						"name": "stable",
+						"entries": []any{
+							map[string]any{
+								"name": "servicemeshoperator3.v3.1.0",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -1,30 +1,102 @@
 package servicemesh_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/blang/semver/v4"
 
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemesh"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
 
-func TestServiceMeshV3Check_NotInstalled(t *testing.T) {
+func listKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		resources.Deployment.GVR():      resources.Deployment.ListKind(),
+		resources.PackageManifest.GVR(): resources.PackageManifest.ListKind(),
+	}
+}
+
+func newIngressOperatorDeployment(envVars map[string]string) *unstructured.Unstructured {
+	envList := make([]any, 0, len(envVars))
+	for k, v := range envVars {
+		envList = append(envList, map[string]any{
+			"name":  k,
+			"value": v,
+		})
+	}
+
+	obj := map[string]any{
+		"apiVersion": resources.Deployment.APIVersion(),
+		"kind":       resources.Deployment.Kind,
+		"metadata": map[string]any{
+			"name":      "ingress-operator",
+			"namespace": "openshift-ingress-operator",
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name": "ingress-operator",
+							"env":  envList,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newPackageManifest(catalogSource string, currentCSVs []string) *unstructured.Unstructured {
+	channels := make([]any, 0, len(currentCSVs))
+	for i, csv := range currentCSVs {
+		channels = append(channels, map[string]any{
+			"name":       fmt.Sprintf("channel-%d", i),
+			"currentCSV": csv,
+		})
+	}
+
+	obj := map[string]any{
+		"apiVersion": resources.PackageManifest.APIVersion(),
+		"kind":       resources.PackageManifest.Kind,
+		"metadata": map[string]any{
+			"name":      "servicemeshoperator3",
+			"namespace": "openshift-marketplace",
+		},
+		"status": map[string]any{
+			"catalogSource": catalogSource,
+			"channels":      channels,
+		},
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+	})
+	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		OLM:            operatorfake.NewSimpleClientset(), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -35,35 +107,49 @@ func TestServiceMeshV3Check_NotInstalled(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeAvailable),
-		"Status":  Equal(metav1.ConditionFalse),
-		"Reason":  Equal(check.ReasonResourceNotFound),
-		"Message": And(
-			ContainSubstring("not installed"),
-			ContainSubstring("latest 3.x"),
-			ContainSubstring("3.1.0"),
-			ContainSubstring("disconnected install"),
-		),
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceFound),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3.1.0"))
+}
+
+func TestServiceMeshV3Check_DeploymentNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
-func TestServiceMeshV3Check_InstalledVersionTooOld(t *testing.T) {
+func TestServiceMeshV3Check_EnvVarMissing(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	sub := &operatorsv1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "servicemeshoperator3",
-			Namespace: "openshift-operators",
-		},
-		Status: operatorsv1alpha1.SubscriptionStatus{
-			InstalledCSV: "servicemeshoperator3.v3.0.0",
-		},
-	}
+	deploy := newIngressOperatorDeployment(map[string]string{})
+	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -74,35 +160,24 @@ func TestServiceMeshV3Check_InstalledVersionTooOld(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeAvailable),
-		"Status":  Equal(metav1.ConditionFalse),
-		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(
-			ContainSubstring("3.0.0"),
-			ContainSubstring("3.1.0"),
-			ContainSubstring("disconnected install"),
-		),
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
-	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator3.v3.0.0"))
 }
 
-func TestServiceMeshV3Check_InstalledVersionMeetsMinimum(t *testing.T) {
+func TestServiceMeshV3Check_PackageManifestNotFound(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	sub := &operatorsv1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "servicemeshoperator3",
-			Namespace: "openshift-operators",
-		},
-		Status: operatorsv1alpha1.SubscriptionStatus{
-			InstalledCSV: "servicemeshoperator3.v3.1.0",
-		},
-	}
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -113,30 +188,26 @@ func TestServiceMeshV3Check_InstalledVersionMeetsMinimum(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeAvailable),
-		"Status":  Equal(metav1.ConditionTrue),
-		"Reason":  Equal(check.ReasonResourceFound),
-		"Message": ContainSubstring("3.1.0"),
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
-	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator3.v3.1.0"))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
-func TestServiceMeshV3Check_InstalledVersionAboveMinimum(t *testing.T) {
+func TestServiceMeshV3Check_WrongCatalogSource(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	sub := &operatorsv1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "servicemeshoperator3",
-			Namespace: "openshift-operators",
-		},
-		Status: operatorsv1alpha1.SubscriptionStatus{
-			InstalledCSV: "servicemeshoperator3.v3.2.0",
-		},
-	}
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+	})
+	// PackageManifest exists but from a non-redhat-operators catalog; the check should not find it.
+	pm := newPackageManifest("custom-operators", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -147,30 +218,26 @@ func TestServiceMeshV3Check_InstalledVersionAboveMinimum(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeAvailable),
-		"Status":  Equal(metav1.ConditionTrue),
-		"Reason":  Equal(check.ReasonResourceFound),
-		"Message": ContainSubstring("3.2.0"),
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
-	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator3.v3.2.0"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("redhat-operators"))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
-func TestServiceMeshV3Check_InstalledVersionUnparseable(t *testing.T) {
+func TestServiceMeshV3Check_VersionNotAvailable(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	sub := &operatorsv1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "servicemeshoperator3",
-			Namespace: "openshift-operators",
-		},
-		Status: operatorsv1alpha1.SubscriptionStatus{
-			InstalledCSV: "servicemeshoperator3-badversion",
-		},
-	}
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+	})
+	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.0.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
-		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -181,10 +248,171 @@ func TestServiceMeshV3Check_InstalledVersionUnparseable(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeAvailable),
-		"Status":  Equal(metav1.ConditionFalse),
-		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("could not be determined"), ContainSubstring("servicemeshoperator3-badversion")),
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
+	}))
+	g.Expect(result.Status.Conditions[0].Remediation).To(And(
+		ContainSubstring("Mirror"),
+		ContainSubstring("redhat-operators"),
+		ContainSubstring("openshift-marketplace"),
+	))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_ContainerWithNoEnvKey(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Simulate a container with no env key at all (e.g. injected sidecar).
+	deploy := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Deployment.APIVersion(),
+			"kind":       resources.Deployment.Kind,
+			"metadata": map[string]any{
+				"name":      "ingress-operator",
+				"namespace": "openshift-ingress-operator",
+			},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
+								"name": "sidecar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_EnvVarEmpty(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "",
+	})
+	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_VersionAvailableInMultipleChannels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "3.2.0",
+	})
+	pm := newPackageManifest("redhat-operators", []string{
+		"servicemeshoperator3.v3.0.0",
+		"servicemeshoperator3.v3.1.0",
+		"servicemeshoperator3.v3.2.0",
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceFound),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3.2.0"))
+}
+
+func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "3.1.0",
+	})
+	// PackageManifest with no catalogSource in status — won't match redhat-operators.
+	pm := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.PackageManifest.APIVersion(),
+			"kind":       resources.PackageManifest.Kind,
+			"metadata": map[string]any{
+				"name":      "servicemeshoperator3",
+				"namespace": "openshift-marketplace",
+			},
+			"status": map[string]any{
+				"channels": []any{
+					map[string]any{
+						"name":       "stable",
+						"currentCSV": "servicemeshoperator3.v3.1.0",
+					},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -1,0 +1,262 @@
+package servicemesh_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemesh"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestServiceMeshV3Check_NotInstalled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:            operatorfake.NewSimpleClientset(), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeAvailable),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonResourceNotFound),
+		"Message": And(
+			ContainSubstring("not installed"),
+			ContainSubstring("latest 3.x"),
+			ContainSubstring("3.1.0"),
+			ContainSubstring("disconnected install"),
+		),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_InstalledVersionTooOld(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemeshoperator3",
+			Namespace: "openshift-operators",
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: "servicemeshoperator3.v3.0.0",
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeAvailable),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonVersionIncompatible),
+		"Message": And(
+			ContainSubstring("3.0.0"),
+			ContainSubstring("3.1.0"),
+			ContainSubstring("disconnected install"),
+		),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator3.v3.0.0"))
+}
+
+func TestServiceMeshV3Check_InstalledVersionMeetsMinimum(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemeshoperator3",
+			Namespace: "openshift-operators",
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: "servicemeshoperator3.v3.1.0",
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeAvailable),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonResourceFound),
+		"Message": ContainSubstring("3.1.0"),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator3.v3.1.0"))
+}
+
+func TestServiceMeshV3Check_InstalledVersionAboveMinimum(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemeshoperator3",
+			Namespace: "openshift-operators",
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: "servicemeshoperator3.v3.2.0",
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeAvailable),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonResourceFound),
+		"Message": ContainSubstring("3.2.0"),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue("operator.opendatahub.io/installed-version", "servicemeshoperator3.v3.2.0"))
+}
+
+func TestServiceMeshV3Check_InstalledVersionUnparseable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemeshoperator3",
+			Namespace: "openshift-operators",
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: "servicemeshoperator3-badversion",
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeAvailable),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonVersionIncompatible),
+		"Message": And(ContainSubstring("could not be determined"), ContainSubstring("servicemeshoperator3-badversion")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_CanApply_2xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	smCheck := servicemesh.NewCheck()
+
+	currentVer := semver.MustParse("2.17.0")
+	targetVer := semver.MustParse("3.0.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := smCheck.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestServiceMeshV3Check_CanApply_2xTo2x(t *testing.T) {
+	g := NewWithT(t)
+
+	smCheck := servicemesh.NewCheck()
+
+	currentVer := semver.MustParse("2.17.0")
+	targetVer := semver.MustParse("2.18.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := smCheck.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestServiceMeshV3Check_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	smCheck := servicemesh.NewCheck()
+
+	currentVer := semver.MustParse("3.0.0")
+	targetVer := semver.MustParse("3.1.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := smCheck.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestServiceMeshV3Check_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	smCheck := servicemesh.NewCheck()
+
+	canApply, err := smCheck.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestServiceMeshV3Check_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	smCheck := servicemesh.NewCheck()
+
+	g.Expect(smCheck.ID()).To(Equal("dependencies.servicemesh.installed"))
+	g.Expect(smCheck.Name()).To(Equal("Dependencies :: Service Mesh v3 :: Installed"))
+	g.Expect(smCheck.Group()).To(Equal(check.GroupDependency))
+	g.Expect(smCheck.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -65,7 +65,7 @@ func newIngressOperatorDeployment(envVars map[string]string) *unstructured.Unstr
 	return &unstructured.Unstructured{Object: obj}
 }
 
-func newPackageManifest(catalogSource string, csvNames []string) *unstructured.Unstructured {
+func newPackageManifest(catalogSource string, channel string, csvNames []string) *unstructured.Unstructured {
 	entries := make([]any, 0, len(csvNames))
 	for _, csv := range csvNames {
 		entries = append(entries, map[string]any{
@@ -75,7 +75,7 @@ func newPackageManifest(catalogSource string, csvNames []string) *unstructured.U
 
 	channels := []any{
 		map[string]any{
-			"name":    "stable",
+			"name":    channel,
 			"entries": entries,
 		},
 	}
@@ -102,8 +102,9 @@ func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
-	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -124,6 +125,7 @@ func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 	}))
 	g.Expect(result.Status.Conditions[0].Message).To(And(
 		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
 		ContainSubstring("redhat-operators"),
 	))
 }
@@ -132,7 +134,7 @@ func TestServiceMeshV3Check_DeploymentNotFound(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -205,7 +207,7 @@ func TestServiceMeshV3Check_EnvVarMissing(t *testing.T) {
 	ctx := t.Context()
 
 	deploy := newIngressOperatorDeployment(map[string]string{})
-	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -233,6 +235,7 @@ func TestServiceMeshV3Check_PackageManifestNotFound(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
@@ -261,9 +264,10 @@ func TestServiceMeshV3Check_WrongCatalogSource(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
 	// PackageManifest exists but from a non-redhat-operators catalog; the check should not find it.
-	pm := newPackageManifest("custom-operators", []string{"servicemeshoperator3.v3.1.0"})
+	pm := newPackageManifest("custom-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -292,8 +296,9 @@ func TestServiceMeshV3Check_VersionNotAvailable(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
-	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.0.0"})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.0.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -312,8 +317,10 @@ func TestServiceMeshV3Check_VersionNotAvailable(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonDependencyUnavailable),
 	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("'stable' channel"))
 	g.Expect(result.Status.Conditions[0].Remediation).To(And(
 		ContainSubstring("Mirror"),
+		ContainSubstring("'stable' channel"),
 		ContainSubstring("redhat-operators"),
 		ContainSubstring("openshift-marketplace"),
 	))
@@ -346,7 +353,7 @@ func TestServiceMeshV3Check_ContainerWithNoEnvKey(t *testing.T) {
 			},
 		},
 	}
-	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -375,7 +382,7 @@ func TestServiceMeshV3Check_EnvVarEmpty(t *testing.T) {
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "",
 	})
-	pm := newPackageManifest("redhat-operators", []string{"servicemeshoperator3.v3.1.0"})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
@@ -403,8 +410,9 @@ func TestServiceMeshV3Check_VersionAvailableAmongMultipleEntries(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.2.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
-	pm := newPackageManifest("redhat-operators", []string{
+	pm := newPackageManifest("redhat-operators", "stable", []string{
 		"servicemeshoperator3.v3.0.0",
 		"servicemeshoperator3.v3.1.0",
 		"servicemeshoperator3.v3.2.0",
@@ -429,6 +437,7 @@ func TestServiceMeshV3Check_VersionAvailableAmongMultipleEntries(t *testing.T) {
 	}))
 	g.Expect(result.Status.Conditions[0].Message).To(And(
 		ContainSubstring("servicemeshoperator3.v3.2.0"),
+		ContainSubstring("'stable' channel"),
 		ContainSubstring("redhat-operators"),
 	))
 }
@@ -439,6 +448,7 @@ func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
 	// PackageManifest with no catalogSource in status — won't match redhat-operators.
 	pm := &unstructured.Unstructured{
@@ -481,6 +491,99 @@ func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_ChannelEnvVarMissing(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+	})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("GATEWAY_API_OPERATOR_CHANNEL"))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_ChannelEnvVarEmpty(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "",
+	})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("GATEWAY_API_OPERATOR_CHANNEL"))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestServiceMeshV3Check_VersionInDifferentChannel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
+	})
+	// The CSV exists in the "candidate" channel, but the check requires "stable".
+	pm := newPackageManifest("redhat-operators", "candidate", []string{"servicemeshoperator3.v3.1.0"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonDependencyUnavailable),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("'stable' channel"))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemesh"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/datasciencecluster"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/dscinitialization"
 	datasciencepipelinesworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
@@ -104,9 +105,10 @@ func NewCommand(
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())
 
-	// Dependencies (2)
+	// Dependencies (3)
 	registry.MustRegister(certmanager.NewCheck())
 	registry.MustRegister(openshift.NewCheck())
+	registry.MustRegister(servicemesh.NewCheck())
 
 	// Workloads (20)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -390,4 +390,12 @@ var (
 		Kind:     "ImageStreamTag",
 		Resource: "imagestreamtags",
 	}
+
+	// PackageManifest is the OLM PackageManifest resource for operator catalog queries.
+	PackageManifest = ResourceType{
+		Group:    "packages.operators.coreos.com",
+		Version:  "v1",
+		Kind:     "PackageManifest",
+		Resource: "packagemanifests",
+	}
 )


### PR DESCRIPTION
## Description

Validates Red Hat Service Mesh v3 operator required by OpenShift Ingress in disconnected environments is available in the redhat-operators catalog source when upgrading from RHOAI 2.x to 3.x. Includes guidance for disconnected installs to mirror appropriate images.

## Testing

- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dependency lint check that validates Service Mesh 2.x→3.x upgrade readiness and provides actionable remediation.

* **Tests**
  * Added comprehensive tests for version/channel detection, permission failures, missing metadata, and diagnostic messaging.

* **Documentation**
  * Updated lint docs to reflect the added dependency registration.

* **Chores**
  * Added support for PackageManifest resources used by the new check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->