### PR TITLE
fix: error when --checks selectors match no registered checks

### DIFF
--- a/pkg/lint/check/registry.go
+++ b/pkg/lint/check/registry.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -140,6 +141,44 @@ func (r *CheckRegistry) ListByPatterns(
 	}
 
 	return result, nil
+}
+
+// MatchesAnyCheck returns true if any registered check matches at least one of the patterns.
+// This is used for early validation that user-provided selectors will match something.
+// Unlike ListByPatterns, this short-circuits on the first match to avoid materializing a full slice.
+func (r *CheckRegistry) MatchesAnyCheck(patterns []string) (bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, check := range r.checks {
+		for _, pattern := range patterns {
+			matched, err := matchesPattern(check, pattern)
+			if err != nil {
+				return false, fmt.Errorf("pattern matching for check %s: %w", check.ID(), err)
+			}
+
+			if matched {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// AllCheckIDs returns all registered check IDs in sorted order.
+func (r *CheckRegistry) AllCheckIDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ids := make([]string, 0, len(r.checks))
+	for id := range r.checks {
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+
+	return ids
 }
 
 // ListByPattern returns checks matching a single selector pattern and group.

--- a/pkg/lint/check/registry_test.go
+++ b/pkg/lint/check/registry_test.go
@@ -240,6 +240,137 @@ func TestCheckRegistry_ListByPatterns_InvalidPattern(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("pattern matching"))
 }
 
+func TestCheckRegistry_AllCheckIDs(t *testing.T) {
+	g := NewWithT(t)
+
+	registry := check.NewRegistry()
+
+	mockChecks := []struct {
+		id    string
+		group check.CheckGroup
+	}{
+		{id: "workloads.notebook.impacted", group: check.GroupWorkload},
+		{id: "components.dashboard", group: check.GroupComponent},
+		{id: "dependencies.certmanager.installed", group: check.GroupDependency},
+	}
+
+	for _, mc := range mockChecks {
+		mockCheck := mocks.NewMockCheck()
+		mockCheck.On("ID").Return(mc.id)
+		mockCheck.On("Group").Return(mc.group)
+		g.Expect(registry.Register(mockCheck)).To(Succeed())
+	}
+
+	ids := registry.AllCheckIDs()
+	g.Expect(ids).To(Equal([]string{
+		"components.dashboard",
+		"dependencies.certmanager.installed",
+		"workloads.notebook.impacted",
+	}))
+}
+
+func TestCheckRegistry_AllCheckIDs_Empty(t *testing.T) {
+	g := NewWithT(t)
+
+	registry := check.NewRegistry()
+	ids := registry.AllCheckIDs()
+	g.Expect(ids).To(BeEmpty())
+}
+
+func TestCheckRegistry_MatchesAnyCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	registry := check.NewRegistry()
+
+	// Register test checks
+	mockChecks := []struct {
+		id    string
+		name  string
+		group check.CheckGroup
+	}{
+		{id: "components.dashboard", name: "Dashboard Component", group: check.GroupComponent},
+		{id: "dependencies.certmanager.installed", name: "Cert Manager", group: check.GroupDependency},
+	}
+
+	for _, mc := range mockChecks {
+		mockCheck := mocks.NewMockCheck()
+		mockCheck.On("ID").Return(mc.id)
+		mockCheck.On("Name").Return(mc.name)
+		mockCheck.On("Group").Return(mc.group)
+		g.Expect(registry.Register(mockCheck)).To(Succeed())
+	}
+
+	tests := []struct {
+		name     string
+		patterns []string
+		want     bool
+	}{
+		{
+			name:     "wildcard matches",
+			patterns: []string{"*"},
+			want:     true,
+		},
+		{
+			name:     "exact ID matches",
+			patterns: []string{"components.dashboard"},
+			want:     true,
+		},
+		{
+			name:     "glob pattern matches",
+			patterns: []string{"*certmanager*"},
+			want:     true,
+		},
+		{
+			name:     "group shortcut matches",
+			patterns: []string{"dependencies"},
+			want:     true,
+		},
+		{
+			name:     "no match returns false",
+			patterns: []string{"nonexistent"},
+			want:     false,
+		},
+		{
+			name:     "hyphenated name does not match unhyphenated ID",
+			patterns: []string{"cert-manager"},
+			want:     false,
+		},
+		{
+			name:     "multiple patterns where one matches",
+			patterns: []string{"nonexistent", "components.dashboard"},
+			want:     true,
+		},
+		{
+			name:     "multiple patterns where none match",
+			patterns: []string{"nonexistent", "also-nonexistent"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, err := registry.MatchesAnyCheck(tt.patterns)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(matched).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestCheckRegistry_MatchesAnyCheck_InvalidPattern(t *testing.T) {
+	g := NewWithT(t)
+
+	registry := check.NewRegistry()
+
+	mockCheck := mocks.NewMockCheck()
+	mockCheck.On("ID").Return("components.dashboard")
+	mockCheck.On("Group").Return(check.GroupComponent)
+
+	g.Expect(registry.Register(mockCheck)).To(Succeed())
+
+	_, err := registry.MatchesAnyCheck([]string{"["})
+	g.Expect(err).To(HaveOccurred())
+}
+
 func TestCheckRegistry_ListByPattern_InvalidPattern(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/fatih/color"
@@ -289,6 +290,24 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 	// Configure check-specific settings
 	c.configureCheckSettings()
 
+	// Validate selectors match at least one registered check (skip for default wildcard)
+	if !isDefaultSelector(c.CheckSelectors) {
+		matched, err := c.registry.MatchesAnyCheck(c.CheckSelectors)
+		if err != nil {
+			return fmt.Errorf("validating check selectors: %w", err)
+		}
+
+		if !matched {
+			noun := "selector"
+			if len(c.CheckSelectors) > 1 {
+				noun = "selectors"
+			}
+
+			return fmt.Errorf("no registered checks match %s: %v\n\nAvailable check IDs:\n  %s",
+				noun, c.CheckSelectors, strings.Join(c.registry.AllCheckIDs(), "\n  "))
+		}
+	}
+
 	// Execute checks using target version for applicability filtering
 	c.IO.Errorf("Running upgrade compatibility checks...")
 	executor := check.NewExecutor(c.registry, c.IO)
@@ -426,6 +445,11 @@ func (c *Command) outputUpgradeTable(ctx context.Context, _ string, results []ch
 	}
 
 	return nil
+}
+
+// isDefaultSelector returns true if the selectors are the default wildcard ["*"].
+func isDefaultSelector(selectors []string) bool {
+	return len(selectors) == 1 && selectors[0] == "*"
 }
 
 // collectNamespaceRequesters fetches the openshift.io/requester annotation for each


### PR DESCRIPTION
## Description

Previously, passing a --checks value that matched no registered checks (e.g., --checks cert-manager) would silently return zero results with a "PASS - all checks passed" verdict. This gave users a false sense of confidence that checks had been evaluated when none actually ran.

This change adds early validation in runUpgradeMode that verifies user-provided --checks selectors match at least one registered check before executing. If no checks match, the command exits with a non-zero exit code and an error message listing all available check IDs to guide the user toward valid selectors.

Validation is skipped for the default wildcard selector ["*"].

Changes:
- Add MatchesAnyCheck() and AllCheckIDs() methods to CheckRegistry
- Add selector validation in runUpgradeMode with pluralized error message
- Add isDefaultSelector() helper to skip validation for default behavior
- Add unit tests for new registry methods

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIs to list all check IDs deterministically and to test whether any provided selector pattern matches registered checks.
  * Selector validation now runs before upgrade operations when non-default selectors are used.

* **Bug Fixes**
  * Improved error output for invalid or non-matching selectors to include a labeled list of available check IDs.

* **Tests**
  * Added unit tests covering listing, matching (including wildcards/globs), and invalid-pattern behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->