### PR TITLE
feat: add install, and graph subcommands for deps command.

### DIFF
--- a/cmd/deps/deps.go
+++ b/cmd/deps/deps.go
@@ -6,41 +6,75 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	depspkg "github.com/opendatahub-io/odh-cli/pkg/deps"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
 const (
 	cmdName  = "deps"
-	cmdShort = "Show operator dependencies for ODH/RHOAI"
+	cmdShort = "Manage operator dependencies for ODH/RHOAI"
 )
 
 const cmdLong = `
-Shows operator dependencies required by ODH/RHOAI components.
+Manage operator dependencies required by ODH/RHOAI components.
 
-Displays dependency status by querying OLM subscriptions on the cluster.
+Without a subcommand, displays dependency status by querying OLM subscriptions.
 Each dependency shows:
   - Installation status (installed, missing, optional)
   - Installed version (if available)
   - Namespace where the operator runs
   - Components that require this dependency
 
-Examples:
+Subcommands:
+  install     Install missing operator dependencies via OLM
+  graph       Show dependency relationships
+`
+
+const cmdExample = `
   # Show all dependencies
   kubectl odh deps
 
   # Show dependencies for a specific version
   kubectl odh deps --version 3.4.0
 
-  # Refresh manifest from odh-gitops (fetch latest)
-  kubectl odh deps --refresh
-
   # Output as JSON
   kubectl odh deps -o json
 
   # Dry run (show manifest data without cluster query)
   kubectl odh deps --dry-run
+
+  # Install all missing required dependencies
+  kubectl odh deps install
+
+  # Install a specific dependency
+  kubectl odh deps install cert-manager
+
+  # Show what would be installed without executing
+  kubectl odh deps install --dry-run
+
+  # Show dependency graph
+  kubectl odh deps graph
 `
+
+// runCommand executes the Complete/Validate/Run lifecycle with error handling.
+//
+//nolint:wrapcheck // HandleError returns an already-handled error
+func runCommand(cobraCmd *cobra.Command, c cmd.Command, outputFormat string) error {
+	if err := c.Complete(); err != nil {
+		return clierrors.HandleError(cobraCmd, err, outputFormat)
+	}
+
+	if err := c.Validate(); err != nil {
+		return clierrors.HandleError(cobraCmd, err, outputFormat)
+	}
+
+	if err := c.Run(cobraCmd.Context()); err != nil {
+		return clierrors.HandleError(cobraCmd, err, outputFormat)
+	}
+
+	return nil
+}
 
 // AddCommand adds the deps command to the root command.
 func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
@@ -50,52 +84,86 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		ErrOut: root.ErrOrStderr(),
 	}
 
-	command := depspkg.NewCommand(streams, flags)
+	// Default list command (backward compatibility)
+	listCommand := depspkg.NewCommand(streams, flags)
 
-	cmd := &cobra.Command{
+	depsCmd := &cobra.Command{
 		Use:           cmdName,
 		Short:         cmdShort,
 		Long:          cmdLong,
+		Example:       cmdExample,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			outputFormat := command.Output
-
-			if err := command.Complete(); err != nil {
-				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
-					return clierrors.NewAlreadyHandledError(err)
-				}
-
-				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
-
-				return clierrors.NewAlreadyHandledError(err)
-			}
-
-			if err := command.Validate(); err != nil {
-				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
-					return clierrors.NewAlreadyHandledError(err)
-				}
-
-				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
-
-				return clierrors.NewAlreadyHandledError(err)
-			}
-
-			if err := command.Run(cmd.Context()); err != nil {
-				if clierrors.WriteStructuredError(cmd.ErrOrStderr(), err, outputFormat) {
-					return clierrors.NewAlreadyHandledError(err)
-				}
-
-				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
-
-				return clierrors.NewAlreadyHandledError(err)
-			}
-
-			return nil
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return runCommand(cobraCmd, listCommand, listCommand.Output)
 		},
 	}
 
-	command.AddFlags(cmd.Flags())
+	listCommand.AddFlags(depsCmd.Flags())
 
-	root.AddCommand(cmd)
+	// Add subcommands
+	addInstallCommand(depsCmd, flags, streams)
+	addGraphCommand(depsCmd, flags, streams)
+
+	root.AddCommand(depsCmd)
+}
+
+// addInstallCommand adds the install subcommand.
+// Note: This command is text-only (progress messages) and does not support --output flag.
+func addInstallCommand(parent *cobra.Command, flags *genericclioptions.ConfigFlags, streams genericiooptions.IOStreams) {
+	installCommand := depspkg.NewInstallCommand(streams, flags)
+
+	installCmd := &cobra.Command{
+		Use:   "install [DEPENDENCY]",
+		Short: "Install missing operator dependencies via OLM",
+		Long: `Install missing operator dependencies required by ODH/RHOAI.
+
+Creates namespace, OperatorGroup, and OLM Subscription for each missing dependency.
+Waits for the CSV (ClusterServiceVersion) to reach Succeeded phase.
+
+If a dependency name is provided, only that dependency is installed.
+Otherwise, all missing required dependencies are installed.
+
+Note: This command outputs progress text only; the parent's --output flag does not apply.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.MaximumNArgs(1),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			installCommand.TargetDep = ""
+			if len(args) > 0 {
+				installCommand.TargetDep = args[0]
+			}
+
+			return runCommand(cobraCmd, installCommand, "")
+		},
+	}
+
+	installCommand.AddFlags(installCmd.Flags())
+	parent.AddCommand(installCmd)
+}
+
+// addGraphCommand adds the graph subcommand.
+// Note: This command is text-only (ASCII visualization) and does not support --output flag.
+func addGraphCommand(parent *cobra.Command, flags *genericclioptions.ConfigFlags, streams genericiooptions.IOStreams) {
+	graphCommand := depspkg.NewGraphCommand(streams, flags)
+
+	graphCmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Show dependency relationships visually",
+		Long: `Display dependency relationships as a formatted list.
+
+Shows which components require which operators, and which operators
+depend on other operators (transitive dependencies).
+
+Note: This command outputs text visualization only; the parent's --output flag does not apply.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return runCommand(cobraCmd, graphCommand, "")
+		},
+	}
+
+	graphCommand.AddFlags(graphCmd.Flags())
+	parent.AddCommand(graphCmd)
 }

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -142,6 +142,16 @@ func checkSingleDependency(ctx context.Context, olmReader client.OLMReader, dep 
 		status.Error = err.Error()
 	}
 
+	// Fallback: if InstalledCSV is empty (not error), search for matching CSV in namespace
+	if err == nil && version == "" {
+		var fallbackErr error
+
+		version, fallbackErr = findMatchingCSVVersion(ctx, olmReader, dep.Namespace, dep.Subscription)
+		if fallbackErr != nil && status.Error == "" {
+			status.Error = fallbackErr.Error()
+		}
+	}
+
 	status.Version = version
 
 	return status
@@ -200,4 +210,27 @@ func getCSV(ctx context.Context, olm client.OLMReader, namespace, name string) (
 	}
 
 	return csv, nil
+}
+
+// findMatchingCSVVersion searches for a Succeeded CSV matching the subscription name.
+// Used as fallback when subscription's InstalledCSV is empty (e.g., OLM resolution issues).
+func findMatchingCSVVersion(ctx context.Context, olm client.OLMReader, namespace, subName string) (string, error) {
+	csvList, err := olm.ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("list CSVs in %s: %w", namespace, err)
+	}
+
+	for i := range csvList.Items {
+		csv := &csvList.Items[i]
+
+		if csv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
+			continue
+		}
+
+		if MatchesSubscription(csv.Name, subName) {
+			return csv.Spec.Version.String(), nil
+		}
+	}
+
+	return "", nil
 }

--- a/pkg/deps/check_test.go
+++ b/pkg/deps/check_test.go
@@ -130,6 +130,8 @@ func TestCheckDependencies_Installed(t *testing.T) {
 	mockCSVReader := &mockclient.MockCSVReader{}
 	mockCSVReader.On("Get", mock.Anything, "cert-manager.v1.14.0", mock.Anything).
 		Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "operators.coreos.com", Resource: "clusterserviceversions"}, "cert-manager.v1.14.0"))
+	mockCSVReader.On("List", mock.Anything, mock.Anything).
+		Return(&operatorsv1alpha1.ClusterServiceVersionList{Items: []operatorsv1alpha1.ClusterServiceVersion{}}, nil)
 
 	mockOLM := &mockclient.MockOLMReader{}
 	mockOLM.On("Available").Return(true)

--- a/pkg/deps/graph.go
+++ b/pkg/deps/graph.go
@@ -1,0 +1,187 @@
+package deps
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	utilserrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+const minHeaderWidth = 40
+
+// Verify GraphCommand implements cmd.Command interface at compile time.
+var _ cmd.Command = (*GraphCommand)(nil)
+
+// GraphCommand holds the deps graph command configuration.
+type GraphCommand struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+
+	Refresh         bool
+	Version         string
+	manifestVersion string
+}
+
+// NewGraphCommand creates a new GraphCommand with defaults.
+func NewGraphCommand(streams genericiooptions.IOStreams, configFlags *genericclioptions.ConfigFlags) *GraphCommand {
+	return &GraphCommand{
+		IO:          iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags: configFlags,
+	}
+}
+
+// AddFlags registers command-specific flags with the provided FlagSet.
+func (c *GraphCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&c.Refresh, "refresh", false, "Fetch latest manifest from odh-gitops")
+	fs.StringVar(&c.Version, "version", "", "ODH/RHOAI version to show dependencies for")
+}
+
+// Complete prepares the command for execution.
+func (c *GraphCommand) Complete() error {
+	return nil
+}
+
+// Validate checks the command options.
+func (c *GraphCommand) Validate() error {
+	// Skip version validation if refreshing (will fetch from remote)
+	if c.Refresh {
+		return nil
+	}
+
+	// Validate version against embedded manifest
+	manifestVer, err := ManifestVersion()
+	if err != nil {
+		return fmt.Errorf("failed to determine manifest version: %w", err)
+	}
+
+	c.manifestVersion = manifestVer
+
+	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
+		return utilserrors.NewValidationError(
+			"VERSION_UNAVAILABLE",
+			fmt.Sprintf("dependency graph for version %q is not available; only version %s is supported", c.Version, c.manifestVersion),
+			"Use --refresh to fetch the latest manifest, or omit --version to use the embedded version",
+		)
+	}
+
+	return nil
+}
+
+// Run executes the graph command.
+func (c *GraphCommand) Run(ctx context.Context) error {
+	result, err := GetManifest(ctx, c.Refresh)
+	if err != nil {
+		return fmt.Errorf("get manifest: %w", err)
+	}
+
+	// Update manifest version from result
+	if result.Version != "" {
+		c.manifestVersion = result.Version
+	}
+
+	// Validate version if specified (for refresh case, validation happens here)
+	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
+		suggestion := "Use --refresh to fetch the latest manifest, or omit --version to use the embedded version"
+		if c.Refresh {
+			suggestion = "Omit --version to use the fetched manifest version"
+		}
+
+		return utilserrors.NewValidationError(
+			"VERSION_UNAVAILABLE",
+			fmt.Sprintf("dependency graph for version %q is not available; only version %s is supported", c.Version, c.manifestVersion),
+			suggestion,
+		)
+	}
+
+	manifest := result.Manifest
+	w := c.IO.Out()
+
+	header := "Dependency Graph for ODH/RHOAI " + c.manifestVersion
+	headerWidth := max(len(header), minHeaderWidth)
+
+	_, _ = fmt.Fprintln(w, header)
+	_, _ = fmt.Fprintln(w, strings.Repeat("=", headerWidth))
+	_, _ = fmt.Fprintln(w)
+
+	deps := manifest.GetDependencies()
+	depMap := buildDepMap(manifest)
+
+	for _, dep := range deps {
+		c.printDepNode(dep, depMap)
+	}
+
+	return nil
+}
+
+// buildDepMap creates a map of dependency name to its transitive dependencies.
+// It computes the full transitive closure, so A -> B -> C will show both B and C for A.
+func buildDepMap(manifest *Manifest) map[string][]string {
+	depMap := make(map[string][]string)
+
+	for name := range manifest.Dependencies {
+		visited := make(map[string]bool)
+		collectTransitiveDeps(manifest, name, visited)
+
+		// Remove self from visited set
+		delete(visited, name)
+
+		transDeps := make([]string, 0, len(visited))
+		for depName := range visited {
+			transDeps = append(transDeps, toDisplayName(depName))
+		}
+
+		sort.Strings(transDeps)
+		depMap[name] = transDeps
+	}
+
+	return depMap
+}
+
+// collectTransitiveDeps recursively collects all transitive dependencies.
+func collectTransitiveDeps(manifest *Manifest, name string, visited map[string]bool) {
+	if visited[name] {
+		return
+	}
+
+	visited[name] = true
+
+	dep, ok := manifest.Dependencies[name]
+	if !ok {
+		return
+	}
+
+	for transName, val := range dep.Dependencies {
+		if isEnabled(val) {
+			collectTransitiveDeps(manifest, transName, visited)
+		}
+	}
+}
+
+func (c *GraphCommand) printDepNode(dep DependencyInfo, depMap map[string][]string) {
+	w := c.IO.Out()
+
+	_, _ = fmt.Fprintf(w, "%s\n", dep.DisplayName)
+
+	requiredBy := "(none)"
+	if len(dep.RequiredBy) > 0 {
+		requiredBy = strings.Join(dep.RequiredBy, ", ")
+	}
+
+	dependsOn := "(none)"
+	if transDeps, ok := depMap[dep.Name]; ok && len(transDeps) > 0 {
+		dependsOn = strings.Join(transDeps, ", ")
+	}
+
+	_, _ = fmt.Fprintf(w, "├── Required by: %s\n", requiredBy)
+	_, _ = fmt.Fprintf(w, "└── Depends on: %s\n", dependsOn)
+	_, _ = fmt.Fprintln(w)
+}

--- a/pkg/deps/graph_test.go
+++ b/pkg/deps/graph_test.go
@@ -1,0 +1,153 @@
+package deps_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testGraphHeader     = "Dependency Graph"
+	testGraphCertMgr    = "Cert Manager"
+	testGraphRequiredBy = "Required by:"
+	testGraphDependsOn  = "Depends on:"
+)
+
+func TestGraphCommand(t *testing.T) {
+	t.Run("Complete", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+
+		err := cmd.Complete()
+
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("Validate", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+
+		err := cmd.Validate()
+
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("AddFlags", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		g.Expect(fs.Lookup("refresh")).ToNot(BeNil())
+		g.Expect(fs.Lookup("version")).ToNot(BeNil())
+	})
+
+	t.Run("Defaults_VersionAndRefresh", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+
+		g.Expect(cmd.Version).To(BeEmpty())
+		g.Expect(cmd.Refresh).To(BeFalse())
+	})
+
+	t.Run("Run", func(t *testing.T) {
+		g := NewWithT(t)
+
+		out := &bytes.Buffer{}
+		streams := genericiooptions.IOStreams{
+			Out:    out,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+
+		err := cmd.Run(t.Context())
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(out.String()).To(ContainSubstring(testGraphHeader))
+		g.Expect(out.String()).To(ContainSubstring(testGraphCertMgr))
+		g.Expect(out.String()).To(ContainSubstring(testGraphRequiredBy))
+		g.Expect(out.String()).To(ContainSubstring(testGraphDependsOn))
+	})
+
+	t.Run("Run_WithRefreshFlag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		out := &bytes.Buffer{}
+		streams := genericiooptions.IOStreams{
+			Out:    out,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+		cmd.Refresh = true
+
+		// Run uses embedded manifest as fallback when refresh fails (no network in tests)
+		// This verifies the refresh flag is wired up and doesn't break execution
+		err := cmd.Run(t.Context())
+
+		// Should succeed using embedded manifest fallback
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(out.String()).To(ContainSubstring(testGraphHeader))
+	})
+
+	t.Run("Run_DynamicHeaderWidth", func(t *testing.T) {
+		g := NewWithT(t)
+
+		out := &bytes.Buffer{}
+		streams := genericiooptions.IOStreams{
+			Out:    out,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewGraphCommand(streams, nil)
+
+		err := cmd.Run(t.Context())
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify header and separator are present
+		output := out.String()
+		lines := bytes.Split([]byte(output), []byte("\n"))
+		g.Expect(len(lines)).To(BeNumerically(">=", 2))
+
+		// First line is header, second is separator
+		headerLine := string(lines[0])
+		separatorLine := string(lines[1])
+
+		// Separator should match header length (dynamic width)
+		g.Expect(len(separatorLine)).To(BeNumerically(">=", len(headerLine)))
+	})
+}

--- a/pkg/deps/install.go
+++ b/pkg/deps/install.go
@@ -1,0 +1,1032 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	utilserrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+// Verify InstallCommand implements cmd.Command interface at compile time.
+var _ cmd.Command = (*InstallCommand)(nil)
+
+const (
+	defaultTimeout       = 5 * time.Minute
+	pollInterval         = 5 * time.Second
+	defaultCatalogSource = "redhat-operators"
+	sourceNamespace      = "openshift-marketplace"
+
+	// csvNamespaceListEveryNPolls limits full-namespace CSV List calls during wait:
+	// only every Nth poll (subscription Get still runs each poll).
+	csvNamespaceListEveryNPolls = 3
+
+	depInstallCheckConcurrency = 8
+
+	// Label for resources created by odh-cli.
+	labelManagedBy      = "app.kubernetes.io/managed-by"
+	labelManagedByValue = "odh-cli"
+
+	// Error messages.
+	msgCreateClientInstall = "create kubernetes client: %w"
+	msgOLMNotAvailableInst = "OLM (Operator Lifecycle Manager) is not available; cannot install dependencies"
+	msgUnknownDependency   = "unknown dependency %q; run 'kubectl odh deps' to see available dependencies"
+
+	// Progress messages.
+	msgInstalling            = "Installing %s...\n"
+	msgCreatingNamespace     = "  Creating namespace %s\n"
+	msgEnsuringOperatorGroup = "  Ensuring OperatorGroup...\n"
+	msgCreatedOperatorGroup  = "  Created OperatorGroup\n"
+	msgOperatorGroupExists   = "  OperatorGroup already exists\n"
+	msgCreatingSubscription  = "  Creating Subscription"
+	msgWaitingForCSV         = "  Waiting for CSV... (%s)\n"
+	msgWaitingForCSVPhase    = "  Waiting for CSV %s... (%s)\n"
+	msgAllInstalled          = "All dependencies are already installed."
+	msgNoDepsToInstall       = "No dependencies to install."
+
+	// Success/failure messages.
+	msgSuccessInstall = "✓ %s %s installed\n"
+	msgFailInstall    = "✗ %s failed: %v\n"
+)
+
+// InstallResult tracks the outcome of a single dependency installation.
+type InstallResult struct {
+	Name        string
+	DisplayName string
+	Status      InstallStatus
+	Version     string
+	Error       error
+}
+
+// InstallStatus represents the outcome of an installation attempt.
+type InstallStatus string
+
+const (
+	InstallStatusInstalled InstallStatus = "installed"
+	InstallStatusFailed    InstallStatus = "failed"
+)
+
+// syncWriter wraps an io.Writer with a mutex for concurrent-safe writes.
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (sw *syncWriter) Write(p []byte) (int, error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+
+	n, err := sw.w.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("write: %w", err)
+	}
+
+	return n, nil
+}
+
+// InstallCommand holds the deps install command configuration.
+type InstallCommand struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+
+	DryRun          bool
+	IncludeOptional bool
+	Timeout         time.Duration
+	TargetDep       string
+	Version         string
+	Refresh         bool
+
+	client          client.Client
+	manifestVersion string
+	useColor        bool
+}
+
+// NewInstallCommand creates a new InstallCommand with defaults.
+func NewInstallCommand(streams genericiooptions.IOStreams, configFlags *genericclioptions.ConfigFlags) *InstallCommand {
+	return &InstallCommand{
+		IO:          iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags: configFlags,
+		Timeout:     defaultTimeout,
+	}
+}
+
+// AddFlags registers command-specific flags with the provided FlagSet.
+func (c *InstallCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would be installed without executing")
+	fs.BoolVar(&c.IncludeOptional, "include-optional", false, "Install optional dependencies in addition to required")
+	fs.DurationVar(&c.Timeout, "timeout", defaultTimeout, "Timeout for waiting on each operator CSV")
+	fs.StringVar(&c.Version, "version", "", "ODH/RHOAI version to install dependencies for")
+	fs.BoolVar(&c.Refresh, "refresh", false, "Fetch latest manifest from odh-gitops")
+}
+
+// Complete prepares the command for execution.
+func (c *InstallCommand) Complete() error {
+	c.useColor = shouldUseColor(c.IO.Out())
+
+	if c.DryRun {
+		return nil
+	}
+
+	cl, err := client.NewClient(c.ConfigFlags)
+	if err != nil {
+		return fmt.Errorf(msgCreateClientInstall, err)
+	}
+
+	c.client = cl
+
+	return nil
+}
+
+// Validate checks the command options.
+func (c *InstallCommand) Validate() error {
+	if c.Timeout <= 0 {
+		return fmt.Errorf("--timeout must be positive, got %v", c.Timeout)
+	}
+
+	if !c.DryRun && !c.client.OLM().Available() {
+		return errors.New(msgOLMNotAvailableInst)
+	}
+
+	// Skip version validation if refreshing (will fetch from remote)
+	if c.Refresh {
+		return nil
+	}
+
+	// Validate version against embedded manifest
+	manifestVer, err := ManifestVersion()
+	if err != nil {
+		return fmt.Errorf("failed to determine manifest version: %w", err)
+	}
+
+	c.manifestVersion = manifestVer
+
+	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
+		return utilserrors.NewValidationError(
+			"VERSION_UNAVAILABLE",
+			fmt.Sprintf("dependencies for version %q are not available; only version %s is supported", c.Version, c.manifestVersion),
+			"Use --refresh to fetch the latest manifest, or omit --version to use the embedded version",
+		)
+	}
+
+	return nil
+}
+
+// Run executes the install command.
+func (c *InstallCommand) Run(ctx context.Context) error {
+	result, err := GetManifest(ctx, c.Refresh)
+	if err != nil {
+		return fmt.Errorf("get manifest: %w", err)
+	}
+
+	// Update manifest version from result
+	if result.Version != "" {
+		c.manifestVersion = result.Version
+	}
+
+	// Validate version if specified (for refresh case, validation happens here)
+	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
+		suggestion := "Use --refresh to fetch the latest manifest, or omit --version to use the embedded version"
+		if c.Refresh {
+			suggestion = "Omit --version to use the fetched manifest version"
+		}
+
+		return utilserrors.NewValidationError(
+			"VERSION_UNAVAILABLE",
+			fmt.Sprintf("dependencies for version %q are not available; only version %s is supported", c.Version, c.manifestVersion),
+			suggestion,
+		)
+	}
+
+	w := c.IO.Out()
+	_, _ = fmt.Fprintf(w, "Installing dependencies for ODH/RHOAI %s\n\n", c.manifestVersion)
+
+	deps := result.Manifest.GetDependencies()
+
+	if c.TargetDep != "" {
+		if !c.isValidDependency(deps, c.TargetDep) {
+			return fmt.Errorf(msgUnknownDependency, c.TargetDep)
+		}
+	}
+
+	if c.DryRun {
+		return c.runDryRun(ctx, deps)
+	}
+
+	return c.runInstall(ctx, deps)
+}
+
+func (c *InstallCommand) isValidDependency(deps []DependencyInfo, name string) bool {
+	for _, d := range deps {
+		if d.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *InstallCommand) runDryRun(_ context.Context, deps []DependencyInfo) error {
+	w := c.IO.Out()
+
+	_, _ = fmt.Fprintln(w, "[DRY RUN] The following resources would be created:")
+	_, _ = fmt.Fprintln(w)
+
+	toInstall := c.filterDepsForDryRun(deps)
+	if len(toInstall) == 0 {
+		_, _ = fmt.Fprintln(w, msgNoDepsToInstall)
+
+		return nil
+	}
+
+	for _, dep := range toInstall {
+		c.printDryRunManifests(w, dep)
+	}
+
+	return nil
+}
+
+func (c *InstallCommand) printDryRunManifests(w io.Writer, dep DependencyInfo) {
+	_, _ = fmt.Fprintf(w, "# %s\n", dep.DisplayName)
+	_, _ = fmt.Fprintln(w, "---")
+
+	// Namespace
+	_, _ = fmt.Fprintf(w, `apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels:
+    %s: %s
+---
+`, dep.Namespace, labelManagedBy, labelManagedByValue)
+
+	// OperatorGroup
+	_, _ = fmt.Fprintf(w, `apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: %s-og
+  namespace: %s
+  labels:
+    %s: %s
+spec:
+`, dep.Namespace, dep.Namespace, labelManagedBy, labelManagedByValue)
+
+	if len(dep.TargetNamespaces) > 0 {
+		_, _ = fmt.Fprintln(w, "  targetNamespaces:")
+		for _, ns := range dep.TargetNamespaces {
+			_, _ = fmt.Fprintf(w, "    - %s\n", ns)
+		}
+	}
+
+	_, _ = fmt.Fprintln(w, "---")
+
+	// Subscription
+	source := dep.Source
+	if source == "" {
+		source = defaultCatalogSource
+	}
+
+	_, _ = fmt.Fprintf(w, `apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    %s: %s
+spec:
+  channel: %s
+  name: %s
+  source: %s
+  sourceNamespace: %s
+  installPlanApproval: Automatic
+---
+`, dep.Subscription, dep.Namespace, labelManagedBy, labelManagedByValue, dep.Channel, dep.Subscription, source, sourceNamespace)
+}
+
+func (c *InstallCommand) runInstall(ctx context.Context, deps []DependencyInfo) error {
+	w := c.IO.Out()
+
+	toInstall, err := c.filterDepsToInstall(ctx, deps)
+	if err != nil {
+		return fmt.Errorf("filter dependencies: %w", err)
+	}
+
+	if len(toInstall) == 0 {
+		_, _ = fmt.Fprintln(w, msgAllInstalled)
+
+		return nil
+	}
+
+	// Phase 1: Create all resources (namespace, operatorgroup, subscription)
+	results := make([]InstallResult, len(toInstall))
+	pendingCSVs := make([]int, 0, len(toInstall))
+
+	for i, dep := range toInstall {
+		results[i] = InstallResult{
+			Name:        dep.Name,
+			DisplayName: dep.DisplayName,
+		}
+
+		if err := c.createDepResources(ctx, dep); err != nil {
+			results[i].Status = InstallStatusFailed
+			results[i].Error = err
+			c.printFailure(w, dep.DisplayName, err)
+		} else {
+			pendingCSVs = append(pendingCSVs, i)
+		}
+	}
+
+	// Phase 2: Wait for all CSVs in parallel
+	if len(pendingCSVs) > 0 {
+		_, _ = fmt.Fprintf(w, "\nWaiting for %d operator(s) to become ready...\n", len(pendingCSVs))
+		c.waitForCSVsParallel(ctx, toInstall, results, pendingCSVs)
+	}
+
+	c.printSummary(w, results)
+
+	// Collect all errors for full error chain
+	var errs []error
+
+	for _, r := range results {
+		if r.Status == InstallStatusFailed && r.Error != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", r.Name, r.Error))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func (c *InstallCommand) waitForCSVsParallel(ctx context.Context, deps []DependencyInfo, results []InstallResult, pendingIndices []int) {
+	sw := &syncWriter{w: c.IO.Out()}
+
+	var mu sync.Mutex
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	for _, idx := range pendingIndices {
+		dep := deps[idx]
+		resultIdx := idx
+
+		g.Go(func() error {
+			version, err := c.waitForCSV(gctx, sw, dep.Namespace, dep.Subscription)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				results[resultIdx].Status = InstallStatusFailed
+				results[resultIdx].Error = err
+				c.printFailure(sw, dep.DisplayName, err)
+			} else {
+				results[resultIdx].Status = InstallStatusInstalled
+				results[resultIdx].Version = version
+				c.printSuccess(sw, dep.DisplayName, version)
+			}
+
+			return nil // Don't fail the group, we track errors in results
+		})
+	}
+
+	_ = g.Wait()
+}
+
+func (c *InstallCommand) filterDepsForDryRun(deps []DependencyInfo) []DependencyInfo {
+	var toInstall []DependencyInfo
+
+	for _, dep := range deps {
+		if c.TargetDep != "" && dep.Name != c.TargetDep {
+			continue
+		}
+
+		if !c.shouldInstallDep(dep) {
+			continue
+		}
+
+		toInstall = append(toInstall, dep)
+	}
+
+	return toInstall
+}
+
+func (c *InstallCommand) filterDepsToInstall(ctx context.Context, deps []DependencyInfo) ([]DependencyInfo, error) {
+	indices := make([]int, 0, len(deps))
+
+	for i, dep := range deps {
+		if c.TargetDep != "" && dep.Name != c.TargetDep {
+			continue
+		}
+
+		if !c.shouldInstallDep(dep) {
+			continue
+		}
+
+		indices = append(indices, i)
+	}
+
+	if len(indices) == 0 {
+		return nil, nil
+	}
+
+	installed := make([]bool, len(indices))
+
+	g, gctx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, depInstallCheckConcurrency)
+
+	for j, depIdx := range indices {
+		dep := deps[depIdx]
+
+		g.Go(func() error {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			ok, err := c.isAlreadyInstalled(gctx, dep)
+			installed[j] = ok
+
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("check installed subscriptions: %w", err)
+	}
+
+	toInstall := make([]DependencyInfo, 0, len(indices))
+
+	for j, depIdx := range indices {
+		if installed[j] {
+			continue
+		}
+
+		toInstall = append(toInstall, deps[depIdx])
+	}
+
+	return toInstall, nil
+}
+
+func (c *InstallCommand) shouldInstallDep(dep DependencyInfo) bool {
+	// If user explicitly named this dependency, always allow it
+	if c.TargetDep != "" && c.TargetDep == dep.Name {
+		return true
+	}
+
+	// Required deps (enabled=true) are always installed
+	if dep.Enabled == enabledTrue {
+		return true
+	}
+
+	// Optional deps (enabled=auto) are installed only with --include-optional
+	// Disabled deps (enabled=false) are never installed in bulk mode
+	if dep.Enabled == enabledAuto && c.IncludeOptional {
+		return true
+	}
+
+	return false
+}
+
+func (c *InstallCommand) isAlreadyInstalled(ctx context.Context, dep DependencyInfo) (bool, error) {
+	sub, err := getSubscription(ctx, c.client.OLM(), dep.Namespace, dep.Subscription)
+	if err != nil {
+		return false, fmt.Errorf("check if %s is installed: %w", dep.Name, err)
+	}
+
+	if sub != nil {
+		// Subscription exists - verify it matches expected spec
+		c.warnIfSubscriptionMismatch(sub, dep)
+
+		return true, nil
+	}
+
+	// No subscription - check for orphaned CSV (installed but subscription deleted)
+	return c.hasSucceededCSV(ctx, dep.Namespace, dep.Subscription)
+}
+
+func (c *InstallCommand) hasSucceededCSV(ctx context.Context, namespace, subName string) (bool, error) {
+	csvList, err := c.client.OLM().ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// meta.IsNoMatchError returns true if the CRD doesn't exist (OLM not installed)
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("list CSVs in %s: %w", namespace, err)
+	}
+
+	for i := range csvList.Items {
+		csv := &csvList.Items[i]
+
+		if csv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
+			continue
+		}
+
+		if MatchesSubscription(csv.Name, subName) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (c *InstallCommand) warnIfSubscriptionMismatch(sub *operatorsv1alpha1.Subscription, dep DependencyInfo) {
+	expectedSource := dep.Source
+	if expectedSource == "" {
+		expectedSource = defaultCatalogSource
+	}
+
+	var mismatches []string
+
+	if sub.Spec.Channel != dep.Channel {
+		mismatches = append(mismatches, fmt.Sprintf("channel: %s (expected %s)", sub.Spec.Channel, dep.Channel))
+	}
+
+	if sub.Spec.CatalogSource != expectedSource {
+		mismatches = append(mismatches, fmt.Sprintf("source: %s (expected %s)", sub.Spec.CatalogSource, expectedSource))
+	}
+
+	if len(mismatches) > 0 {
+		w := c.IO.Out()
+		_, _ = fmt.Fprintf(w, "  Warning: %s subscription has different spec: %s\n", dep.DisplayName, strings.Join(mismatches, ", "))
+	}
+}
+
+func (c *InstallCommand) createDepResources(ctx context.Context, dep DependencyInfo) error {
+	w := c.IO.Out()
+
+	_, _ = fmt.Fprintf(w, msgInstalling, dep.DisplayName)
+	_, _ = fmt.Fprintf(w, msgCreatingNamespace, dep.Namespace)
+
+	if err := c.createNamespace(ctx, dep.Namespace); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprint(w, msgEnsuringOperatorGroup)
+
+	created, err := c.ensureOperatorGroup(ctx, dep.Namespace, dep.TargetNamespaces)
+	if err != nil {
+		return err
+	}
+
+	if created {
+		_, _ = fmt.Fprint(w, msgCreatedOperatorGroup)
+	} else {
+		_, _ = fmt.Fprint(w, msgOperatorGroupExists)
+	}
+
+	_, _ = fmt.Fprintln(w, msgCreatingSubscription)
+
+	if err := c.createSubscription(ctx, dep); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *InstallCommand) createNamespace(ctx context.Context, name string) error {
+	ns := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+		},
+	}
+
+	unstructuredNS, err := toUnstructured(ns)
+	if err != nil {
+		return fmt.Errorf("create namespace %s: %w", name, err)
+	}
+
+	_, err = c.client.Dynamic().Resource(corev1.SchemeGroupVersion.WithResource("namespaces")).
+		Create(ctx, unstructuredNS, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create namespace %s: %w", name, err)
+	}
+
+	return nil
+}
+
+func (c *InstallCommand) ensureOperatorGroup(ctx context.Context, namespace string, targetNamespaces []string) (bool, error) {
+	gvr := operatorsv1.SchemeGroupVersion.WithResource("operatorgroups")
+
+	// Check if any OperatorGroup already exists in the namespace
+	list, err := c.client.Dynamic().Resource(gvr).Namespace(namespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("list operatorgroups: %w", err)
+	}
+
+	// If an OperatorGroup already exists, check if TargetNamespaces match
+	if len(list.Items) > 0 {
+		existing := &list.Items[0]
+		existingTargets, _, _ := unstructured.NestedStringSlice(existing.Object, "spec", "targetNamespaces")
+
+		if !slicesEqualUnordered(existingTargets, targetNamespaces) {
+			return false, fmt.Errorf(
+				"operatorgroup %s/%s exists with targetNamespaces %v, but requested %v",
+				namespace, existing.GetName(), existingTargets, targetNamespaces,
+			)
+		}
+
+		return false, nil
+	}
+
+	og := &operatorsv1.OperatorGroup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operators.coreos.com/v1",
+			Kind:       "OperatorGroup",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespace + "-og",
+			Namespace: namespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+		},
+		Spec: operatorsv1.OperatorGroupSpec{
+			TargetNamespaces: targetNamespaces,
+		},
+	}
+
+	unstructuredOG, err := toUnstructured(og)
+	if err != nil {
+		return false, fmt.Errorf("create operatorgroup: %w", err)
+	}
+
+	_, err = c.client.Dynamic().Resource(gvr).Namespace(namespace).
+		Create(ctx, unstructuredOG, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return false, nil // Another actor created it between List and Create
+		}
+
+		return false, fmt.Errorf("create operatorgroup: %w", err)
+	}
+
+	return true, nil
+}
+
+func (c *InstallCommand) createSubscription(ctx context.Context, dep DependencyInfo) error {
+	source := dep.Source
+	if source == "" {
+		source = defaultCatalogSource
+	}
+
+	sub := &operatorsv1alpha1.Subscription{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operators.coreos.com/v1alpha1",
+			Kind:       "Subscription",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dep.Subscription,
+			Namespace: dep.Namespace,
+			Labels: map[string]string{
+				labelManagedBy: labelManagedByValue,
+			},
+		},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			Channel:                dep.Channel,
+			Package:                dep.Subscription,
+			CatalogSource:          source,
+			CatalogSourceNamespace: sourceNamespace,
+			InstallPlanApproval:    operatorsv1alpha1.ApprovalAutomatic,
+		},
+	}
+
+	gvr := operatorsv1alpha1.SchemeGroupVersion.WithResource("subscriptions")
+
+	unstructuredSub, err := toUnstructured(sub)
+	if err != nil {
+		return fmt.Errorf("create subscription: %w", err)
+	}
+
+	_, err = c.client.Dynamic().Resource(gvr).Namespace(dep.Namespace).
+		Create(ctx, unstructuredSub, metav1.CreateOptions{})
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create subscription: %w", err)
+		}
+
+		// Subscription already exists - verify it matches expected spec
+		return c.verifyExistingSubscription(ctx, dep, source)
+	}
+
+	return nil
+}
+
+func (c *InstallCommand) verifyExistingSubscription(ctx context.Context, dep DependencyInfo, expectedSource string) error {
+	existing, err := c.client.OLM().Subscriptions(dep.Namespace).Get(ctx, dep.Subscription, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get existing subscription: %w", err)
+	}
+
+	var mismatches []string
+
+	if existing.Spec.Channel != dep.Channel {
+		mismatches = append(mismatches, fmt.Sprintf("channel: %s (expected %s)", existing.Spec.Channel, dep.Channel))
+	}
+
+	if existing.Spec.CatalogSource != expectedSource {
+		mismatches = append(mismatches, fmt.Sprintf("source: %s (expected %s)", existing.Spec.CatalogSource, expectedSource))
+	}
+
+	if len(mismatches) > 0 {
+		w := c.IO.Out()
+		_, _ = fmt.Fprintf(w, "  Warning: Subscription exists with different spec: %s\n", strings.Join(mismatches, ", "))
+	}
+
+	return nil
+}
+
+// csvResult holds the result of a CSV check.
+type csvResult struct {
+	version string
+	ready   bool
+	err     error
+	printed bool // true if a status message was already printed
+}
+
+// tryCSVFromSubscription returns a CSV version when the subscription points at a succeeded CSV.
+func (c *InstallCommand) tryCSVFromSubscription(
+	ctx context.Context,
+	w io.Writer,
+	namespace string,
+	subName string,
+	startTime time.Time,
+) csvResult {
+	sub, err := getSubscription(ctx, c.client.OLM(), namespace, subName)
+	if err != nil {
+		return csvResult{err: fmt.Errorf("get subscription: %w", err)}
+	}
+
+	// Subscription not found yet - still waiting
+	if sub == nil {
+		return csvResult{ready: false}
+	}
+
+	// Check for subscription-level resolution failures
+	for _, cond := range sub.Status.Conditions {
+		if cond.Type == "ResolutionFailed" && cond.Status == "True" {
+			return csvResult{err: fmt.Errorf("subscription resolution failed: %s", cond.Message)}
+		}
+	}
+
+	if sub.Status.InstalledCSV == "" {
+		return csvResult{ready: false}
+	}
+
+	csv, err := c.client.OLM().ClusterServiceVersions(namespace).Get(ctx, sub.Status.InstalledCSV, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return csvResult{ready: false}
+		}
+
+		return csvResult{err: fmt.Errorf("get CSV %s: %w", sub.Status.InstalledCSV, err)}
+	}
+
+	//nolint:exhaustive // default case handles all other phases
+	switch csv.Status.Phase {
+	case operatorsv1alpha1.CSVPhaseSucceeded:
+		return csvResult{version: csv.Spec.Version.String(), ready: true}
+
+	case operatorsv1alpha1.CSVPhaseFailed:
+		// Terminal failure - don't keep polling
+		reason := csv.Status.Reason
+		if reason == "" {
+			reason = "unknown"
+		}
+
+		return csvResult{err: fmt.Errorf("CSV %s failed: %s", csv.Name, reason)}
+
+	default:
+		// Pending, Installing, InstallReady, Unknown, Replacing, Deleting - keep polling
+		elapsed := time.Since(startTime).Round(time.Second)
+		_, _ = fmt.Fprintf(w, msgWaitingForCSVPhase, csv.Status.Phase, elapsed)
+
+		return csvResult{ready: false, printed: true}
+	}
+}
+
+// findSucceededCSVInNamespace lists CSVs and returns a version when a succeeded CSV matches the subscription.
+func (c *InstallCommand) findSucceededCSVInNamespace(ctx context.Context, namespace string, subName string) csvResult {
+	csvList, err := c.client.OLM().ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return csvResult{err: fmt.Errorf("list CSVs in %s: %w", namespace, err)}
+	}
+
+	for i := range csvList.Items {
+		csv := &csvList.Items[i]
+
+		if csv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
+			continue
+		}
+
+		if MatchesSubscription(csv.Name, subName) {
+			return csvResult{version: csv.Spec.Version.String(), ready: true}
+		}
+	}
+
+	return csvResult{ready: false}
+}
+
+func (c *InstallCommand) waitForCSV(ctx context.Context, w io.Writer, namespace, subName string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	startTime := time.Now()
+	pollCount := 0
+
+	for {
+		pollCount++
+
+		result := c.tryCSVFromSubscription(ctx, w, namespace, subName, startTime)
+		if result.err != nil {
+			return "", result.err
+		}
+
+		if result.ready {
+			return result.version, nil
+		}
+
+		// Every Nth poll, also check for existing CSVs in the namespace
+		if pollCount%csvNamespaceListEveryNPolls == 0 {
+			prevPrinted := result.printed
+			result = c.findSucceededCSVInNamespace(ctx, namespace, subName)
+			result.printed = prevPrinted || result.printed
+
+			if result.err != nil {
+				return "", result.err
+			}
+
+			if result.ready {
+				return result.version, nil
+			}
+		}
+
+		// Only print generic message if tryCSVFromSubscription didn't print a phase-specific one
+		if !result.printed {
+			elapsed := time.Since(startTime).Round(time.Second)
+			_, _ = fmt.Fprintf(w, msgWaitingForCSV, elapsed)
+		}
+
+		select {
+		case <-ctx.Done():
+			elapsed := time.Since(startTime).Round(time.Second)
+
+			return "", fmt.Errorf("timeout waiting for CSV after %s: %w", elapsed, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// MatchesSubscription checks if a CSV name matches the subscription package.
+// CSV names follow the pattern "<package>.v<version>" (e.g., "kueue-operator.v0.10.0").
+func MatchesSubscription(csvName, subName string) bool {
+	csvLower := strings.ToLower(csvName)
+	subLower := strings.ToLower(subName)
+
+	// Exact prefix match: "kueue-operator.v" for subscription "kueue-operator"
+	if strings.HasPrefix(csvLower, subLower+".v") {
+		return true
+	}
+
+	// Handle "openshift-" prefix: subscription "openshift-cert-manager-operator" -> CSV "cert-manager-operator.v1.19.0"
+	subWithoutPrefix := strings.TrimPrefix(subLower, "openshift-")
+	if subWithoutPrefix != subLower && strings.HasPrefix(csvLower, subWithoutPrefix+".v") {
+		return true
+	}
+
+	// Try adding "-operator" suffix for subscriptions that don't have it
+	// e.g., subscription "cert-manager" -> CSV "cert-manager-operator.v1.0.0"
+	if !strings.HasSuffix(subWithoutPrefix, "-operator") && !strings.HasSuffix(subWithoutPrefix, "operator") {
+		if strings.HasPrefix(csvLower, subWithoutPrefix+"-operator.v") {
+			return true
+		}
+	}
+
+	// Handle Red Hat naming: subscription "-product" -> CSV "-operator"
+	// e.g., subscription "opentelemetry-product" -> CSV "opentelemetry-operator.v0.144.0-2"
+	if subBase, found := strings.CutSuffix(subWithoutPrefix, "-product"); found {
+		if strings.HasPrefix(csvLower, subBase+"-operator.v") {
+			return true
+		}
+	}
+
+	// Extract package part from CSV (before ".v")
+	idx := strings.Index(csvLower, ".v")
+	if idx <= 0 {
+		return false // No version suffix, not a valid CSV name pattern
+	}
+
+	csvPackage := csvLower[:idx]
+
+	// Compare normalized forms (hyphens removed) for strict equality
+	// This handles variations like "jobset-operator" vs "job-set-operator"
+	csvNorm := strings.ReplaceAll(csvPackage, "-", "")
+	subNorm := strings.ReplaceAll(subWithoutPrefix, "-", "")
+
+	return csvNorm == subNorm
+}
+
+func (c *InstallCommand) printSuccess(w io.Writer, name, version string) {
+	if c.useColor {
+		_, _ = fmt.Fprintf(w, colorGreen+msgSuccessInstall+colorReset, name, version)
+	} else {
+		_, _ = fmt.Fprintf(w, msgSuccessInstall, name, version)
+	}
+}
+
+func (c *InstallCommand) printFailure(w io.Writer, name string, err error) {
+	if c.useColor {
+		_, _ = fmt.Fprintf(w, colorRed+msgFailInstall+colorReset, name, err)
+	} else {
+		_, _ = fmt.Fprintf(w, msgFailInstall, name, err)
+	}
+}
+
+func (c *InstallCommand) printSummary(w io.Writer, results []InstallResult) {
+	var installed, failed int
+
+	var failedNames []string
+
+	for _, r := range results {
+		switch r.Status {
+		case InstallStatusInstalled:
+			installed++
+		case InstallStatusFailed:
+			failed++
+			failedNames = append(failedNames, r.DisplayName)
+		}
+	}
+
+	_, _ = fmt.Fprintln(w)
+
+	summary := fmt.Sprintf("Summary: %d installed", installed)
+	if failed > 0 {
+		summary += fmt.Sprintf(", %d failed (%s)", failed, strings.Join(failedNames, ", "))
+	}
+
+	_, _ = fmt.Fprintln(w, summary)
+}
+
+// toUnstructured converts a typed object to unstructured.
+func toUnstructured(obj any) (*unstructured.Unstructured, error) {
+	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("convert to unstructured: %w", err)
+	}
+
+	return &unstructured.Unstructured{Object: data}, nil
+}
+
+// slicesEqualUnordered reports whether two string slices contain the same elements
+// regardless of order. Duplicates are handled via a count map so
+// ["a","a","b"] ≠ ["a","b"] as expected.
+func slicesEqualUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	counts := make(map[string]int, len(a))
+	for _, v := range a {
+		counts[v]++
+	}
+
+	for _, v := range b {
+		counts[v]--
+		if counts[v] < 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/deps/install_internal_test.go
+++ b/pkg/deps/install_internal_test.go
@@ -1,0 +1,410 @@
+package deps
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestShouldInstallDep(t *testing.T) {
+	tests := []struct {
+		name            string
+		targetDep       string
+		includeOptional bool
+		dep             DependencyInfo
+		want            bool
+	}{
+		{
+			name:      "target dep matches - always install",
+			targetDep: "cert-manager",
+			dep:       DependencyInfo{Name: "cert-manager", Enabled: "false"},
+			want:      true,
+		},
+		{
+			name:      "target dep matches optional - always install",
+			targetDep: "kueue",
+			dep:       DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:      true,
+		},
+		{
+			name:      "required dep - install",
+			targetDep: "",
+			dep:       DependencyInfo{Name: "cert-manager", Enabled: "true"},
+			want:      true,
+		},
+		{
+			name:      "optional dep without flag - skip",
+			targetDep: "",
+			dep:       DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:      false,
+		},
+		{
+			name:      "disabled dep without flag - skip",
+			targetDep: "",
+			dep:       DependencyInfo{Name: "servicemesh", Enabled: "false"},
+			want:      false,
+		},
+		{
+			name:            "optional dep with flag - install",
+			targetDep:       "",
+			includeOptional: true,
+			dep:             DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:            true,
+		},
+		{
+			name:            "disabled dep with flag - still skip",
+			targetDep:       "",
+			includeOptional: true,
+			dep:             DependencyInfo{Name: "servicemesh", Enabled: "false"},
+			want:            false,
+		},
+		{
+			name:      "different target dep - use normal rules",
+			targetDep: "other-dep",
+			dep:       DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			streams := genericiooptions.IOStreams{
+				Out:    &bytes.Buffer{},
+				ErrOut: &bytes.Buffer{},
+			}
+
+			cmd := &InstallCommand{
+				IO:              iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+				TargetDep:       tt.targetDep,
+				IncludeOptional: tt.includeOptional,
+			}
+
+			got := cmd.shouldInstallDep(tt.dep)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestSlicesEqualUnordered(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want bool
+	}{
+		{
+			name: "equal same order",
+			a:    []string{"a", "b", "c"},
+			b:    []string{"a", "b", "c"},
+			want: true,
+		},
+		{
+			name: "equal different order",
+			a:    []string{"a", "b", "c"},
+			b:    []string{"c", "a", "b"},
+			want: true,
+		},
+		{
+			name: "different lengths",
+			a:    []string{"a", "b"},
+			b:    []string{"a", "b", "c"},
+			want: false,
+		},
+		{
+			name: "different elements",
+			a:    []string{"a", "b", "c"},
+			b:    []string{"a", "b", "d"},
+			want: false,
+		},
+		{
+			name: "duplicates matter - same counts",
+			a:    []string{"a", "a", "b"},
+			b:    []string{"a", "b", "a"},
+			want: true,
+		},
+		{
+			name: "duplicates matter - different counts",
+			a:    []string{"a", "a", "b"},
+			b:    []string{"a", "b", "b"},
+			want: false,
+		},
+		{
+			name: "both empty",
+			a:    []string{},
+			b:    []string{},
+			want: true,
+		},
+		{
+			name: "one empty",
+			a:    []string{"a"},
+			b:    []string{},
+			want: false,
+		},
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := slicesEqualUnordered(tt.a, tt.b)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestRunDryRun(t *testing.T) {
+	t.Run("with deps to install", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			Out:    &buf,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := &InstallCommand{
+			IO: iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		}
+
+		deps := []DependencyInfo{
+			{
+				Name:         "cert-manager",
+				DisplayName:  "Cert Manager",
+				Namespace:    "cert-manager-operator",
+				Subscription: "cert-manager",
+				Channel:      "stable",
+				Enabled:      "true",
+			},
+		}
+
+		err := cmd.runDryRun(context.Background(), deps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		g.Expect(output).To(ContainSubstring("[DRY RUN]"))
+		g.Expect(output).To(ContainSubstring("Cert Manager"))
+		g.Expect(output).To(ContainSubstring("kind: Namespace"))
+		g.Expect(output).To(ContainSubstring("kind: OperatorGroup"))
+		g.Expect(output).To(ContainSubstring("kind: Subscription"))
+		g.Expect(output).To(ContainSubstring("cert-manager-operator"))
+		g.Expect(output).To(ContainSubstring("app.kubernetes.io/managed-by: odh-cli"))
+	})
+
+	t.Run("no deps to install", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			Out:    &buf,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := &InstallCommand{
+			IO: iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		}
+
+		// Optional dep without --include-optional flag
+		deps := []DependencyInfo{
+			{
+				Name:    "kueue",
+				Enabled: "auto",
+			},
+		}
+
+		err := cmd.runDryRun(context.Background(), deps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		g.Expect(output).To(ContainSubstring("[DRY RUN]"))
+		g.Expect(output).To(ContainSubstring("No dependencies to install"))
+	})
+
+	t.Run("with target dep", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			Out:    &buf,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := &InstallCommand{
+			IO:        iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+			TargetDep: "kueue",
+		}
+
+		deps := []DependencyInfo{
+			{
+				Name:        "cert-manager",
+				DisplayName: "Cert Manager",
+				Namespace:   "cert-manager-operator",
+				Enabled:     "true",
+			},
+			{
+				Name:         "kueue",
+				DisplayName:  "Kueue",
+				Namespace:    "openshift-kueue-operator",
+				Subscription: "kueue-operator",
+				Channel:      "stable",
+				Enabled:      "auto",
+			},
+		}
+
+		err := cmd.runDryRun(context.Background(), deps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		// Should only show kueue, not cert-manager
+		g.Expect(output).To(ContainSubstring("Kueue"))
+		g.Expect(output).ToNot(ContainSubstring("Cert Manager"))
+	})
+}
+
+func TestSyncWriter(t *testing.T) {
+	t.Run("concurrent writes are safe", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		sw := &syncWriter{w: &buf}
+
+		var wg sync.WaitGroup
+		numWriters := 10
+		writesPerWriter := 100
+
+		for i := range numWriters {
+			wg.Add(1)
+
+			go func(writerID int) {
+				defer wg.Done()
+
+				for range writesPerWriter {
+					_, err := sw.Write([]byte("x"))
+					g.Expect(err).ToNot(HaveOccurred())
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		// All writes should complete
+		g.Expect(buf.Len()).To(Equal(numWriters * writesPerWriter))
+	})
+
+	t.Run("content is preserved", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		sw := &syncWriter{w: &buf}
+
+		_, err := sw.Write([]byte("hello "))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = sw.Write([]byte("world"))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(buf.String()).To(Equal("hello world"))
+	})
+}
+
+func TestEnsureOperatorGroup(t *testing.T) {
+	t.Run("returns false when AlreadyExists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+		err := operatorsv1.AddToScheme(scheme)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		listKinds := map[schema.GroupVersionResource]string{
+			operatorsv1.SchemeGroupVersion.WithResource("operatorgroups"): "OperatorGroupList",
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		// Configure fake to return AlreadyExists on Create
+		dynamicClient.PrependReactor("create", "operatorgroups", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewAlreadyExists(
+				schema.GroupResource{Group: "operators.coreos.com", Resource: "operatorgroups"},
+				"test-og",
+			)
+		})
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := &InstallCommand{
+			IO:     iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+			client: testClient,
+		}
+
+		created, err := cmd.ensureOperatorGroup(ctx, "test-namespace", nil)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(created).To(BeFalse(), "should return false when OG already exists")
+	})
+
+	t.Run("returns true when created successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+		err := operatorsv1.AddToScheme(scheme)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		listKinds := map[schema.GroupVersionResource]string{
+			operatorsv1.SchemeGroupVersion.WithResource("operatorgroups"): "OperatorGroupList",
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := &InstallCommand{
+			IO:     iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+			client: testClient,
+		}
+
+		created, err := cmd.ensureOperatorGroup(ctx, "test-namespace", nil)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(created).To(BeTrue(), "should return true when OG is created")
+	})
+}

--- a/pkg/deps/install_test.go
+++ b/pkg/deps/install_test.go
@@ -1,0 +1,202 @@
+package deps_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testDefaultTimeout = 5 * time.Minute
+	testFlagDryRun     = "dry-run"
+	testFlagOptional   = "include-optional"
+	testFlagTimeout    = "timeout"
+	testFlagVersion    = "version"
+	testFlagRefresh    = "refresh"
+)
+
+func TestMatchesSubscription(t *testing.T) {
+	tests := []struct {
+		name    string
+		csvName string
+		subName string
+		want    bool
+	}{
+		// Exact prefix matches
+		{"exact match", "kueue-operator.v0.10.0", "kueue-operator", true},
+		{"exact match cert-manager", "cert-manager.v1.14.0", "cert-manager", true},
+		{"exact match with longer version", "kueue-operator.v0.10.0-rc1", "kueue-operator", true},
+
+		// openshift- prefix handling
+		{"openshift prefix", "cert-manager-operator.v1.19.0", "openshift-cert-manager-operator", true},
+		{"openshift prefix servicemesh", "servicemeshoperator.v2.5.0", "openshift-servicemeshoperator", true},
+
+		// Red Hat -product to -operator naming
+		{"product to operator opentelemetry", "opentelemetry-operator.v0.144.0-2", "opentelemetry-product", true},
+		{"product to operator tempo", "tempo-operator.v0.20.0-3", "tempo-product", true},
+
+		// Hyphen normalization (equality, not prefix)
+		{"hyphen variation jobset", "job-set-operator.v1.0.0", "jobset-operator", true},
+		{"hyphen variation reverse", "jobset-operator.v1.0.0", "job-set-operator", true},
+
+		// Auto-append -operator suffix (exact, not normalized)
+		{"auto append operator suffix", "cert-manager-operator.v1.0.0", "cert-manager", true},
+		{"auto append operator kueue", "kueue-operator.v1.0.0", "kueue", true},
+
+		// Should NOT match - different operators
+		{"different operator", "other-operator.v1.0.0", "kueue-operator", false},
+		{"partial match should fail", "kueue-operator-extra.v1.0.0", "kueue-operator", false},
+		{"prefix false positive prevented", "ab-c-operator.v1.0.0", "abc", false},
+		{"substring should fail", "my-kueue-operator.v1.0.0", "kueue-operator", false},
+		{"normalized prefix should not match", "abcoperator.v1.0.0", "abc", false},
+
+		// Edge cases
+		{"empty csv", "", "kueue-operator", false},
+		{"empty subscription", "kueue-operator.v1.0.0", "", false},
+		{"no version suffix", "kueue-operator", "kueue-operator", false},
+		{"case insensitive", "KUEUE-OPERATOR.v1.0.0", "kueue-operator", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := deps.MatchesSubscription(tt.csvName, tt.subName)
+			g.Expect(got).To(Equal(tt.want), "MatchesSubscription(%q, %q)", tt.csvName, tt.subName)
+		})
+	}
+}
+
+func TestInstallCommand(t *testing.T) {
+	t.Run("Complete_DryRun", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.DryRun = true
+
+		err := cmd.Complete()
+
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("Defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+
+		g.Expect(cmd.DryRun).To(BeFalse())
+		g.Expect(cmd.IncludeOptional).To(BeFalse())
+		g.Expect(cmd.Timeout).To(Equal(testDefaultTimeout))
+		g.Expect(cmd.TargetDep).To(BeEmpty())
+	})
+
+	t.Run("AddFlags", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		g.Expect(fs.Lookup(testFlagDryRun)).ToNot(BeNil())
+		g.Expect(fs.Lookup(testFlagOptional)).ToNot(BeNil())
+		g.Expect(fs.Lookup(testFlagTimeout)).ToNot(BeNil())
+		g.Expect(fs.Lookup(testFlagVersion)).ToNot(BeNil())
+		g.Expect(fs.Lookup(testFlagRefresh)).ToNot(BeNil())
+	})
+
+	t.Run("Defaults_VersionAndRefresh", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+
+		g.Expect(cmd.Version).To(BeEmpty())
+		g.Expect(cmd.Refresh).To(BeFalse())
+	})
+
+	t.Run("Validate_Success_DryRun", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.DryRun = true
+		cmd.Timeout = testDefaultTimeout
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("Validate_InvalidTimeout_Zero", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.DryRun = true
+		cmd.Timeout = 0
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("timeout"))
+	})
+
+	t.Run("Validate_InvalidTimeout_Negative", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.DryRun = true
+		cmd.Timeout = -1 * time.Minute
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("timeout"))
+	})
+}

--- a/pkg/deps/manifest.go
+++ b/pkg/deps/manifest.go
@@ -3,17 +3,34 @@ package deps
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/opendatahub-io/odh-cli/pkg/output"
 )
 
 const (
 	msgParseManifest = "parse manifest: %w"
+
+	enabledTrue = "true"
+	enabledAuto = "auto"
 )
+
+// allowedCatalogSources is the allow-list of trusted OLM catalog sources.
+// This prevents supply-chain attacks via untrusted catalogs (CWE-829).
+//
+//nolint:gochecknoglobals // static security allow-list
+var allowedCatalogSources = map[string]bool{
+	"":                    true, // empty defaults to redhat-operators
+	"redhat-operators":    true,
+	"community-operators": true,
+	"certified-operators": true,
+	"redhat-marketplace":  true,
+}
 
 //nolint:gochecknoglobals // static lookup table for display names
 var displayNames = map[string]string{
@@ -63,10 +80,11 @@ type Dependency struct {
 
 // OLMConfig contains OLM subscription details.
 type OLMConfig struct {
-	Channel   string `yaml:"channel"`
-	Name      string `yaml:"name"`      // Subscription name
-	Namespace string `yaml:"namespace"` // Operator namespace
-	Source    string `yaml:"source"`    // Catalog source (optional, defaults to redhat-operators)
+	Channel          string   `yaml:"channel"`
+	Name             string   `yaml:"name"`             // Subscription name
+	Namespace        string   `yaml:"namespace"`        // Operator namespace
+	Source           string   `yaml:"source"`           // Catalog source (optional, defaults to redhat-operators)
+	TargetNamespaces []string `yaml:"targetNamespaces"` // OperatorGroup target namespaces
 }
 
 // Component represents an ODH/RHOAI component configuration.
@@ -74,15 +92,17 @@ type Component struct {
 	Dependencies map[string]any `yaml:"dependencies"`
 }
 
-// DependencyInfo is a flattened view of a dependency for display (dry-run mode).
+// DependencyInfo is a flattened view of a dependency for display and installation.
 type DependencyInfo struct {
-	Name         string   `json:"name"                 jsonschema:"description=Dependency identifier"                yaml:"name"`
-	DisplayName  string   `json:"displayName"          jsonschema:"description=Human-readable name"                  yaml:"displayName"`
-	Enabled      string   `json:"enabled"              jsonschema:"description=Enable state (auto/true/false)"       yaml:"enabled"`
-	Subscription string   `json:"subscription"         jsonschema:"description=OLM subscription name"                yaml:"subscription"`
-	Namespace    string   `json:"namespace"            jsonschema:"description=Operator namespace"                   yaml:"namespace"`
-	Channel      string   `json:"channel,omitempty"    jsonschema:"description=OLM channel"                          yaml:"channel,omitempty"`
-	RequiredBy   []string `json:"requiredBy,omitempty" jsonschema:"description=Components requiring this dependency" yaml:"requiredBy,omitempty"`
+	Name             string   `json:"name"                       jsonschema:"description=Dependency identifier"                yaml:"name"`
+	DisplayName      string   `json:"displayName"                jsonschema:"description=Human-readable name"                  yaml:"displayName"`
+	Enabled          string   `json:"enabled"                    jsonschema:"description=Enable state (auto/true/false)"       yaml:"enabled"`
+	Subscription     string   `json:"subscription"               jsonschema:"description=OLM subscription name"                yaml:"subscription"`
+	Namespace        string   `json:"namespace"                  jsonschema:"description=Operator namespace"                   yaml:"namespace"`
+	Channel          string   `json:"channel,omitempty"          jsonschema:"description=OLM channel"                          yaml:"channel,omitempty"`
+	Source           string   `json:"source,omitempty"           jsonschema:"description=Catalog source name"                  yaml:"source,omitempty"`
+	TargetNamespaces []string `json:"targetNamespaces,omitempty" jsonschema:"description=Target namespaces for operator"       yaml:"targetNamespaces,omitempty"`
+	RequiredBy       []string `json:"requiredBy,omitempty"       jsonschema:"description=Components requiring this dependency" yaml:"requiredBy,omitempty"`
 }
 
 // DependencyManifestList wraps dependency manifest info with a self-describing envelope.
@@ -102,14 +122,76 @@ func NewDependencyManifestList(deps []DependencyInfo) *DependencyManifestList {
 	}
 }
 
-// Parse parses values.yaml content into a Manifest.
+// Parse parses values.yaml content into a Manifest and validates security-sensitive fields.
 func Parse(data []byte) (*Manifest, error) {
 	var m Manifest
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf(msgParseManifest, err)
 	}
 
+	if err := m.validate(); err != nil {
+		return nil, fmt.Errorf("validate manifest: %w", err)
+	}
+
 	return &m, nil
+}
+
+// validate checks security-sensitive fields in the manifest.
+// This prevents supply-chain attacks via untrusted catalog sources (CWE-829)
+// and privilege escalation via attacker-controlled target namespaces (CWE-269).
+func (m *Manifest) validate() error {
+	for name, dep := range m.Dependencies {
+		if err := validateOLMConfig(name, dep.OLM); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateOLMConfig validates security-sensitive OLM configuration fields.
+func validateOLMConfig(depName string, olm OLMConfig) error {
+	// Validate catalog source against allow-list
+	if !allowedCatalogSources[olm.Source] {
+		return fmt.Errorf(
+			"dependency %q: untrusted catalog source %q; allowed: redhat-operators, community-operators, certified-operators, redhat-marketplace",
+			depName, olm.Source,
+		)
+	}
+
+	// Validate target namespaces
+	for _, ns := range olm.TargetNamespaces {
+		if err := validateTargetNamespace(depName, ns, olm.Namespace); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateTargetNamespace validates a single target namespace entry.
+func validateTargetNamespace(depName, ns, operatorNamespace string) error {
+	// Validate as DNS-1123 label
+	if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+		return fmt.Errorf(
+			"dependency %q: invalid targetNamespace %q: %s",
+			depName, ns, strings.Join(errs, ", "),
+		)
+	}
+
+	// Reject system namespaces unless it's the operator's own namespace
+	if ns == operatorNamespace {
+		return nil
+	}
+
+	if strings.HasPrefix(ns, "kube-") || strings.HasPrefix(ns, "openshift-") {
+		return fmt.Errorf(
+			"dependency %q: targetNamespace %q is a system namespace; only the operator's own namespace %q is allowed",
+			depName, ns, operatorNamespace,
+		)
+	}
+
+	return nil
 }
 
 // GetDependencies returns a flat list of dependencies with their metadata, sorted by name.
@@ -119,13 +201,15 @@ func (m *Manifest) GetDependencies() []DependencyInfo {
 	deps := make([]DependencyInfo, 0, len(m.Dependencies))
 	for name, dep := range m.Dependencies {
 		info := DependencyInfo{
-			Name:         name,
-			DisplayName:  toDisplayName(name),
-			Enabled:      dep.Enabled,
-			Subscription: dep.OLM.Name,
-			Namespace:    dep.OLM.Namespace,
-			Channel:      dep.OLM.Channel,
-			RequiredBy:   requiredBy[name],
+			Name:             name,
+			DisplayName:      toDisplayName(name),
+			Enabled:          dep.Enabled,
+			Subscription:     dep.OLM.Name,
+			Namespace:        dep.OLM.Namespace,
+			Channel:          dep.OLM.Channel,
+			Source:           dep.OLM.Source,
+			TargetNamespaces: dep.OLM.TargetNamespaces,
+			RequiredBy:       requiredBy[name],
 		}
 		deps = append(deps, info)
 	}
@@ -184,7 +268,7 @@ func isEnabled(val any) bool {
 	case bool:
 		return v
 	case string:
-		return v == "true" || v == "auto"
+		return v == enabledTrue || v == enabledAuto
 	default:
 		return false
 	}


### PR DESCRIPTION
## Description

Adds `install` and `graph` subcommands to the `deps` command for managing ODH/RHOAI operator dependencies via OLM.

### New Commands

**`kubectl odh deps install [DEPENDENCY]`**
- Creates namespace, OperatorGroup, and OLM Subscription for missing dependencies
- Waits for CSV to reach Succeeded phase
- Supports `--dry-run` to preview resources without applying
- Supports `--include-optional` to install optional (enabled=auto) dependencies
- Supports `--timeout` for CSV wait duration (default 5m)
- Labels created resources with `app.kubernetes.io/managed-by: odh-cli`
- Warns if existing Subscription has different channel/source
- Fails fast on API errors during CSV wait (instead of timing out silently)

**`kubectl odh deps graph`**
- Displays dependency relationships visually
- Shows which components require each operator
- Shows transitive dependencies between operators

### Backward Compatibility

Running `kubectl odh deps` without a subcommand still executes the list behavior (shows dependency status).

### Files Changed

- `cmd/deps/deps.go` - Refactored to support subcommands
- `pkg/deps/manifest.go` - Extended with fields for install support (Config, TargetNamespaces, Source)
- `pkg/deps/install.go` - Install command implementation
- `pkg/deps/graph.go` - Graph command implementation
- `pkg/deps/*_test.go` - Unit tests for new commands

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top-level dependency manager with new subcommands: install (with --dry-run, target selection, --timeout, --include-optional) and graph (with --refresh), plus updated help/examples.
  * Graph output: human-readable dependency relationships and required/depends-on lists.
  * Dry-run prints install YAML; live install reports per-dependency results and waits for readiness.

* **Bug Fixes**
  * Improved version detection by falling back to cluster-wide CSV lookup when needed.

* **Tests**
  * Added tests covering graph, install, matching logic, dry-run output, and install decisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->