### PR TITLE
feat: add deps command for ODH/RHOAI operator dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ config.local.yaml
 *.local
 .claude/
 bkp
+
+# Embedded dependency manifest (downloaded at build time)
+pkg/deps/data/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ project_name: kubectl-odh
 before:
   hooks:
     - go mod tidy
+    - make fetch-deps
 
 builds:
   - id: kubectl-odh

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,14 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# Pinned commit SHA from odh-gitops for reproducible builds
+ODH_GITOPS_COMMIT ?= 1a55af06b8fe85c8ed63b1eff680477d9bf86be3
+
 # Build flags
 LDFLAGS = -X 'github.com/opendatahub-io/odh-cli/internal/version.Version=$(VERSION)' \
           -X 'github.com/opendatahub-io/odh-cli/internal/version.Commit=$(COMMIT)' \
-          -X 'github.com/opendatahub-io/odh-cli/internal/version.Date=$(DATE)'
+          -X 'github.com/opendatahub-io/odh-cli/internal/version.Date=$(DATE)' \
+          -X 'github.com/opendatahub-io/odh-cli/pkg/deps.gitopsRef=$(ODH_GITOPS_COMMIT)'
 
 # Linter configuration
 LINT_TIMEOUT := 10m
@@ -37,9 +41,19 @@ GOVULNCHECK ?= go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Fetch dependency manifest from odh-gitops
+.PHONY: fetch-deps
+fetch-deps:
+	@mkdir -p pkg/deps/data
+	@echo "Fetching dependency manifest from odh-gitops (commit: $(ODH_GITOPS_COMMIT))..."
+	@curl -fsSL "https://raw.githubusercontent.com/opendatahub-io/odh-gitops/$(ODH_GITOPS_COMMIT)/charts/rhai-on-openshift-chart/values.yaml" \
+		-o pkg/deps/data/values.yaml
+	@curl -fsSL "https://raw.githubusercontent.com/opendatahub-io/odh-gitops/$(ODH_GITOPS_COMMIT)/charts/rhai-on-openshift-chart/Chart.yaml" \
+		-o pkg/deps/data/Chart.yaml
+
 # Build the binary
 .PHONY: build
-build:
+build: fetch-deps
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) cmd/main.go
 
@@ -87,7 +101,7 @@ check: lint
 
 # Run tests
 .PHONY: test
-test:
+test: fetch-deps
 	go test -coverprofile=coverage.out ./...
 
 # Build container image without pushing (creates local manifest)
@@ -134,4 +148,5 @@ help:
 	@echo "  vulncheck   - Run vulnerability scanner"
 	@echo "  check       - Run all checks (lint)"
 	@echo "  test        - Run tests"
+	@echo "  fetch-deps  - Fetch dependency manifest from odh-gitops"
 	@echo "  help        - Show this help message"

--- a/cmd/deps/deps.go
+++ b/cmd/deps/deps.go
@@ -1,0 +1,101 @@
+package deps
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	depspkg "github.com/opendatahub-io/odh-cli/pkg/deps"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	cmdName  = "deps"
+	cmdShort = "Show operator dependencies for ODH/RHOAI"
+)
+
+const cmdLong = `
+Shows operator dependencies required by ODH/RHOAI components.
+
+Displays dependency status by querying OLM subscriptions on the cluster.
+Each dependency shows:
+  - Installation status (installed, missing, optional)
+  - Installed version (if available)
+  - Namespace where the operator runs
+  - Components that require this dependency
+
+Examples:
+  # Show all dependencies
+  kubectl odh deps
+
+  # Show dependencies for a specific version
+  kubectl odh deps --version 3.4.0
+
+  # Refresh manifest from odh-gitops (fetch latest)
+  kubectl odh deps --refresh
+
+  # Output as JSON
+  kubectl odh deps -o json
+
+  # Dry run (show manifest data without cluster query)
+  kubectl odh deps --dry-run
+`
+
+// AddCommand adds the deps command to the root command.
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+	streams := genericiooptions.IOStreams{
+		In:     root.InOrStdin(),
+		Out:    root.OutOrStdout(),
+		ErrOut: root.ErrOrStderr(),
+	}
+
+	command := depspkg.NewCommand(streams, flags)
+
+	cmd := &cobra.Command{
+		Use:           cmdName,
+		Short:         cmdShort,
+		Long:          cmdLong,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat := command.Output
+
+			if err := command.Complete(); err != nil {
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+					return clierrors.NewAlreadyHandledError(err)
+				}
+
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			if err := command.Validate(); err != nil {
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+					return clierrors.NewAlreadyHandledError(err)
+				}
+
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+					return clierrors.NewAlreadyHandledError(err)
+				}
+
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			return nil
+		},
+	}
+
+	command.AddFlags(cmd.Flags())
+
+	root.AddCommand(cmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/opendatahub-io/odh-cli/cmd/deps"
 	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
 	"github.com/opendatahub-io/odh-cli/cmd/version"
@@ -31,6 +32,7 @@ func main() {
 	version.AddCommand(cmd, flags)
 	lint.AddCommand(cmd, flags)
 	get.AddCommand(cmd, flags)
+	deps.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		if !errors.Is(err, clierrors.ErrAlreadyHandled) {

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -1,0 +1,161 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	msgOLMNotAvailable = "OLM (Operator Lifecycle Manager) is not available in this cluster; cannot check operator dependencies"
+)
+
+// ErrOLMNotAvailable is returned when OLM is not installed in the cluster.
+var ErrOLMNotAvailable = errors.New(msgOLMNotAvailable)
+
+// Status represents the installation status of a dependency.
+type Status string
+
+const (
+	StatusInstalled Status = "installed"
+	StatusMissing   Status = "missing"
+	StatusOptional  Status = "optional"
+	StatusUnknown   Status = "unknown"
+)
+
+// DependencyStatus represents the checked status of a dependency on the cluster.
+type DependencyStatus struct {
+	Name         string   `json:"name"                 yaml:"name"`
+	DisplayName  string   `json:"displayName"          yaml:"displayName"`
+	Status       Status   `json:"status"               yaml:"status"`
+	Version      string   `json:"version,omitempty"    yaml:"version,omitempty"`
+	Namespace    string   `json:"namespace"            yaml:"namespace"`
+	Subscription string   `json:"subscription"         yaml:"subscription"`
+	RequiredBy   []string `json:"requiredBy,omitempty" yaml:"requiredBy,omitempty"`
+	Error        string   `json:"error,omitempty"      yaml:"error,omitempty"`
+}
+
+// CheckDependencies queries the cluster for dependency installation status.
+func CheckDependencies(ctx context.Context, olmReader client.OLMReader, manifest *Manifest) ([]DependencyStatus, error) {
+	if !olmReader.Available() {
+		return nil, ErrOLMNotAvailable
+	}
+
+	deps := manifest.GetDependencies()
+	results := make([]DependencyStatus, 0, len(deps))
+
+	for _, dep := range deps {
+		status := checkSingleDependency(ctx, olmReader, dep)
+		results = append(results, status)
+	}
+
+	// Sort by name for consistent output
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	return results, nil
+}
+
+func checkSingleDependency(ctx context.Context, olmReader client.OLMReader, dep DependencyInfo) DependencyStatus {
+	status := DependencyStatus{
+		Name:         dep.Name,
+		DisplayName:  dep.DisplayName,
+		Namespace:    dep.Namespace,
+		Subscription: dep.Subscription,
+		RequiredBy:   dep.RequiredBy,
+	}
+
+	sub, err := getSubscription(ctx, olmReader, dep.Namespace, dep.Subscription)
+	if err != nil {
+		status.Status = StatusUnknown
+		status.Error = err.Error()
+
+		return status
+	}
+
+	if sub == nil {
+		// Not installed - check if optional or required
+		if dep.Enabled == "auto" || dep.Enabled == "false" {
+			status.Status = StatusOptional
+		} else {
+			status.Status = StatusMissing
+		}
+
+		return status
+	}
+
+	status.Status = StatusInstalled
+
+	version, err := getVersionFromCSV(ctx, olmReader, dep.Namespace, sub.Status.InstalledCSV)
+	if err != nil {
+		status.Error = err.Error()
+	}
+
+	status.Version = version
+
+	return status
+}
+
+func getVersionFromCSV(ctx context.Context, olmReader client.OLMReader, namespace, csvName string) (string, error) {
+	if csvName == "" {
+		return "", nil
+	}
+
+	csv, err := getCSV(ctx, olmReader, namespace, csvName)
+	if err != nil {
+		return "", err
+	}
+
+	if csv == nil {
+		return "", nil
+	}
+
+	return csv.Spec.Version.String(), nil
+}
+
+// getSubscription retrieves an OLM subscription by namespace and name.
+// Returns (nil, nil) if not found, (nil, err) for other API errors.
+func getSubscription(ctx context.Context, olm client.OLMReader, namespace, name string) (*operatorsv1alpha1.Subscription, error) {
+	if namespace == "" || name == "" {
+		return nil, nil
+	}
+
+	sub, err := olm.Subscriptions(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("get subscription %s/%s: %w", namespace, name, err)
+	}
+
+	return sub, nil
+}
+
+// getCSV retrieves a ClusterServiceVersion by namespace and name.
+// Returns (nil, nil) if not found, (nil, err) for other API errors.
+func getCSV(ctx context.Context, olm client.OLMReader, namespace, name string) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	if namespace == "" || name == "" {
+		return nil, nil
+	}
+
+	csv, err := olm.ClusterServiceVersions(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("get csv %s/%s: %w", namespace, name, err)
+	}
+
+	return csv, nil
+}

--- a/pkg/deps/check_test.go
+++ b/pkg/deps/check_test.go
@@ -1,0 +1,212 @@
+package deps_test
+
+import (
+	"testing"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/mock"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	mockclient "github.com/opendatahub-io/odh-cli/pkg/util/test/mocks/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCheckDependencies_OLMNotAvailable(t *testing.T) {
+	g := NewWithT(t)
+
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(false)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"certManager": {Enabled: "true"},
+		},
+	}
+
+	_, err := deps.CheckDependencies(t.Context(), mockOLM, manifest)
+
+	g.Expect(err).To(MatchError(deps.ErrOLMNotAvailable))
+	mockOLM.AssertExpectations(t)
+}
+
+func TestCheckDependencies_MissingDependency(t *testing.T) {
+	g := NewWithT(t)
+
+	mockSubReader := &mockclient.MockSubscriptionReader{}
+	mockSubReader.On("Get", mock.Anything, "cert-manager", mock.Anything).
+		Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "operators.coreos.com", Resource: "subscriptions"}, "cert-manager"))
+
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(true)
+	mockOLM.On("Subscriptions", "cert-manager").Return(mockSubReader)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"certManager": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+				},
+			},
+		},
+	}
+
+	statuses, err := deps.CheckDependencies(t.Context(), mockOLM, manifest)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(statuses).To(HaveLen(1))
+	g.Expect(statuses[0].Status).To(Equal(deps.StatusMissing))
+
+	mockOLM.AssertExpectations(t)
+	mockSubReader.AssertExpectations(t)
+}
+
+func TestCheckDependencies_OptionalStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled string
+		want    deps.Status
+	}{
+		{"auto is optional", "auto", deps.StatusOptional},
+		{"false is optional", "false", deps.StatusOptional},
+		{"true is missing", "true", deps.StatusMissing},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mockSubReader := &mockclient.MockSubscriptionReader{}
+			mockSubReader.On("Get", mock.Anything, "servicemeshoperator", mock.Anything).
+				Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "operators.coreos.com", Resource: "subscriptions"}, "servicemeshoperator"))
+
+			mockOLM := &mockclient.MockOLMReader{}
+			mockOLM.On("Available").Return(true)
+			mockOLM.On("Subscriptions", "openshift-operators").Return(mockSubReader)
+
+			manifest := &deps.Manifest{
+				Dependencies: map[string]deps.Dependency{
+					"serviceMesh": {
+						Enabled: tt.enabled,
+						OLM: deps.OLMConfig{
+							Name:      "servicemeshoperator",
+							Namespace: "openshift-operators",
+						},
+					},
+				},
+			}
+
+			statuses, err := deps.CheckDependencies(t.Context(), mockOLM, manifest)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(statuses[0].Status).To(Equal(tt.want))
+
+			mockOLM.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCheckDependencies_Installed(t *testing.T) {
+	g := NewWithT(t)
+
+	mockSubReader := &mockclient.MockSubscriptionReader{}
+	mockSubReader.On("Get", mock.Anything, "cert-manager", mock.Anything).
+		Return(&operatorsv1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cert-manager",
+				Namespace: "cert-manager",
+			},
+			Status: operatorsv1alpha1.SubscriptionStatus{
+				InstalledCSV: "cert-manager.v1.14.0",
+			},
+		}, nil)
+
+	mockCSVReader := &mockclient.MockCSVReader{}
+	mockCSVReader.On("Get", mock.Anything, "cert-manager.v1.14.0", mock.Anything).
+		Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "operators.coreos.com", Resource: "clusterserviceversions"}, "cert-manager.v1.14.0"))
+
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(true)
+	mockOLM.On("Subscriptions", "cert-manager").Return(mockSubReader)
+	mockOLM.On("ClusterServiceVersions", "cert-manager").Return(mockCSVReader)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"certManager": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+				},
+			},
+		},
+	}
+
+	statuses, err := deps.CheckDependencies(t.Context(), mockOLM, manifest)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(statuses).To(HaveLen(1))
+	g.Expect(statuses[0].Status).To(Equal(deps.StatusInstalled))
+	g.Expect(statuses[0].Name).To(Equal("certManager"))
+	g.Expect(statuses[0].DisplayName).To(Equal("Cert Manager"))
+
+	mockOLM.AssertExpectations(t)
+}
+
+func TestCheckDependencies_EmptyNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(true)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"test": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "test-sub",
+					Namespace: "",
+				},
+			},
+		},
+	}
+
+	statuses, err := deps.CheckDependencies(t.Context(), mockOLM, manifest)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(statuses[0].Status).To(Equal(deps.StatusMissing))
+
+	mockOLM.AssertExpectations(t)
+}
+
+func TestCheckDependencies_EmptySubscription(t *testing.T) {
+	g := NewWithT(t)
+
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(true)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"test": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "",
+					Namespace: "test-ns",
+				},
+			},
+		},
+	}
+
+	statuses, err := deps.CheckDependencies(t.Context(), mockOLM, manifest)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(statuses[0].Status).To(Equal(deps.StatusMissing))
+
+	mockOLM.AssertExpectations(t)
+}

--- a/pkg/deps/command.go
+++ b/pkg/deps/command.go
@@ -1,0 +1,374 @@
+package deps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	utilserrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+// Verify Command implements cmd.Command interface at compile time.
+var _ cmd.Command = (*Command)(nil)
+
+const (
+	outputTable = "table"
+	outputJSON  = "json"
+	outputYAML  = "yaml"
+
+	yamlIndent         = 2
+	tableWidthNormal   = 130
+	tableWidthExpanded = 150
+	semverParts        = 3
+
+	msgCreateClient       = "create kubernetes client: %w"
+	msgInvalidOutput      = "invalid output format %q: must be table, json, or yaml"
+	msgNoManifestVersion  = "failed to determine manifest version from embedded Chart.yaml"
+	msgVersionUnavailable = "dependency graph for version %q is not available; only version %s is supported"
+	msgGetManifest        = "get manifest: %w"
+	msgVersionMismatch    = "cluster version %s does not match dependency graph version %s; use --dry-run to view the manifest without cluster validation"
+	msgCheckDeps          = "check dependencies: %w"
+	msgEncodeJSON         = "encode json: %w"
+	msgEncodeYAML         = "encode yaml: %w"
+
+	suggestionVersionUnavailable        = "Use --refresh to fetch the latest manifest, or omit --version to use the embedded version"
+	suggestionVersionUnavailableRefresh = "Omit --version to use the fetched manifest version"
+	suggestionVersionMismatch           = "Use --dry-run to view the manifest without cluster validation"
+)
+
+// Command holds the deps command configuration.
+type Command struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+
+	Refresh bool
+	DryRun  bool
+	Output  string
+	Version string
+
+	client          client.Client
+	clusterVersion  string
+	manifestVersion string
+	useColor        bool
+}
+
+// NewCommand creates a new Command with defaults.
+func NewCommand(streams genericiooptions.IOStreams, configFlags *genericclioptions.ConfigFlags) *Command {
+	return &Command{
+		IO:          iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags: configFlags,
+		Output:      outputTable,
+	}
+}
+
+// AddFlags registers command-specific flags with the provided FlagSet.
+func (c *Command) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&c.Refresh, "refresh", false, "Fetch latest manifest from odh-gitops")
+	fs.BoolVar(&c.DryRun, "dry-run", false, "Show manifest data without querying cluster")
+	fs.StringVarP(&c.Output, "output", "o", outputTable, "Output format: table, json, yaml")
+	fs.StringVar(&c.Version, "version", "", "ODH/RHOAI version to show dependencies for")
+}
+
+// Complete prepares the command for execution.
+func (c *Command) Complete() error {
+	c.useColor = shouldUseColor(c.IO.Out())
+
+	if c.DryRun {
+		return nil
+	}
+
+	cl, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf(msgCreateClient, err)
+	}
+
+	c.client = cl
+
+	return nil
+}
+
+// shouldUseColor checks if colored output should be used.
+// Returns false if NO_COLOR env is set, the writer is not an *os.File, or not a terminal.
+func shouldUseColor(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// Validate checks the command options.
+func (c *Command) Validate() error {
+	switch c.Output {
+	case outputTable, outputJSON, outputYAML:
+	default:
+		return fmt.Errorf(msgInvalidOutput, c.Output)
+	}
+
+	if c.Refresh {
+		return nil
+	}
+
+	manifestVer, err := ManifestVersion()
+	if err != nil {
+		return fmt.Errorf("%s: %w", msgNoManifestVersion, err)
+	}
+
+	c.manifestVersion = manifestVer
+
+	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
+		return utilserrors.NewValidationError(
+			"VERSION_UNAVAILABLE",
+			fmt.Sprintf(msgVersionUnavailable, c.Version, c.manifestVersion),
+			suggestionVersionUnavailable,
+		)
+	}
+
+	return nil
+}
+
+// Run executes the command.
+func (c *Command) Run(ctx context.Context) error {
+	result, err := GetManifest(ctx, c.Refresh)
+	if err != nil {
+		return fmt.Errorf(msgGetManifest, err)
+	}
+
+	if result.Version != "" {
+		c.manifestVersion = result.Version
+	}
+
+	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
+		suggestion := suggestionVersionUnavailable
+		if c.Refresh {
+			suggestion = suggestionVersionUnavailableRefresh
+		}
+
+		return utilserrors.NewValidationError(
+			"VERSION_UNAVAILABLE",
+			fmt.Sprintf(msgVersionUnavailable, c.Version, c.manifestVersion),
+			suggestion,
+		)
+	}
+
+	if c.DryRun {
+		return c.printDryRun(result.Manifest)
+	}
+
+	ver, err := version.Detect(ctx, c.client)
+	if err != nil {
+		_, _ = fmt.Fprintf(c.IO.ErrOut(), "Warning: failed to detect cluster version: %v\n", err)
+	} else if ver != nil {
+		c.clusterVersion = ver.String()
+
+		if !majorMinorMatch(c.clusterVersion, c.manifestVersion) {
+			return utilserrors.NewValidationError(
+				"VERSION_MISMATCH",
+				fmt.Sprintf(msgVersionMismatch, c.clusterVersion, c.manifestVersion),
+				suggestionVersionMismatch,
+			)
+		}
+	}
+
+	statuses, err := CheckDependencies(ctx, c.client.OLM(), result.Manifest)
+	if err != nil {
+		return fmt.Errorf(msgCheckDeps, err)
+	}
+
+	return c.printResults(statuses)
+}
+
+func (c *Command) printDryRun(manifest *Manifest) error {
+	deps := manifest.GetDependencies()
+
+	switch c.Output {
+	case outputJSON:
+		return c.printJSON(deps)
+	case outputYAML:
+		return c.printYAML(deps)
+	default:
+		return c.printDryRunTable(deps)
+	}
+}
+
+func (c *Command) printResults(statuses []DependencyStatus) error {
+	switch c.Output {
+	case outputJSON:
+		return c.printJSON(statuses)
+	case outputYAML:
+		return c.printYAML(statuses)
+	default:
+		return c.printTable(statuses)
+	}
+}
+
+func (c *Command) printTable(statuses []DependencyStatus) error {
+	w := c.IO.Out()
+
+	_, _ = fmt.Fprintf(w, "Dependency graph: ODH/RHOAI %s\n", c.manifestVersion)
+	if c.clusterVersion != "" {
+		_, _ = fmt.Fprintf(w, "Installed version: %s\n", c.clusterVersion)
+	}
+
+	_, _ = fmt.Fprintln(w)
+
+	_, _ = fmt.Fprintf(w, "%-26s %-10s %-8s %-42s %s\n",
+		"OPERATOR", "STATUS", "VERSION", "NAMESPACE", "REQUIRED BY")
+	_, _ = fmt.Fprint(w, strings.Repeat("-", tableWidthNormal)+"\n")
+
+	for _, s := range statuses {
+		statusIcon := c.statusToIcon(s.Status)
+
+		ver := s.Version
+		if ver == "" {
+			ver = "-"
+		}
+
+		requiredBy := strings.Join(s.RequiredBy, ", ")
+		if requiredBy == "" {
+			requiredBy = "-"
+		}
+
+		_, _ = fmt.Fprintf(w, "%-26s %-10s %-8s %-42s %s\n",
+			s.DisplayName,
+			statusIcon,
+			ver,
+			s.Namespace,
+			requiredBy,
+		)
+	}
+
+	return nil
+}
+
+func (c *Command) printDryRunTable(deps []DependencyInfo) error {
+	w := c.IO.Out()
+
+	_, _ = fmt.Fprintf(w, "[DRY RUN] Dependency graph for ODH/RHOAI %s (no cluster query)\n\n", c.manifestVersion)
+
+	_, _ = fmt.Fprintf(w, "%-25s %-10s %-35s %-35s %s\n",
+		"OPERATOR", "ENABLED", "SUBSCRIPTION", "NAMESPACE", "REQUIRED BY")
+	_, _ = fmt.Fprint(w, strings.Repeat("-", tableWidthExpanded)+"\n")
+
+	for _, d := range deps {
+		requiredBy := strings.Join(d.RequiredBy, ", ")
+		if requiredBy == "" {
+			requiredBy = "-"
+		}
+
+		_, _ = fmt.Fprintf(w, "%-25s %-10s %-35s %-35s %s\n",
+			d.DisplayName,
+			d.Enabled,
+			d.Subscription,
+			d.Namespace,
+			requiredBy,
+		)
+	}
+
+	return nil
+}
+
+func (c *Command) printJSON(data any) error {
+	encoder := json.NewEncoder(c.IO.Out())
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf(msgEncodeJSON, err)
+	}
+
+	return nil
+}
+
+func (c *Command) printYAML(data any) error {
+	encoder := yaml.NewEncoder(c.IO.Out())
+	encoder.SetIndent(yamlIndent)
+
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf(msgEncodeYAML, err)
+	}
+
+	return nil
+}
+
+const (
+	colorReset  = "\033[0m"
+	colorGreen  = "\033[32m"
+	colorRed    = "\033[31m"
+	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
+)
+
+func (c *Command) statusToIcon(status Status) string {
+	switch status {
+	case StatusInstalled:
+		if c.useColor {
+			return colorGreen + "✓ installed" + colorReset
+		}
+
+		return "✓ installed"
+	case StatusMissing:
+		if c.useColor {
+			return colorRed + "✗ MISSING" + colorReset
+		}
+
+		return "✗ MISSING"
+	case StatusOptional:
+		if c.useColor {
+			return colorYellow + "○ optional" + colorReset
+		}
+
+		return "○ optional"
+	case StatusUnknown:
+		if c.useColor {
+			return colorCyan + "? unknown" + colorReset
+		}
+
+		return "? unknown"
+	default:
+		return string(status)
+	}
+}
+
+// majorMinorMatch checks if two versions have the same major.minor.
+// Handles versions with or without "v" prefix (e.g., "v2.17.0" and "2.17.0").
+func majorMinorMatch(v1, v2 string) bool {
+	if v1 == "" || v2 == "" {
+		return false
+	}
+
+	// Strip leading "v" prefix if present
+	v1 = strings.TrimPrefix(v1, "v")
+	v2 = strings.TrimPrefix(v2, "v")
+
+	ver1, err := semver.Parse(v1)
+	if err != nil {
+		return false
+	}
+
+	ver2, err := semver.Parse(v2)
+	if err != nil {
+		return false
+	}
+
+	return ver1.Major == ver2.Major && ver1.Minor == ver2.Minor
+}

--- a/pkg/deps/command_test.go
+++ b/pkg/deps/command_test.go
@@ -1,0 +1,65 @@
+package deps_test
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCommand_Validate_OutputFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantErr bool
+	}{
+		{"table format", "table", false},
+		{"json format", "json", false},
+		{"yaml format", "yaml", false},
+		{"invalid format", "xml", true},
+		{"empty format", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			streams := genericiooptions.IOStreams{
+				Out:    &bytes.Buffer{},
+				ErrOut: &bytes.Buffer{},
+			}
+
+			cmd := deps.NewCommand(streams, nil)
+			cmd.Output = tt.output
+			cmd.Refresh = true
+
+			err := cmd.Validate()
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestCommand_Complete_DryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	streams := genericiooptions.IOStreams{
+		Out:    &bytes.Buffer{},
+		ErrOut: &bytes.Buffer{},
+	}
+
+	cmd := deps.NewCommand(streams, nil)
+	cmd.DryRun = true
+
+	err := cmd.Complete()
+
+	g.Expect(err).ToNot(HaveOccurred())
+}

--- a/pkg/deps/embed.go
+++ b/pkg/deps/embed.go
@@ -1,0 +1,26 @@
+package deps
+
+import (
+	_ "embed"
+)
+
+//go:embed data/values.yaml
+var embeddedManifest []byte
+
+//go:embed data/Chart.yaml
+var embeddedChart []byte
+
+// EmbeddedManifest returns the embedded values.yaml content.
+func EmbeddedManifest() []byte {
+	return embeddedManifest
+}
+
+// chartMetadata represents the relevant fields from Chart.yaml.
+type chartMetadata struct {
+	AppVersion string `yaml:"appVersion"`
+}
+
+// ManifestVersion returns the appVersion from the embedded Chart.yaml.
+func ManifestVersion() (string, error) {
+	return parseChartVersion(embeddedChart)
+}

--- a/pkg/deps/embed_test.go
+++ b/pkg/deps/embed_test.go
@@ -1,0 +1,36 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestEmbeddedManifest(t *testing.T) {
+	g := NewWithT(t)
+
+	data := deps.EmbeddedManifest()
+
+	if len(data) == 0 {
+		t.Skip("Skipping: embedded manifest not available (run 'make fetch-deps' first)")
+	}
+
+	manifest, err := deps.Parse(data)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(manifest).ToNot(BeNil())
+}
+
+func TestManifestVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	version, err := deps.ManifestVersion()
+
+	if err != nil {
+		t.Skip("Skipping: embedded Chart.yaml not available (run 'make fetch-deps' first)")
+	}
+
+	g.Expect(len(version)).To(BeNumerically(">=", 3))
+}

--- a/pkg/deps/fetch.go
+++ b/pkg/deps/fetch.go
@@ -1,0 +1,165 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	gitopsBaseURL = "https://raw.githubusercontent.com/opendatahub-io/odh-gitops"
+	valuesPath    = "charts/rhai-on-openshift-chart/values.yaml"
+	chartPath     = "charts/rhai-on-openshift-chart/Chart.yaml"
+	fetchTimeout  = 30 * time.Second
+	maxFetchSize  = 5 * 1024 * 1024 // 5MB max response size
+
+	msgFetchManifest = "fetch latest manifest: %w"
+	msgFetchChart    = "fetch chart metadata: %w"
+	msgCreateRequest = "create request: %w"
+	msgFetchFile     = "fetch file: %w"
+	msgFetchHTTP     = "fetch file %s: HTTP %d"
+	msgReadResponse  = "read response: %w"
+)
+
+// gitopsRef is the default commit SHA for fetching manifests.
+// Can be overridden at build time via ldflags or at runtime via ODH_GITOPS_COMMIT env var.
+//
+//nolint:gochecknoglobals // build-time injection requires package-level var
+var gitopsRef = "1a55af06b8fe85c8ed63b1eff680477d9bf86be3"
+
+// getGitopsRef returns the gitops commit ref to use.
+// Priority: ODH_GITOPS_COMMIT env var > build-time ldflags > default.
+func getGitopsRef() string {
+	if ref := os.Getenv("ODH_GITOPS_COMMIT"); ref != "" {
+		return ref
+	}
+
+	return gitopsRef
+}
+
+// ErrEmbeddedEmpty is returned when the embedded manifest is empty.
+var ErrEmbeddedEmpty = errors.New("embedded manifest is empty")
+
+// ManifestResult contains the parsed manifest and its version.
+type ManifestResult struct {
+	Manifest *Manifest
+	Version  string
+}
+
+// GetManifest returns the parsed manifest and version, using embedded data by default.
+// If refresh is true, fetches the latest manifest from GitHub.
+//
+//nolint:revive // refresh flag is intentional API design for CLI command
+func GetManifest(ctx context.Context, refresh bool) (*ManifestResult, error) {
+	if refresh {
+		return fetchAndParseManifest(ctx, gitopsBaseURL)
+	}
+
+	return parseEmbeddedManifest()
+}
+
+func fetchAndParseManifest(ctx context.Context, baseURL string) (*ManifestResult, error) {
+	valuesData, err := fetchFile(ctx, baseURL, valuesPath)
+	if err != nil {
+		return nil, fmt.Errorf(msgFetchManifest, err)
+	}
+
+	manifest, err := Parse(valuesData)
+	if err != nil {
+		return nil, err
+	}
+
+	chartData, err := fetchFile(ctx, baseURL, chartPath)
+	if err != nil {
+		return nil, fmt.Errorf(msgFetchChart, err)
+	}
+
+	version, err := parseChartVersion(chartData)
+	if err != nil {
+		return nil, fmt.Errorf(msgFetchChart, err)
+	}
+
+	return &ManifestResult{
+		Manifest: manifest,
+		Version:  version,
+	}, nil
+}
+
+func parseEmbeddedManifest() (*ManifestResult, error) {
+	data := EmbeddedManifest()
+	if len(data) == 0 {
+		return nil, ErrEmbeddedEmpty
+	}
+
+	manifest, err := Parse(data)
+	if err != nil {
+		return nil, err
+	}
+
+	version, err := ManifestVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ManifestResult{
+		Manifest: manifest,
+		Version:  version,
+	}, nil
+}
+
+// fetchFile downloads a file from a given base URL and path.
+func fetchFile(ctx context.Context, baseURL string, path string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/%s", baseURL, getGitopsRef(), path)
+
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf(msgCreateRequest, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf(msgFetchFile, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(msgFetchHTTP, path, resp.StatusCode)
+	}
+
+	// Read up to maxFetchSize + 1 to detect overflow
+	limitedReader := io.LimitReader(resp.Body, maxFetchSize+1)
+
+	data, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, fmt.Errorf(msgReadResponse, err)
+	}
+
+	if len(data) > maxFetchSize {
+		return nil, fmt.Errorf("response exceeds maximum size of %d bytes", maxFetchSize)
+	}
+
+	return data, nil
+}
+
+// parseChartVersion extracts appVersion from Chart.yaml content.
+func parseChartVersion(data []byte) (string, error) {
+	var chart chartMetadata
+	if err := yaml.Unmarshal(data, &chart); err != nil {
+		return "", fmt.Errorf("parse Chart.yaml: %w", err)
+	}
+
+	if chart.AppVersion == "" {
+		return "", errors.New("parse Chart.yaml: appVersion field is empty")
+	}
+
+	return chart.AppVersion, nil
+}

--- a/pkg/deps/fetch_test.go
+++ b/pkg/deps/fetch_test.go
@@ -1,0 +1,60 @@
+package deps_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetManifest_EmbeddedMode(t *testing.T) {
+	g := NewWithT(t)
+
+	result, err := deps.GetManifest(t.Context(), false)
+
+	if err != nil {
+		if errors.Is(err, deps.ErrEmbeddedEmpty) {
+			t.Skip("Skipping: embedded manifest not available")
+		}
+
+		t.Fatalf("GetManifest(refresh=false) error = %v", err)
+	}
+
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Manifest).ToNot(BeNil())
+}
+
+func TestGetManifest_EmbeddedMode_HasDependencies(t *testing.T) {
+	g := NewWithT(t)
+
+	result, err := deps.GetManifest(t.Context(), false)
+
+	if err != nil {
+		if errors.Is(err, deps.ErrEmbeddedEmpty) {
+			t.Skip("Skipping: embedded manifest not available")
+		}
+
+		t.Fatalf("GetManifest(refresh=false) error = %v", err)
+	}
+
+	g.Expect(result.Manifest.Dependencies).ToNot(BeEmpty())
+}
+
+func TestGetManifest_EmbeddedMode_HasVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	result, err := deps.GetManifest(t.Context(), false)
+
+	if err != nil {
+		if errors.Is(err, deps.ErrEmbeddedEmpty) {
+			t.Skip("Skipping: embedded manifest not available")
+		}
+
+		t.Fatalf("GetManifest(refresh=false) error = %v", err)
+	}
+
+	g.Expect(result.Version).ToNot(BeEmpty())
+	g.Expect(len(result.Version)).To(BeNumerically(">=", 3))
+}

--- a/pkg/deps/manifest.go
+++ b/pkg/deps/manifest.go
@@ -1,0 +1,181 @@
+package deps
+
+import (
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	msgParseManifest = "parse manifest: %w"
+)
+
+//nolint:gochecknoglobals // static lookup table for display names
+var displayNames = map[string]string{
+	// Dependencies
+	"certManager":             "Cert Manager",
+	"leaderWorkerSet":         "Leader Worker Set",
+	"jobSet":                  "Job Set",
+	"rhcl":                    "Red Hat Connectivity Link",
+	"customMetricsAutoscaler": "Custom Metrics Autoscaler",
+	"serviceMesh":             "Service Mesh",
+	"serverless":              "Serverless",
+	"authorino":               "Authorino",
+	"kueue":                   "Kueue",
+	"opentelemetry":           "OpenTelemetry",
+	"tempo":                   "Tempo",
+	"clusterObservability":    "Cluster Observability",
+	"nfd":                     "Node Feature Discovery",
+	"nvidiaGPUOperator":       "NVIDIA GPU Operator",
+	// Components
+	"aipipelines":        "AI Pipelines",
+	"dashboard":          "Dashboard",
+	"feastoperator":      "Feast Operator",
+	"kserve":             "KServe",
+	"modelregistry":      "Model Registry",
+	"ray":                "Ray",
+	"trainer":            "Trainer",
+	"trainingoperator":   "Training Operator",
+	"trustyai":           "TrustyAI",
+	"workbenches":        "Workbenches",
+	"mlflowoperator":     "MLflow Operator",
+	"llamastackoperator": "LlamaStack Operator",
+	"sparkoperator":      "Spark Operator",
+}
+
+// Manifest represents the parsed values.yaml structure from odh-gitops.
+type Manifest struct {
+	Dependencies map[string]Dependency `yaml:"dependencies"`
+	Components   map[string]Component  `yaml:"components"`
+}
+
+// Dependency represents an operator dependency configuration.
+type Dependency struct {
+	Enabled      string         `yaml:"enabled"` // "auto", "true", "false"
+	OLM          OLMConfig      `yaml:"olm"`
+	Dependencies map[string]any `yaml:"dependencies"` // Transitive dependencies
+}
+
+// OLMConfig contains OLM subscription details.
+type OLMConfig struct {
+	Channel   string `yaml:"channel"`
+	Name      string `yaml:"name"`      // Subscription name
+	Namespace string `yaml:"namespace"` // Operator namespace
+	Source    string `yaml:"source"`    // Catalog source (optional, defaults to redhat-operators)
+}
+
+// Component represents an ODH/RHOAI component configuration.
+type Component struct {
+	Dependencies map[string]any `yaml:"dependencies"`
+}
+
+// DependencyInfo is a flattened view of a dependency for display.
+type DependencyInfo struct {
+	Name         string   `json:"name"                 yaml:"name"`
+	DisplayName  string   `json:"displayName"          yaml:"displayName"`
+	Enabled      string   `json:"enabled"              yaml:"enabled"`
+	Subscription string   `json:"subscription"         yaml:"subscription"`
+	Namespace    string   `json:"namespace"            yaml:"namespace"`
+	Channel      string   `json:"channel,omitempty"    yaml:"channel,omitempty"`
+	RequiredBy   []string `json:"requiredBy,omitempty" yaml:"requiredBy,omitempty"`
+}
+
+// Parse parses values.yaml content into a Manifest.
+func Parse(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf(msgParseManifest, err)
+	}
+
+	return &m, nil
+}
+
+// GetDependencies returns a flat list of dependencies with their metadata, sorted by name.
+func (m *Manifest) GetDependencies() []DependencyInfo {
+	requiredBy := m.buildRequiredByMap()
+
+	deps := make([]DependencyInfo, 0, len(m.Dependencies))
+	for name, dep := range m.Dependencies {
+		info := DependencyInfo{
+			Name:         name,
+			DisplayName:  toDisplayName(name),
+			Enabled:      dep.Enabled,
+			Subscription: dep.OLM.Name,
+			Namespace:    dep.OLM.Namespace,
+			Channel:      dep.OLM.Channel,
+			RequiredBy:   requiredBy[name],
+		}
+		deps = append(deps, info)
+	}
+
+	sort.Slice(deps, func(i, j int) bool {
+		return deps[i].Name < deps[j].Name
+	})
+
+	return deps
+}
+
+// buildRequiredByMap builds a reverse map of dependency -> components that need it.
+func (m *Manifest) buildRequiredByMap() map[string][]string {
+	depSets := make(map[string]sets.Set[string])
+
+	addEntry := func(depName, requiredBy string) {
+		if depSets[depName] == nil {
+			depSets[depName] = sets.New[string]()
+		}
+
+		depSets[depName].Insert(requiredBy)
+	}
+
+	// From components
+	for compName, comp := range m.Components {
+		for depName, val := range comp.Dependencies {
+			if isEnabled(val) {
+				addEntry(depName, toDisplayName(compName))
+			}
+		}
+	}
+
+	// From transitive dependencies
+	for depName, dep := range m.Dependencies {
+		for transDepName, val := range dep.Dependencies {
+			if isEnabled(val) {
+				addEntry(transDepName, toDisplayName(depName))
+			}
+		}
+	}
+
+	// Convert sets to sorted slices
+	result := make(map[string][]string, len(depSets))
+	for depName, set := range depSets {
+		result[depName] = sets.List(set)
+	}
+
+	return result
+}
+
+// isEnabled checks if a dependency value indicates it's enabled.
+// Only bool true or strings "true"/"auto" are considered enabled.
+// All other types (int, map, slice, etc.) return false.
+func isEnabled(val any) bool {
+	switch v := val.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "auto"
+	default:
+		return false
+	}
+}
+
+// toDisplayName converts camelCase to human-readable name.
+func toDisplayName(name string) string {
+	if display, ok := displayNames[name]; ok {
+		return display
+	}
+
+	return name
+}

--- a/pkg/deps/manifest_test.go
+++ b/pkg/deps/manifest_test.go
@@ -1,0 +1,253 @@
+package deps_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+const testManifestWithDependencies = `
+dependencies:
+  certManager:
+    enabled: "true"
+    olm:
+      name: cert-manager
+      namespace: cert-manager
+      channel: stable
+  serviceMesh:
+    enabled: "auto"
+    olm:
+      name: servicemeshoperator
+      namespace: openshift-operators
+components:
+  kserve:
+    dependencies:
+      certManager: true
+      serviceMesh: true
+`
+
+const testManifestEmpty = `
+dependencies: {}
+components: {}
+`
+
+const testManifestInvalid = `not: valid: yaml: here`
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr bool
+		check   func(*GomegaWithT, *deps.Manifest)
+	}{
+		{
+			name:    "valid manifest with dependencies",
+			data:    testManifestWithDependencies,
+			wantErr: false,
+			check: func(g *GomegaWithT, m *deps.Manifest) {
+				g.Expect(m.Dependencies).To(HaveLen(2))
+				g.Expect(m.Dependencies["certManager"].Enabled).To(Equal("true"))
+				g.Expect(m.Dependencies["certManager"].OLM.Name).To(Equal("cert-manager"))
+				g.Expect(m.Components).To(HaveLen(1))
+			},
+		},
+		{
+			name:    "empty manifest",
+			data:    testManifestEmpty,
+			wantErr: false,
+			check: func(g *GomegaWithT, m *deps.Manifest) {
+				g.Expect(m.Dependencies).To(BeEmpty())
+			},
+		},
+		{
+			name:    "invalid yaml",
+			data:    testManifestInvalid,
+			wantErr: true,
+			check:   nil,
+		},
+		{
+			name:    "empty data",
+			data:    "",
+			wantErr: false,
+			check: func(g *GomegaWithT, m *deps.Manifest) {
+				g.Expect(m.Dependencies).To(BeEmpty())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := deps.Parse([]byte(tt.data))
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tt.check != nil {
+				tt.check(g, got)
+			}
+		})
+	}
+}
+
+func TestGetDependencies(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"certManager": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+					Channel:   "stable",
+				},
+			},
+			"serviceMesh": {
+				Enabled: "auto",
+				OLM: deps.OLMConfig{
+					Name:      "servicemeshoperator",
+					Namespace: "openshift-operators",
+				},
+			},
+		},
+		Components: map[string]deps.Component{
+			"kserve": {
+				Dependencies: map[string]any{
+					"certManager": true,
+					"serviceMesh": true,
+				},
+			},
+		},
+	}
+
+	depsInfo := manifest.GetDependencies()
+
+	g.Expect(depsInfo).To(HaveLen(2))
+	g.Expect(depsInfo[0].Name).To(Equal("certManager"))
+	g.Expect(depsInfo[1].Name).To(Equal("serviceMesh"))
+	g.Expect(depsInfo[0].DisplayName).To(Equal("Cert Manager"))
+	g.Expect(depsInfo[0].RequiredBy).To(ContainElement("KServe"))
+}
+
+func TestGetDependencies_TransitiveDependencies(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"serviceMesh": {
+				Enabled: "auto",
+				OLM: deps.OLMConfig{
+					Name:      "servicemeshoperator",
+					Namespace: "openshift-operators",
+				},
+				Dependencies: map[string]any{
+					"certManager": true,
+				},
+			},
+			"certManager": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+				},
+			},
+		},
+		Components: map[string]deps.Component{},
+	}
+
+	depsInfo := manifest.GetDependencies()
+
+	var certManager *deps.DependencyInfo
+	for i := range depsInfo {
+		if depsInfo[i].Name == "certManager" {
+			certManager = &depsInfo[i]
+
+			break
+		}
+	}
+
+	g.Expect(certManager).ToNot(BeNil())
+	g.Expect(certManager.RequiredBy).To(ContainElement("Service Mesh"))
+}
+
+func TestGetDependencies_NoDuplicatesInRequiredBy(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"certManager": {
+				Enabled: "true",
+				OLM: deps.OLMConfig{
+					Name:      "cert-manager",
+					Namespace: "cert-manager",
+				},
+			},
+		},
+		Components: map[string]deps.Component{
+			"kserve": {
+				Dependencies: map[string]any{
+					"certManager": true,
+				},
+			},
+			"modelregistry": {
+				Dependencies: map[string]any{
+					"certManager": true,
+				},
+			},
+		},
+	}
+
+	depsInfo := manifest.GetDependencies()
+
+	g.Expect(depsInfo).To(HaveLen(1))
+	g.Expect(depsInfo[0].RequiredBy).To(HaveLen(2))
+	g.Expect(depsInfo[0].RequiredBy[0]).To(Equal("KServe"))
+	g.Expect(depsInfo[0].RequiredBy[1]).To(Equal("Model Registry"))
+}
+
+func TestGetDependencies_DisabledDependencies(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{
+			"certManager": {
+				Enabled: "true",
+				OLM:     deps.OLMConfig{Name: "cert-manager"},
+			},
+		},
+		Components: map[string]deps.Component{
+			"kserve": {
+				Dependencies: map[string]any{
+					"certManager": false,
+				},
+			},
+		},
+	}
+
+	depsInfo := manifest.GetDependencies()
+
+	g.Expect(depsInfo).To(HaveLen(1))
+	g.Expect(depsInfo[0].RequiredBy).To(BeEmpty())
+}
+
+func TestGetDependencies_EmptyManifest(t *testing.T) {
+	g := NewWithT(t)
+
+	manifest := &deps.Manifest{
+		Dependencies: map[string]deps.Dependency{},
+		Components:   map[string]deps.Component{},
+	}
+
+	depsInfo := manifest.GetDependencies()
+
+	g.Expect(depsInfo).To(BeEmpty())
+}

--- a/pkg/util/errors/types.go
+++ b/pkg/util/errors/types.go
@@ -69,6 +69,17 @@ func NewConfigError(err error) *ConfigError {
 	return &ConfigError{cause: err}
 }
 
+// NewValidationError creates a StructuredError for user input validation failures.
+func NewValidationError(code, message, suggestion string) *StructuredError {
+	return &StructuredError{
+		Code:       code,
+		Message:    message,
+		Category:   CategoryValidation,
+		Retriable:  false,
+		Suggestion: suggestion,
+	}
+}
+
 // errorEnvelope wraps a StructuredError for JSON/YAML output rendering.
 type errorEnvelope struct {
 	Error *StructuredError `json:"error" yaml:"error"`

--- a/pkg/util/test/mocks/client/olm.go
+++ b/pkg/util/test/mocks/client/olm.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"context"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/mock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// MockOLMReader is a mock implementation of client.OLMReader using testify/mock.
+type MockOLMReader struct {
+	mock.Mock
+}
+
+var _ client.OLMReader = (*MockOLMReader)(nil)
+
+func (m *MockOLMReader) Available() bool {
+	args := m.Called()
+
+	return args.Bool(0)
+}
+
+func (m *MockOLMReader) Subscriptions(namespace string) client.SubscriptionReader {
+	args := m.Called(namespace)
+	if args.Get(0) == nil {
+		return nil
+	}
+
+	result, _ := args.Get(0).(client.SubscriptionReader)
+
+	return result
+}
+
+func (m *MockOLMReader) ClusterServiceVersions(namespace string) client.CSVReader {
+	args := m.Called(namespace)
+	if args.Get(0) == nil {
+		return nil
+	}
+
+	result, _ := args.Get(0).(client.CSVReader)
+
+	return result
+}
+
+// MockSubscriptionReader is a mock implementation of client.SubscriptionReader.
+type MockSubscriptionReader struct {
+	mock.Mock
+}
+
+var _ client.SubscriptionReader = (*MockSubscriptionReader)(nil)
+
+func (m *MockSubscriptionReader) List(ctx context.Context, opts metav1.ListOptions) (*operatorsv1alpha1.SubscriptionList, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*operatorsv1alpha1.SubscriptionList)
+
+	return result, args.Error(1)
+}
+
+func (m *MockSubscriptionReader) Get(ctx context.Context, name string, opts metav1.GetOptions) (*operatorsv1alpha1.Subscription, error) {
+	args := m.Called(ctx, name, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*operatorsv1alpha1.Subscription)
+
+	return result, args.Error(1)
+}
+
+// MockCSVReader is a mock implementation of client.CSVReader.
+type MockCSVReader struct {
+	mock.Mock
+}
+
+var _ client.CSVReader = (*MockCSVReader)(nil)
+
+func (m *MockCSVReader) List(ctx context.Context, opts metav1.ListOptions) (*operatorsv1alpha1.ClusterServiceVersionList, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*operatorsv1alpha1.ClusterServiceVersionList)
+
+	return result, args.Error(1)
+}
+
+func (m *MockCSVReader) Get(ctx context.Context, name string, opts metav1.GetOptions) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	args := m.Called(ctx, name, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*operatorsv1alpha1.ClusterServiceVersion)
+
+	return result, args.Error(1)
+}


### PR DESCRIPTION
## Description

Add `kubectl odh deps` command to display operator dependencies required by ODH/RHOAI components.

Features:
- Shows installation status (installed, missing, optional) with colored icons
- Displays installed version from CSV
- Shows namespace and required-by relationships
- Supports `--dry-run`, `--refresh`, `-o json/yaml`

**Note:** Currently only supports ODH/RHOAI 3.4.x (dependency graph for other versions not available in odh-gitops)

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deps CLI command to fetch dependency manifests, inspect cluster operator status, and render results in table/json/yaml with dry-run, refresh, and optional version gating.

* **Chores**
  * Build/test now fetch manifest files before running; CI hook updated to run pre-build fetch; VCS ignore updated to exclude fetched artifacts.

* **Tests**
  * Added unit tests and mocks covering manifest parsing, embedded/fetched manifests, fetch logic, and dependency/status checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->