### PR TITLE
chore: improve wording for servicemesh.installed check

### DIFF
--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -23,6 +23,10 @@ const kind = "servicemesh-v3"
 
 const displayName = "Red Hat Service Mesh v3"
 
+// mirrorRemediationFmt is the shared remediation template for failures where the required
+// servicemeshoperator3 CSV is not available in the cluster catalog.
+const mirrorRemediationFmt = "Mirror %s into the '%s' channel of the redhat-operators catalog source in the openshift-marketplace namespace. See the pre-requisite instructions in the RHOAI 2.x to 3.x upgrade guide."
+
 // Check validates that the required Service Mesh v3 version is available in the cluster's operator catalog.
 type Check struct {
 	check.BaseCheck
@@ -158,8 +162,8 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			check.ConditionTypeAvailable,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonResourceNotFound),
-			check.WithMessage("servicemeshoperator3 PackageManifest from redhat-operators not found in openshift-marketplace"),
-			check.WithRemediation("Mirror servicemeshoperator3 into the redhat-operators catalog source in the openshift-marketplace namespace."),
+			check.WithMessage("servicemeshoperator3 PackageManifest not found in redhat-operators catalog (required: %s in '%s' channel)", requiredCSV, requiredChannel),
+			check.WithRemediation(fmt.Sprintf(mirrorRemediationFmt, requiredCSV, requiredChannel)),
 			check.WithImpact(result.ImpactBlocking),
 		))
 
@@ -189,7 +193,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonDependencyUnavailable),
 			check.WithMessage("%s version %s is not available in the '%s' channel of the cluster catalog", displayName, displayVersion, requiredChannel),
-			check.WithRemediation(fmt.Sprintf("Mirror %s into the '%s' channel of the redhat-operators catalog source in the openshift-marketplace namespace. See the pre-requisite instructions in the RHOAI 2.x to 3.x upgrade guide.", requiredCSV, requiredChannel)),
+			check.WithRemediation(fmt.Sprintf(mirrorRemediationFmt, requiredCSV, requiredChannel)),
 			check.WithImpact(result.ImpactBlocking),
 		))
 	}

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -255,6 +255,18 @@ func TestServiceMeshV3Check_PackageManifestNotFound(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
+	g.Expect(result.Status.Conditions[0].Message).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
+		ContainSubstring("redhat-operators"),
+	))
+	g.Expect(result.Status.Conditions[0].Remediation).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
+		ContainSubstring("redhat-operators"),
+		ContainSubstring("openshift-marketplace"),
+		ContainSubstring("upgrade guide"),
+	))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
@@ -286,7 +298,18 @@ func TestServiceMeshV3Check_WrongCatalogSource(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
-	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("redhat-operators"))
+	g.Expect(result.Status.Conditions[0].Message).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
+		ContainSubstring("redhat-operators"),
+	))
+	g.Expect(result.Status.Conditions[0].Remediation).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
+		ContainSubstring("redhat-operators"),
+		ContainSubstring("openshift-marketplace"),
+		ContainSubstring("upgrade guide"),
+	))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
@@ -491,6 +514,18 @@ func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
+	g.Expect(result.Status.Conditions[0].Message).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
+		ContainSubstring("redhat-operators"),
+	))
+	g.Expect(result.Status.Conditions[0].Remediation).To(And(
+		ContainSubstring("servicemeshoperator3.v3.1.0"),
+		ContainSubstring("'stable' channel"),
+		ContainSubstring("redhat-operators"),
+		ContainSubstring("openshift-marketplace"),
+		ContainSubstring("upgrade guide"),
+	))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 


### PR DESCRIPTION
## Description

The PackageManifest-not-found error previously gave generic guidance that did not mention the specific version or channel required. This could lead users to mirror servicemeshoperator3 without the correct version, resulting in a second failure on re-run.

- Add required CSV and channel to the PackageManifest-not-found message so version info is visible in the summary table
- Extract shared remediation string (mirrorRemediationFmt) so both the PackageManifest-not-found and version-not-available errors give identical remediation guidance
- Update tests to assert on version-specific message and remediation

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced service mesh dependency validation error messages to include required operator version and channel information.
  * Improved remediation guidance with detailed instructions for mirroring operators to the appropriate catalog source.

* **Tests**
  * Updated test assertions to validate enhanced error messaging and remediation guidance for service mesh validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->