### PR TITLE
Allow optional configuration for FIPS build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ ARG DATE=unknown
 
 # Build using Makefile with cross-compilation
 RUN make build \
+    CGO_ENABLED=1 \
+    GOEXPERIMENT=strictfipsruntime \
+    GO_BUILD_TAGS="-tags strictfipsruntime" \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     VERSION=${VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ CONTAINER_TAGS ?= $(VERSION)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+# FIPS-related build vars for build recipe
+# To build for fips:
+# make build CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO_BUILD_TAGS="-tags strictfipsruntime"
+CGO_ENABLED ?= 0
+GOEXPERIMENT ?=
+GO_BUILD_TAGS ?=
+
 ## Tools
 GOLANGCI_VERSION ?= v2.8.0
 GOLANGCI ?= go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
@@ -54,8 +61,8 @@ fetch-deps:
 # Build the binary
 .PHONY: build
 build: fetch-deps
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
-		go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) cmd/main.go
+	CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+		go build $(GO_BUILD_TAGS) -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) cmd/main.go
 
 # Run the doctor command
 .PHONY: run


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

The container build uses Red Hat's Go toolchain, so it's fine to build with FIPS in mind there, but making it the default in `make build` would cause that to break for most people, since the upstream Go toolchain doesn't understand `GOEXPERIMENT=strictfipsruntime`.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration with support for FIPS compliance mode and flexible compilation parameters via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->