### PR TITLE
chore: updates to target 3.3.2 release

### DIFF
--- a/pkg/lint/checks/components/kueue/kueue.go
+++ b/pkg/lint/checks/components/kueue/kueue.go
@@ -21,14 +21,14 @@ const (
 	checkTypeManagementState = "management-state"
 
 	// Deferred: parameterize hardcoded version references using ComponentRequest.TargetVersion.
-	msgManagedProhibited   = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when you have migrated to the Red Hat build of Kueue Operator and the Kueue managementState is Unmanaged."
-	msgUnmanagedProhibited = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when the Kueue managementState is Unmanaged."
-	msgManagedBlocking     = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Managed but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
-	msgUnmanagedBlocking   = "The 3.3.1 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Unmanaged but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
+	msgManagedProhibited   = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when you have migrated to the Red Hat build of Kueue Operator and the Kueue managementState is Unmanaged."
+	msgUnmanagedProhibited = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when the Kueue managementState is Unmanaged."
+	msgManagedBlocking     = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Managed but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
+	msgUnmanagedBlocking   = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Unmanaged but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
 )
 
 // ManagementStateCheck validates that Kueue managementState is Removed before upgrading to 3.x.
-// In RHOAI 3.3.1, only the Removed state is supported. A future 3.3.x release will support
+// In RHOAI 3.3.2, only the Removed state is supported. A future 3.3.x release will support
 // Unmanaged with the Red Hat build of Kueue Operator.
 //
 // The check distinguishes between clusters that are actively using Kueue (namespaces or workloads

--- a/pkg/lint/checks/components/kueue/kueue_test.go
+++ b/pkg/lint/checks/components/kueue/kueue_test.go
@@ -85,7 +85,7 @@ func TestManagementStateCheck_CanApply_NoDSC(t *testing.T) {
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -104,7 +104,7 @@ func TestManagementStateCheck_CanApply_NotConfigured(t *testing.T) {
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{dsc},
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -127,7 +127,7 @@ func TestManagementStateCheck_ManagedProhibited(t *testing.T) {
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns, nb},
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -144,7 +144,7 @@ func TestManagementStateCheck_ManagedProhibited(t *testing.T) {
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
 	g.Expect(result.Annotations).To(And(
 		HaveKeyWithValue("component.opendatahub.io/management-state", "Managed"),
-		HaveKeyWithValue("check.opendatahub.io/target-version", "3.3.1"),
+		HaveKeyWithValue("check.opendatahub.io/target-version", "3.3.2"),
 	))
 }
 
@@ -157,7 +157,7 @@ func TestManagementStateCheck_ManagedBlocking(t *testing.T) {
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"})},
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -188,7 +188,7 @@ func TestManagementStateCheck_UnmanagedProhibited(t *testing.T) {
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"}), nb},
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -214,7 +214,7 @@ func TestManagementStateCheck_UnmanagedBlocking(t *testing.T) {
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"})},
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()
@@ -252,7 +252,7 @@ func TestManagementStateCheck_CanApply_ManagementState(t *testing.T) {
 				ListKinds:      listKinds,
 				Objects:        []*unstructured.Unstructured{dsc},
 				CurrentVersion: "2.25.0",
-				TargetVersion:  "3.3.1",
+				TargetVersion:  "3.3.2",
 			})
 
 			canApply, err := chk.CanApply(t.Context(), target)
@@ -285,7 +285,7 @@ func TestManagementStateCheck_KueueUsageViaNamespaceLabel(t *testing.T) {
 			ListKinds:      listKinds,
 			Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns},
 			CurrentVersion: "2.25.0",
-			TargetVersion:  "3.3.1",
+			TargetVersion:  "3.3.2",
 		})
 
 		chk := kueue.NewManagementStateCheck()
@@ -306,7 +306,7 @@ func TestManagementStateCheck_KueueUsageViaNamespaceLabel(t *testing.T) {
 			ListKinds:      listKinds,
 			Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns},
 			CurrentVersion: "2.25.0",
-			TargetVersion:  "3.3.1",
+			TargetVersion:  "3.3.2",
 		})
 
 		chk := kueue.NewManagementStateCheck()
@@ -329,7 +329,7 @@ func TestManagementStateCheck_KueueUsageViaWorkloadLabel(t *testing.T) {
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), nb},
 		CurrentVersion: "2.25.0",
-		TargetVersion:  "3.3.1",
+		TargetVersion:  "3.3.2",
 	})
 
 	chk := kueue.NewManagementStateCheck()

--- a/pkg/util/version/helpers_test.go
+++ b/pkg/util/version/helpers_test.go
@@ -251,7 +251,7 @@ func TestSameMajorMinor(t *testing.T) {
 		{
 			name:     "3.x to 3.x same minor returns true",
 			a:        toVersionPtr("3.3.0"),
-			b:        toVersionPtr("3.3.1"),
+			b:        toVersionPtr("3.3.2"),
 			expected: true,
 		},
 		{
@@ -290,8 +290,8 @@ func TestMajorMinorLabel(t *testing.T) {
 			expected: "3.0",
 		},
 		{
-			name:     "3.3.1 returns 3.3",
-			version:  toVersionPtr("3.3.1"),
+			name:     "3.3.2 returns 3.3",
+			version:  toVersionPtr("3.3.2"),
 			expected: "3.3",
 		},
 		{


### PR DESCRIPTION
## Description

for reasons not worth explicitly outlining in this PR description - the version of RHOAI we are targeting for migration is now 3.3.2 (when previously it was 3.3.1).

While CanApply() checks - and the majority of string references - are generally only gated on 3.3 - there were a handful of references in user-facing strings and unit tests that still explicitly listed 3.3.1.

For sake of ease and consistency - this PR does a wholesale replace of the "3.3.1" string with "3.3.2" - even in cases where it was "just" a unit test and didn't strictly speaking require changes.
- This was an old fashioned "global search and replace" - no AI used in construction of this change set :smile:


## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed
