### PR TITLE
RHOAIENG-54611 feat: implement stable exit code mapping for CLI error categories

### DIFF
--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -67,6 +68,15 @@ const cmdExample = `
   kubectl odh lint --target-version 3.1
 `
 
+// wrapHandledError wraps an error as already-handled with its derived exit code,
+// used when the error has been rendered to output and should not be printed again.
+func wrapHandledError(err error) error {
+	//nolint:wrapcheck // NewAlreadyHandledError is a same-module constructor
+	return clierrors.NewAlreadyHandledError(
+		clierrors.NewExitCodeError(clierrors.ExitCodeFromError(err), err),
+	)
+}
+
 // AddCommand adds the lint command to the root command.
 func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 	streams := genericiooptions.IOStreams{
@@ -91,7 +101,7 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 			// Complete phase
 			if err := command.Complete(); err != nil {
 				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
-					return clierrors.NewAlreadyHandledError(err)
+					return wrapHandledError(err)
 				}
 
 				if command.Verbose {
@@ -101,13 +111,15 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 					clierrors.WriteTextError(cmd.ErrOrStderr(), err)
 				}
 
-				return clierrors.NewAlreadyHandledError(err)
+				return wrapHandledError(err)
 			}
 
 			// Validate phase
 			if err := command.Validate(); err != nil {
-				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
-					return clierrors.NewAlreadyHandledError(err)
+				exitErr := clierrors.NewExitCodeError(clierrors.ExitValidation, err)
+
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), exitErr, outputFormat) {
+					return clierrors.NewAlreadyHandledError(exitErr)
 				}
 
 				if command.Verbose {
@@ -117,14 +129,19 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 					clierrors.WriteTextError(cmd.ErrOrStderr(), err)
 				}
 
-				return clierrors.NewAlreadyHandledError(err)
+				return clierrors.NewAlreadyHandledError(exitErr)
 			}
 
 			// Run phase
 			err := command.Run(cmd.Context())
 			if err != nil {
+				// Verdict errors (findings already rendered) propagate directly
+				if errors.Is(err, clierrors.ErrAlreadyHandled) {
+					return err //nolint:wrapcheck // already wrapped by NewAlreadyHandledError
+				}
+
 				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
-					return clierrors.NewAlreadyHandledError(err)
+					return wrapHandledError(err)
 				}
 
 				if command.Verbose {
@@ -134,7 +151,7 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 					clierrors.WriteTextError(cmd.ErrOrStderr(), err)
 				}
 
-				return clierrors.NewAlreadyHandledError(err)
+				return wrapHandledError(err)
 			}
 
 			return nil

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,12 +37,12 @@ func main() {
 	components.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
+		exitCode := int(clierrors.ExitCodeFromError(err))
+
 		if !errors.Is(err, clierrors.ErrAlreadyHandled) {
-			if _, writeErr := os.Stderr.WriteString(err.Error() + "\n"); writeErr != nil {
-				os.Exit(1)
-			}
+			_, _ = os.Stderr.WriteString(err.Error() + "\n")
 		}
 
-		os.Exit(1)
+		os.Exit(exitCode)
 	}
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -65,6 +65,60 @@ kubectl odh lint --target-version 3.3.0
 kubectl odh version
 ```
 
+## Exit Codes
+
+The CLI uses differentiated exit codes to help automation tools and CI/CD pipelines
+take appropriate action based on the type of outcome.
+
+| Exit Code | Category   | Description                                              |
+|-----------|------------|----------------------------------------------------------|
+| 0         | Success    | Process completed without issues.                        |
+| 1         | Error      | General runtime or unexpected errors.                    |
+| 2         | Warning    | Process finished, but advisory warnings were found.      |
+| 3         | Validation | Invalid user input or configuration errors.              |
+| 4         | Auth       | Authentication or authorization failures.                |
+| 5         | Connection | Network issues, timeouts, or service unavailability.     |
+
+### Precedence
+
+When multiple issues occur, the exit code reflects the highest priority error:
+
+1. Connection/Timeout (5) - Infrastructure failure
+2. Auth (4) - Security-related failures
+3. Validation (3) - Input-related failures
+4. Error (1) - Catch-all runtime errors
+5. Warning (2) - Only used if no higher-level errors exist
+
+### Lint Command Exit Codes
+
+The lint command maps finding impact levels to exit codes:
+
+- **Prohibited or Blocking findings** → Exit 1 (upgrade cannot proceed)
+- **Advisory findings only** → Exit 2 (upgrade can proceed, review recommended)
+- **No findings** → Exit 0 (clean)
+
+If a lint check fails to execute due to infrastructure issues (auth, connection),
+the corresponding exit code (4 or 5) takes precedence over finding-based exit codes.
+
+### Structured Error Output
+
+When using `-o json` or `-o yaml`, error responses include an `exitCode` field
+in the structured output, allowing automation tools to parse the exit code without
+relying on shell `$?`:
+
+```json
+{
+  "error": {
+    "code": "AUTH_FAILED",
+    "message": "token expired",
+    "category": "authentication",
+    "exitCode": 4,
+    "retriable": false,
+    "suggestion": "Refresh your kubeconfig credentials with 'oc login' or 'kubectl config'"
+  }
+}
+```
+
 ## Key Architecture Decisions
 
 ### Core Principles

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -2,7 +2,6 @@ package lint
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -39,12 +38,20 @@ import (
 	trainingoperatorworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
 // Verify Command implements cmd.Command interface at compile time.
 var _ cmd.Command = (*Command)(nil)
+
+const (
+	msgProhibitedOrBlocking = "prohibited or blocking findings detected: upgrade cannot proceed"
+	msgAdvisoryFindings     = "advisory findings detected: review recommended before upgrade"
+	msgInfrastructureErrors = "one or more checks failed due to infrastructure errors"
+	msgCheckExecErrors      = "check execution errors detected: %w"
+)
 
 // Command contains the lint command configuration.
 type Command struct {
@@ -249,8 +256,10 @@ func (c *Command) Run(ctx context.Context) error {
 
 	// Reject downgrades when explicit --target-version is provided
 	if targetVersion.LT(*currentVersion) {
-		return fmt.Errorf("target version %s is older than current version %s (downgrades not supported)",
-			c.TargetVersion, currentVersion.String())
+		//nolint:wrapcheck // NewExitCodeError is a same-module constructor, not an external error
+		return clierrors.NewExitCodeError(clierrors.ExitValidation,
+			fmt.Errorf("target version %s is older than current version %s (downgrades not supported)",
+				c.TargetVersion, currentVersion.String()))
 	}
 
 	return c.runUpgradeMode(ctx, currentVersion)
@@ -334,8 +343,12 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 		resultsByGroup[group] = results
 	}
 
-	// Flatten, strip nil results, and apply severity filter
+	// Flatten results and compute the highest-priority exit code from execution
+	// errors BEFORE filtering, so failures with Result == nil are not dropped.
 	flatResults := FlattenResults(resultsByGroup)
+	execSummary := highestPriorityExecError(flatResults)
+
+	// Strip nil results and apply severity filter for display/verdict
 	flatResults = slices.DeleteFunc(flatResults, func(exec check.CheckExecution) bool {
 		return exec.Result == nil
 	})
@@ -346,13 +359,15 @@ func (c *Command) runUpgradeMode(ctx context.Context, currentVersion *semver.Ver
 		return err
 	}
 
-	// Print verdict and determine exit code
-	return c.printVerdictAndExit(flatResults)
+	// Print verdict and determine exit code from findings
+	findingsErr := c.evaluateVerdict(flatResults)
+
+	return resolveExitError(execSummary, findingsErr, c.OutputFormat)
 }
 
-// printVerdictAndExit prints a prominent result verdict for table output and returns
-// an error if fail-on conditions are met (to control exit code).
-func (c *Command) printVerdictAndExit(results []check.CheckExecution) error {
+// evaluateVerdict prints a prominent result verdict for table output and returns
+// an error carrying the appropriate ExitCode when fail-on conditions are met.
+func (c *Command) evaluateVerdict(results []check.CheckExecution) error {
 	var hasProhibited, hasBlocking, hasAdvisory bool
 
 	for _, exec := range results {
@@ -376,8 +391,80 @@ func (c *Command) printVerdictAndExit(results []check.CheckExecution) error {
 		printVerdict(c.IO.Out(), hasProhibited, hasBlocking, hasAdvisory)
 	}
 
-	if hasProhibited {
-		return errors.New("prohibited findings detected: upgrade is not possible")
+	if hasProhibited || hasBlocking {
+		//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+		return clierrors.NewExitCodeError(
+			clierrors.ExitError,
+			fmt.Errorf("%w: %s", clierrors.ErrLintBlocked, msgProhibitedOrBlocking),
+		)
+	}
+
+	if hasAdvisory {
+		//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+		return clierrors.NewExitCodeError(
+			clierrors.ExitWarning,
+			fmt.Errorf("%w: %s", clierrors.ErrLintAdvisory, msgAdvisoryFindings),
+		)
+	}
+
+	return nil
+}
+
+// execErrorSummary holds the highest-priority execution error info.
+type execErrorSummary struct {
+	exitCode clierrors.ExitCode
+	err      error
+}
+
+// highestPriorityExecError scans check executions for infrastructure errors
+// (auth, connection, etc.) and returns the highest-priority exit code found.
+func highestPriorityExecError(results []check.CheckExecution) execErrorSummary {
+	summary := execErrorSummary{exitCode: clierrors.ExitSuccess}
+
+	for _, exec := range results {
+		if exec.Error != nil {
+			code := clierrors.ExitCodeFromError(exec.Error)
+			if clierrors.IsHigherPriority(code, summary.exitCode) {
+				summary.exitCode = code
+				summary.err = exec.Error
+			}
+		}
+	}
+
+	return summary
+}
+
+// resolveExitError determines the final error to return based on execution
+// errors and findings verdict, preferring infrastructure errors when they
+// have higher or equal priority.
+//
+// When exit codes are equal (e.g., both ExitError), infrastructure errors
+// take precedence because they indicate a check couldn't run properly,
+// which is more actionable than findings from checks that did complete.
+func resolveExitError(execSummary execErrorSummary, findingsErr error, outputFormat OutputFormat) error {
+	if execSummary.exitCode != clierrors.ExitSuccess {
+		findingsExitCode := clierrors.ExitCodeFromError(findingsErr)
+		// Prefer exec errors when priority is higher OR equal (see comment above)
+		if clierrors.IsHigherPriority(execSummary.exitCode, findingsExitCode) ||
+			execSummary.exitCode == findingsExitCode {
+			if findingsErr != nil {
+				//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+				return clierrors.NewExitCodeError(execSummary.exitCode,
+					fmt.Errorf(msgCheckExecErrors, execSummary.err))
+			}
+
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(execSummary.exitCode,
+				fmt.Errorf(msgInfrastructureErrors+": %w", execSummary.err))
+		}
+	}
+
+	if findingsErr != nil {
+		if outputFormat == OutputFormatTable {
+			return clierrors.NewAlreadyHandledError(findingsErr) //nolint:wrapcheck // wrapping is done by NewAlreadyHandledError
+		}
+
+		return findingsErr
 	}
 
 	return nil

--- a/pkg/lint/verdict_test.go
+++ b/pkg/lint/verdict_test.go
@@ -1,0 +1,320 @@
+//nolint:testpackage // internal test: exercises unexported evaluateVerdict method
+package lint
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testVerdictGroup       = "test"
+	testVerdictKind        = "resource"
+	testVerdictCheckName   = "check"
+	testVerdictDescription = "test check"
+)
+
+func newTestCommand() *Command {
+	var out, errOut bytes.Buffer
+	streams := genericiooptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &out,
+		ErrOut: &errOut,
+	}
+
+	return NewCommand(streams, genericclioptions.NewConfigFlags(true))
+}
+
+func buildExecution(impact result.Impact) check.CheckExecution {
+	dr := result.New(testVerdictGroup, testVerdictKind, testVerdictCheckName, testVerdictDescription)
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeAvailable,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonResourceNotFound),
+		check.WithMessage("test finding"),
+		check.WithImpact(impact),
+	))
+
+	return check.CheckExecution{Result: dr}
+}
+
+func buildPassingExecution() check.CheckExecution {
+	dr := result.New(testVerdictGroup, testVerdictKind, testVerdictCheckName, testVerdictDescription)
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeAvailable,
+		metav1.ConditionTrue,
+		check.WithReason(check.ReasonResourceAvailable),
+		check.WithMessage("all good"),
+	))
+
+	return check.CheckExecution{Result: dr}
+}
+
+func TestEvaluateVerdict(t *testing.T) {
+	cases := []struct {
+		name              string
+		results           []check.CheckExecution
+		wantErr           bool
+		wantCode          clierrors.ExitCode
+		notAlreadyHandled bool
+	}{
+		{
+			name:    "should return nil for all-passing results",
+			results: []check.CheckExecution{buildPassingExecution()},
+		},
+		{
+			name:     "should return ExitError for prohibited findings",
+			results:  []check.CheckExecution{buildExecution(result.ImpactProhibited)},
+			wantErr:  true,
+			wantCode: clierrors.ExitError,
+		},
+		{
+			name:     "should return ExitError for blocking findings",
+			results:  []check.CheckExecution{buildExecution(result.ImpactBlocking)},
+			wantErr:  true,
+			wantCode: clierrors.ExitError,
+		},
+		{
+			name:     "should return ExitWarning for advisory-only findings",
+			results:  []check.CheckExecution{buildExecution(result.ImpactAdvisory)},
+			wantErr:  true,
+			wantCode: clierrors.ExitWarning,
+		},
+		{
+			name: "should return ExitError when both prohibited and advisory findings exist",
+			results: []check.CheckExecution{
+				buildExecution(result.ImpactProhibited),
+				buildExecution(result.ImpactAdvisory),
+			},
+			wantErr:           true,
+			wantCode:          clierrors.ExitError,
+			notAlreadyHandled: true,
+		},
+		{
+			name: "should return ExitError when both blocking and advisory findings exist",
+			results: []check.CheckExecution{
+				buildExecution(result.ImpactBlocking),
+				buildExecution(result.ImpactAdvisory),
+			},
+			wantErr:  true,
+			wantCode: clierrors.ExitError,
+		},
+		{
+			name: "should skip nil results",
+			results: []check.CheckExecution{
+				{Result: nil},
+				buildExecution(result.ImpactAdvisory),
+			},
+			wantErr:  true,
+			wantCode: clierrors.ExitWarning,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cmd := newTestCommand()
+			cmd.OutputFormat = OutputFormatJSON
+
+			err := cmd.evaluateVerdict(tc.results)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(clierrors.ExitCodeFromError(err)).To(Equal(tc.wantCode))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			if tc.notAlreadyHandled {
+				g.Expect(errors.Is(err, clierrors.ErrAlreadyHandled)).To(BeFalse())
+			}
+		})
+	}
+}
+
+func buildExecutionWithError(execErr error) check.CheckExecution {
+	return check.CheckExecution{
+		Result: nil,
+		Error:  execErr,
+	}
+}
+
+func TestHighestPriorityExecError(t *testing.T) {
+	connErr := clierrors.NewExitCodeError(clierrors.ExitConnection, errors.New("connection failed"))
+	authErr := clierrors.NewExitCodeError(clierrors.ExitAuth, errors.New("auth failed"))
+	genericErr := errors.New("generic error")
+
+	cases := []struct {
+		name     string
+		results  []check.CheckExecution
+		wantCode clierrors.ExitCode
+		wantErr  bool
+	}{
+		{
+			name:     "should return ExitSuccess for no errors",
+			results:  []check.CheckExecution{buildPassingExecution()},
+			wantCode: clierrors.ExitSuccess,
+			wantErr:  false,
+		},
+		{
+			name:     "should return connection error code",
+			results:  []check.CheckExecution{buildExecutionWithError(connErr)},
+			wantCode: clierrors.ExitConnection,
+			wantErr:  true,
+		},
+		{
+			name:     "should return auth error code",
+			results:  []check.CheckExecution{buildExecutionWithError(authErr)},
+			wantCode: clierrors.ExitAuth,
+			wantErr:  true,
+		},
+		{
+			name: "should return highest priority when multiple errors exist",
+			results: []check.CheckExecution{
+				buildExecutionWithError(authErr),
+				buildExecutionWithError(connErr),
+			},
+			wantCode: clierrors.ExitConnection,
+			wantErr:  true,
+		},
+		{
+			name: "should classify generic error as ExitError",
+			results: []check.CheckExecution{
+				buildExecutionWithError(genericErr),
+			},
+			wantCode: clierrors.ExitError,
+			wantErr:  true,
+		},
+		{
+			name: "should ignore nil errors in results",
+			results: []check.CheckExecution{
+				{Result: nil, Error: nil},
+				buildExecutionWithError(authErr),
+			},
+			wantCode: clierrors.ExitAuth,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			summary := highestPriorityExecError(tc.results)
+
+			g.Expect(summary.exitCode).To(Equal(tc.wantCode))
+			if tc.wantErr {
+				g.Expect(summary.err).To(HaveOccurred())
+			} else {
+				g.Expect(summary.err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestResolveExitError(t *testing.T) {
+	connErr := errors.New("connection failed")
+	findingsErr := clierrors.NewExitCodeError(clierrors.ExitError,
+		fmt.Errorf("%w: blocked", clierrors.ErrLintBlocked))
+	advisoryErr := clierrors.NewExitCodeError(clierrors.ExitWarning,
+		fmt.Errorf("%w: advisory", clierrors.ErrLintAdvisory))
+
+	cases := []struct {
+		name         string
+		execSummary  execErrorSummary
+		findingsErr  error
+		outputFormat OutputFormat
+		wantCode     clierrors.ExitCode
+		wantErr      bool
+	}{
+		{
+			name:         "should return nil when no errors",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitSuccess},
+			findingsErr:  nil,
+			outputFormat: OutputFormatJSON,
+			wantErr:      false,
+		},
+		{
+			name:         "should return findings error when no exec errors",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitSuccess},
+			findingsErr:  findingsErr,
+			outputFormat: OutputFormatJSON,
+			wantCode:     clierrors.ExitError,
+			wantErr:      true,
+		},
+		{
+			name:         "should prefer exec error when higher priority than findings",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitConnection, err: connErr},
+			findingsErr:  findingsErr,
+			outputFormat: OutputFormatJSON,
+			wantCode:     clierrors.ExitConnection,
+			wantErr:      true,
+		},
+		{
+			name:         "should prefer exec error when equal priority to findings",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitError, err: connErr},
+			findingsErr:  findingsErr,
+			outputFormat: OutputFormatJSON,
+			wantCode:     clierrors.ExitError,
+			wantErr:      true,
+		},
+		{
+			name:         "should return findings when higher priority than exec error",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitWarning, err: connErr},
+			findingsErr:  findingsErr,
+			outputFormat: OutputFormatJSON,
+			wantCode:     clierrors.ExitError,
+			wantErr:      true,
+		},
+		{
+			name:         "should wrap as AlreadyHandled for table format",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitSuccess},
+			findingsErr:  advisoryErr,
+			outputFormat: OutputFormatTable,
+			wantCode:     clierrors.ExitWarning,
+			wantErr:      true,
+		},
+		{
+			name:         "should return exec error when no findings",
+			execSummary:  execErrorSummary{exitCode: clierrors.ExitConnection, err: connErr},
+			findingsErr:  nil,
+			outputFormat: OutputFormatJSON,
+			wantCode:     clierrors.ExitConnection,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := resolveExitError(tc.execSummary, tc.findingsErr, tc.outputFormat)
+
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(clierrors.ExitCodeFromError(err)).To(Equal(tc.wantCode))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+
+	t.Run("should wrap as AlreadyHandled for table format with findings", func(t *testing.T) {
+		g := NewWithT(t)
+		err := resolveExitError(
+			execErrorSummary{exitCode: clierrors.ExitSuccess},
+			advisoryErr,
+			OutputFormatTable,
+		)
+
+		g.Expect(errors.Is(err, clierrors.ErrAlreadyHandled)).To(BeTrue())
+	})
+}

--- a/pkg/util/client/config.go
+++ b/pkg/util/client/config.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"fmt"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 
@@ -44,7 +42,7 @@ func NewRESTConfig(
 ) (*rest.Config, error) {
 	restConfig, err := configFlags.ToRESTConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create REST config: %w", clierrors.NewConfigError(err))
+		return nil, clierrors.NewConfigError(err)
 	}
 
 	ConfigureThrottling(restConfig, qps, burst)

--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -2,9 +2,12 @@ package errors
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"io/fs"
 	"net"
+	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -26,10 +29,16 @@ const (
 	suggestionCanceled        = "Operation was canceled"
 	suggestionFilePath        = "Verify the file path exists and is readable (e.g. --kubeconfig)"
 	suggestionConfig          = "Check your kubeconfig: verify the --context, --cluster, and --kubeconfig flags are correct"
+	suggestionTLS             = "Verify the certificate authority bundle, check the server certificate validity, and ensure the hostname matches the certificate"
+	suggestionDNS             = "Verify the server hostname in your kubeconfig is correct and DNS is configured"
+	suggestionPermission      = "Check file and directory permissions for the target path"
+	suggestionLintAdvisory    = "Review the advisory findings before proceeding with the upgrade"
+	suggestionLintBlocked     = "Address the prohibited or blocking findings before proceeding with the upgrade"
+	suggestionInputValidation = "Check the command arguments and flags"
 )
 
-// apiErrorEntry maps an apierrors check function to its structured error fields.
-type apiErrorEntry struct {
+// errorEntry maps an error-check function to its structured error fields.
+type errorEntry struct {
 	check      func(error) bool
 	code       string
 	category   ErrorCategory
@@ -42,7 +51,7 @@ type apiErrorEntry struct {
 // appear before broader ones (e.g. IsInternalError) that match the same status code.
 //
 //nolint:gochecknoglobals // package-level lookup table is intentional
-var apiErrorTable = []apiErrorEntry{
+var apiErrorTable = []errorEntry{
 	{apierrors.IsUnauthorized, "AUTH_FAILED", CategoryAuthentication, false, suggestionAuthentication},
 	{apierrors.IsForbidden, "AUTHZ_DENIED", CategoryAuthorization, false, suggestionAuthorization},
 	{apierrors.IsNotFound, "NOT_FOUND", CategoryNotFound, false, suggestionNotFound},
@@ -66,6 +75,24 @@ var apiErrorTable = []apiErrorEntry{
 	{apierrors.IsStoreReadError, "STORE_READ_ERROR", CategoryServer, true, suggestionServer},
 }
 
+// localErrorTable classifies non-Kubernetes errors by inspecting the error
+// chain for well-known Go types (context, filesystem, TLS, DNS, net).
+// Order matters: specific checks (e.g. isTLSError, isDNSError) must appear
+// before broader ones (e.g. isNetworkError) that match the same underlying types.
+//
+//nolint:gochecknoglobals // package-level lookup table is intentional
+var localErrorTable = []errorEntry{
+	{isDeadlineExceeded, "TIMEOUT", CategoryTimeout, true, suggestionTimeout},
+	{isContextCanceled, "CANCELED", CategoryInternal, false, suggestionCanceled},
+	{isPermissionError, "PERMISSION_DENIED", CategoryValidation, false, suggestionPermission},
+	{isFilesystemError, "CONFIG_INVALID", CategoryValidation, false, suggestionFilePath},
+	{isConfigError, "CONFIG_INVALID", CategoryValidation, false, suggestionConfig},
+	{isTLSError, "TLS_CERT_INVALID", CategoryAuthentication, false, suggestionTLS},
+	{isDNSError, "DNS_FAILED", CategoryConnection, true, suggestionDNS},
+	{isNetworkTimeout, "NET_TIMEOUT", CategoryTimeout, true, suggestionTimeout},
+	{isNetworkError, "CONN_FAILED", CategoryConnection, true, suggestionConnection},
+}
+
 // Classify inspects an error and returns a StructuredError with the
 // appropriate category, error code, retriable flag, and suggestion.
 func Classify(err error) *StructuredError {
@@ -78,12 +105,89 @@ func Classify(err error) *StructuredError {
 		return structuredErr
 	}
 
-	for _, entry := range apiErrorTable {
+	if result := matchEntry(apiErrorTable, err); result != nil {
+		return result
+	}
+
+	if result := matchEntry(localErrorTable, err); result != nil {
+		return result
+	}
+
+	// When an ExitCodeError wraps a plain (unclassifiable) error, derive the
+	// structured fields from the explicit exit code so the JSON/YAML output
+	// reflects the intended category rather than falling through to INTERNAL.
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		return classifyFromExitCode(exitErr.Code, err)
+	}
+
+	return &StructuredError{
+		Code:       "INTERNAL",
+		Message:    err.Error(),
+		Category:   CategoryInternal,
+		ExitCode:   int(ExitCodeFromCategory(CategoryInternal)),
+		Retriable:  false,
+		Suggestion: suggestionInternal,
+		cause:      err,
+	}
+}
+
+// classifyFromExitCode builds a StructuredError from an explicit ExitCode
+// when the wrapped error itself is not classifiable.
+func classifyFromExitCode(code ExitCode, err error) *StructuredError {
+	switch code { //nolint:exhaustive // ExitSuccess is not an error
+	case ExitWarning:
+		return &StructuredError{
+			Code: "LINT_ADVISORY", Message: err.Error(),
+			Category: CategoryValidation, ExitCode: int(ExitWarning),
+			Suggestion: suggestionLintAdvisory, cause: err,
+		}
+	case ExitValidation:
+		return &StructuredError{
+			Code: "VALIDATION_FAILED", Message: err.Error(),
+			Category: CategoryValidation, ExitCode: int(ExitValidation),
+			Suggestion: suggestionInputValidation, cause: err,
+		}
+	case ExitAuth:
+		return &StructuredError{
+			Code: "AUTH_FAILED", Message: err.Error(),
+			Category: CategoryAuthentication, ExitCode: int(ExitAuth),
+			Suggestion: suggestionAuthentication, cause: err,
+		}
+	case ExitConnection:
+		return &StructuredError{
+			Code: "CONN_FAILED", Message: err.Error(),
+			Category: CategoryConnection, ExitCode: int(ExitConnection),
+			Retriable: true, Suggestion: suggestionConnection, cause: err,
+		}
+	case ExitError:
+		// Check if this is a lint finding (prohibited/blocking) vs general error
+		if errors.Is(err, ErrLintBlocked) {
+			return &StructuredError{
+				Code: "LINT_BLOCKED", Message: err.Error(),
+				Category: CategoryValidation, ExitCode: int(ExitError),
+				Suggestion: suggestionLintBlocked, cause: err,
+			}
+		}
+
+		fallthrough
+	default:
+		return &StructuredError{
+			Code: "INTERNAL", Message: err.Error(),
+			Category: CategoryInternal, ExitCode: int(ExitError),
+			Suggestion: suggestionInternal, cause: err,
+		}
+	}
+}
+
+func matchEntry(table []errorEntry, err error) *StructuredError {
+	for _, entry := range table {
 		if entry.check(err) {
 			return &StructuredError{
 				Code:       entry.code,
 				Message:    err.Error(),
 				Category:   entry.category,
+				ExitCode:   int(ExitCodeFromCategory(entry.category)),
 				Retriable:  entry.retriable,
 				Suggestion: entry.suggestion,
 				cause:      err,
@@ -91,78 +195,11 @@ func Classify(err error) *StructuredError {
 		}
 	}
 
-	switch {
-	case errors.Is(err, context.DeadlineExceeded):
-		return &StructuredError{
-			Code:       "TIMEOUT",
-			Message:    err.Error(),
-			Category:   CategoryTimeout,
-			Retriable:  true,
-			Suggestion: suggestionTimeout,
-			cause:      err,
-		}
-
-	case errors.Is(err, context.Canceled):
-		return &StructuredError{
-			Code:       "CANCELED",
-			Message:    err.Error(),
-			Category:   CategoryInternal,
-			Retriable:  false,
-			Suggestion: suggestionCanceled,
-			cause:      err,
-		}
-
-	case isFilesystemError(err):
-		return &StructuredError{
-			Code:       "CONFIG_INVALID",
-			Message:    err.Error(),
-			Category:   CategoryValidation,
-			Retriable:  false,
-			Suggestion: suggestionFilePath,
-			cause:      err,
-		}
-
-	case isConfigError(err):
-		return &StructuredError{
-			Code:       "CONFIG_INVALID",
-			Message:    err.Error(),
-			Category:   CategoryValidation,
-			Retriable:  false,
-			Suggestion: suggestionConfig,
-			cause:      err,
-		}
-
-	case isNetworkTimeout(err):
-		return &StructuredError{
-			Code:       "NET_TIMEOUT",
-			Message:    err.Error(),
-			Category:   CategoryTimeout,
-			Retriable:  true,
-			Suggestion: suggestionTimeout,
-			cause:      err,
-		}
-
-	case isNetworkError(err):
-		return &StructuredError{
-			Code:       "CONN_FAILED",
-			Message:    err.Error(),
-			Category:   CategoryConnection,
-			Retriable:  true,
-			Suggestion: suggestionConnection,
-			cause:      err,
-		}
-
-	default:
-		return &StructuredError{
-			Code:       "INTERNAL",
-			Message:    err.Error(),
-			Category:   CategoryInternal,
-			Retriable:  false,
-			Suggestion: suggestionInternal,
-			cause:      err,
-		}
-	}
+	return nil
 }
+
+func isDeadlineExceeded(err error) bool { return errors.Is(err, context.DeadlineExceeded) }
+func isContextCanceled(err error) bool  { return errors.Is(err, context.Canceled) }
 
 func isFilesystemError(err error) bool {
 	var pathErr *fs.PathError
@@ -180,6 +217,28 @@ func isNetworkError(err error) bool {
 	var netErr net.Error
 
 	return errors.As(err, &netErr)
+}
+
+func isTLSError(err error) bool {
+	var unknownAuth x509.UnknownAuthorityError
+	var certInvalid x509.CertificateInvalidError
+	var hostnameErr x509.HostnameError
+	var recordHeader tls.RecordHeaderError
+
+	return errors.As(err, &unknownAuth) ||
+		errors.As(err, &certInvalid) ||
+		errors.As(err, &hostnameErr) ||
+		errors.As(err, &recordHeader)
+}
+
+func isDNSError(err error) bool {
+	var dnsErr *net.DNSError
+
+	return errors.As(err, &dnsErr)
+}
+
+func isPermissionError(err error) bool {
+	return errors.Is(err, os.ErrPermission)
 }
 
 func isNetworkTimeout(err error) bool {

--- a/pkg/util/errors/errors_test.go
+++ b/pkg/util/errors/errors_test.go
@@ -2,10 +2,14 @@ package errors_test
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
+	"os"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +39,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
 		g.Expect(result).To(HaveField("Code", Equal("AUTH_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 		g.Expect(result).To(HaveField("Suggestion", Not(BeEmpty())))
 		g.Expect(result.Unwrap()).To(Equal(err))
@@ -48,6 +53,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthorization)))
 		g.Expect(result).To(HaveField("Code", Equal("AUTHZ_DENIED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -59,6 +65,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryNotFound)))
 		g.Expect(result).To(HaveField("Code", Equal("NOT_FOUND")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -70,6 +77,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryConflict)))
 		g.Expect(result).To(HaveField("Code", Equal("CONFLICT")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -81,6 +89,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryTimeout)))
 		g.Expect(result).To(HaveField("Code", Equal("SERVER_TIMEOUT")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -91,6 +100,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("SERVER_UNAVAILABLE")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -101,6 +111,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("SERVER_ERROR")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -112,6 +123,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryConflict)))
 		g.Expect(result).To(HaveField("Code", Equal("ALREADY_EXISTS")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -123,6 +135,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -133,6 +146,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("BAD_REQUEST")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -144,6 +158,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("METHOD_NOT_SUPPORTED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -155,6 +170,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("NOT_ACCEPTABLE")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -166,6 +182,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("UNSUPPORTED_MEDIA_TYPE")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -176,6 +193,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("REQUEST_TOO_LARGE")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -187,6 +205,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("GONE")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -197,6 +216,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("RESOURCE_EXPIRED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -207,6 +227,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryTimeout)))
 		g.Expect(result).To(HaveField("Code", Equal("GATEWAY_TIMEOUT")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -217,6 +238,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("RATE_LIMITED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -228,6 +250,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("UNEXPECTED_SERVER_ERROR")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -238,6 +261,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("UNEXPECTED_OBJECT")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -251,6 +275,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryServer)))
 		g.Expect(result).To(HaveField("Code", Equal("STORE_READ_ERROR")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -262,6 +287,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
 		g.Expect(result).To(HaveField("Code", Equal("AUTH_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
 	})
 
 	t.Run("should classify network timeout", func(t *testing.T) {
@@ -271,6 +297,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryTimeout)))
 		g.Expect(result).To(HaveField("Code", Equal("NET_TIMEOUT")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -281,6 +308,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryConnection)))
 		g.Expect(result).To(HaveField("Code", Equal("CONN_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -290,6 +318,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryTimeout)))
 		g.Expect(result).To(HaveField("Code", Equal("TIMEOUT")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
 		g.Expect(result).To(HaveField("Retriable", BeTrue()))
 	})
 
@@ -299,6 +328,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryInternal)))
 		g.Expect(result).To(HaveField("Code", Equal("CANCELED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -309,6 +339,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("CONFIG_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 		g.Expect(result).To(HaveField("Suggestion", Not(BeEmpty())))
 	})
@@ -321,6 +352,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("CONFIG_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 	})
 
 	t.Run("should classify config error as validation", func(t *testing.T) {
@@ -330,6 +362,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("CONFIG_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 		g.Expect(result).To(HaveField("Suggestion", ContainSubstring("kubeconfig")))
 	})
@@ -342,6 +375,109 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
 		g.Expect(result).To(HaveField("Code", Equal("CONFIG_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
+	})
+
+	t.Run("should classify x509 unknown authority as TLS error", func(t *testing.T) {
+		g := NewWithT(t)
+		err := x509.UnknownAuthorityError{}
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
+		g.Expect(result).To(HaveField("Code", Equal("TLS_CERT_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+		g.Expect(result).To(HaveField("Suggestion", ContainSubstring("certificate")))
+	})
+
+	t.Run("should classify x509 certificate invalid as TLS error", func(t *testing.T) {
+		g := NewWithT(t)
+		err := x509.CertificateInvalidError{Reason: x509.Expired}
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
+		g.Expect(result).To(HaveField("Code", Equal("TLS_CERT_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+	})
+
+	t.Run("should classify x509 hostname error as TLS error", func(t *testing.T) {
+		g := NewWithT(t)
+		err := x509.HostnameError{
+			Host:        "wrong.example.com",
+			Certificate: &x509.Certificate{DNSNames: []string{"actual.example.com"}},
+		}
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
+		g.Expect(result).To(HaveField("Code", Equal("TLS_CERT_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
+	})
+
+	t.Run("should classify TLS record header error as TLS error", func(t *testing.T) {
+		g := NewWithT(t)
+		err := tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
+		g.Expect(result).To(HaveField("Code", Equal("TLS_CERT_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
+	})
+
+	t.Run("should classify wrapped TLS error as TLS error", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsErr := x509.UnknownAuthorityError{}
+		wrapped := fmt.Errorf("failed to connect: %w", tlsErr)
+		result := clierrors.Classify(wrapped)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
+		g.Expect(result).To(HaveField("Code", Equal("TLS_CERT_INVALID")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
+	})
+
+	t.Run("should classify DNS error as connection", func(t *testing.T) {
+		g := NewWithT(t)
+		err := &net.DNSError{Err: "no such host", Name: "api.cluster.example.com"}
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryConnection)))
+		g.Expect(result).To(HaveField("Code", Equal("DNS_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
+		g.Expect(result).To(HaveField("Retriable", BeTrue()))
+		g.Expect(result).To(HaveField("Suggestion", ContainSubstring("hostname")))
+	})
+
+	t.Run("should classify wrapped DNS error as connection", func(t *testing.T) {
+		g := NewWithT(t)
+		dnsErr := &net.DNSError{Err: "no such host", Name: "api.cluster.example.com"}
+		wrapped := fmt.Errorf("dial tcp: %w", dnsErr)
+		result := clierrors.Classify(wrapped)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryConnection)))
+		g.Expect(result).To(HaveField("Code", Equal("DNS_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
+	})
+
+	t.Run("should classify OS permission denied as validation", func(t *testing.T) {
+		g := NewWithT(t)
+		err := fmt.Errorf("socket bind: %w", os.ErrPermission)
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
+		g.Expect(result).To(HaveField("Code", Equal("PERMISSION_DENIED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+		g.Expect(result).To(HaveField("Suggestion", ContainSubstring("permissions")))
+	})
+
+	t.Run("should classify filesystem permission error as permission denied", func(t *testing.T) {
+		g := NewWithT(t)
+		err := &fs.PathError{Op: "open", Path: "/etc/secret", Err: os.ErrPermission}
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
+		g.Expect(result).To(HaveField("Code", Equal("PERMISSION_DENIED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
 	})
 
 	t.Run("should classify unknown error as internal", func(t *testing.T) {
@@ -350,6 +486,7 @@ func TestClassify(t *testing.T) {
 
 		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryInternal)))
 		g.Expect(result).To(HaveField("Code", Equal("INTERNAL")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
 		g.Expect(result).To(HaveField("Retriable", BeFalse()))
 	})
 
@@ -375,5 +512,84 @@ func TestClassify(t *testing.T) {
 		g.Expect(wrapped).To(MatchError(ContainSubstring("token expired")))
 		g.Expect(errors.Is(wrapped, clierrors.ErrAlreadyHandled)).To(BeTrue())
 		g.Expect(errors.Is(wrapped, original)).To(BeTrue())
+	})
+
+	t.Run("should classify ExitCodeError with ExitWarning as LINT_ADVISORY", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitWarning, errors.New("lint advisory found"))
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
+		g.Expect(result).To(HaveField("Code", Equal("LINT_ADVISORY")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitWarning))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+		g.Expect(result).To(HaveField("Suggestion", Not(BeEmpty())))
+	})
+
+	t.Run("should classify wrapped ExitCodeError with ExitWarning as LINT_ADVISORY", func(t *testing.T) {
+		g := NewWithT(t)
+		inner := clierrors.NewExitCodeError(clierrors.ExitWarning, errors.New("advisory detected"))
+		wrapped := fmt.Errorf("lint check failed: %w", inner)
+		result := clierrors.Classify(wrapped)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
+		g.Expect(result).To(HaveField("Code", Equal("LINT_ADVISORY")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitWarning))))
+	})
+
+	t.Run("should classify ExitCodeError with ExitValidation as VALIDATION_FAILED", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitValidation, errors.New("validation failed"))
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
+		g.Expect(result).To(HaveField("Code", Equal("VALIDATION_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitValidation))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+	})
+
+	t.Run("should classify ExitCodeError with ExitAuth as AUTH_FAILED", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitAuth, errors.New("auth failed"))
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryAuthentication)))
+		g.Expect(result).To(HaveField("Code", Equal("AUTH_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitAuth))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+	})
+
+	t.Run("should classify ExitCodeError with ExitConnection as CONN_FAILED", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitConnection, errors.New("connection failed"))
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryConnection)))
+		g.Expect(result).To(HaveField("Code", Equal("CONN_FAILED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitConnection))))
+		g.Expect(result).To(HaveField("Retriable", BeTrue()))
+	})
+
+	t.Run("should classify ExitCodeError with unknown code as INTERNAL", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitError, errors.New("generic error"))
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryInternal)))
+		g.Expect(result).To(HaveField("Code", Equal("INTERNAL")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
+		g.Expect(result).To(HaveField("Retriable", BeFalse()))
+	})
+
+	t.Run("should classify ExitCodeError with ErrLintBlocked as LINT_BLOCKED", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitError,
+			fmt.Errorf("%w: upgrade cannot proceed", clierrors.ErrLintBlocked))
+		result := clierrors.Classify(err)
+
+		g.Expect(result).To(HaveField("Category", Equal(clierrors.CategoryValidation)))
+		g.Expect(result).To(HaveField("Code", Equal("LINT_BLOCKED")))
+		g.Expect(result).To(HaveField("ExitCode", Equal(int(clierrors.ExitError))))
+		g.Expect(result).To(HaveField("Suggestion", ContainSubstring("prohibited or blocking findings")))
 	})
 }

--- a/pkg/util/errors/exitcode.go
+++ b/pkg/util/errors/exitcode.go
@@ -1,0 +1,98 @@
+package errors
+
+import "errors"
+
+// ExitCode represents a CLI process exit code.
+type ExitCode int
+
+const (
+	ExitSuccess    ExitCode = 0 // Process completed without issues
+	ExitError      ExitCode = 1 // General runtime/unexpected errors
+	ExitWarning    ExitCode = 2 // Process finished, but advisory warnings were found
+	ExitValidation ExitCode = 3 // Invalid user input or configuration errors
+	ExitAuth       ExitCode = 4 // Authentication or authorization failures
+	ExitConnection ExitCode = 5 // Network issues, timeouts, or downstream service unavailability
+)
+
+const (
+	prioritySuccess    = iota // lowest
+	priorityWarning           // advisory findings
+	priorityError             // runtime errors
+	priorityValidation        // input / config errors
+	priorityAuth              // authentication / authorization
+	priorityConnection        // network / timeout (highest)
+)
+
+// exitCodePriority defines the precedence of each exit code.
+// Higher value = higher priority. Used by HigherPriority to resolve
+// conflicts when multiple error categories occur.
+//
+//nolint:gochecknoglobals // package-level lookup table is intentional
+var exitCodePriority = map[ExitCode]int{
+	ExitSuccess:    prioritySuccess,
+	ExitWarning:    priorityWarning,
+	ExitError:      priorityError,
+	ExitValidation: priorityValidation,
+	ExitAuth:       priorityAuth,
+	ExitConnection: priorityConnection,
+}
+
+// ExitCodeFromCategory maps an ErrorCategory to its corresponding ExitCode.
+func ExitCodeFromCategory(category ErrorCategory) ExitCode {
+	switch category {
+	case CategoryAuthentication, CategoryAuthorization:
+		return ExitAuth
+	case CategoryConnection, CategoryTimeout:
+		return ExitConnection
+	case CategoryValidation:
+		return ExitValidation
+	case CategoryServer, CategoryNotFound, CategoryConflict, CategoryInternal:
+		return ExitError
+	}
+
+	return ExitError
+}
+
+// ExitCodeFromError inspects the error chain and returns the appropriate ExitCode.
+// It checks for ExitCodeError first (explicit exit code), then falls back to
+// classifying the error via Classify().
+func ExitCodeFromError(err error) ExitCode {
+	if err == nil {
+		return ExitSuccess
+	}
+
+	var exitErr *ExitCodeError
+	if errors.As(err, &exitErr) {
+		return exitErr.Code
+	}
+
+	var structErr *StructuredError
+	if errors.As(err, &structErr) {
+		// Honor explicit ExitCode if set; otherwise derive from Category.
+		if structErr.ExitCode != 0 {
+			return ExitCode(structErr.ExitCode)
+		}
+
+		return ExitCodeFromCategory(structErr.Category)
+	}
+
+	classified := Classify(err)
+
+	return ExitCodeFromCategory(classified.Category)
+}
+
+// priority returns the precedence of code. Unknown codes default to
+// priorityError so they are never silently treated as success.
+func priority(code ExitCode) int {
+	if p, ok := exitCodePriority[code]; ok {
+		return p
+	}
+
+	return priorityError
+}
+
+// IsHigherPriority reports whether a has strictly higher precedence than b.
+// Precedence order: Connection(5) > Auth(4) > Validation(3) > Error(1) > Warning(2) > Success(0).
+func IsHigherPriority(a, b ExitCode) bool {
+	return priority(a) > priority(b)
+}

--- a/pkg/util/errors/exitcode_test.go
+++ b/pkg/util/errors/exitcode_test.go
@@ -1,0 +1,216 @@
+package errors_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testMsgAdvisory       = "advisory"
+	testMsgForbidden      = "forbidden"
+	testMsgTokenExpired   = "token expired"
+	testMsgSomethingBroke = "something broke"
+	testMsgAdvisoryFound  = "advisory found"
+	testMsgOriginalError  = "original error"
+	testMsgBadInput       = "bad input"
+	testMsgTimeout        = "timeout"
+	testCodeAuthFailed    = "AUTH_FAILED"
+	testUnknownCategory   = "unknown_category"
+)
+
+func TestExitCodeFromCategory(t *testing.T) {
+	cases := []struct {
+		name     string
+		category clierrors.ErrorCategory
+		want     clierrors.ExitCode
+	}{
+		{"authentication maps to ExitAuth", clierrors.CategoryAuthentication, clierrors.ExitAuth},
+		{"authorization maps to ExitAuth", clierrors.CategoryAuthorization, clierrors.ExitAuth},
+		{"connection maps to ExitConnection", clierrors.CategoryConnection, clierrors.ExitConnection},
+		{"timeout maps to ExitConnection", clierrors.CategoryTimeout, clierrors.ExitConnection},
+		{"validation maps to ExitValidation", clierrors.CategoryValidation, clierrors.ExitValidation},
+		{"server maps to ExitError", clierrors.CategoryServer, clierrors.ExitError},
+		{"not_found maps to ExitError", clierrors.CategoryNotFound, clierrors.ExitError},
+		{"conflict maps to ExitError", clierrors.CategoryConflict, clierrors.ExitError},
+		{"internal maps to ExitError", clierrors.CategoryInternal, clierrors.ExitError},
+		{"unknown category maps to ExitError", testUnknownCategory, clierrors.ExitError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(clierrors.ExitCodeFromCategory(tc.category)).To(Equal(tc.want))
+		})
+	}
+}
+
+func TestExitCodeFromError(t *testing.T) {
+	structErrAuth := &clierrors.StructuredError{
+		Code:     testCodeAuthFailed,
+		Message:  testMsgTokenExpired,
+		Category: clierrors.CategoryAuthentication,
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want clierrors.ExitCode
+	}{
+		{
+			name: "nil error returns ExitSuccess",
+			err:  nil,
+			want: clierrors.ExitSuccess,
+		},
+		{
+			name: "ExitCodeError returns its code",
+			err:  clierrors.NewExitCodeError(clierrors.ExitWarning, errors.New(testMsgAdvisory)),
+			want: clierrors.ExitWarning,
+		},
+		{
+			name: "wrapped ExitCodeError returns its code",
+			err:  fmt.Errorf("outer: %w", clierrors.NewExitCodeError(clierrors.ExitAuth, errors.New(testMsgForbidden))),
+			want: clierrors.ExitAuth,
+		},
+		{
+			name: "StructuredError maps via category",
+			err:  structErrAuth,
+			want: clierrors.ExitAuth,
+		},
+		{
+			name: "StructuredError with explicit ExitCode uses that code",
+			err: &clierrors.StructuredError{
+				Category: clierrors.CategoryInternal,
+				ExitCode: int(clierrors.ExitWarning),
+				Message:  "explicit exit code takes precedence",
+			},
+			want: clierrors.ExitWarning,
+		},
+		{
+			name: "plain error classifies as ExitError",
+			err:  errors.New(testMsgSomethingBroke),
+			want: clierrors.ExitError,
+		},
+		{
+			name: "ExitCodeError takes priority over StructuredError in chain",
+			err:  clierrors.NewExitCodeError(clierrors.ExitConnection, structErrAuth),
+			want: clierrors.ExitConnection,
+		},
+		{
+			name: "AlreadyHandledError wrapping plain error returns ExitError",
+			err:  clierrors.NewAlreadyHandledError(errors.New(testMsgSomethingBroke)),
+			want: clierrors.ExitError,
+		},
+		{
+			name: "AlreadyHandledError preserves inner ExitCodeError code",
+			err:  clierrors.NewAlreadyHandledError(clierrors.NewExitCodeError(clierrors.ExitWarning, errors.New(testMsgAdvisoryFound))),
+			want: clierrors.ExitWarning,
+		},
+		{
+			name: "double-wrapped ExitCodeError uses outermost code",
+			err:  clierrors.NewExitCodeError(clierrors.ExitConnection, clierrors.NewExitCodeError(clierrors.ExitWarning, errors.New(testMsgAdvisoryFound))),
+			want: clierrors.ExitConnection,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(clierrors.ExitCodeFromError(tc.err)).To(Equal(tc.want))
+		})
+	}
+}
+
+func TestIsHigherPriority(t *testing.T) {
+	pairCases := []struct {
+		name string
+		a    clierrors.ExitCode
+		b    clierrors.ExitCode
+		want bool
+	}{
+		{"connection beats auth", clierrors.ExitConnection, clierrors.ExitAuth, true},
+		{"auth beats validation", clierrors.ExitAuth, clierrors.ExitValidation, true},
+		{"validation beats error", clierrors.ExitValidation, clierrors.ExitError, true},
+		{"error beats warning", clierrors.ExitError, clierrors.ExitWarning, true},
+		{"warning beats success", clierrors.ExitWarning, clierrors.ExitSuccess, true},
+		{"same code is not strictly higher", clierrors.ExitAuth, clierrors.ExitAuth, false},
+		{"lower does not beat higher", clierrors.ExitWarning, clierrors.ExitConnection, false},
+		{"success does not beat error", clierrors.ExitSuccess, clierrors.ExitError, false},
+	}
+
+	for _, tc := range pairCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(clierrors.IsHigherPriority(tc.a, tc.b)).To(Equal(tc.want))
+		})
+	}
+
+	t.Run("unknown code is treated as at least error priority", func(t *testing.T) {
+		g := NewWithT(t)
+		unknown := clierrors.ExitCode(99)
+
+		g.Expect(clierrors.IsHigherPriority(unknown, clierrors.ExitSuccess)).To(BeTrue())
+		g.Expect(clierrors.IsHigherPriority(unknown, clierrors.ExitWarning)).To(BeTrue())
+	})
+
+	t.Run("known high-priority code still beats unknown", func(t *testing.T) {
+		g := NewWithT(t)
+		unknown := clierrors.ExitCode(99)
+
+		g.Expect(clierrors.IsHigherPriority(clierrors.ExitConnection, unknown)).To(BeTrue())
+		g.Expect(clierrors.IsHigherPriority(clierrors.ExitAuth, unknown)).To(BeTrue())
+		g.Expect(clierrors.IsHigherPriority(clierrors.ExitValidation, unknown)).To(BeTrue())
+	})
+
+	t.Run("all defined exit codes beat ExitSuccess", func(t *testing.T) {
+		g := NewWithT(t)
+		codes := []clierrors.ExitCode{
+			clierrors.ExitError,
+			clierrors.ExitWarning,
+			clierrors.ExitValidation,
+			clierrors.ExitAuth,
+			clierrors.ExitConnection,
+		}
+		for _, code := range codes {
+			g.Expect(clierrors.IsHigherPriority(code, clierrors.ExitSuccess)).To(BeTrue())
+		}
+	})
+}
+
+func TestExitCodeError(t *testing.T) {
+	t.Run("should implement error interface", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitWarning, errors.New(testMsgAdvisoryFound))
+		g.Expect(err.Error()).To(Equal(testMsgAdvisoryFound))
+	})
+
+	t.Run("should unwrap to original error", func(t *testing.T) {
+		g := NewWithT(t)
+		original := errors.New(testMsgOriginalError)
+		err := clierrors.NewExitCodeError(clierrors.ExitAuth, original)
+		g.Expect(errors.Is(err, original)).To(BeTrue())
+	})
+
+	t.Run("should preserve exit code", func(t *testing.T) {
+		g := NewWithT(t)
+		err := clierrors.NewExitCodeError(clierrors.ExitValidation, errors.New(testMsgBadInput))
+
+		var exitErr *clierrors.ExitCodeError
+		g.Expect(errors.As(err, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(clierrors.ExitValidation))
+	})
+
+	t.Run("should be extractable via errors.As", func(t *testing.T) {
+		g := NewWithT(t)
+		inner := clierrors.NewExitCodeError(clierrors.ExitConnection, errors.New(testMsgTimeout))
+		wrapped := fmt.Errorf("wrapper: %w", inner)
+
+		var exitErr *clierrors.ExitCodeError
+		g.Expect(errors.As(wrapped, &exitErr)).To(BeTrue())
+		g.Expect(exitErr.Code).To(Equal(clierrors.ExitConnection))
+	})
+}

--- a/pkg/util/errors/types.go
+++ b/pkg/util/errors/types.go
@@ -10,6 +10,12 @@ import (
 // be printed again by the caller.
 var ErrAlreadyHandled = errors.New("error already rendered to output")
 
+// ErrLintBlocked is a sentinel error for prohibited or blocking lint findings.
+var ErrLintBlocked = errors.New("prohibited or blocking findings detected")
+
+// ErrLintAdvisory is a sentinel error for advisory-only lint findings.
+var ErrLintAdvisory = errors.New("advisory findings detected")
+
 // ErrorCategory represents the classification of a structured error.
 type ErrorCategory string
 
@@ -31,6 +37,7 @@ type StructuredError struct {
 	Code       string        `json:"code"       yaml:"code"`
 	Message    string        `json:"message"    yaml:"message"`
 	Category   ErrorCategory `json:"category"   yaml:"category"`
+	ExitCode   int           `json:"exitCode"   yaml:"exitCode"`
 	Retriable  bool          `json:"retriable"  yaml:"retriable"`
 	Suggestion string        `json:"suggestion" yaml:"suggestion"`
 
@@ -78,6 +85,36 @@ func NewValidationError(code, message, suggestion string) *StructuredError {
 		Retriable:  false,
 		Suggestion: suggestion,
 	}
+}
+
+// ExitCodeError wraps an error with an explicit exit code.
+// Used when a command needs to signal a specific exit code that
+// cannot be derived from error classification (e.g., exit 2 for warnings).
+type ExitCodeError struct {
+	Code ExitCode
+	Err  error
+}
+
+// Error implements the error interface.
+func (e *ExitCodeError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error, preserving the error chain.
+func (e *ExitCodeError) Unwrap() error {
+	return e.Err
+}
+
+// NewExitCodeError creates an error that carries an explicit exit code.
+// Returns nil when err is nil so callers can safely write
+// return NewExitCodeError(code, maybeNilErr) without creating a non-nil interface
+// wrapping a nil pointer (a common Go pitfall).
+func NewExitCodeError(code ExitCode, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &ExitCodeError{Code: code, Err: err}
 }
 
 // errorEnvelope wraps a StructuredError for JSON/YAML output rendering.


### PR DESCRIPTION
## Description

Replace the blanket `os.Exit(1)` in `cmd/main.go` with differentiated exit codes (0-5) derived from structured error classification, enabling automation tools and CI/CD pipelines to branch on specific failure types.

## What is implemented

- `ExitCode` type with 6 stable codes and priority-based precedence resolution so the highest-severity exit code wins when multiple issues occur
- `ExitCodeError` wrapper to carry explicit exit codes through the error chain
- `ExitCode` field added to `StructuredError` for JSON/YAML output
- Refactored `Classify()` from switch-based to table-driven design for extensibility
- Added TLS/certificate, DNS, and OS permission error classifiers
- Lint command returns exit 1 for prohibited/blocking findings, exit 2 for advisory, exit 3 for downgrade rejection; infrastructure errors (auth, connection) take precedence
- Design docs updated with exit code table and precedence rules

| Exit Code | Category   | Description                                          |
|-----------|------------|------------------------------------------------------|
| 0         | Success    | Process completed without issues                     |
| 1         | Error      | General runtime or unexpected errors                 |
| 2         | Warning    | Process finished, but advisory warnings were found   |
| 3         | Validation | Invalid user input or configuration errors           |
| 4         | Auth       | Authentication or authorization failures             |
| 5         | Connection | Network issues, timeouts, or service unavailability  |

**Precedence:** Connection(5) > Auth(4) > Validation(3) > Error(1) > Warning(2) > Success(0)

## Testing

```bash
go test -v -count=1 ./pkg/util/errors/... ./pkg/lint -run "TestClassify|TestExitCode|TestHigherPriority|TestExitCodeError|TestWriteTextError|TestWriteStructuredError|TestEvaluateVerdict"
```

## Review checklist

- [x] New functionality includes tests
- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] Code follows project conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now emits and respects structured exit codes (0–5) with precedence; commands return derived exit status and JSON/YAML output include an exitCode field.
  * Introduced explicit exit-code error type to carry and propagate numeric exit codes.

* **Documentation**
  * Added exit code reference, precedence rules, and structured error-output requirements.

* **Bug Fixes**
  * Improved exit-code propagation across validate/run/complete paths; main now exits with the derived code.

* **Tests**
  * Expanded tests for exit-code mapping, precedence, classification, and lint verdict evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->