### PR TITLE
feat: add get command for ODH/RHOAI resources

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -1,0 +1,119 @@
+package get
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	getpkg "github.com/opendatahub-io/odh-cli/pkg/get"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	cmdName  = "get"
+	cmdShort = "Get ODH/RHOAI resources"
+	maxArgs  = 2
+)
+
+const cmdLong = `
+Display one or more ODH/RHOAI resources without knowing CRD group/version details.
+
+Supported resources:
+  notebooks (nb)                              Kubeflow Notebooks
+  inferenceservices (isvc)                     KServe InferenceServices
+  servingruntimes (sr)                         KServe ServingRuntimes
+  datasciencepipelinesapplications (pipeline)  Data Science Pipelines
+
+Table output shows ODH-relevant columns tuned for each resource type.
+If the CRD is not installed, a friendly message is shown instead of an error.
+`
+
+const cmdExample = `
+  # List notebooks in the current namespace
+  kubectl odh get nb
+
+  # List inference services across all namespaces
+  kubectl odh get isvc -A
+
+  # Get a specific notebook in a namespace
+  kubectl odh get nb my-notebook -n my-project
+
+  # List serving runtimes with label filter
+  kubectl odh get sr -l app=my-model
+
+  # List pipelines as JSON
+  kubectl odh get pipeline -o json
+`
+
+// AddCommand adds the get command to the root command.
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+	streams := genericiooptions.IOStreams{
+		In:     root.InOrStdin(),
+		Out:    root.OutOrStdout(),
+		ErrOut: root.ErrOrStderr(),
+	}
+
+	command := getpkg.NewCommand(streams, flags)
+
+	cmd := &cobra.Command{
+		Use:           "get RESOURCE [NAME]",
+		Short:         cmdShort,
+		Long:          cmdLong,
+		Example:       cmdExample,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.RangeArgs(1, maxArgs),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return getpkg.Names(), cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			command.ResourceName = args[0]
+			if len(args) > 1 {
+				command.ItemName = args[1]
+			}
+
+			outputFormat := command.OutputFormat
+
+			if err := command.Complete(); err != nil {
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+					return clierrors.NewAlreadyHandledError(err)
+				}
+
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			if err := command.Validate(); err != nil {
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+					return clierrors.NewAlreadyHandledError(err)
+				}
+
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+					return clierrors.NewAlreadyHandledError(err)
+				}
+
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			return nil
+		},
+	}
+
+	command.AddFlags(cmd.Flags())
+
+	root.AddCommand(cmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
 	"github.com/opendatahub-io/odh-cli/cmd/version"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
@@ -29,6 +30,7 @@ func main() {
 
 	version.AddCommand(cmd, flags)
 	lint.AddCommand(cmd, flags)
+	get.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		if !errors.Is(err, clierrors.ErrAlreadyHandled) {

--- a/pkg/get/command.go
+++ b/pkg/get/command.go
@@ -1,0 +1,215 @@
+package get
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+var _ cmd.Command = (*Command)(nil)
+
+const (
+	outputFormatTable = "table"
+	outputFormatJSON  = "json"
+	outputFormatYAML  = "yaml"
+
+	msgCRDNotInstalled = "resource type %q is not installed on this cluster\n"
+)
+
+// Command contains the get command configuration.
+type Command struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+	Client      client.Client
+
+	// ResourceName is the positional arg identifying the resource type (e.g. "nb").
+	ResourceName string
+	// ItemName is the optional positional arg for a specific resource name.
+	ItemName string
+
+	// Namespace is the resolved target namespace (populated during Complete).
+	Namespace string
+	// AllNamespaces lists resources across all namespaces when true.
+	AllNamespaces bool
+	// LabelSelector filters resources by label (e.g. "app=my-model").
+	LabelSelector string
+	// OutputFormat controls output rendering: table, json, or yaml.
+	OutputFormat string
+
+	// ResolvedType is the ResourceType resolved from ResourceName during Complete.
+	ResolvedType resources.ResourceType
+}
+
+// NewCommand creates a new get Command with defaults.
+func NewCommand(
+	streams genericiooptions.IOStreams,
+	configFlags *genericclioptions.ConfigFlags,
+) *Command {
+	return &Command{
+		IO:           iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags:  configFlags,
+		OutputFormat: outputFormatTable,
+	}
+}
+
+// AddFlags registers command-specific flags.
+// Note: -n/--namespace is already registered by ConfigFlags on the root command.
+func (c *Command) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&c.AllNamespaces, "all-namespaces", "A", false, "List resources across all namespaces")
+	fs.StringVarP(&c.LabelSelector, "selector", "l", "", "Label selector to filter resources (e.g. app=my-model)")
+	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+}
+
+// Complete resolves derived fields after flag parsing.
+func (c *Command) Complete() error {
+	rt, err := Resolve(c.ResourceName)
+	if err != nil {
+		return fmt.Errorf("resolving resource type: %w", err)
+	}
+
+	c.ResolvedType = rt
+
+	if !c.AllNamespaces {
+		ns, _, err := c.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return fmt.Errorf("determining namespace: %w", err)
+		}
+
+		c.Namespace = ns
+	}
+
+	k8sClient, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+
+	c.Client = k8sClient
+
+	return nil
+}
+
+// Validate checks that all options are valid before execution.
+func (c *Command) Validate() error {
+	if c.AllNamespaces && c.ConfigFlags.Namespace != nil && *c.ConfigFlags.Namespace != "" {
+		return errors.New("--all-namespaces and --namespace are mutually exclusive")
+	}
+
+	switch c.OutputFormat {
+	case outputFormatTable, outputFormatJSON, outputFormatYAML:
+	default:
+		return fmt.Errorf("invalid output format %q (must be one of: table, json, yaml)", c.OutputFormat)
+	}
+
+	return nil
+}
+
+// Run executes the get command.
+func (c *Command) Run(ctx context.Context) error {
+	if c.ItemName != "" {
+		return c.getResource(ctx)
+	}
+
+	return c.listResources(ctx)
+}
+
+// listResources lists resources of the resolved type.
+func (c *Command) listResources(ctx context.Context) error {
+	opts := []client.ListResourcesOption{}
+	if c.Namespace != "" {
+		opts = append(opts, client.WithNamespace(c.Namespace))
+	}
+
+	if c.LabelSelector != "" {
+		opts = append(opts, client.WithLabelSelector(c.LabelSelector))
+	}
+
+	items, err := c.Client.List(ctx, c.ResolvedType, opts...)
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			c.IO.Fprintf(msgCRDNotInstalled, c.ResolvedType.Kind)
+
+			return nil
+		}
+
+		if !client.IsPermissionError(err) {
+			return fmt.Errorf("listing %s: %w", c.ResolvedType.Kind, err)
+		}
+
+		c.IO.Errorf("Warning: insufficient permissions to list %s", c.ResolvedType.Kind)
+		items = []*unstructured.Unstructured{}
+	}
+
+	return c.renderOutput(items)
+}
+
+// getResource retrieves a single named resource.
+func (c *Command) getResource(ctx context.Context) error {
+	opts := []client.GetOption{}
+	if c.Namespace != "" {
+		opts = append(opts, client.InNamespace(c.Namespace))
+	}
+
+	// Verify resource type exists by attempting a lightweight List.
+	// This reliably detects CRD-missing vs resource-missing since List returns
+	// empty results (no error) when CRD exists but no resources match.
+	listOpts := []client.ListResourcesOption{client.WithLimit(1)}
+	if c.Namespace != "" {
+		listOpts = append(listOpts, client.WithNamespace(c.Namespace))
+	}
+
+	_, listErr := c.Client.List(ctx, c.ResolvedType, listOpts...)
+	if listErr != nil {
+		if client.IsResourceTypeNotFound(listErr) {
+			c.IO.Fprintf(msgCRDNotInstalled, c.ResolvedType.Kind)
+
+			return nil
+		}
+
+		return fmt.Errorf("verifying resource type %s: %w", c.ResolvedType.Kind, listErr)
+	}
+
+	item, err := c.Client.GetResource(ctx, c.ResolvedType, c.ItemName, opts...)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if c.Namespace == "" {
+				return fmt.Errorf("%s %q not found: %w", c.ResolvedType.Kind, c.ItemName, err)
+			}
+
+			return fmt.Errorf("%s %q not found in namespace %q: %w", c.ResolvedType.Kind, c.ItemName, c.Namespace, err)
+		}
+
+		return fmt.Errorf("getting %s %q: %w", c.ResolvedType.Kind, c.ItemName, err)
+	}
+
+	if item == nil {
+		c.IO.Errorf("Warning: insufficient permissions to get %s %q", c.ResolvedType.Kind, c.ItemName)
+
+		return nil
+	}
+
+	return c.renderOutput([]*unstructured.Unstructured{item})
+}
+
+// renderOutput dispatches to the appropriate output formatter.
+func (c *Command) renderOutput(items []*unstructured.Unstructured) error {
+	switch c.OutputFormat {
+	case outputFormatJSON:
+		return outputJSON(c.IO.Out(), items)
+	case outputFormatYAML:
+		return outputYAML(c.IO.Out(), items)
+	default:
+		return outputTable(c.IO.Out(), items, c.ResolvedType, c.AllNamespaces)
+	}
+}

--- a/pkg/get/command_test.go
+++ b/pkg/get/command_test.go
@@ -1,0 +1,346 @@
+package get_test
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/get"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testNamespace = "test-ns"
+	testNotebook1 = "notebook-alpha"
+	testNotebook2 = "notebook-beta"
+	testISVCName  = "my-isvc"
+	testImage1    = "quay.io/image:v1"
+	testImage2    = "quay.io/image:v2"
+	testISVCURL   = "https://my-isvc.example.com"
+	testTimestamp = "2025-01-01T00:00:00Z"
+)
+
+//nolint:gochecknoglobals // Test fixture - shared across test functions
+var listKinds = map[schema.GroupVersionResource]string{
+	resources.Notebook.GVR():                          resources.Notebook.ListKind(),
+	resources.InferenceService.GVR():                  resources.InferenceService.ListKind(),
+	resources.ServingRuntime.GVR():                    resources.ServingRuntime.ListKind(),
+	resources.DataSciencePipelinesApplicationV1.GVR(): resources.DataSciencePipelinesApplicationV1.ListKind(),
+}
+
+func newNotebook(name, namespace, image string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Notebook.APIVersion(),
+			"kind":       resources.Notebook.Kind,
+			"metadata": map[string]any{
+				"name":              name,
+				"namespace":         namespace,
+				"creationTimestamp": testTimestamp,
+			},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{"image": image},
+						},
+					},
+				},
+			},
+			"status": map[string]any{
+				"readyReplicas": int64(1),
+			},
+		},
+	}
+}
+
+func newInferenceService(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.InferenceService.APIVersion(),
+			"kind":       resources.InferenceService.Kind,
+			"metadata": map[string]any{
+				"name":              name,
+				"namespace":         namespace,
+				"creationTimestamp": testTimestamp,
+			},
+			"status": map[string]any{
+				"url": testISVCURL,
+				"conditions": []any{
+					map[string]any{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestCommand(k8sClient client.Client) (*get.Command, *bytes.Buffer) {
+	var out bytes.Buffer
+
+	cmd := &get.Command{
+		IO:           iostreams.NewIOStreams(nil, &out, &out),
+		Client:       k8sClient,
+		OutputFormat: "table",
+		Namespace:    testNamespace,
+	}
+
+	return cmd, &out
+}
+
+func newDynamicClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+// --- Registry Tests ---
+
+func TestResolve(t *testing.T) {
+	t.Run("resolves canonical name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rt, err := get.Resolve("notebooks")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt).To(Equal(resources.Notebook))
+	})
+
+	t.Run("resolves alias nb to Notebook", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rt, err := get.Resolve("nb")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt).To(Equal(resources.Notebook))
+	})
+
+	t.Run("resolves alias isvc to InferenceService", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rt, err := get.Resolve("isvc")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt).To(Equal(resources.InferenceService))
+	})
+
+	t.Run("resolves alias sr to ServingRuntime", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rt, err := get.Resolve("sr")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt).To(Equal(resources.ServingRuntime))
+	})
+
+	t.Run("resolves alias pipeline to DataSciencePipelinesApplicationV1", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rt, err := get.Resolve("pipeline")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt).To(Equal(resources.DataSciencePipelinesApplicationV1))
+	})
+
+	t.Run("is case-insensitive", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rt, err := get.Resolve("NB")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rt).To(Equal(resources.Notebook))
+	})
+
+	t.Run("returns error for unknown resource with available list", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := get.Resolve("unknown")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown resource type"))
+		g.Expect(err.Error()).To(ContainSubstring("nb"))
+		g.Expect(err.Error()).To(ContainSubstring("notebooks"))
+	})
+}
+
+func TestNames(t *testing.T) {
+	g := NewWithT(t)
+
+	names := get.Names()
+	g.Expect(names).To(ContainElements("nb", "notebooks", "isvc", "inferenceservices", "sr", "servingruntimes", "pipeline", "datasciencepipelinesapplications"))
+	// Verify sorted
+	for i := 1; i < len(names); i++ {
+		g.Expect(names[i] >= names[i-1]).To(BeTrue(), "Names() should return sorted list")
+	}
+}
+
+// --- Command Tests ---
+
+func TestListNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb1 := newNotebook(testNotebook1, testNamespace, testImage1)
+	nb2 := newNotebook(testNotebook2, testNamespace, testImage2)
+
+	k8sClient := newDynamicClient(nb1, nb2)
+	cmd, out := newTestCommand(k8sClient)
+	cmd.ResourceName = "nb"
+	cmd.ResolvedType = resources.Notebook
+
+	err := cmd.Run(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := out.String()
+	g.Expect(output).To(ContainSubstring("NAME"))
+	g.Expect(output).To(ContainSubstring("IMAGE"))
+	g.Expect(output).To(ContainSubstring("READY"))
+	g.Expect(output).To(ContainSubstring("AGE"))
+	g.Expect(output).To(ContainSubstring(testNotebook1))
+	g.Expect(output).To(ContainSubstring(testNotebook2))
+	g.Expect(output).To(ContainSubstring(testImage1))
+	g.Expect(output).To(ContainSubstring(testImage2))
+}
+
+func TestGetSpecificResource(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	isvc := newInferenceService(testISVCName, testNamespace)
+
+	k8sClient := newDynamicClient(isvc)
+	cmd, out := newTestCommand(k8sClient)
+	cmd.ResourceName = "isvc"
+	cmd.ItemName = testISVCName
+	cmd.ResolvedType = resources.InferenceService
+
+	err := cmd.Run(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := out.String()
+	g.Expect(output).To(ContainSubstring(testISVCName))
+	g.Expect(output).To(ContainSubstring(testISVCURL))
+}
+
+func TestListNotebooksAllNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb1 := newNotebook(testNotebook1, testNamespace, testImage1)
+	nb2 := newNotebook(testNotebook2, "other-ns", testImage2)
+
+	k8sClient := newDynamicClient(nb1, nb2)
+	cmd, out := newTestCommand(k8sClient)
+	cmd.ResourceName = "nb"
+	cmd.AllNamespaces = true
+	cmd.Namespace = ""
+	cmd.ResolvedType = resources.Notebook
+
+	err := cmd.Run(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := out.String()
+	g.Expect(output).To(ContainSubstring("NAMESPACE"))
+	g.Expect(output).To(ContainSubstring(testNamespace))
+	g.Expect(output).To(ContainSubstring("other-ns"))
+}
+
+func TestJSONOutput(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook(testNotebook1, testNamespace, testImage1)
+
+	k8sClient := newDynamicClient(nb)
+	cmd, out := newTestCommand(k8sClient)
+	cmd.ResourceName = "nb"
+	cmd.OutputFormat = "json"
+	cmd.ResolvedType = resources.Notebook
+
+	err := cmd.Run(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := out.String()
+	g.Expect(output).To(ContainSubstring(`"kind"`))
+	g.Expect(output).To(ContainSubstring(testNotebook1))
+}
+
+// --- Validation Tests ---
+
+func TestValidate(t *testing.T) {
+	t.Run("rejects all-namespaces with explicit namespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ns := "my-ns"
+		cmd := &get.Command{
+			AllNamespaces: true,
+			OutputFormat:  "table",
+			ConfigFlags:   configFlagsWithNamespace(&ns),
+		}
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+	})
+
+	t.Run("rejects invalid output format", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &get.Command{
+			OutputFormat: "xml",
+			ConfigFlags:  configFlagsWithNamespace(nil),
+		}
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid output format"))
+	})
+
+	t.Run("accepts valid output formats", func(t *testing.T) {
+		g := NewWithT(t)
+
+		for _, format := range []string{"table", "json", "yaml"} {
+			cmd := &get.Command{
+				OutputFormat: format,
+				ConfigFlags:  configFlagsWithNamespace(nil),
+			}
+
+			err := cmd.Validate()
+			g.Expect(err).ToNot(HaveOccurred(), "format %q should be valid", format)
+		}
+	})
+}
+
+// --- Empty Result Tests ---
+
+func TestListReturnsEmptyTable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newDynamicClient()
+	cmd, out := newTestCommand(k8sClient)
+	cmd.ResourceName = "nb"
+	cmd.ResolvedType = resources.Notebook
+
+	err := cmd.Run(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := out.String()
+	g.Expect(output).To(ContainSubstring("NAME"))
+	g.Expect(output).ToNot(ContainSubstring(testNotebook1))
+}
+
+// --- Helpers ---
+
+func configFlagsWithNamespace(ns *string) *genericclioptions.ConfigFlags {
+	return &genericclioptions.ConfigFlags{
+		Namespace: ns,
+	}
+}

--- a/pkg/get/output.go
+++ b/pkg/get/output.go
@@ -1,0 +1,233 @@
+package get
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
+	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
+	printeryaml "github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	colName       = "NAME"
+	colNamespace  = "NAMESPACE"
+	colImage      = "IMAGE"
+	colReady      = "READY"
+	colAge        = "AGE"
+	colURL        = "URL"
+	colDisabled   = "DISABLED"
+	colModelType  = "MODELTYPE"
+	colContainers = "CONTAINERS"
+
+	jqName      = ".metadata.name"
+	jqNamespace = ".metadata.namespace"
+	jqAge       = ".metadata.creationTimestamp"
+
+	jqNotebookImage = ".spec.template.spec.containers[0].image"
+	jqNotebookReady = ".status.readyReplicas // 0"
+
+	jqInferenceServiceURL   = `.status.url // ""`
+	jqInferenceServiceReady = `(.status.conditions // [])[] | select(.type=="Ready") | .status // "Unknown"`
+
+	jqServingRuntimeDisabled   = ".spec.disabled // false"
+	jqServingRuntimeModelType  = `(.spec.supportedModelFormats // [])[0].name // ""`
+	jqServingRuntimeContainers = ".spec.containers // [] | length"
+
+	jqPipelineReady = `(.status.conditions // [])[] | select(.type=="Ready") | .status // "Unknown"`
+)
+
+// ageFormatter converts a creationTimestamp string to a human-readable age.
+func ageFormatter(value any) any {
+	ts, ok := value.(string)
+	if !ok {
+		return "<unknown>"
+	}
+
+	return formatAge(ts)
+}
+
+const hoursPerDay = 24
+
+// formatAge computes a human-readable duration string from an RFC 3339 timestamp.
+func formatAge(timestamp string) string {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return "<unknown>"
+	}
+
+	d := time.Since(t)
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(math.Floor(d.Hours()/hoursPerDay)))
+	}
+}
+
+// notebookColumns returns table columns for Notebook resources.
+func notebookColumns(prefix []table.Column) []table.Column {
+	return append(prefix,
+		table.NewColumn(colImage).JQ(jqNotebookImage),
+		table.NewColumn(colReady).JQ(jqNotebookReady),
+		ageColumn(),
+	)
+}
+
+// inferenceServiceColumns returns table columns for InferenceService resources.
+func inferenceServiceColumns(prefix []table.Column) []table.Column {
+	return append(prefix,
+		table.NewColumn(colURL).JQ(jqInferenceServiceURL),
+		table.NewColumn(colReady).JQ(jqInferenceServiceReady),
+		ageColumn(),
+	)
+}
+
+// servingRuntimeColumns returns table columns for ServingRuntime resources.
+func servingRuntimeColumns(prefix []table.Column) []table.Column {
+	return append(prefix,
+		table.NewColumn(colDisabled).JQ(jqServingRuntimeDisabled),
+		table.NewColumn(colModelType).JQ(jqServingRuntimeModelType),
+		table.NewColumn(colContainers).JQ(jqServingRuntimeContainers),
+		ageColumn(),
+	)
+}
+
+// pipelineColumns returns table columns for DataSciencePipelinesApplication resources.
+func pipelineColumns(prefix []table.Column) []table.Column {
+	return append(prefix,
+		table.NewColumn(colReady).JQ(jqPipelineReady),
+		ageColumn(),
+	)
+}
+
+// nameOnlyColumns returns just the NAME column.
+func nameOnlyColumns() []table.Column {
+	return []table.Column{
+		table.NewColumn(colName).JQ(jqName),
+	}
+}
+
+// namespacedNameColumns returns NAMESPACE and NAME columns for cross-namespace listing.
+func namespacedNameColumns() []table.Column {
+	return []table.Column{
+		table.NewColumn(colNamespace).JQ(jqNamespace),
+		table.NewColumn(colName).JQ(jqName),
+	}
+}
+
+// ageColumn returns a column that renders human-readable age from creationTimestamp.
+func ageColumn() table.Column {
+	return table.NewColumn(colAge).JQ(jqAge).Fn(ageFormatter)
+}
+
+// columnConfig holds parameters for building table columns.
+type columnConfig struct {
+	resourceType  resources.ResourceType
+	allNamespaces bool
+}
+
+// columns returns the full set of table columns for the configured resource type.
+func (c columnConfig) columns() []table.Column {
+	prefix := nameOnlyColumns()
+	if c.allNamespaces {
+		prefix = namespacedNameColumns()
+	}
+
+	switch c.resourceType {
+	case resources.Notebook:
+		return notebookColumns(prefix)
+	case resources.InferenceService:
+		return inferenceServiceColumns(prefix)
+	case resources.ServingRuntime:
+		return servingRuntimeColumns(prefix)
+	case resources.DataSciencePipelinesApplicationV1:
+		return pipelineColumns(prefix)
+	default:
+		return prefix
+	}
+}
+
+// outputTable renders resources as a formatted table.
+func outputTable(
+	w io.Writer,
+	items []*unstructured.Unstructured,
+	rt resources.ResourceType,
+	allNamespaces bool,
+) error {
+	cfg := columnConfig{resourceType: rt, allNamespaces: allNamespaces}
+	columns := cfg.columns()
+
+	renderer := table.NewWithColumns[*unstructured.Unstructured](w, columns...)
+
+	for _, item := range items {
+		if err := renderer.Append(item); err != nil {
+			return fmt.Errorf("rendering row: %w", err)
+		}
+	}
+
+	if err := renderer.Render(); err != nil {
+		return fmt.Errorf("rendering table: %w", err)
+	}
+
+	return nil
+}
+
+// outputJSON renders resources as JSON.
+func outputJSON(w io.Writer, items []*unstructured.Unstructured) error {
+	output := toOutputList(items)
+
+	renderer := printerjson.NewRenderer[any](
+		printerjson.WithWriter[any](w),
+	)
+
+	if err := renderer.Render(output); err != nil {
+		return fmt.Errorf("rendering JSON: %w", err)
+	}
+
+	return nil
+}
+
+// outputYAML renders resources as YAML.
+func outputYAML(w io.Writer, items []*unstructured.Unstructured) error {
+	output := toOutputList(items)
+
+	renderer := printeryaml.NewRenderer[any](
+		printeryaml.WithWriter[any](w),
+	)
+
+	if err := renderer.Render(output); err != nil {
+		return fmt.Errorf("rendering YAML: %w", err)
+	}
+
+	return nil
+}
+
+// toOutputList converts items to a raw object or list suitable for JSON/YAML rendering.
+// Returns the single item directly if there is exactly one, otherwise wraps in a List.
+func toOutputList(items []*unstructured.Unstructured) any {
+	if len(items) == 1 {
+		return items[0].Object
+	}
+
+	rawItems := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		rawItems = append(rawItems, item.Object)
+	}
+
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items":      rawItems,
+	}
+}

--- a/pkg/get/registry.go
+++ b/pkg/get/registry.go
@@ -1,0 +1,71 @@
+package get
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+// resourceEntry maps a canonical resource name to its ResourceType.
+//
+//nolint:gochecknoglobals // Registry of supported get-command resource types
+var resourceMap = map[string]resources.ResourceType{
+	"notebooks":                        resources.Notebook,
+	"inferenceservices":                resources.InferenceService,
+	"servingruntimes":                  resources.ServingRuntime,
+	"datasciencepipelinesapplications": resources.DataSciencePipelinesApplicationV1,
+}
+
+// aliasMap maps short aliases to canonical resource names.
+//
+//nolint:gochecknoglobals // Registry of short aliases for resource types
+var aliasMap = map[string]string{
+	"nb":       "notebooks",
+	"isvc":     "inferenceservices",
+	"sr":       "servingruntimes",
+	"pipeline": "datasciencepipelinesapplications",
+}
+
+// Resolve looks up a resource name or alias and returns the corresponding ResourceType.
+// It checks aliases first, then canonical names.
+func Resolve(name string) (resources.ResourceType, error) {
+	lower := strings.ToLower(name)
+
+	if canonical, ok := aliasMap[lower]; ok {
+		return resourceMap[canonical], nil
+	}
+
+	if rt, ok := resourceMap[lower]; ok {
+		return rt, nil
+	}
+
+	return resources.ResourceType{}, fmt.Errorf(
+		"unknown resource type %q (available: %s)",
+		name, strings.Join(Names(), ", "),
+	)
+}
+
+// Names returns a sorted list of all valid resource names and aliases
+// for use in help text and tab completion.
+func Names() []string {
+	seen := make(map[string]struct{}, len(resourceMap)+len(aliasMap))
+
+	for name := range resourceMap {
+		seen[name] = struct{}{}
+	}
+
+	for alias := range aliasMap {
+		seen[alias] = struct{}{}
+	}
+
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}

--- a/pkg/util/jq/jq.go
+++ b/pkg/util/jq/jq.go
@@ -29,6 +29,10 @@ func convertValue(value any) (any, error) {
 
 	// Handle *unstructured.Unstructured by pointer
 	if v, ok := value.(*unstructured.Unstructured); ok {
+		if v == nil {
+			return nil, nil
+		}
+
 		return v.Object, nil
 	}
 


### PR DESCRIPTION
## Description

Adds `kubectl odh get` command that provides simplified access to ODH/RHOAI custom resources without requiring users to know CRD group/version details.

**Supported resource types:**

| Resource | Alias | Kind |
|----------|-------|------|
| `notebooks` | `nb` | Kubeflow Notebook |
| `inferenceservices` | `isvc` | KServe InferenceService |
| `servingruntimes` | `sr` | KServe ServingRuntime |
| `datasciencepipelinesapplications` | `pipeline` | Data Science Pipelines |

**Features:**
- Resource registry with canonical names and short aliases
- Table output with ODH-specific columns per resource type (image, ready status, URL, age, etc.)
- JSON and YAML output formats (`-o json`, `-o yaml`)
- Standard kubectl flags: `-n`, `-A`, `-l`
- Graceful handling of missing CRDs, 403 Forbidden, and not-found errors
- Tab completion for resource type names

**New files:**
- `pkg/get/registry.go` — resource name/alias resolution
- `pkg/get/command.go` — command lifecycle (AddFlags/Complete/Validate/Run)
- `pkg/get/output.go` — table column definitions and output formatters
- `cmd/get/get.go` — Cobra wrapper
- `pkg/get/command_test.go` — unit tests with fake dynamic clients

**Modified files:**
- `cmd/main.go` — wire in the get subcommand
- `pkg/util/jq/jq.go` — defensive nil guard for typed nil pointers

## Usage
```
# List notebooks in current namespace
kubectl odh get nb

# List notebooks across all namespaces
kubectl odh get nb -A

# Get a specific notebook
kubectl odh get nb my-notebook -n my-project

# List inference services with label selector
kubectl odh get isvc -l app=my-model

# List serving runtimes
kubectl odh get sr -n my-project

# List pipelines in JSON format
kubectl odh get pipeline -o json

# Get a specific resource in YAML
kubectl odh get nb my-notebook -n my-project -o yaml
```
## Testing

- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] New functionality includes tests

## Review checklist

- [X] Code follows project conventions (see docs/coding/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `get` command to list and retrieve resources with namespace filtering and kubectl-style persistent flags
  * Support for table, JSON, and YAML outputs and shell completion for resource names

* **Tests**
  * Added comprehensive tests covering resolution, listing, retrieval, output formats, and edge cases

* **Bug Fixes**
  * Fixed nil-handling for unstructured conversions to avoid panics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->