### PR TITLE
feat: Add components command to access Each odh component

### DIFF
--- a/cmd/components/components.go
+++ b/cmd/components/components.go
@@ -1,0 +1,152 @@
+package components
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	componentspkg "github.com/opendatahub-io/odh-cli/pkg/components"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	cmdName  = "components"
+	cmdShort = "View and manage ODH component lifecycle"
+)
+
+const cmdLong = `
+View and manage ODH/RHOAI component lifecycle.
+
+Components are feature modules managed by the DataScienceCluster (DSC) resource.
+Each component has a managementState: Managed, Unmanaged, or Removed.
+
+The component list is dynamically discovered from the DSC spec and enriched
+with health information from component CRs (when available).
+`
+
+const cmdExample = `
+  # List all components with their state and health
+  kubectl odh components
+
+  # List components as JSON
+  kubectl odh components -o json
+
+  # List components as YAML
+  kubectl odh components -o yaml
+
+  # Describe a specific component
+  kubectl odh components describe kserve
+
+  # Enable a component
+  kubectl odh components enable ray
+
+  # Disable a component
+  kubectl odh components disable trustyai
+`
+
+// command is the interface for all component subcommands.
+type command interface {
+	AddFlags(fs *pflag.FlagSet)
+	Complete() error
+	Validate() error
+	Run(ctx context.Context) error
+}
+
+// mutateCommand extends command with SetComponentName for enable/disable.
+type mutateCommand interface {
+	command
+	SetComponentName(name string)
+}
+
+// runCommand executes the Complete/Validate/Run lifecycle with error handling.
+//
+//nolint:wrapcheck // HandleError returns an already-handled error
+func runCommand(cmd *cobra.Command, c command, outputFormat string) error {
+	if err := c.Complete(); err != nil {
+		return clierrors.HandleError(cmd, err, outputFormat)
+	}
+
+	if err := c.Validate(); err != nil {
+		return clierrors.HandleError(cmd, err, outputFormat)
+	}
+
+	if err := c.Run(cmd.Context()); err != nil {
+		return clierrors.HandleError(cmd, err, outputFormat)
+	}
+
+	return nil
+}
+
+// AddCommand adds the components command to the root command.
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+	streams := genericiooptions.IOStreams{
+		In:     root.InOrStdin(),
+		Out:    root.OutOrStdout(),
+		ErrOut: root.ErrOrStderr(),
+	}
+
+	listCommand := componentspkg.NewListCommand(streams, flags)
+
+	cmd := &cobra.Command{
+		Use:           cmdName,
+		Short:         cmdShort,
+		Long:          cmdLong,
+		Example:       cmdExample,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCommand(cmd, listCommand, listCommand.OutputFormat)
+		},
+	}
+
+	listCommand.AddFlags(cmd.Flags())
+
+	addDescribeCommand(cmd, flags, streams)
+	addMutateCommand(cmd, componentspkg.NewEnableCommand(streams, flags), "enable COMPONENT", "Enable a component (set managementState to Managed)")
+	addMutateCommand(cmd, componentspkg.NewDisableCommand(streams, flags), "disable COMPONENT", "Disable a component (set managementState to Removed)")
+
+	root.AddCommand(cmd)
+}
+
+func addDescribeCommand(parent *cobra.Command, flags *genericclioptions.ConfigFlags, streams genericiooptions.IOStreams) {
+	describeCommand := componentspkg.NewDescribeCommand(streams, flags)
+
+	cmd := &cobra.Command{
+		Use:           "describe COMPONENT",
+		Short:         "Show detailed information about a component",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			describeCommand.ComponentName = args[0]
+
+			return runCommand(cmd, describeCommand, describeCommand.OutputFormat)
+		},
+	}
+
+	describeCommand.AddFlags(cmd.Flags())
+	parent.AddCommand(cmd)
+}
+
+func addMutateCommand(parent *cobra.Command, command mutateCommand, use, short string) {
+	cmd := &cobra.Command{
+		Use:           use,
+		Short:         short,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			command.SetComponentName(args[0])
+
+			return runCommand(cmd, command, "")
+		},
+	}
+
+	command.AddFlags(cmd.Flags())
+	parent.AddCommand(cmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/opendatahub-io/odh-cli/cmd/components"
 	"github.com/opendatahub-io/odh-cli/cmd/deps"
 	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
@@ -33,6 +34,7 @@ func main() {
 	lint.AddCommand(cmd, flags)
 	get.AddCommand(cmd, flags)
 	deps.AddCommand(cmd, flags)
+	components.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		if !errors.Is(err, clierrors.ErrAlreadyHandled) {

--- a/pkg/components/commands.go
+++ b/pkg/components/commands.go
@@ -1,0 +1,156 @@
+package components
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+var (
+	_ cmd.Command = (*EnableCommand)(nil)
+	_ cmd.Command = (*DisableCommand)(nil)
+)
+
+// EnableCommand contains the enable subcommand configuration.
+type EnableCommand struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+	Client      client.Client
+
+	ComponentName string
+	DryRun        bool
+	Yes           bool
+}
+
+// NewEnableCommand creates a new EnableCommand with defaults.
+func NewEnableCommand(
+	streams genericiooptions.IOStreams,
+	configFlags *genericclioptions.ConfigFlags,
+) *EnableCommand {
+	return &EnableCommand{
+		IO:          iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags: configFlags,
+	}
+}
+
+// SetComponentName sets the component name from command args.
+func (c *EnableCommand) SetComponentName(name string) {
+	c.ComponentName = name
+}
+
+// AddFlags registers command-specific flags.
+func (c *EnableCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would change without applying")
+	fs.BoolVarP(&c.Yes, "yes", "y", false, "Skip confirmation prompt")
+}
+
+// Complete resolves derived fields after flag parsing.
+func (c *EnableCommand) Complete() error {
+	k8sClient, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+
+	c.Client = k8sClient
+
+	return nil
+}
+
+// Validate checks that all options are valid before execution.
+func (c *EnableCommand) Validate() error {
+	if c.ComponentName == "" {
+		return errors.New("component name is required")
+	}
+
+	return nil
+}
+
+// Run executes the enable command.
+func (c *EnableCommand) Run(ctx context.Context) error {
+	return MutateComponentState(ctx, MutateConfig{
+		IO:            c.IO,
+		Client:        c.Client,
+		ComponentName: c.ComponentName,
+		TargetState:   constants.ManagementStateManaged,
+		ActionVerb:    "enable",
+		DryRun:        c.DryRun,
+		SkipConfirm:   c.Yes,
+	})
+}
+
+// DisableCommand contains the disable subcommand configuration.
+type DisableCommand struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+	Client      client.Client
+
+	ComponentName string
+	DryRun        bool
+	Yes           bool
+}
+
+// NewDisableCommand creates a new DisableCommand with defaults.
+func NewDisableCommand(
+	streams genericiooptions.IOStreams,
+	configFlags *genericclioptions.ConfigFlags,
+) *DisableCommand {
+	return &DisableCommand{
+		IO:          iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags: configFlags,
+	}
+}
+
+// SetComponentName sets the component name from command args.
+func (c *DisableCommand) SetComponentName(name string) {
+	c.ComponentName = name
+}
+
+// AddFlags registers command-specific flags.
+func (c *DisableCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would change without applying")
+	fs.BoolVarP(&c.Yes, "yes", "y", false, "Skip confirmation prompt")
+}
+
+// Complete resolves derived fields after flag parsing.
+func (c *DisableCommand) Complete() error {
+	k8sClient, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+
+	c.Client = k8sClient
+
+	return nil
+}
+
+// Validate checks that all options are valid before execution.
+func (c *DisableCommand) Validate() error {
+	if c.ComponentName == "" {
+		return errors.New("component name is required")
+	}
+
+	return nil
+}
+
+// Run executes the disable command.
+func (c *DisableCommand) Run(ctx context.Context) error {
+	return MutateComponentState(ctx, MutateConfig{
+		IO:            c.IO,
+		Client:        c.Client,
+		ComponentName: c.ComponentName,
+		TargetState:   constants.ManagementStateRemoved,
+		ActionVerb:    "disable",
+		DryRun:        c.DryRun,
+		SkipConfirm:   c.Yes,
+	})
+}

--- a/pkg/components/commands_test.go
+++ b/pkg/components/commands_test.go
@@ -1,0 +1,69 @@
+package components_test
+
+import (
+	"bytes"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newEnableCommand() (*components.EnableCommand, *bytes.Buffer) {
+	var out bytes.Buffer
+
+	streams := genericiooptions.IOStreams{
+		In:     nil,
+		Out:    &out,
+		ErrOut: &out,
+	}
+
+	cmd := components.NewEnableCommand(streams, nil)
+	cmd.IO = iostreams.NewIOStreams(nil, &out, &out)
+
+	return cmd, &out
+}
+
+func newDisableCommand() (*components.DisableCommand, *bytes.Buffer) {
+	var out bytes.Buffer
+
+	streams := genericiooptions.IOStreams{
+		In:     nil,
+		Out:    &out,
+		ErrOut: &out,
+	}
+
+	cmd := components.NewDisableCommand(streams, nil)
+	cmd.IO = iostreams.NewIOStreams(nil, &out, &out)
+
+	return cmd, &out
+}
+
+func TestEnableCommand_Validate(t *testing.T) {
+	t.Run("requires component name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _ := newEnableCommand()
+		cmd.ComponentName = ""
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("component name is required"))
+	})
+}
+
+func TestDisableCommand_Validate(t *testing.T) {
+	t.Run("requires component name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _ := newDisableCommand()
+		cmd.ComponentName = ""
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("component name is required"))
+	})
+}

--- a/pkg/components/describe.go
+++ b/pkg/components/describe.go
@@ -1,0 +1,199 @@
+package components
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
+	printeryaml "github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+var _ cmd.Command = (*DescribeCommand)(nil)
+
+const (
+	reasonColumnWidth  = 25
+	messageColumnWidth = 50
+)
+
+// ComponentDetails holds detailed information about a component.
+type ComponentDetails struct {
+	Name            string             `json:"name"`
+	ManagementState string             `json:"managementState"`
+	Ready           *bool              `json:"ready,omitempty"`
+	Message         string             `json:"message,omitempty"`
+	Conditions      []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// DescribeCommand contains the describe subcommand configuration.
+type DescribeCommand struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+	Client      client.Client
+
+	ComponentName string
+	OutputFormat  string
+}
+
+// NewDescribeCommand creates a new DescribeCommand with defaults.
+func NewDescribeCommand(
+	streams genericiooptions.IOStreams,
+	configFlags *genericclioptions.ConfigFlags,
+) *DescribeCommand {
+	return &DescribeCommand{
+		IO:           iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags:  configFlags,
+		OutputFormat: outputFormatTable,
+	}
+}
+
+// AddFlags registers command-specific flags.
+func (c *DescribeCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+}
+
+// Complete resolves derived fields after flag parsing.
+func (c *DescribeCommand) Complete() error {
+	k8sClient, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+
+	c.Client = k8sClient
+
+	return nil
+}
+
+// Validate checks that all options are valid before execution.
+func (c *DescribeCommand) Validate() error {
+	if c.ComponentName == "" {
+		return errors.New("component name is required")
+	}
+
+	switch c.OutputFormat {
+	case outputFormatTable, outputFormatJSON, outputFormatYAML:
+	default:
+		return ErrInvalidOutputFormat(c.OutputFormat)
+	}
+
+	return nil
+}
+
+// Run executes the describe command.
+func (c *DescribeCommand) Run(ctx context.Context) error {
+	component, err := GetComponent(ctx, c.Client, c.ComponentName)
+	if err != nil {
+		return fmt.Errorf("getting component: %w", err)
+	}
+
+	details := &ComponentDetails{
+		Name:            component.Name,
+		ManagementState: component.ManagementState,
+	}
+
+	if component.IsActive() {
+		health, err := GetComponentHealth(ctx, c.Client, c.ComponentName)
+		if err != nil {
+			c.IO.Errorf("warning: could not fetch health: %v", err)
+		} else {
+			details.Ready = health.Ready
+			details.Message = health.Message
+			details.Conditions = health.Conditions
+		}
+	}
+
+	return c.renderOutput(details)
+}
+
+// renderOutput dispatches to the appropriate output formatter.
+func (c *DescribeCommand) renderOutput(details *ComponentDetails) error {
+	switch c.OutputFormat {
+	case outputFormatJSON:
+		return c.outputJSON(details)
+	case outputFormatYAML:
+		return c.outputYAML(details)
+	default:
+		return c.outputTable(details)
+	}
+}
+
+func (c *DescribeCommand) outputTable(details *ComponentDetails) error {
+	c.IO.Fprintf("Name:              %s", details.Name)
+	c.IO.Fprintf("Management State:  %s", details.ManagementState)
+
+	if details.Ready != nil {
+		ready := readyNo
+		if *details.Ready {
+			ready = readyYes
+		}
+
+		c.IO.Fprintf("Ready:             %s", ready)
+	}
+
+	if details.Message != "" {
+		c.IO.Fprintf("Message:           %s", details.Message)
+	}
+
+	if len(details.Conditions) > 0 {
+		c.IO.Fprintln()
+		c.IO.Fprintln("Conditions:")
+		c.printConditionsTable(details.Conditions)
+	}
+
+	return nil
+}
+
+func (c *DescribeCommand) printConditionsTable(conditions []metav1.Condition) {
+	c.IO.Fprintf("  %-15s %-8s %-25s %s", "TYPE", "STATUS", "REASON", "MESSAGE")
+
+	for _, cond := range conditions {
+		c.IO.Fprintf("  %-15s %-8s %-25s %s",
+			cond.Type,
+			cond.Status,
+			truncateString(cond.Reason, reasonColumnWidth),
+			truncateString(cond.Message, messageColumnWidth),
+		)
+	}
+}
+
+func truncateString(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+
+	return string(runes[:maxLen-3]) + "..."
+}
+
+func (c *DescribeCommand) outputJSON(details *ComponentDetails) error {
+	renderer := printerjson.NewRenderer[*ComponentDetails](
+		printerjson.WithWriter[*ComponentDetails](c.IO.Out()),
+	)
+
+	if err := renderer.Render(details); err != nil {
+		return fmt.Errorf("rendering JSON: %w", err)
+	}
+
+	return nil
+}
+
+func (c *DescribeCommand) outputYAML(details *ComponentDetails) error {
+	renderer := printeryaml.NewRenderer[*ComponentDetails](
+		printeryaml.WithWriter[*ComponentDetails](c.IO.Out()),
+	)
+
+	if err := renderer.Render(details); err != nil {
+		return fmt.Errorf("rendering YAML: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/components/describe_test.go
+++ b/pkg/components/describe_test.go
@@ -1,0 +1,204 @@
+package components_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newDescribeCommandTestClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.DataScienceCluster.GVR():                                     resources.DataScienceCluster.ListKind(),
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "dashboards"}: "DashboardList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "kserves"}:    "KserveList",
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newDescribeCommand(k8sClient client.Client) (*components.DescribeCommand, *bytes.Buffer) {
+	var out bytes.Buffer
+
+	streams := genericiooptions.IOStreams{
+		In:     nil,
+		Out:    &out,
+		ErrOut: &out,
+	}
+
+	cmd := components.NewDescribeCommand(streams, nil)
+	cmd.Client = k8sClient
+	cmd.IO = iostreams.NewIOStreams(nil, &out, &out)
+
+	return cmd, &out
+}
+
+func TestDescribeCommand_Validate(t *testing.T) {
+	t.Run("requires component name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _ := newDescribeCommand(nil)
+		cmd.ComponentName = ""
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("component name is required"))
+	})
+
+	t.Run("rejects invalid output format", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _ := newDescribeCommand(nil)
+		cmd.ComponentName = "dashboard"
+		cmd.OutputFormat = "csv"
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("csv"))
+	})
+}
+
+func TestDescribeCommand_Run(t *testing.T) {
+	t.Run("describes component as table", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		dashboardCR := newDashboardCR(true, "")
+		k8sClient := newDescribeCommandTestClient(dsc, dashboardCR)
+		cmd, out := newDescribeCommand(k8sClient)
+		cmd.ComponentName = "dashboard"
+		cmd.OutputFormat = "table"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("Name:"))
+		g.Expect(output).To(ContainSubstring("dashboard"))
+		g.Expect(output).To(ContainSubstring("Management State:"))
+		g.Expect(output).To(ContainSubstring("Managed"))
+		g.Expect(output).To(ContainSubstring("Ready:"))
+		g.Expect(output).To(ContainSubstring("Yes"))
+	})
+
+	t.Run("describes component as JSON", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"kserve": map[string]any{
+				"managementState": "Removed",
+			},
+		})
+
+		k8sClient := newDescribeCommandTestClient(dsc)
+		cmd, out := newDescribeCommand(k8sClient)
+		cmd.ComponentName = "kserve"
+		cmd.OutputFormat = "json"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result map[string]any
+		err = json.Unmarshal(out.Bytes(), &result)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result["name"]).To(Equal("kserve"))
+		g.Expect(result["managementState"]).To(Equal("Removed"))
+	})
+
+	t.Run("returns error for non-existent component", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		k8sClient := newDescribeCommandTestClient(dsc)
+		cmd, _ := newDescribeCommand(k8sClient)
+		cmd.ComponentName = "nonexistent"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	t.Run("includes conditions when available", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		dashboardCR := newDashboardCR(true, "All good")
+		k8sClient := newDescribeCommandTestClient(dsc, dashboardCR)
+		cmd, out := newDescribeCommand(k8sClient)
+		cmd.ComponentName = "dashboard"
+		cmd.OutputFormat = "table"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("Conditions:"))
+		g.Expect(output).To(ContainSubstring("TYPE"))
+		g.Expect(output).To(ContainSubstring("STATUS"))
+		g.Expect(output).To(ContainSubstring("Ready"))
+	})
+
+	t.Run("does not fetch health for Removed components", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"ray": map[string]any{
+				"managementState": "Removed",
+			},
+		})
+
+		k8sClient := newDescribeCommandTestClient(dsc)
+		cmd, out := newDescribeCommand(k8sClient)
+		cmd.ComponentName = "ray"
+		cmd.OutputFormat = "table"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("ray"))
+		g.Expect(output).To(ContainSubstring("Removed"))
+		g.Expect(output).ToNot(ContainSubstring("Ready:"))
+	})
+}

--- a/pkg/components/discovery.go
+++ b/pkg/components/discovery.go
@@ -1,0 +1,109 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+// DiscoverComponents dynamically reads all components from the DSC singleton.
+// It iterates over .spec.components and extracts the managementState for each.
+func DiscoverComponents(ctx context.Context, r client.Reader) ([]ComponentInfo, error) {
+	dsc, err := client.GetDataScienceCluster(ctx, r)
+	if err != nil {
+		return nil, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return ExtractComponents(dsc)
+}
+
+// ExtractComponents extracts component information from a DSC object.
+func ExtractComponents(dsc *unstructured.Unstructured) ([]ComponentInfo, error) {
+	componentsMap, err := jq.Query[map[string]any](dsc, ".spec.components")
+	if err != nil {
+		return nil, fmt.Errorf("querying spec.components: %w", err)
+	}
+
+	if componentsMap == nil {
+		return []ComponentInfo{}, nil
+	}
+
+	components := make([]ComponentInfo, 0, len(componentsMap))
+
+	for name := range componentsMap {
+		state := getManagementState(dsc, name)
+
+		components = append(components, ComponentInfo{
+			Name:            name,
+			ManagementState: state,
+		})
+	}
+
+	sort.Slice(components, func(i, j int) bool {
+		return components[i].Name < components[j].Name
+	})
+
+	return components, nil
+}
+
+// GetComponent returns information for a specific component from the DSC.
+func GetComponent(ctx context.Context, r client.Reader, name string) (*ComponentInfo, error) {
+	dsc, err := client.GetDataScienceCluster(ctx, r)
+	if err != nil {
+		return nil, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return GetComponentFromDSC(dsc, name)
+}
+
+// GetComponentFromDSC extracts component information from an already-fetched DSC.
+func GetComponentFromDSC(dsc *unstructured.Unstructured, name string) (*ComponentInfo, error) {
+	componentsMap, err := jq.Query[map[string]any](dsc, ".spec.components")
+	if err != nil {
+		return nil, fmt.Errorf("querying spec.components: %w", err)
+	}
+
+	if _, exists := componentsMap[name]; !exists {
+		return nil, ErrComponentNotFound(name, sortedKeys(componentsMap))
+	}
+
+	state := getManagementState(dsc, name)
+
+	return &ComponentInfo{
+		Name:            name,
+		ManagementState: state,
+	}, nil
+}
+
+// sortedKeys returns sorted keys from a map.
+func sortedKeys(m map[string]any) []string {
+	if m == nil {
+		return nil
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// getManagementState retrieves the managementState for a component.
+// Returns "Removed" if the component or state is not configured.
+func getManagementState(dsc *unstructured.Unstructured, componentName string) string {
+	state, found, err := unstructured.NestedString(dsc.Object, "spec", "components", componentName, "managementState")
+	if err != nil || !found || state == "" {
+		return constants.ManagementStateRemoved
+	}
+
+	return state
+}

--- a/pkg/components/discovery_test.go
+++ b/pkg/components/discovery_test.go
@@ -1,0 +1,164 @@
+package components_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoglobals // Test fixture
+var dscListKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newDSC(componentsSpec map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"spec": map[string]any{
+				"components": componentsSpec,
+			},
+		},
+	}
+}
+
+func newTestClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func TestDiscoverComponents(t *testing.T) {
+	t.Run("discovers components from DSC", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+			"kserve": map[string]any{
+				"managementState": "Removed",
+			},
+			"ray": map[string]any{
+				"managementState": "Unmanaged",
+			},
+		})
+
+		k8sClient := newTestClient(dsc)
+
+		result, err := components.DiscoverComponents(ctx, k8sClient)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(HaveLen(3))
+
+		// Results should be sorted alphabetically
+		g.Expect(result[0].Name).To(Equal("dashboard"))
+		g.Expect(result[0].ManagementState).To(Equal("Managed"))
+		g.Expect(result[1].Name).To(Equal("kserve"))
+		g.Expect(result[1].ManagementState).To(Equal("Removed"))
+		g.Expect(result[2].Name).To(Equal("ray"))
+		g.Expect(result[2].ManagementState).To(Equal("Unmanaged"))
+	})
+
+	t.Run("returns empty list when components map is empty", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{})
+
+		k8sClient := newTestClient(dsc)
+
+		result, err := components.DiscoverComponents(ctx, k8sClient)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(BeEmpty())
+	})
+
+	t.Run("defaults to Removed when managementState is missing", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{},
+		})
+
+		k8sClient := newTestClient(dsc)
+
+		result, err := components.DiscoverComponents(ctx, k8sClient)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].ManagementState).To(Equal("Removed"))
+	})
+}
+
+func TestGetComponent(t *testing.T) {
+	t.Run("returns component info for valid component", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"kserve": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		k8sClient := newTestClient(dsc)
+
+		result, err := components.GetComponent(ctx, k8sClient, "kserve")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Name).To(Equal("kserve"))
+		g.Expect(result.ManagementState).To(Equal("Managed"))
+	})
+
+	t.Run("returns error for non-existent component", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		k8sClient := newTestClient(dsc)
+
+		_, err := components.GetComponent(ctx, k8sClient, "unknown-component")
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+}
+
+func TestGetComponent_NoDSC(t *testing.T) {
+	t.Run("returns error when DSC does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.Background()
+
+		k8sClient := newTestClient()
+
+		_, err := components.GetComponent(ctx, k8sClient, "dashboard")
+
+		g.Expect(err).To(HaveOccurred())
+	})
+}

--- a/pkg/components/errors_test.go
+++ b/pkg/components/errors_test.go
@@ -1,0 +1,54 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestErrComponentNotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	available := []string{"dashboard", "kserve", "ray"}
+	err := components.ErrComponentNotFound("unknown", available)
+
+	g.Expect(err).To(BeAssignableToTypeOf(&clierrors.StructuredError{}))
+	g.Expect(err.Code).To(Equal("COMPONENT_NOT_FOUND"))
+	g.Expect(err.Message).To(ContainSubstring("unknown"))
+	g.Expect(err.Category).To(Equal(clierrors.CategoryNotFound))
+	g.Expect(err.Retriable).To(BeFalse())
+	g.Expect(err.Suggestion).To(ContainSubstring("dashboard"))
+	g.Expect(err.Suggestion).To(ContainSubstring("kserve"))
+	g.Expect(err.Suggestion).To(ContainSubstring("ray"))
+}
+
+func TestErrInvalidOutputFormat(t *testing.T) {
+	g := NewWithT(t)
+
+	err := components.ErrInvalidOutputFormat("xml")
+
+	g.Expect(err).To(BeAssignableToTypeOf(&clierrors.StructuredError{}))
+	g.Expect(err.Code).To(Equal("INVALID_OUTPUT_FORMAT"))
+	g.Expect(err.Message).To(ContainSubstring("xml"))
+	g.Expect(err.Category).To(Equal(clierrors.CategoryValidation))
+	g.Expect(err.Retriable).To(BeFalse())
+	g.Expect(err.Suggestion).To(ContainSubstring("table"))
+	g.Expect(err.Suggestion).To(ContainSubstring("json"))
+	g.Expect(err.Suggestion).To(ContainSubstring("yaml"))
+}
+
+func TestErrUserAborted(t *testing.T) {
+	g := NewWithT(t)
+
+	err := components.ErrUserAborted()
+
+	g.Expect(err).To(BeAssignableToTypeOf(&clierrors.StructuredError{}))
+	g.Expect(err.Code).To(Equal("USER_ABORTED"))
+	g.Expect(err.Message).To(ContainSubstring("aborted"))
+	g.Expect(err.Category).To(Equal(clierrors.CategoryValidation))
+	g.Expect(err.Retriable).To(BeFalse())
+	g.Expect(err.Suggestion).To(ContainSubstring("--yes"))
+}

--- a/pkg/components/health.go
+++ b/pkg/components/health.go
@@ -1,0 +1,113 @@
+package components
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/conditions"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+// HealthInfo contains health status extracted from a component CR.
+type HealthInfo struct {
+	Ready      *bool
+	Message    string
+	Conditions []metav1.Condition
+}
+
+// EnrichWithHealth adds health information to components by querying component CRs.
+// Health fetches run in parallel for better performance with many active components.
+// If the component CR API is unavailable (older ODH), Ready will be nil.
+func EnrichWithHealth(ctx context.Context, r client.Reader, components []ComponentInfo) []ComponentInfo {
+	enriched := make([]ComponentInfo, len(components))
+	copy(enriched, components)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	for i := range enriched {
+		if !enriched[i].IsActive() {
+			continue
+		}
+
+		g.Go(func() error {
+			health, err := GetComponentHealth(ctx, r, enriched[i].Name)
+			if err != nil {
+				if client.IsResourceTypeNotFound(err) {
+					return nil
+				}
+
+				enriched[i].Message = err.Error()
+
+				return nil
+			}
+
+			enriched[i].Ready = health.Ready
+			enriched[i].Message = health.Message
+
+			return nil
+		})
+	}
+
+	_ = g.Wait() // Errors are handled per-component, not propagated
+
+	return enriched
+}
+
+// GetComponentHealth retrieves health information for a specific component.
+func GetComponentHealth(ctx context.Context, r client.Reader, name string) (*HealthInfo, error) {
+	rt := resources.GetComponentCR(name)
+	if rt == nil {
+		return nil, fmt.Errorf("unknown component CR for %q", name)
+	}
+
+	items, err := r.List(ctx, *rt)
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			return nil, fmt.Errorf("component CR API unavailable: %w", err)
+		}
+
+		return nil, fmt.Errorf("listing component CR: %w", err)
+	}
+
+	if len(items) == 0 {
+		return &HealthInfo{}, nil
+	}
+
+	return extractHealthFromCR(items[0])
+}
+
+// extractHealthFromCR parses health info from a component CR's status.
+func extractHealthFromCR(cr *unstructured.Unstructured) (*HealthInfo, error) {
+	health := &HealthInfo{}
+
+	conds, err := jq.Query[[]metav1.Condition](cr, ".status.conditions // []")
+	if err != nil && !errors.Is(err, jq.ErrNotFound) {
+		return nil, fmt.Errorf("querying conditions: %w", err)
+	}
+
+	health.Conditions = conds
+
+	ready := conditions.FindReady(conds)
+	if ready != nil {
+		isReady := ready.Status == metav1.ConditionTrue
+		health.Ready = &isReady
+
+		if !isReady && ready.Message != "" {
+			health.Message = ready.Message
+		}
+	}
+
+	if health.Message == "" {
+		health.Message = conditions.CollectDegradedMessages(conds)
+	}
+
+	return health, nil
+}

--- a/pkg/components/health_test.go
+++ b/pkg/components/health_test.go
@@ -1,0 +1,179 @@
+package components_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+const componentCRGroup = "components.platform.opendatahub.io"
+
+func newDashboardCR(ready bool, message string) *unstructured.Unstructured {
+	conditions := []any{
+		map[string]any{
+			"type":    "Ready",
+			"status":  boolToConditionStatus(ready),
+			"reason":  "ComponentReady",
+			"message": message,
+		},
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": componentCRGroup + "/v1alpha1",
+			"kind":       "Dashboard",
+			"metadata": map[string]any{
+				"name": "default",
+			},
+			"status": map[string]any{
+				"conditions": conditions,
+			},
+		},
+	}
+}
+
+func boolToConditionStatus(b bool) string {
+	if b {
+		return string(metav1.ConditionTrue)
+	}
+
+	return string(metav1.ConditionFalse)
+}
+
+func newHealthTestClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.DataScienceCluster.GVR():                                     resources.DataScienceCluster.ListKind(),
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "dashboards"}: "DashboardList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "kserves"}:    "KserveList",
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func TestEnrichWithHealth(t *testing.T) {
+	t.Run("enriches active components with health info", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dashboardCR := newDashboardCR(true, "")
+		k8sClient := newHealthTestClient(dashboardCR)
+
+		comps := []components.ComponentInfo{
+			{Name: "dashboard", ManagementState: "Managed"},
+		}
+
+		result := components.EnrichWithHealth(ctx, k8sClient, comps)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].Ready).ToNot(BeNil())
+		g.Expect(*result[0].Ready).To(BeTrue())
+	})
+
+	t.Run("skips health enrichment for Removed components", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		k8sClient := newHealthTestClient()
+
+		comps := []components.ComponentInfo{
+			{Name: "dashboard", ManagementState: "Removed"},
+		}
+
+		result := components.EnrichWithHealth(ctx, k8sClient, comps)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].Ready).To(BeNil())
+	})
+
+	t.Run("preserves original slice when enrichment fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// No CR exists, so health fetch will fail gracefully
+		k8sClient := newHealthTestClient()
+
+		comps := []components.ComponentInfo{
+			{Name: "dashboard", ManagementState: "Managed"},
+		}
+
+		result := components.EnrichWithHealth(ctx, k8sClient, comps)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].Name).To(Equal("dashboard"))
+		g.Expect(result[0].Ready).To(BeNil())
+		g.Expect(result[0].Message).To(BeEmpty())
+	})
+}
+
+func TestGetComponentHealth(t *testing.T) {
+	t.Run("returns health info for known component", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dashboardCR := newDashboardCR(true, "All systems operational")
+		k8sClient := newHealthTestClient(dashboardCR)
+
+		health, err := components.GetComponentHealth(ctx, k8sClient, "dashboard")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(health).ToNot(BeNil())
+		g.Expect(health.Ready).ToNot(BeNil())
+		g.Expect(*health.Ready).To(BeTrue())
+	})
+
+	t.Run("returns not ready with message", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dashboardCR := newDashboardCR(false, "Deployment pending")
+		k8sClient := newHealthTestClient(dashboardCR)
+
+		health, err := components.GetComponentHealth(ctx, k8sClient, "dashboard")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(health.Ready).ToNot(BeNil())
+		g.Expect(*health.Ready).To(BeFalse())
+		g.Expect(health.Message).To(Equal("Deployment pending"))
+	})
+
+	t.Run("returns error for unknown component", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		k8sClient := newHealthTestClient()
+
+		_, err := components.GetComponentHealth(ctx, k8sClient, "unknown-component")
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unknown component CR"))
+	})
+
+	t.Run("returns empty health when no CR instances exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		k8sClient := newHealthTestClient()
+
+		health, err := components.GetComponentHealth(ctx, k8sClient, "dashboard")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(health).ToNot(BeNil())
+		g.Expect(health.Ready).To(BeNil())
+	})
+}

--- a/pkg/components/list.go
+++ b/pkg/components/list.go
@@ -1,0 +1,204 @@
+package components
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
+	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
+	printeryaml "github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+var _ cmd.Command = (*ListCommand)(nil)
+
+const (
+	outputFormatTable = "table"
+	outputFormatJSON  = "json"
+	outputFormatYAML  = "yaml"
+)
+
+const (
+	colName  = "NAME"
+	colState = "STATE"
+	colReady = "READY"
+	colMsg   = "MESSAGE"
+)
+
+// ListCommand contains the components list command configuration.
+type ListCommand struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+	Client      client.Client
+
+	OutputFormat string
+}
+
+// NewListCommand creates a new ListCommand with defaults.
+func NewListCommand(
+	streams genericiooptions.IOStreams,
+	configFlags *genericclioptions.ConfigFlags,
+) *ListCommand {
+	return &ListCommand{
+		IO:           iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags:  configFlags,
+		OutputFormat: outputFormatTable,
+	}
+}
+
+// AddFlags registers command-specific flags.
+func (c *ListCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+}
+
+// Complete resolves derived fields after flag parsing.
+func (c *ListCommand) Complete() error {
+	k8sClient, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf("creating Kubernetes client: %w", err)
+	}
+
+	c.Client = k8sClient
+
+	return nil
+}
+
+// Validate checks that all options are valid before execution.
+func (c *ListCommand) Validate() error {
+	switch c.OutputFormat {
+	case outputFormatTable, outputFormatJSON, outputFormatYAML:
+	default:
+		return ErrInvalidOutputFormat(c.OutputFormat)
+	}
+
+	return nil
+}
+
+// Run executes the components list command.
+func (c *ListCommand) Run(ctx context.Context) error {
+	components, err := DiscoverComponents(ctx, c.Client)
+	if err != nil {
+		return fmt.Errorf("discovering components: %w", err)
+	}
+
+	components = EnrichWithHealth(ctx, c.Client, components)
+
+	return c.renderOutput(components)
+}
+
+// renderOutput dispatches to the appropriate output formatter.
+func (c *ListCommand) renderOutput(components []ComponentInfo) error {
+	switch c.OutputFormat {
+	case outputFormatJSON:
+		return OutputJSON(c.IO.Out(), components)
+	case outputFormatYAML:
+		return OutputYAML(c.IO.Out(), components)
+	default:
+		return OutputTable(c.IO.Out(), components)
+	}
+}
+
+// readyFormatter converts Ready bool pointer to display string.
+func readyFormatter(value any) any {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			return readyYes
+		}
+
+		return readyNo
+	case *bool:
+		if v == nil {
+			return "-"
+		}
+
+		if *v {
+			return readyYes
+		}
+
+		return readyNo
+	case nil:
+		return "-"
+	default:
+		return readyUnknown
+	}
+}
+
+// componentColumns returns the base table columns for component list.
+func componentColumns() []table.Column {
+	return []table.Column{
+		table.NewColumn(colName).JQ(".name"),
+		table.NewColumn(colState).JQ(".managementState"),
+		table.NewColumn(colReady).JQ(".ready").Fn(readyFormatter),
+	}
+}
+
+// messageColumn returns the optional message column.
+func messageColumn() table.Column {
+	return table.NewColumn(colMsg).JQ(`.message // ""`)
+}
+
+// OutputTable renders components as a formatted table.
+func OutputTable(w io.Writer, components []ComponentInfo) error {
+	columns := componentColumns()
+
+	for _, c := range components {
+		if c.Message != "" {
+			columns = append(columns, messageColumn())
+
+			break
+		}
+	}
+
+	renderer := table.NewWithColumns[ComponentInfo](w, columns...)
+
+	for _, c := range components {
+		if err := renderer.Append(c); err != nil {
+			return fmt.Errorf("rendering row: %w", err)
+		}
+	}
+
+	if err := renderer.Render(); err != nil {
+		return fmt.Errorf("rendering table: %w", err)
+	}
+
+	return nil
+}
+
+// OutputJSON renders components as JSON.
+func OutputJSON(w io.Writer, components []ComponentInfo) error {
+	output := ComponentList{Components: components}
+
+	renderer := printerjson.NewRenderer[ComponentList](
+		printerjson.WithWriter[ComponentList](w),
+	)
+
+	if err := renderer.Render(output); err != nil {
+		return fmt.Errorf("rendering JSON: %w", err)
+	}
+
+	return nil
+}
+
+// OutputYAML renders components as YAML.
+func OutputYAML(w io.Writer, components []ComponentInfo) error {
+	output := ComponentList{Components: components}
+
+	renderer := printeryaml.NewRenderer[ComponentList](
+		printeryaml.WithWriter[ComponentList](w),
+	)
+
+	if err := renderer.Render(output); err != nil {
+		return fmt.Errorf("rendering YAML: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/components/list_test.go
+++ b/pkg/components/list_test.go
@@ -1,0 +1,311 @@
+package components_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newListCommandTestClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.DataScienceCluster.GVR():                                               resources.DataScienceCluster.ListKind(),
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "dashboards"}:           "DashboardList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "kserves"}:              "KserveList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "rays"}:                 "RayList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "workbenches"}:          "WorkbenchesList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "trustyais"}:            "TrustyAIList",
+		{Group: componentCRGroup, Version: "v1alpha1", Resource: "datasciencepipelines"}: "DataSciencePipelinesList",
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newListCommand(k8sClient client.Client) (*components.ListCommand, *bytes.Buffer) {
+	var out bytes.Buffer
+
+	streams := genericiooptions.IOStreams{
+		In:     nil,
+		Out:    &out,
+		ErrOut: &out,
+	}
+
+	cmd := components.NewListCommand(streams, nil)
+	cmd.Client = k8sClient
+	cmd.IO = iostreams.NewIOStreams(nil, &out, &out)
+
+	return cmd, &out
+}
+
+func TestListCommand_Validate(t *testing.T) {
+	t.Run("rejects invalid output format", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _ := newListCommand(nil)
+		cmd.OutputFormat = "xml"
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("xml"))
+	})
+}
+
+func TestListCommand_Run(t *testing.T) {
+	t.Run("lists components as table", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+			"kserve": map[string]any{
+				"managementState": "Removed",
+			},
+		})
+
+		k8sClient := newListCommandTestClient(dsc)
+		cmd, out := newListCommand(k8sClient)
+		cmd.OutputFormat = "table"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("NAME"))
+		g.Expect(output).To(ContainSubstring("STATE"))
+		g.Expect(output).To(ContainSubstring("dashboard"))
+		g.Expect(output).To(ContainSubstring("Managed"))
+		g.Expect(output).To(ContainSubstring("kserve"))
+		g.Expect(output).To(ContainSubstring("Removed"))
+	})
+
+	t.Run("lists components as JSON", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"ray": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		k8sClient := newListCommandTestClient(dsc)
+		cmd, out := newListCommand(k8sClient)
+		cmd.OutputFormat = "json"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring(`"components"`))
+		g.Expect(output).To(ContainSubstring(`"name"`))
+		g.Expect(output).To(ContainSubstring(`"ray"`))
+	})
+
+	t.Run("lists components as YAML", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"workbenches": map[string]any{
+				"managementState": "Unmanaged",
+			},
+		})
+
+		k8sClient := newListCommandTestClient(dsc)
+		cmd, out := newListCommand(k8sClient)
+		cmd.OutputFormat = "yaml"
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("components:"))
+		g.Expect(output).To(ContainSubstring("workbenches"))
+		g.Expect(output).To(ContainSubstring("Unmanaged"))
+	})
+}
+
+func TestListCommand_RunWithHealth(t *testing.T) {
+	t.Run("enriches managed components with health info", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		dashboardCR := newDashboardCR(true, "")
+		k8sClient := newListCommandTestClient(dsc, dashboardCR)
+		cmd, out := newListCommand(k8sClient)
+
+		err := cmd.Run(ctx)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("dashboard"))
+		g.Expect(output).To(ContainSubstring("Yes"))
+	})
+}
+
+// --- Output function tests ---
+
+func TestOutputTable(t *testing.T) {
+	t.Run("shows MESSAGE column when components have messages", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		ready := true
+		notReady := false
+
+		comps := []components.ComponentInfo{
+			{Name: "dashboard", ManagementState: "Managed", Ready: &ready},
+			{Name: "ray", ManagementState: "Managed", Ready: &notReady, Message: "Degraded"},
+		}
+
+		err := components.OutputTable(&buf, comps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		g.Expect(output).To(ContainSubstring("NAME"))
+		g.Expect(output).To(ContainSubstring("STATE"))
+		g.Expect(output).To(ContainSubstring("READY"))
+		g.Expect(output).To(ContainSubstring("MESSAGE"))
+		g.Expect(output).To(ContainSubstring("Degraded"))
+	})
+
+	t.Run("hides MESSAGE column when no components have messages", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		ready := true
+
+		comps := []components.ComponentInfo{
+			{Name: "dashboard", ManagementState: "Managed", Ready: &ready},
+			{Name: "kserve", ManagementState: "Removed", Ready: nil},
+		}
+
+		err := components.OutputTable(&buf, comps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		g.Expect(output).To(ContainSubstring("NAME"))
+		g.Expect(output).To(ContainSubstring("STATE"))
+		g.Expect(output).To(ContainSubstring("READY"))
+		g.Expect(output).ToNot(ContainSubstring("MESSAGE"))
+	})
+}
+
+func TestOutputJSON(t *testing.T) {
+	t.Run("renders components as valid JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		ready := true
+
+		comps := []components.ComponentInfo{
+			{Name: "dashboard", ManagementState: "Managed", Ready: &ready},
+			{Name: "kserve", ManagementState: "Removed"},
+		}
+
+		err := components.OutputJSON(&buf, comps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result map[string]any
+		err = json.Unmarshal(buf.Bytes(), &result)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(result).To(HaveKey("components"))
+
+		compList, ok := result["components"].([]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(compList).To(HaveLen(2))
+
+		first := compList[0].(map[string]any)
+		g.Expect(first["name"]).To(Equal("dashboard"))
+		g.Expect(first["managementState"]).To(Equal("Managed"))
+		g.Expect(first["ready"]).To(BeTrue())
+	})
+
+	t.Run("omits nil ready field", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+
+		comps := []components.ComponentInfo{
+			{Name: "kserve", ManagementState: "Removed"},
+		}
+
+		err := components.OutputJSON(&buf, comps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result map[string]any
+		err = json.Unmarshal(buf.Bytes(), &result)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		compList := result["components"].([]any)
+		first := compList[0].(map[string]any)
+		g.Expect(first).ToNot(HaveKey("ready"))
+	})
+}
+
+func TestOutputYAML(t *testing.T) {
+	t.Run("renders components as valid YAML", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		ready := false
+
+		comps := []components.ComponentInfo{
+			{Name: "ray", ManagementState: "Unmanaged", Ready: &ready, Message: "Not ready"},
+		}
+
+		err := components.OutputYAML(&buf, comps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result map[string]any
+		err = yaml.Unmarshal(buf.Bytes(), &result)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(result).To(HaveKey("components"))
+
+		compList := result["components"].([]any)
+		g.Expect(compList).To(HaveLen(1))
+
+		first := compList[0].(map[string]any)
+		g.Expect(first["name"]).To(Equal("ray"))
+		g.Expect(first["managementState"]).To(Equal("Unmanaged"))
+		g.Expect(first["ready"]).To(BeFalse())
+		g.Expect(first["message"]).To(Equal("Not ready"))
+	})
+}

--- a/pkg/components/mutate.go
+++ b/pkg/components/mutate.go
@@ -1,0 +1,100 @@
+package components
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+// MutateConfig holds common configuration for component state mutations.
+type MutateConfig struct {
+	IO            iostreams.Interface
+	Client        client.Client
+	ComponentName string
+	TargetState   string
+	ActionVerb    string
+	DryRun        bool
+	SkipConfirm   bool
+}
+
+// MutateComponentState changes a component's managementState.
+func MutateComponentState(ctx context.Context, cfg MutateConfig) error {
+	dsc, err := client.GetDataScienceCluster(ctx, cfg.Client)
+	if err != nil {
+		return fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	component, err := GetComponentFromDSC(dsc, cfg.ComponentName)
+	if err != nil {
+		return fmt.Errorf("getting component: %w", err)
+	}
+
+	if component.ManagementState == cfg.TargetState {
+		cfg.IO.Fprintf("Component '%s' is already %sd (%s)", cfg.ComponentName, cfg.ActionVerb, cfg.TargetState)
+
+		return nil
+	}
+
+	patch := buildComponentPatch(cfg.ComponentName, cfg.TargetState)
+
+	patchBytes, err := json.MarshalIndent(patch, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	if !cfg.SkipConfirm && !cfg.DryRun {
+		prompt := fmt.Sprintf("Are you sure you want to %s component '%s'?", cfg.ActionVerb, cfg.ComponentName)
+		if !confirmation.Prompt(cfg.IO, prompt) {
+			return ErrUserAborted()
+		}
+	}
+
+	opts := []client.PatchOption{}
+	if cfg.DryRun {
+		opts = append(opts, client.WithDryRun())
+		cfg.IO.Fprintln("DRY RUN: Validating patch against API server...")
+		cfg.IO.Fprintln()
+		cfg.IO.Fprintf("%s", string(patchBytes))
+		cfg.IO.Fprintln()
+	}
+
+	_, err = cfg.Client.Patch(
+		ctx,
+		resources.DataScienceCluster,
+		dsc.GetName(),
+		types.MergePatchType,
+		patchBytes,
+		opts...,
+	)
+	if err != nil {
+		return fmt.Errorf("patching DataScienceCluster: %w", err)
+	}
+
+	if cfg.DryRun {
+		cfg.IO.Fprintf("DRY RUN: Patch validated successfully. No changes made.")
+	} else {
+		cfg.IO.Fprintf("Component '%s' %sd successfully (managementState: %s)", cfg.ComponentName, cfg.ActionVerb, cfg.TargetState)
+	}
+
+	return nil
+}
+
+// buildComponentPatch creates a merge patch for changing component managementState.
+func buildComponentPatch(componentName, state string) map[string]any {
+	return map[string]any{
+		"spec": map[string]any{
+			"components": map[string]any{
+				componentName: map[string]any{
+					"managementState": state,
+				},
+			},
+		},
+	}
+}

--- a/pkg/components/mutate_test.go
+++ b/pkg/components/mutate_test.go
@@ -1,0 +1,247 @@
+package components_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newMutateTestClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newMutateTestClientWithTracker(objects ...runtime.Object) (client.Client, *dynamicfake.FakeDynamicClient) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	}), dynamicClient
+}
+
+func TestMutateComponentState(t *testing.T) {
+	t.Run("mutates component state successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"ray": map[string]any{
+				"managementState": "Removed",
+			},
+		})
+
+		var out bytes.Buffer
+		k8sClient := newMutateTestClient(dsc)
+
+		cfg := components.MutateConfig{
+			IO:            iostreams.NewIOStreams(nil, &out, &out),
+			Client:        k8sClient,
+			ComponentName: "ray",
+			TargetState:   "Managed",
+			ActionVerb:    "enable",
+			SkipConfirm:   true,
+		}
+
+		err := components.MutateComponentState(ctx, cfg)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("ray"))
+		g.Expect(output).To(ContainSubstring("enabled successfully"))
+	})
+
+	t.Run("reports no-op when already in target state", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		var out bytes.Buffer
+		k8sClient := newMutateTestClient(dsc)
+
+		cfg := components.MutateConfig{
+			IO:            iostreams.NewIOStreams(nil, &out, &out),
+			Client:        k8sClient,
+			ComponentName: "dashboard",
+			TargetState:   "Managed",
+			ActionVerb:    "enable",
+			SkipConfirm:   true,
+		}
+
+		err := components.MutateComponentState(ctx, cfg)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("already enabled"))
+	})
+
+	t.Run("dry-run shows patch without applying", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"trustyai": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		var out bytes.Buffer
+		k8sClient, fakeClient := newMutateTestClientWithTracker(dsc)
+
+		cfg := components.MutateConfig{
+			IO:            iostreams.NewIOStreams(nil, &out, &out),
+			Client:        k8sClient,
+			ComponentName: "trustyai",
+			TargetState:   "Removed",
+			ActionVerb:    "disable",
+			DryRun:        true,
+		}
+
+		err := components.MutateComponentState(ctx, cfg)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("DRY RUN"))
+		g.Expect(output).To(ContainSubstring("trustyai"))
+		g.Expect(output).To(ContainSubstring("managementState"))
+		g.Expect(output).To(ContainSubstring("Removed"))
+		g.Expect(output).To(ContainSubstring("No changes made"))
+
+		// Verify dry-run option was passed to the API
+		actions := fakeClient.Actions()
+		var patchAction k8stesting.PatchActionImpl
+		for _, action := range actions {
+			if pa, ok := action.(k8stesting.PatchActionImpl); ok {
+				patchAction = pa
+
+				break
+			}
+		}
+		g.Expect(patchAction.Name).ToNot(BeEmpty(), "expected a patch action")
+		g.Expect(patchAction.GetPatchType()).To(Equal(types.MergePatchType))
+		// Verify DryRun option was set
+		patchOpts := patchAction.GetPatchOptions()
+		g.Expect(patchOpts.DryRun).To(ContainElement("All"), "dry-run option should be passed to API")
+	})
+
+	t.Run("returns error when user aborts confirmation", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"ray": map[string]any{
+				"managementState": "Removed",
+			},
+		})
+
+		var out bytes.Buffer
+		in := strings.NewReader("n\n")
+		k8sClient := newMutateTestClient(dsc)
+
+		cfg := components.MutateConfig{
+			IO:            iostreams.NewIOStreams(in, &out, &out),
+			Client:        k8sClient,
+			ComponentName: "ray",
+			TargetState:   "Managed",
+			ActionVerb:    "enable",
+			SkipConfirm:   false,
+		}
+
+		err := components.MutateComponentState(ctx, cfg)
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("aborted"))
+	})
+
+	t.Run("proceeds when user confirms", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"ray": map[string]any{
+				"managementState": "Removed",
+			},
+		})
+
+		var out bytes.Buffer
+		in := strings.NewReader("y\n")
+		k8sClient := newMutateTestClient(dsc)
+
+		cfg := components.MutateConfig{
+			IO:            iostreams.NewIOStreams(in, &out, &out),
+			Client:        k8sClient,
+			ComponentName: "ray",
+			TargetState:   "Managed",
+			ActionVerb:    "enable",
+			SkipConfirm:   false,
+		}
+
+		err := components.MutateComponentState(ctx, cfg)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := out.String()
+		g.Expect(output).To(ContainSubstring("enabled successfully"))
+	})
+
+	t.Run("returns error for non-existent component", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := newDSC(map[string]any{
+			"dashboard": map[string]any{
+				"managementState": "Managed",
+			},
+		})
+
+		var out bytes.Buffer
+		k8sClient := newMutateTestClient(dsc)
+
+		cfg := components.MutateConfig{
+			IO:            iostreams.NewIOStreams(nil, &out, &out),
+			Client:        k8sClient,
+			ComponentName: "nonexistent",
+			TargetState:   "Managed",
+			ActionVerb:    "enable",
+			SkipConfirm:   true,
+		}
+
+		err := components.MutateComponentState(ctx, cfg)
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+}

--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -1,0 +1,69 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	readyYes     = "Yes"
+	readyNo      = "No"
+	readyUnknown = "?"
+)
+
+// ComponentInfo holds the state and health information for a DSC component.
+type ComponentInfo struct {
+	Name            string `json:"name"`
+	ManagementState string `json:"managementState"`
+	Ready           *bool  `json:"ready,omitempty"`
+	Message         string `json:"message,omitempty"`
+}
+
+// ComponentList wraps a slice of ComponentInfo for JSON/YAML output.
+type ComponentList struct {
+	Components []ComponentInfo `json:"components"`
+}
+
+// IsActive returns true if the component is Managed or Unmanaged (not Removed).
+func (c ComponentInfo) IsActive() bool {
+	return c.ManagementState == constants.ManagementStateManaged ||
+		c.ManagementState == constants.ManagementStateUnmanaged
+}
+
+// ErrComponentNotFound creates a structured error for unknown components.
+func ErrComponentNotFound(name string, available []string) *clierrors.StructuredError {
+	suggestion := "Available components: " + strings.Join(available, ", ")
+
+	return &clierrors.StructuredError{
+		Code:       "COMPONENT_NOT_FOUND",
+		Message:    fmt.Sprintf("component %q not found in DataScienceCluster", name),
+		Category:   clierrors.CategoryNotFound,
+		Retriable:  false,
+		Suggestion: suggestion,
+	}
+}
+
+// ErrInvalidOutputFormat creates a structured error for invalid output formats.
+func ErrInvalidOutputFormat(format string) *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       "INVALID_OUTPUT_FORMAT",
+		Message:    fmt.Sprintf("invalid output format %q (must be one of: table, json, yaml)", format),
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: "Use --output with one of: table, json, yaml",
+	}
+}
+
+// ErrUserAborted creates a structured error when user cancels an operation.
+func ErrUserAborted() *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       "USER_ABORTED",
+		Message:    "aborted by user",
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: "Use --yes flag to skip confirmation",
+	}
+}

--- a/pkg/resources/component_crs.go
+++ b/pkg/resources/component_crs.go
@@ -1,0 +1,45 @@
+package resources
+
+const componentCRGroup = "components.platform.opendatahub.io"
+
+// ComponentCRResourceTypes maps DSC component names to their corresponding
+// component CR resource types from the components.platform.opendatahub.io API group.
+// These CRs are v1alpha1 and may not exist on older ODH versions.
+//
+//nolint:gochecknoglobals // Component CR mapping is static configuration
+var ComponentCRResourceTypes = map[string]ResourceType{
+	// DSC v2 component names
+	"aipipelines":        newComponentCR("datasciencepipelines", "DataSciencePipelines"),
+	"dashboard":          newComponentCR("dashboards", "Dashboard"),
+	"feastoperator":      newComponentCR("feastoperators", "FeastOperator"),
+	"kserve":             newComponentCR("kserves", "Kserve"),
+	"llamastackoperator": newComponentCR("llamastackoperators", "LlamaStackOperator"),
+	"mlflowoperator":     newComponentCR("mlflowoperators", "MLflowOperator"),
+	"modelregistry":      newComponentCR("modelregistries", "ModelRegistry"),
+	"ray":                newComponentCR("rays", "Ray"),
+	"sparkoperator":      newComponentCR("sparkoperators", "SparkOperator"),
+	"trainer":            newComponentCR("trainers", "Trainer"),
+	"trainingoperator":   newComponentCR("trainingoperators", "TrainingOperator"),
+	"trustyai":           newComponentCR("trustyais", "TrustyAI"),
+	"workbenches":        newComponentCR("workbenches", "Workbenches"),
+}
+
+func newComponentCR(resource, kind string) ResourceType {
+	return ResourceType{
+		Group:    componentCRGroup,
+		Version:  "v1alpha1",
+		Kind:     kind,
+		Resource: resource,
+	}
+}
+
+// GetComponentCR returns the ResourceType for a component CR by name.
+// Returns nil if the component is not found.
+func GetComponentCR(name string) *ResourceType {
+	rt, ok := ComponentCRResourceTypes[name]
+	if !ok {
+		return nil
+	}
+
+	return &rt
+}

--- a/pkg/resources/component_crs_test.go
+++ b/pkg/resources/component_crs_test.go
@@ -1,0 +1,104 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+func TestComponentCRResourceTypes(t *testing.T) {
+	expectedComponents := []string{
+		"aipipelines",
+		"dashboard",
+		"feastoperator",
+		"kserve",
+		"llamastackoperator",
+		"mlflowoperator",
+		"modelregistry",
+		"ray",
+		"sparkoperator",
+		"trainer",
+		"trainingoperator",
+		"trustyai",
+		"workbenches",
+	}
+
+	for _, name := range expectedComponents {
+		t.Run(name, func(t *testing.T) {
+			rt, ok := resources.ComponentCRResourceTypes[name]
+			if !ok {
+				t.Fatalf("component %q not found in ComponentCRResourceTypes", name)
+			}
+
+			if rt.Group != "components.platform.opendatahub.io" {
+				t.Errorf("group = %q, want components.platform.opendatahub.io", rt.Group)
+			}
+
+			if rt.Version != "v1alpha1" {
+				t.Errorf("version = %q, want v1alpha1", rt.Version)
+			}
+
+			if rt.Kind == "" {
+				t.Error("kind should not be empty")
+			}
+
+			if rt.Resource == "" {
+				t.Error("resource should not be empty")
+			}
+		})
+	}
+}
+
+func TestGetComponentCR(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		wantNil   bool
+		wantKind  string
+	}{
+		{
+			name:      "returns ResourceType for known component",
+			component: "kserve",
+			wantNil:   false,
+			wantKind:  "Kserve",
+		},
+		{
+			name:      "returns ResourceType for dashboard",
+			component: "dashboard",
+			wantNil:   false,
+			wantKind:  "Dashboard",
+		},
+		{
+			name:      "returns nil for unknown component",
+			component: "unknown",
+			wantNil:   true,
+		},
+		{
+			name:      "returns nil for empty string",
+			component: "",
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resources.GetComponentCR(tt.component)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+
+				return
+			}
+
+			if got == nil {
+				t.Fatal("expected non-nil ResourceType")
+			}
+
+			if got.Kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", got.Kind, tt.wantKind)
+			}
+		})
+	}
+}

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -80,14 +80,14 @@ var (
 	// DataScienceCluster is the OpenShift AI DataScienceCluster resource.
 	DataScienceCluster = ResourceType{
 		Group:    "datasciencecluster.opendatahub.io",
-		Version:  "v1",
+		Version:  "v2",
 		Kind:     "DataScienceCluster",
 		Resource: "datascienceclusters",
 	}
 
 	DSCInitialization = ResourceType{
 		Group:    "dscinitialization.opendatahub.io",
-		Version:  "v1",
+		Version:  "v2",
 		Kind:     "DSCInitialization",
 		Resource: "dscinitializations",
 	}

--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -1,12 +1,17 @@
 package client
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	olmclientset "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
@@ -14,6 +19,9 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util"
 )
 
 // Compile-time verification that defaultClient implements Client (and therefore Reader + Writer).
@@ -122,4 +130,43 @@ func NewDiscoveryClient(configFlags *genericclioptions.ConfigFlags) (discovery.D
 	}
 
 	return discoveryClient, nil
+}
+
+// Patch applies a patch to an existing cluster-scoped resource.
+func (c *defaultClient) Patch(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	name string,
+	patchType types.PatchType,
+	data []byte,
+	opts ...PatchOption,
+) (*unstructured.Unstructured, error) {
+	if name == "" {
+		return nil, errors.New("resource name cannot be empty")
+	}
+
+	if len(data) == 0 {
+		return nil, errors.New("patch data cannot be empty")
+	}
+
+	cfg := &PatchConfig{}
+	util.ApplyOptions(cfg, opts...)
+
+	patchOpts := metav1.PatchOptions{}
+	if cfg.DryRun {
+		patchOpts.DryRun = []string{metav1.DryRunAll}
+	}
+
+	if cfg.FieldOwner != "" {
+		patchOpts.FieldManager = cfg.FieldOwner
+	}
+
+	gvr := resourceType.GVR()
+
+	result, err := c.dynamic.Resource(gvr).Patch(ctx, name, patchType, data, patchOpts)
+	if err != nil {
+		return nil, fmt.Errorf("patching resource: %w", err)
+	}
+
+	return result, nil
 }

--- a/pkg/util/client/helpers.go
+++ b/pkg/util/client/helpers.go
@@ -503,3 +503,26 @@ func isCRDEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
 
 	return false
 }
+
+// PatchConfig holds options for customizing Patch operations.
+type PatchConfig struct {
+	DryRun     bool
+	FieldOwner string
+}
+
+// PatchOption is a functional option for configuring Patch operations.
+type PatchOption = util.Option[PatchConfig]
+
+// WithDryRun enables dry-run mode for the patch operation.
+func WithDryRun() PatchOption {
+	return util.FunctionalOption[PatchConfig](func(c *PatchConfig) {
+		c.DryRun = true
+	})
+}
+
+// WithFieldOwner sets the field owner for server-side apply.
+func WithFieldOwner(owner string) PatchOption {
+	return util.FunctionalOption[PatchConfig](func(c *PatchConfig) {
+		c.FieldOwner = owner
+	})
+}

--- a/pkg/util/client/helpers_test.go
+++ b/pkg/util/client/helpers_test.go
@@ -380,8 +380,8 @@ func TestListMetadata_NamespaceScoped(t *testing.T) {
 func createDSCInitialization(applicationsNamespace string) runtime.Object {
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": "dscinitialization.opendatahub.io/v1",
-			"kind":       "DSCInitialization",
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
 			"metadata": map[string]any{
 				"name": "default-dsci",
 			},
@@ -401,8 +401,8 @@ func createDSCInitialization(applicationsNamespace string) runtime.Object {
 func createDSCInitializationWithEmptySpec() runtime.Object {
 	return &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": "dscinitialization.opendatahub.io/v1",
-			"kind":       "DSCInitialization",
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
 			"metadata": map[string]any{
 				"name": "default-dsci",
 			},

--- a/pkg/util/client/interfaces.go
+++ b/pkg/util/client/interfaces.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/metadata"
@@ -72,8 +73,19 @@ type Reader interface {
 }
 
 // Writer provides write access to Kubernetes resources.
-// Currently empty -- write operations will be added as needed.
-type Writer any
+type Writer interface {
+	// Patch applies a patch to an existing resource.
+	// patchType should be one of: types.JSONPatchType, types.MergePatchType,
+	// types.StrategicMergePatchType, or types.ApplyPatchType (for server-side apply).
+	Patch(
+		ctx context.Context,
+		resourceType resources.ResourceType,
+		name string,
+		patchType types.PatchType,
+		data []byte,
+		opts ...PatchOption,
+	) (*unstructured.Unstructured, error)
+}
 
 // Client provides full access to Kubernetes resources.
 // Embeds Reader and Writer, and exposes the underlying clientsets

--- a/pkg/util/client/patch_test.go
+++ b/pkg/util/client/patch_test.go
@@ -1,0 +1,158 @@
+//nolint:testpackage // Tests internal implementation
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+func createTestDSC() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"spec": map[string]any{
+				"components": map[string]any{
+					"dashboard": map[string]any{
+						"managementState": "Managed",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPatch(t *testing.T) {
+	t.Run("applies merge patch successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := createTestDSC()
+		scheme := runtime.NewScheme()
+		_ = metav1.AddMetaToScheme(scheme)
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsc)
+
+		client := &defaultClient{
+			dynamic: dynamicClient,
+		}
+
+		patch := map[string]any{
+			"spec": map[string]any{
+				"components": map[string]any{
+					"ray": map[string]any{
+						"managementState": "Managed",
+					},
+				},
+			},
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		result, err := client.Patch(
+			ctx,
+			resources.DataScienceCluster,
+			"default-dsc",
+			types.MergePatchType,
+			patchBytes,
+		)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.GetName()).To(Equal("default-dsc"))
+	})
+
+	t.Run("returns error for non-existent resource", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.Background()
+
+		scheme := runtime.NewScheme()
+		_ = metav1.AddMetaToScheme(scheme)
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		client := &defaultClient{
+			dynamic: dynamicClient,
+		}
+
+		patch := map[string]any{
+			"spec": map[string]any{},
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = client.Patch(
+			ctx,
+			resources.DataScienceCluster,
+			"nonexistent",
+			types.MergePatchType,
+			patchBytes,
+		)
+
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestPatchConfig_Options(t *testing.T) {
+	t.Run("WithDryRun sets dry run flag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &PatchConfig{}
+		opt := WithDryRun()
+		opt.ApplyTo(cfg)
+
+		g.Expect(cfg.DryRun).To(BeTrue())
+	})
+
+	t.Run("WithFieldOwner sets field owner", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &PatchConfig{}
+		opt := WithFieldOwner("test-owner")
+		opt.ApplyTo(cfg)
+
+		g.Expect(cfg.FieldOwner).To(Equal("test-owner"))
+	})
+
+	t.Run("multiple options can be combined", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &PatchConfig{}
+		opts := []PatchOption{
+			WithDryRun(),
+			WithFieldOwner("my-controller"),
+		}
+
+		for _, opt := range opts {
+			opt.ApplyTo(cfg)
+		}
+
+		g.Expect(cfg.DryRun).To(BeTrue())
+		g.Expect(cfg.FieldOwner).To(Equal("my-controller"))
+	})
+}

--- a/pkg/util/conditions/conditions.go
+++ b/pkg/util/conditions/conditions.go
@@ -1,0 +1,65 @@
+package conditions
+
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// FindCondition finds a condition by type from a list of conditions.
+// Returns nil if not found.
+func FindCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}
+
+// FindReady finds the Ready condition from a list of conditions.
+// Returns nil if not found.
+func FindReady(conditions []metav1.Condition) *metav1.Condition {
+	return FindCondition(conditions, "Ready")
+}
+
+// IsTrue checks if a condition type is present and has status True.
+func IsTrue(conditions []metav1.Condition, conditionType string) bool {
+	cond := FindCondition(conditions, conditionType)
+
+	return cond != nil && cond.Status == metav1.ConditionTrue
+}
+
+// IsFalse checks if a condition type is present and has status False.
+func IsFalse(conditions []metav1.Condition, conditionType string) bool {
+	cond := FindCondition(conditions, conditionType)
+
+	return cond != nil && cond.Status == metav1.ConditionFalse
+}
+
+// CollectMessages collects messages from conditions matching the given types
+// that have status True. Returns a semicolon-separated string.
+func CollectMessages(conditions []metav1.Condition, conditionTypes ...string) string {
+	var messages []string
+
+	typeSet := make(map[string]struct{}, len(conditionTypes))
+	for _, t := range conditionTypes {
+		typeSet[t] = struct{}{}
+	}
+
+	for _, c := range conditions {
+		if _, ok := typeSet[c.Type]; ok {
+			if c.Status == metav1.ConditionTrue && c.Message != "" {
+				messages = append(messages, c.Message)
+			}
+		}
+	}
+
+	return strings.Join(messages, "; ")
+}
+
+// CollectDegradedMessages collects messages from Degraded conditions that are True.
+func CollectDegradedMessages(conditions []metav1.Condition) string {
+	return CollectMessages(conditions, "Degraded")
+}

--- a/pkg/util/conditions/conditions_test.go
+++ b/pkg/util/conditions/conditions_test.go
@@ -1,0 +1,200 @@
+package conditions_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/conditions"
+)
+
+func TestFindCondition(t *testing.T) {
+	tests := []struct {
+		name          string
+		conditions    []metav1.Condition
+		conditionType string
+		wantFound     bool
+		wantStatus    metav1.ConditionStatus
+	}{
+		{
+			name: "finds existing condition",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionTrue},
+				{Type: "Degraded", Status: metav1.ConditionFalse},
+			},
+			conditionType: "Ready",
+			wantFound:     true,
+			wantStatus:    metav1.ConditionTrue,
+		},
+		{
+			name: "returns nil for missing condition",
+			conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionTrue},
+			},
+			conditionType: "Degraded",
+			wantFound:     false,
+		},
+		{
+			name:          "handles empty conditions",
+			conditions:    []metav1.Condition{},
+			conditionType: "Ready",
+			wantFound:     false,
+		},
+		{
+			name:          "handles nil conditions",
+			conditions:    nil,
+			conditionType: "Ready",
+			wantFound:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := conditions.FindCondition(tt.conditions, tt.conditionType)
+
+			if tt.wantFound {
+				if got == nil {
+					t.Fatalf("expected condition, got nil")
+				}
+
+				if got.Status != tt.wantStatus {
+					t.Errorf("status = %v, want %v", got.Status, tt.wantStatus)
+				}
+			} else {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestFindReady(t *testing.T) {
+	conds := []metav1.Condition{
+		{Type: "Available", Status: metav1.ConditionTrue},
+		{Type: "Ready", Status: metav1.ConditionFalse, Message: "not ready"},
+	}
+
+	got := conditions.FindReady(conds)
+	if got == nil {
+		t.Fatal("expected Ready condition, got nil")
+	}
+
+	if got.Status != metav1.ConditionFalse {
+		t.Errorf("status = %v, want False", got.Status)
+	}
+}
+
+func TestIsTrue(t *testing.T) {
+	conds := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+		{Type: "Degraded", Status: metav1.ConditionFalse},
+	}
+
+	if !conditions.IsTrue(conds, "Ready") {
+		t.Error("expected Ready to be true")
+	}
+
+	if conditions.IsTrue(conds, "Degraded") {
+		t.Error("expected Degraded to not be true")
+	}
+
+	if conditions.IsTrue(conds, "Missing") {
+		t.Error("expected Missing to not be true")
+	}
+}
+
+func TestIsFalse(t *testing.T) {
+	conds := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+		{Type: "Degraded", Status: metav1.ConditionFalse},
+	}
+
+	if conditions.IsFalse(conds, "Ready") {
+		t.Error("expected Ready to not be false")
+	}
+
+	if !conditions.IsFalse(conds, "Degraded") {
+		t.Error("expected Degraded to be false")
+	}
+
+	if conditions.IsFalse(conds, "Missing") {
+		t.Error("expected Missing to not be false")
+	}
+}
+
+func TestCollectMessages(t *testing.T) {
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		conditionTypes []string
+		want           string
+	}{
+		{
+			name: "collects messages from matching conditions",
+			conditions: []metav1.Condition{
+				{Type: "Degraded", Status: metav1.ConditionTrue, Message: "error 1"},
+				{Type: "Degraded", Status: metav1.ConditionTrue, Message: "error 2"},
+				{Type: "Ready", Status: metav1.ConditionFalse, Message: "not ready"},
+			},
+			conditionTypes: []string{"Degraded"},
+			want:           "error 1; error 2",
+		},
+		{
+			name: "ignores conditions with status False",
+			conditions: []metav1.Condition{
+				{Type: "Degraded", Status: metav1.ConditionFalse, Message: "should ignore"},
+				{Type: "Degraded", Status: metav1.ConditionTrue, Message: "real error"},
+			},
+			conditionTypes: []string{"Degraded"},
+			want:           "real error",
+		},
+		{
+			name: "ignores empty messages",
+			conditions: []metav1.Condition{
+				{Type: "Degraded", Status: metav1.ConditionTrue, Message: ""},
+				{Type: "Degraded", Status: metav1.ConditionTrue, Message: "has message"},
+			},
+			conditionTypes: []string{"Degraded"},
+			want:           "has message",
+		},
+		{
+			name: "collects from multiple condition types",
+			conditions: []metav1.Condition{
+				{Type: "Error", Status: metav1.ConditionTrue, Message: "error msg"},
+				{Type: "Warning", Status: metav1.ConditionTrue, Message: "warning msg"},
+			},
+			conditionTypes: []string{"Error", "Warning"},
+			want:           "error msg; warning msg",
+		},
+		{
+			name:           "returns empty string for no matches",
+			conditions:     []metav1.Condition{},
+			conditionTypes: []string{"Degraded"},
+			want:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := conditions.CollectMessages(tt.conditions, tt.conditionTypes...)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectDegradedMessages(t *testing.T) {
+	conds := []metav1.Condition{
+		{Type: "Degraded", Status: metav1.ConditionTrue, Message: "component failing"},
+		{Type: "Ready", Status: metav1.ConditionFalse, Message: "not ready"},
+	}
+
+	got := conditions.CollectDegradedMessages(conds)
+	want := "component failing"
+
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/util/errors/output.go
+++ b/pkg/util/errors/output.go
@@ -6,8 +6,25 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
+
+// HandleError writes the error in the appropriate format and returns an already-handled error.
+// It tries structured output (JSON/YAML) first based on outputFormat, then falls back to text.
+func HandleError(cmd *cobra.Command, err error, outputFormat string) error {
+	if err == nil {
+		return nil
+	}
+
+	if WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
+		return NewAlreadyHandledError(err)
+	}
+
+	WriteTextError(cmd.ErrOrStderr(), err)
+
+	return NewAlreadyHandledError(err)
+}
 
 // WriteSuggestion classifies an error and renders only the suggestion line.
 func WriteSuggestion(w io.Writer, err error) {


### PR DESCRIPTION
## Description

Add a new `components` command to view and manage ODH/RHOAI component lifecycle. Components are dynamically discovered from the DataScienceCluster (DSC) v2 API spec.

### Subcommands

| Command | Description |
|---------|-------------|
| `kubectl odh components` | List all components with state and health |
| `kubectl odh components describe <name>` | Show detailed component info including conditions |
| `kubectl odh components enable <name>` | Set component managementState to Managed |
| `kubectl odh components disable <name>` | Set component managementState to Removed |

### Features

- **Dynamic discovery**: Components are read from DSC `.spec.components` - no hardcoded list
- **Health enrichment**: Ready status fetched from component CRs (`components.platform.opendatahub.io`)
- **Multiple output formats**: Table (default), JSON, YAML via `-o` flag
- **Dry-run support**: `--dry-run` flag shows patch without applying
- **Confirmation prompts**: Enable/disable require confirmation (skip with `-y`)
- **Centralized error handling**: Added `HandleError` helper to `pkg/util/errors`

### Example Usage

```bash
# List all components
kubectl odh components

# List as JSON
kubectl odh components -o json

# Describe a component
kubectl odh components describe kserve

# Enable a component
kubectl odh components enable ray

# Disable with dry-run
kubectl odh components disable trustyai --dry-run
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New components command: list, describe, enable, disable with table/JSON/YAML output.
  * List shows management state and optional health/ready/message; describe shows detailed conditions and status.
  * Enable/disable support --dry-run and interactive confirmation.

* **Chores**
  * API resource versions bumped to v2.
  * Centralized CLI error handling and improved patching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->