### PR TITLE
feat: add output envelope for JSON/YAML responses

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -2,7 +2,10 @@ package version
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"runtime"
 
 	"github.com/spf13/cobra"
 
@@ -18,32 +21,70 @@ const (
 
 // AddCommand adds the version subcommand to the root command.
 func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
-	var outputFormat string
+	var (
+		outputFormat string
+		verbose      bool
+		quiet        bool
+	)
 
 	cmd := &cobra.Command{
 		Use:          cmdName,
 		Short:        cmdShort,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if verbose && quiet {
+				return errors.New("--verbose and --quiet are mutually exclusive")
+			}
+
+			// Determine output writer (suppress if quiet)
+			out := cmd.OutOrStdout()
+			if quiet {
+				out = io.Discard
+			}
+
 			switch outputFormat {
 			case "json":
-				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder := json.NewEncoder(out)
 				encoder.SetIndent("", "  ")
 
-				err := encoder.Encode(map[string]string{
+				data := map[string]string{
 					"version": version.GetVersion(),
 					"commit":  version.GetCommit(),
 					"date":    version.GetDate(),
-				})
+				}
 
+				if verbose {
+					data["goVersion"] = runtime.Version()
+					data["platform"] = runtime.GOOS + "/" + runtime.GOARCH
+				}
+
+				err := encoder.Encode(data)
 				if err != nil {
 					return fmt.Errorf("failed to encode version information as JSON: %w", err)
 				}
 
 				return nil
 			default:
+				if verbose {
+					_, err := fmt.Fprintf(
+						out,
+						"kubectl-odh version %s\n  Commit:     %s\n  Built:      %s\n  Go version: %s\n  Platform:   %s\n",
+						version.GetVersion(),
+						version.GetCommit(),
+						version.GetDate(),
+						runtime.Version(),
+						runtime.GOOS+"/"+runtime.GOARCH,
+					)
+
+					if err != nil {
+						return fmt.Errorf("failed to write version information: %w", err)
+					}
+
+					return nil
+				}
+
 				_, err := fmt.Fprintf(
-					cmd.OutOrStdout(),
+					out,
 					"kubectl-odh version %s (commit: %s, built: %s)\n",
 					version.GetVersion(),
 					version.GetCommit(),
@@ -60,6 +101,8 @@ func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
 	}
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text|json)")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress all output")
 
 	root.AddCommand(cmd)
 }

--- a/pkg/components/describe.go
+++ b/pkg/components/describe.go
@@ -42,6 +42,8 @@ type DescribeCommand struct {
 
 	ComponentName string
 	OutputFormat  string
+	Verbose       bool
+	Quiet         bool
 }
 
 // NewDescribeCommand creates a new DescribeCommand with defaults.
@@ -59,16 +61,27 @@ func NewDescribeCommand(
 // AddFlags registers command-specific flags.
 func (c *DescribeCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
+	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 }
 
 // Complete resolves derived fields after flag parsing.
 func (c *DescribeCommand) Complete() error {
+	if c.Verbose && c.Quiet {
+		return errors.New("--verbose and --quiet are mutually exclusive")
+	}
+
 	k8sClient, err := client.NewClient(c.ConfigFlags)
 	if err != nil {
 		return fmt.Errorf("creating Kubernetes client: %w", err)
 	}
 
 	c.Client = k8sClient
+
+	// Wrap IO only when --quiet is explicitly passed
+	if c.Quiet {
+		c.IO = iostreams.NewFullQuietWrapper(c.IO)
+	}
 
 	return nil
 }
@@ -175,11 +188,12 @@ func truncateString(s string, maxLen int) string {
 }
 
 func (c *DescribeCommand) outputJSON(details *ComponentDetails) error {
-	renderer := printerjson.NewRenderer[*ComponentDetails](
-		printerjson.WithWriter[*ComponentDetails](c.IO.Out()),
+	result := NewComponentDetailsResult(*details)
+	renderer := printerjson.NewRenderer[*ComponentDetailsResult](
+		printerjson.WithWriter[*ComponentDetailsResult](c.IO.Out()),
 	)
 
-	if err := renderer.Render(details); err != nil {
+	if err := renderer.Render(result); err != nil {
 		return fmt.Errorf("rendering JSON: %w", err)
 	}
 
@@ -187,11 +201,12 @@ func (c *DescribeCommand) outputJSON(details *ComponentDetails) error {
 }
 
 func (c *DescribeCommand) outputYAML(details *ComponentDetails) error {
-	renderer := printeryaml.NewRenderer[*ComponentDetails](
-		printeryaml.WithWriter[*ComponentDetails](c.IO.Out()),
+	result := NewComponentDetailsResult(*details)
+	renderer := printeryaml.NewRenderer[*ComponentDetailsResult](
+		printeryaml.WithWriter[*ComponentDetailsResult](c.IO.Out()),
 	)
 
-	if err := renderer.Render(details); err != nil {
+	if err := renderer.Render(result); err != nil {
 		return fmt.Errorf("rendering YAML: %w", err)
 	}
 

--- a/pkg/components/describe_test.go
+++ b/pkg/components/describe_test.go
@@ -126,8 +126,21 @@ func TestDescribeCommand_Run(t *testing.T) {
 		var result map[string]any
 		err = json.Unmarshal(out.Bytes(), &result)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result["name"]).To(Equal("kserve"))
-		g.Expect(result["managementState"]).To(Equal("Removed"))
+
+		// Verify envelope fields
+		g.Expect(result["apiVersion"]).To(Equal("cli.opendatahub.io/v1"))
+		g.Expect(result["kind"]).To(Equal("ComponentDetails"))
+		g.Expect(result["metadata"]).ToNot(BeNil())
+		metadata, ok := result["metadata"].(map[string]any)
+		g.Expect(ok).To(BeTrue(), "metadata should be a map")
+		g.Expect(metadata["command"]).To(Equal("components-describe"))
+		g.Expect(result["status"]).ToNot(BeNil())
+
+		// Verify component data is nested under "component"
+		component, ok := result["component"].(map[string]any)
+		g.Expect(ok).To(BeTrue(), "component should be a nested object")
+		g.Expect(component["name"]).To(Equal("kserve"))
+		g.Expect(component["managementState"]).To(Equal("Removed"))
 	})
 
 	t.Run("returns error for non-existent component", func(t *testing.T) {

--- a/pkg/components/list.go
+++ b/pkg/components/list.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -40,6 +41,8 @@ type ListCommand struct {
 	Client      client.Client
 
 	OutputFormat string
+	Verbose      bool
+	Quiet        bool
 }
 
 // NewListCommand creates a new ListCommand with defaults.
@@ -57,16 +60,27 @@ func NewListCommand(
 // AddFlags registers command-specific flags.
 func (c *ListCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
+	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 }
 
 // Complete resolves derived fields after flag parsing.
 func (c *ListCommand) Complete() error {
+	if c.Verbose && c.Quiet {
+		return errors.New("--verbose and --quiet are mutually exclusive")
+	}
+
 	k8sClient, err := client.NewClient(c.ConfigFlags)
 	if err != nil {
 		return fmt.Errorf("creating Kubernetes client: %w", err)
 	}
 
 	c.Client = k8sClient
+
+	// Wrap IO only when --quiet is explicitly passed
+	if c.Quiet {
+		c.IO = iostreams.NewFullQuietWrapper(c.IO)
+	}
 
 	return nil
 }
@@ -175,13 +189,13 @@ func OutputTable(w io.Writer, components []ComponentInfo) error {
 
 // OutputJSON renders components as JSON.
 func OutputJSON(w io.Writer, components []ComponentInfo) error {
-	output := ComponentList{Components: components}
+	list := NewComponentList(components)
 
-	renderer := printerjson.NewRenderer[ComponentList](
-		printerjson.WithWriter[ComponentList](w),
+	renderer := printerjson.NewRenderer[*ComponentList](
+		printerjson.WithWriter[*ComponentList](w),
 	)
 
-	if err := renderer.Render(output); err != nil {
+	if err := renderer.Render(list); err != nil {
 		return fmt.Errorf("rendering JSON: %w", err)
 	}
 
@@ -190,13 +204,13 @@ func OutputJSON(w io.Writer, components []ComponentInfo) error {
 
 // OutputYAML renders components as YAML.
 func OutputYAML(w io.Writer, components []ComponentInfo) error {
-	output := ComponentList{Components: components}
+	list := NewComponentList(components)
 
-	renderer := printeryaml.NewRenderer[ComponentList](
-		printeryaml.WithWriter[ComponentList](w),
+	renderer := printeryaml.NewRenderer[*ComponentList](
+		printeryaml.WithWriter[*ComponentList](w),
 	)
 
-	if err := renderer.Render(output); err != nil {
+	if err := renderer.Render(list); err != nil {
 		return fmt.Errorf("rendering YAML: %w", err)
 	}
 

--- a/pkg/components/list_test.go
+++ b/pkg/components/list_test.go
@@ -243,6 +243,14 @@ func TestOutputJSON(t *testing.T) {
 		err = json.Unmarshal(buf.Bytes(), &result)
 		g.Expect(err).ToNot(HaveOccurred())
 
+		// Verify envelope fields
+		g.Expect(result["apiVersion"]).To(Equal("cli.opendatahub.io/v1"))
+		g.Expect(result["kind"]).To(Equal("ComponentList"))
+		g.Expect(result["metadata"]).ToNot(BeNil())
+		metadata := result["metadata"].(map[string]any)
+		g.Expect(metadata["command"]).To(Equal("components-list"))
+		g.Expect(result["status"]).ToNot(BeNil())
+
 		g.Expect(result).To(HaveKey("components"))
 
 		compList, ok := result["components"].([]any)
@@ -297,12 +305,23 @@ func TestOutputYAML(t *testing.T) {
 		err = yaml.Unmarshal(buf.Bytes(), &result)
 		g.Expect(err).ToNot(HaveOccurred())
 
+		// Verify envelope fields
+		g.Expect(result["apiVersion"]).To(Equal("cli.opendatahub.io/v1"))
+		g.Expect(result["kind"]).To(Equal("ComponentList"))
+		g.Expect(result["metadata"]).ToNot(BeNil())
+		metadata, ok := result["metadata"].(map[string]any)
+		g.Expect(ok).To(BeTrue(), "metadata should be a map")
+		g.Expect(metadata["command"]).To(Equal("components-list"))
+		g.Expect(result["status"]).ToNot(BeNil())
+
 		g.Expect(result).To(HaveKey("components"))
 
-		compList := result["components"].([]any)
+		compList, ok := result["components"].([]any)
+		g.Expect(ok).To(BeTrue(), "components should be a list")
 		g.Expect(compList).To(HaveLen(1))
 
-		first := compList[0].(map[string]any)
+		first, ok := compList[0].(map[string]any)
+		g.Expect(ok).To(BeTrue(), "component should be a map")
 		g.Expect(first["name"]).To(Equal("ray"))
 		g.Expect(first["managementState"]).To(Equal("Unmanaged"))
 		g.Expect(first["ready"]).To(BeFalse())

--- a/pkg/components/types.go
+++ b/pkg/components/types.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/output"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
@@ -22,15 +23,81 @@ type ComponentInfo struct {
 	Message         string `json:"message,omitempty"`
 }
 
-// ComponentList wraps a slice of ComponentInfo for JSON/YAML output.
+// ComponentList wraps a slice of ComponentInfo with a self-describing envelope.
 type ComponentList struct {
-	Components []ComponentInfo `json:"components"`
+	output.Envelope
+
+	Components []ComponentInfo `json:"components" yaml:"components"`
+}
+
+// NewComponentList creates a new ComponentList with envelope fields populated.
+func NewComponentList(components []ComponentInfo) *ComponentList {
+	list := &ComponentList{
+		Envelope:   output.NewEnvelope("ComponentList", "components-list"),
+		Components: components,
+	}
+	list.computeStatus()
+
+	return list
+}
+
+// computeStatus calculates the Status based on component health.
+func (l *ComponentList) computeStatus() {
+	var warnings, errs int
+	for _, c := range l.Components {
+		if !c.IsActive() {
+			continue
+		}
+		if c.Ready == nil {
+			warnings++
+		} else if !*c.Ready {
+			errs++
+		}
+	}
+	l.SetStatus(warnings, errs)
 }
 
 // IsActive returns true if the component is Managed or Unmanaged (not Removed).
 func (c ComponentInfo) IsActive() bool {
 	return c.ManagementState == constants.ManagementStateManaged ||
 		c.ManagementState == constants.ManagementStateUnmanaged
+}
+
+// ComponentDetailsResult wraps ComponentDetails with a self-describing envelope.
+type ComponentDetailsResult struct {
+	output.Envelope
+
+	Component ComponentDetails `json:"component" yaml:"component"`
+}
+
+// NewComponentDetailsResult creates a new ComponentDetailsResult with envelope fields populated.
+func NewComponentDetailsResult(details ComponentDetails) *ComponentDetailsResult {
+	result := &ComponentDetailsResult{
+		Envelope:  output.NewEnvelope("ComponentDetails", "components-describe"),
+		Component: details,
+	}
+	result.computeStatus()
+
+	return result
+}
+
+// computeStatus calculates the Status based on component health.
+func (r *ComponentDetailsResult) computeStatus() {
+	// Skip status computation for inactive (Removed) components
+	if r.Component.ManagementState != constants.ManagementStateManaged &&
+		r.Component.ManagementState != constants.ManagementStateUnmanaged {
+		r.SetStatus(0, 0)
+
+		return
+	}
+
+	var warnings, errs int
+	if r.Component.Ready == nil {
+		warnings++
+	} else if !*r.Component.Ready {
+		errs++
+	}
+	r.SetStatus(warnings, errs)
 }
 
 // ErrComponentNotFound creates a structured error for unknown components.

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -11,6 +11,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/opendatahub-io/odh-cli/pkg/output"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
@@ -41,6 +42,47 @@ type DependencyStatus struct {
 	Subscription string   `json:"subscription"         yaml:"subscription"`
 	RequiredBy   []string `json:"requiredBy,omitempty" yaml:"requiredBy,omitempty"`
 	Error        string   `json:"error,omitempty"      yaml:"error,omitempty"`
+}
+
+// DependencyList wraps dependency statuses with a self-describing envelope.
+type DependencyList struct {
+	output.Envelope
+
+	Dependencies []DependencyStatus `json:"dependencies" yaml:"dependencies"`
+}
+
+// NewDependencyList creates a new DependencyList with envelope fields populated.
+func NewDependencyList(statuses []DependencyStatus) *DependencyList {
+	list := &DependencyList{
+		Envelope:     output.NewEnvelope("DependencyList", "deps"),
+		Dependencies: statuses,
+	}
+	list.computeStatus()
+
+	return list
+}
+
+// computeStatus calculates the Status based on Dependencies.
+func (l *DependencyList) computeStatus() {
+	var warnings, errs int
+	for _, d := range l.Dependencies {
+		// Check for per-dependency errors first
+		if d.Error != "" {
+			errs++
+
+			continue
+		}
+
+		switch d.Status {
+		case StatusMissing:
+			errs++
+		case StatusUnknown:
+			warnings++
+		case StatusInstalled, StatusOptional:
+			// No action needed for installed or optional dependencies.
+		}
+	}
+	l.SetStatus(warnings, errs)
 }
 
 // CheckDependencies queries the cluster for dependency installation status.

--- a/pkg/deps/check_test.go
+++ b/pkg/deps/check_test.go
@@ -210,3 +210,65 @@ func TestCheckDependencies_EmptySubscription(t *testing.T) {
 
 	mockOLM.AssertExpectations(t)
 }
+
+func TestNewDependencyList_EnvelopeFields(t *testing.T) {
+	g := NewWithT(t)
+
+	statuses := []deps.DependencyStatus{
+		{Name: "certManager", DisplayName: "Cert Manager", Status: deps.StatusInstalled},
+		{Name: "serviceMesh", DisplayName: "Service Mesh", Status: deps.StatusMissing},
+	}
+
+	list := deps.NewDependencyList(statuses)
+
+	g.Expect(list.APIVersion).To(Equal("cli.opendatahub.io/v1"))
+	g.Expect(list.Kind).To(Equal("DependencyList"))
+	g.Expect(list.Metadata.Command).To(Equal("deps"))
+	g.Expect(list.Metadata.CLIVersion).ToNot(BeEmpty())
+	g.Expect(list.Metadata.GeneratedAt).ToNot(BeEmpty())
+	g.Expect(list.Status).ToNot(BeNil())
+	g.Expect(list.Dependencies).To(HaveLen(2))
+}
+
+func TestNewDependencyList_ComputesStatus(t *testing.T) {
+	t.Run("success when all installed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		statuses := []deps.DependencyStatus{
+			{Name: "certManager", Status: deps.StatusInstalled},
+			{Name: "serviceMesh", Status: deps.StatusOptional},
+		}
+
+		list := deps.NewDependencyList(statuses)
+
+		g.Expect(list.Status.Result).To(Equal("success"))
+		g.Expect(list.Status.Errors).To(Equal(0))
+		g.Expect(list.Status.Warnings).To(Equal(0))
+	})
+
+	t.Run("failure when missing", func(t *testing.T) {
+		g := NewWithT(t)
+
+		statuses := []deps.DependencyStatus{
+			{Name: "certManager", Status: deps.StatusMissing},
+		}
+
+		list := deps.NewDependencyList(statuses)
+
+		g.Expect(list.Status.Result).To(Equal("failure"))
+		g.Expect(list.Status.Errors).To(Equal(1))
+	})
+
+	t.Run("warning when unknown", func(t *testing.T) {
+		g := NewWithT(t)
+
+		statuses := []deps.DependencyStatus{
+			{Name: "certManager", Status: deps.StatusUnknown},
+		}
+
+		list := deps.NewDependencyList(statuses)
+
+		g.Expect(list.Status.Result).To(Equal("warning"))
+		g.Expect(list.Status.Warnings).To(Equal(1))
+	})
+}

--- a/pkg/deps/command.go
+++ b/pkg/deps/command.go
@@ -3,6 +3,7 @@ package deps
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +33,7 @@ const (
 	outputYAML  = "yaml"
 
 	yamlIndent         = 2
-	tableWidthNormal   = 130
+	tableWidthNormal   = 145
 	tableWidthExpanded = 150
 	semverParts        = 3
 
@@ -60,6 +61,8 @@ type Command struct {
 	DryRun  bool
 	Output  string
 	Version string
+	Verbose bool
+	Quiet   bool
 
 	client          client.Client
 	clusterVersion  string
@@ -82,11 +85,22 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show manifest data without querying cluster")
 	fs.StringVarP(&c.Output, "output", "o", outputTable, "Output format: table, json, yaml")
 	fs.StringVar(&c.Version, "version", "", "ODH/RHOAI version to show dependencies for")
+	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
+	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 }
 
 // Complete prepares the command for execution.
 func (c *Command) Complete() error {
+	if c.Verbose && c.Quiet {
+		return errors.New("--verbose and --quiet are mutually exclusive")
+	}
+
 	c.useColor = shouldUseColor(c.IO.Out())
+
+	// Wrap IO only when --quiet is explicitly passed
+	if c.Quiet {
+		c.IO = iostreams.NewFullQuietWrapper(c.IO)
+	}
 
 	if c.DryRun {
 		return nil
@@ -177,7 +191,7 @@ func (c *Command) Run(ctx context.Context) error {
 
 	ver, err := version.Detect(ctx, c.client)
 	if err != nil {
-		_, _ = fmt.Fprintf(c.IO.ErrOut(), "Warning: failed to detect cluster version: %v\n", err)
+		c.IO.Errorf("Warning: failed to detect cluster version: %v", err)
 	} else if ver != nil {
 		c.clusterVersion = ver.String()
 
@@ -203,9 +217,9 @@ func (c *Command) printDryRun(manifest *Manifest) error {
 
 	switch c.Output {
 	case outputJSON:
-		return c.printJSON(deps)
+		return c.printJSON(NewDependencyManifestList(deps))
 	case outputYAML:
-		return c.printYAML(deps)
+		return c.printYAML(NewDependencyManifestList(deps))
 	default:
 		return c.printDryRunTable(deps)
 	}
@@ -214,9 +228,9 @@ func (c *Command) printDryRun(manifest *Manifest) error {
 func (c *Command) printResults(statuses []DependencyStatus) error {
 	switch c.Output {
 	case outputJSON:
-		return c.printJSON(statuses)
+		return c.printJSON(NewDependencyList(statuses))
 	case outputYAML:
-		return c.printYAML(statuses)
+		return c.printYAML(NewDependencyList(statuses))
 	default:
 		return c.printTable(statuses)
 	}
@@ -232,7 +246,7 @@ func (c *Command) printTable(statuses []DependencyStatus) error {
 
 	_, _ = fmt.Fprintln(w)
 
-	_, _ = fmt.Fprintf(w, "%-26s %-10s %-8s %-42s %s\n",
+	_, _ = fmt.Fprintf(w, "%-26s %-12s %-20s %-42s %s\n",
 		"OPERATOR", "STATUS", "VERSION", "NAMESPACE", "REQUIRED BY")
 	_, _ = fmt.Fprint(w, strings.Repeat("-", tableWidthNormal)+"\n")
 
@@ -249,7 +263,7 @@ func (c *Command) printTable(statuses []DependencyStatus) error {
 			requiredBy = "-"
 		}
 
-		_, _ = fmt.Fprintf(w, "%-26s %-10s %-8s %-42s %s\n",
+		_, _ = fmt.Fprintf(w, "%-26s %-12s %-20s %-42s %s\n",
 			s.DisplayName,
 			statusIcon,
 			ver,

--- a/pkg/deps/fetch.go
+++ b/pkg/deps/fetch.go
@@ -55,7 +55,7 @@ type ManifestResult struct {
 // GetManifest returns the parsed manifest and version, using embedded data by default.
 // If refresh is true, fetches the latest manifest from GitHub.
 //
-//nolint:revive // refresh flag is intentional API design for CLI command
+//nolint:revive // flag-parameter: refresh is intentional API design for CLI command
 func GetManifest(ctx context.Context, refresh bool) (*ManifestResult, error) {
 	if refresh {
 		return fetchAndParseManifest(ctx, gitopsBaseURL)

--- a/pkg/deps/manifest.go
+++ b/pkg/deps/manifest.go
@@ -7,6 +7,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/output"
 )
 
 const (
@@ -81,6 +83,23 @@ type DependencyInfo struct {
 	Namespace    string   `json:"namespace"            yaml:"namespace"`
 	Channel      string   `json:"channel,omitempty"    yaml:"channel,omitempty"`
 	RequiredBy   []string `json:"requiredBy,omitempty" yaml:"requiredBy,omitempty"`
+}
+
+// DependencyManifestList wraps dependency manifest info with a self-describing envelope.
+// Used for dry-run output where cluster is not queried. Status is intentionally omitted
+// because no cluster state is available to compute warnings/errors.
+type DependencyManifestList struct {
+	output.Envelope
+
+	Dependencies []DependencyInfo `json:"dependencies" yaml:"dependencies"`
+}
+
+// NewDependencyManifestList creates a new DependencyManifestList with envelope fields populated.
+func NewDependencyManifestList(deps []DependencyInfo) *DependencyManifestList {
+	return &DependencyManifestList{
+		Envelope:     output.NewEnvelope("DependencyManifestList", "deps"),
+		Dependencies: deps,
+	}
 }
 
 // Parse parses values.yaml content into a Manifest.

--- a/pkg/deps/manifest_test.go
+++ b/pkg/deps/manifest_test.go
@@ -251,3 +251,21 @@ func TestGetDependencies_EmptyManifest(t *testing.T) {
 
 	g.Expect(depsInfo).To(BeEmpty())
 }
+
+func TestNewDependencyManifestList_EnvelopeFields(t *testing.T) {
+	g := NewWithT(t)
+
+	depsInfo := []deps.DependencyInfo{
+		{Name: "certManager", DisplayName: "Cert Manager", Enabled: "true"},
+	}
+
+	list := deps.NewDependencyManifestList(depsInfo)
+
+	g.Expect(list.APIVersion).To(Equal("cli.opendatahub.io/v1"))
+	g.Expect(list.Kind).To(Equal("DependencyManifestList"))
+	g.Expect(list.Metadata.Command).To(Equal("deps"))
+	g.Expect(list.Metadata.CLIVersion).ToNot(BeEmpty())
+	g.Expect(list.Metadata.GeneratedAt).ToNot(BeEmpty())
+	g.Expect(list.Status).To(BeNil())
+	g.Expect(list.Dependencies).To(HaveLen(1))
+}

--- a/pkg/get/command.go
+++ b/pkg/get/command.go
@@ -47,6 +47,10 @@ type Command struct {
 	LabelSelector string
 	// OutputFormat controls output rendering: table, json, or yaml.
 	OutputFormat string
+	// Verbose enables verbose output.
+	Verbose bool
+	// Quiet suppresses all non-essential output.
+	Quiet bool
 
 	// ResolvedType is the ResourceType resolved from ResourceName during Complete.
 	ResolvedType resources.ResourceType
@@ -70,10 +74,16 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.AllNamespaces, "all-namespaces", "A", false, "List resources across all namespaces")
 	fs.StringVarP(&c.LabelSelector, "selector", "l", "", "Label selector to filter resources (e.g. app=my-model)")
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
+	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 }
 
 // Complete resolves derived fields after flag parsing.
 func (c *Command) Complete() error {
+	if c.Verbose && c.Quiet {
+		return errors.New("--verbose and --quiet are mutually exclusive")
+	}
+
 	rt, err := Resolve(c.ResourceName)
 	if err != nil {
 		return fmt.Errorf("resolving resource type: %w", err)
@@ -96,6 +106,11 @@ func (c *Command) Complete() error {
 	}
 
 	c.Client = k8sClient
+
+	// Wrap IO only when --quiet is explicitly passed
+	if c.Quiet {
+		c.IO = iostreams.NewFullQuietWrapper(c.IO)
+	}
 
 	return nil
 }

--- a/pkg/lint/check/result/result.go
+++ b/pkg/lint/check/result/result.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/opendatahub-io/odh-cli/pkg/output"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 )
 
@@ -29,6 +30,10 @@ const (
 	// forms, avoiding naive derivation from Kind. Especially useful for multi-kind results
 	// where the result-level AnnotationResourceCRDName cannot represent all types.
 	AnnotationObjectCRDName = "result.opendatahub.io/crd-name"
+)
+
+const (
+	diagnosticResultListKind = "DiagnosticResultList"
 )
 
 const (
@@ -382,21 +387,45 @@ func (r *DiagnosticResult) AddImpactedObjects(
 	}
 }
 
-// DiagnosticResultList represents a list of diagnostic results.
+// DiagnosticResultList represents a list of diagnostic results with a self-describing
+// envelope for schema versioning and tool integration.
 type DiagnosticResultList struct {
+	output.Envelope
+
 	ClusterVersion   *string             `json:"clusterVersion,omitempty"   yaml:"clusterVersion,omitempty"`
 	TargetVersion    *string             `json:"targetVersion,omitempty"    yaml:"targetVersion,omitempty"`
 	OpenShiftVersion *string             `json:"openShiftVersion,omitempty" yaml:"openShiftVersion,omitempty"`
 	Results          []*DiagnosticResult `json:"results"                    yaml:"results"`
 }
 
-// NewDiagnosticResultList creates a new list.
+// ComputeStatus calculates the Status based on Results.
+func (l *DiagnosticResultList) ComputeStatus() {
+	var warnings, errs int
+	for _, r := range l.Results {
+		if r == nil {
+			continue
+		}
+		impact := r.GetImpact()
+		switch impact {
+		case ImpactProhibited, ImpactBlocking:
+			errs++
+		case ImpactAdvisory:
+			warnings++
+		case ImpactNone:
+			// No action needed for passing checks.
+		}
+	}
+	l.SetStatus(warnings, errs)
+}
+
+// NewDiagnosticResultList creates a new list with envelope fields pre-populated.
 func NewDiagnosticResultList(
 	clusterVersion *string,
 	targetVersion *string,
 	openShiftVersion *string,
 ) *DiagnosticResultList {
 	return &DiagnosticResultList{
+		Envelope:         output.NewEnvelope(diagnosticResultListKind, "lint"),
 		ClusterVersion:   clusterVersion,
 		TargetVersion:    targetVersion,
 		OpenShiftVersion: openShiftVersion,

--- a/pkg/lint/check/result/result_test.go
+++ b/pkg/lint/check/result/result_test.go
@@ -2,12 +2,14 @@ package result_test
 
 import (
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/output"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
@@ -1007,4 +1009,77 @@ func TestAddImpactedObjects(t *testing.T) {
 	g.Expect(dr.ImpactedObjects[0].Name).To(Equal("obj1"))
 	g.Expect(dr.ImpactedObjects[1].Name).To(Equal("obj2"))
 	g.Expect(dr.ImpactedObjects[2].Name).To(Equal("obj3"))
+}
+
+// DiagnosticResultList envelope tests
+
+func TestNewDiagnosticResultList_EnvelopeFields(t *testing.T) {
+	g := NewWithT(t)
+
+	clusterVer := "2.25.0"
+	targetVer := "3.0.0"
+	ocpVer := "4.16.0"
+
+	list := result.NewDiagnosticResultList(&clusterVer, &targetVer, &ocpVer)
+
+	g.Expect(list.APIVersion).To(Equal(output.APIVersion))
+	g.Expect(list.Kind).To(Equal("DiagnosticResultList"))
+	g.Expect(list.Metadata.Command).To(Equal("lint"))
+	g.Expect(list.Metadata.CLIVersion).ToNot(BeEmpty())
+}
+
+func TestNewDiagnosticResultList_GeneratedAtIsValidTimestamp(t *testing.T) {
+	g := NewWithT(t)
+
+	before := time.Now().UTC().Truncate(time.Second)
+	list := result.NewDiagnosticResultList(nil, nil, nil)
+	after := time.Now().UTC().Truncate(time.Second).Add(time.Second)
+
+	parsed, err := time.Parse(time.RFC3339, list.Metadata.GeneratedAt)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(parsed).To(BeTemporally(">=", before))
+	g.Expect(parsed).To(BeTemporally("<=", after))
+}
+
+func TestNewDiagnosticResultList_ExistingFieldsUnchanged(t *testing.T) {
+	g := NewWithT(t)
+
+	clusterVer := "2.25.0"
+	targetVer := "3.0.0"
+	ocpVer := "4.16.0"
+
+	list := result.NewDiagnosticResultList(&clusterVer, &targetVer, &ocpVer)
+
+	g.Expect(list.ClusterVersion).To(HaveValue(Equal("2.25.0")))
+	g.Expect(list.TargetVersion).To(HaveValue(Equal("3.0.0")))
+	g.Expect(list.OpenShiftVersion).To(HaveValue(Equal("4.16.0")))
+	g.Expect(list.Results).ToNot(BeNil())
+	g.Expect(list.Results).To(BeEmpty())
+}
+
+func TestNewDiagnosticResultList_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	list := result.NewDiagnosticResultList(nil, nil, nil)
+
+	g.Expect(list.APIVersion).To(Equal(output.APIVersion))
+	g.Expect(list.Kind).To(Equal("DiagnosticResultList"))
+	g.Expect(list.ClusterVersion).To(BeNil())
+	g.Expect(list.TargetVersion).To(BeNil())
+	g.Expect(list.OpenShiftVersion).To(BeNil())
+}
+
+func TestDiagnosticResultList_ComputeStatus_NilResults(t *testing.T) {
+	g := NewWithT(t)
+
+	list := result.NewDiagnosticResultList(nil, nil, nil)
+
+	// Append a nil entry to Results
+	list.Results = append(list.Results, nil)
+	list.Results = append(list.Results, result.New("component", "test", "check", "description"))
+
+	// Should not panic and should compute status correctly
+	g.Expect(func() { list.ComputeStatus() }).ToNot(Panic())
+	g.Expect(list.Status).ToNot(BeNil())
+	g.Expect(list.Status.Result).To(Equal(output.StatusSuccess))
 }

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -154,6 +154,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&c.SeverityLevel), "severity", string(SeverityLevelInfo), flagDescSeverity)
 	fs.StringArrayVar(&c.CheckSelectors, "checks", []string{"*"}, flagDescChecks)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
+	fs.BoolVarP(&c.Quiet, "quiet", "q", false, flagDescQuiet)
 	fs.BoolVar(&c.Debug, "debug", false, flagDescDebug)
 	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
@@ -166,6 +167,11 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 
 // Complete populates Options and performs pre-validation setup.
 func (c *Command) Complete() error {
+	// Validate mutual exclusivity of verbose and quiet
+	if c.Verbose && c.Quiet {
+		return errors.New("--verbose and --quiet are mutually exclusive")
+	}
+
 	// Complete shared options (creates client)
 	if err := c.SharedOptions.Complete(); err != nil {
 		return fmt.Errorf("completing shared options: %w", err)
@@ -176,8 +182,11 @@ func (c *Command) Complete() error {
 	}
 	color.NoColor = c.NoColor
 
-	// Wrap IO with QuietWrapper if NOT in verbose or debug mode (default is quiet)
-	if !c.Verbose && !c.Debug {
+	// Wrap IO based on verbosity settings
+	switch {
+	case c.Quiet:
+		c.IO = iostreams.NewFullQuietWrapper(c.IO)
+	case !c.Verbose && !c.Debug:
 		c.IO = iostreams.NewQuietWrapper(c.IO)
 	}
 

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -83,6 +83,9 @@ type SharedOptions struct {
 	// Verbose enables progress messages (default: false, quiet by default)
 	Verbose bool
 
+	// Quiet suppresses all non-essential output (mutually exclusive with Verbose)
+	Quiet bool
+
 	// Debug enables detailed diagnostic logging for troubleshooting (default: false)
 	Debug bool
 
@@ -440,10 +443,14 @@ func OutputJSON(
 	// Create the list
 	list := result.NewDiagnosticResultList(clusterVersion, targetVersion, openShiftVersion)
 
-	// Add all results in execution order
+	// Add all results in execution order, skipping nil results
 	for _, exec := range results {
-		list.Results = append(list.Results, exec.Result)
+		if exec.Result != nil {
+			list.Results = append(list.Results, exec.Result)
+		}
 	}
+
+	list.ComputeStatus()
 
 	renderer := printerjson.NewRenderer[*result.DiagnosticResultList](
 		printerjson.WithWriter[*result.DiagnosticResultList](out),
@@ -467,10 +474,14 @@ func OutputYAML(
 	// Create the list
 	list := result.NewDiagnosticResultList(clusterVersion, targetVersion, openShiftVersion)
 
-	// Add all results in execution order
+	// Add all results in execution order, skipping nil results
 	for _, exec := range results {
-		list.Results = append(list.Results, exec.Result)
+		if exec.Result != nil {
+			list.Results = append(list.Results, exec.Result)
+		}
 	}
+
+	list.ComputeStatus()
 
 	renderer := printeryaml.NewRenderer[*result.DiagnosticResultList](
 		printeryaml.WithWriter[*result.DiagnosticResultList](out),

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -6,6 +6,7 @@ const (
 	flagDescOutput             = "output format (table|json|yaml)"
 	flagDescSeverity           = "minimum severity level to display (prohibited|critical|warning|info)"
 	flagDescVerbose            = "show impacted objects and summary information"
+	flagDescQuiet              = "suppress all non-essential output (only show structured data or errors)"
 	flagDescDebug              = "show detailed diagnostic logs for troubleshooting"
 	flagDescTimeout            = "operation timeout (e.g., 10m, 30m)"
 	flagDescQPS                = "Kubernetes API QPS limit (queries per second)"

--- a/pkg/output/envelope.go
+++ b/pkg/output/envelope.go
@@ -1,0 +1,113 @@
+package output
+
+import (
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/internal/version"
+)
+
+// APIVersion is the shared schema version for all CLI structured output.
+// Consumers can branch on this value to handle format changes across CLI releases.
+const APIVersion = "cli.opendatahub.io/v1"
+
+// Status result constants.
+const (
+	StatusSuccess = "success"
+	StatusWarning = "warning"
+	StatusFailure = "failure"
+)
+
+// Metadata contains contextual information about when and how the output was produced.
+// Shared across all command output types for consistent self-describing envelopes.
+type Metadata struct {
+	// GeneratedAt is the RFC3339 timestamp of when the output was produced
+	GeneratedAt string `json:"generatedAt" yaml:"generatedAt"`
+
+	// Command identifies which CLI command generated this output
+	Command string `json:"command" yaml:"command"`
+
+	// CLIVersion is the semantic version of the CLI binary that produced this output
+	CLIVersion string `json:"cliVersion" yaml:"cliVersion"`
+}
+
+// Status provides a summary of the command execution result.
+// Included in output envelope for quick pass/fail determination.
+type Status struct {
+	// Result indicates overall outcome: "success", "warning", or "failure"
+	Result string `json:"result" yaml:"result"`
+
+	// Warnings count of non-blocking issues found
+	Warnings int `json:"warnings" yaml:"warnings"`
+
+	// Errors count of blocking issues found
+	Errors int `json:"errors" yaml:"errors"`
+}
+
+// NewMetadata creates a Metadata with the current timestamp and CLI version.
+// Each command passes its own name (e.g., "lint", "backup", "status").
+func NewMetadata(command string) Metadata {
+	return Metadata{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Command:     command,
+		CLIVersion:  version.GetVersion(),
+	}
+}
+
+// NewStatus creates a Status with auto-determined result based on counts.
+// Result is "failure" if errors > 0, "warning" if warnings > 0, otherwise "success".
+// Negative inputs are clamped to zero.
+func NewStatus(warnings, errors int) Status {
+	if warnings < 0 {
+		warnings = 0
+	}
+	if errors < 0 {
+		errors = 0
+	}
+
+	result := StatusSuccess
+	if errors > 0 {
+		result = StatusFailure
+	} else if warnings > 0 {
+		result = StatusWarning
+	}
+
+	return Status{
+		Result:   result,
+		Warnings: warnings,
+		Errors:   errors,
+	}
+}
+
+// Envelope contains the common envelope fields for all command outputs.
+// Embed this struct in command-specific output types to get consistent
+// self-describing envelopes without duplicating field definitions.
+//
+// Example usage:
+//
+//	type ComponentList struct {
+//	    output.Envelope
+//	    Components []ComponentInfo `json:"components"`
+//	}
+type Envelope struct {
+	APIVersion string   `json:"apiVersion"       yaml:"apiVersion"`
+	Kind       string   `json:"kind"             yaml:"kind"`
+	Metadata   Metadata `json:"metadata"         yaml:"metadata"`
+	Status     *Status  `json:"status,omitempty" yaml:"status,omitempty"`
+}
+
+// NewEnvelope creates an Envelope with standard fields populated.
+// The kind parameter should be the output type name (e.g., "ComponentList").
+// The command parameter identifies which CLI command produced the output.
+func NewEnvelope(kind, command string) Envelope {
+	return Envelope{
+		APIVersion: APIVersion,
+		Kind:       kind,
+		Metadata:   NewMetadata(command),
+	}
+}
+
+// SetStatus sets the status on the envelope based on warning/error counts.
+func (e *Envelope) SetStatus(warnings, errors int) {
+	status := NewStatus(warnings, errors)
+	e.Status = &status
+}

--- a/pkg/output/envelope_test.go
+++ b/pkg/output/envelope_test.go
@@ -1,0 +1,128 @@
+package output_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/output"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewMetadata_PopulatesGeneratedAt(t *testing.T) {
+	g := NewWithT(t)
+
+	before := time.Now().UTC().Truncate(time.Second)
+	meta := output.NewMetadata("lint")
+	after := time.Now().UTC().Truncate(time.Second).Add(time.Second)
+
+	g.Expect(meta.GeneratedAt).ToNot(BeEmpty())
+
+	parsed, err := time.Parse(time.RFC3339, meta.GeneratedAt)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(parsed).To(BeTemporally(">=", before))
+	g.Expect(parsed).To(BeTemporally("<=", after))
+}
+
+func TestNewMetadata_SetsCommand(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("lint command", func(t *testing.T) {
+		meta := output.NewMetadata("lint")
+		g.Expect(meta.Command).To(Equal("lint"))
+	})
+
+	t.Run("backup command", func(t *testing.T) {
+		meta := output.NewMetadata("backup")
+		g.Expect(meta.Command).To(Equal("backup"))
+	})
+
+	t.Run("status command", func(t *testing.T) {
+		meta := output.NewMetadata("status")
+		g.Expect(meta.Command).To(Equal("status"))
+	})
+}
+
+func TestNewMetadata_SetsCLIVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	meta := output.NewMetadata("lint")
+	g.Expect(meta.CLIVersion).ToNot(BeEmpty())
+}
+
+func TestAPIVersion_IsStable(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(output.APIVersion).To(Equal("cli.opendatahub.io/v1"))
+}
+
+func TestNewStatus_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	status := output.NewStatus(0, 0)
+
+	g.Expect(status.Result).To(Equal(output.StatusSuccess))
+	g.Expect(status.Warnings).To(Equal(0))
+	g.Expect(status.Errors).To(Equal(0))
+}
+
+func TestNewStatus_Warning(t *testing.T) {
+	g := NewWithT(t)
+
+	status := output.NewStatus(3, 0)
+
+	g.Expect(status.Result).To(Equal(output.StatusWarning))
+	g.Expect(status.Warnings).To(Equal(3))
+	g.Expect(status.Errors).To(Equal(0))
+}
+
+func TestNewStatus_Failure(t *testing.T) {
+	g := NewWithT(t)
+
+	status := output.NewStatus(2, 1)
+
+	g.Expect(status.Result).To(Equal(output.StatusFailure))
+	g.Expect(status.Warnings).To(Equal(2))
+	g.Expect(status.Errors).To(Equal(1))
+}
+
+func TestNewStatus_FailureTakesPrecedence(t *testing.T) {
+	g := NewWithT(t)
+
+	// Even with warnings, errors should result in failure
+	status := output.NewStatus(5, 3)
+
+	g.Expect(status.Result).To(Equal(output.StatusFailure))
+}
+
+func TestStatusConstants(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(output.StatusSuccess).To(Equal("success"))
+	g.Expect(output.StatusWarning).To(Equal("warning"))
+	g.Expect(output.StatusFailure).To(Equal("failure"))
+}
+
+func TestNewEnvelope(t *testing.T) {
+	g := NewWithT(t)
+
+	env := output.NewEnvelope("TestKind", "test-cmd")
+
+	g.Expect(env.APIVersion).To(Equal(output.APIVersion))
+	g.Expect(env.Kind).To(Equal("TestKind"))
+	g.Expect(env.Metadata.Command).To(Equal("test-cmd"))
+	g.Expect(env.Metadata.GeneratedAt).ToNot(BeEmpty())
+	g.Expect(env.Status).To(BeNil())
+}
+
+func TestEnvelope_SetStatus(t *testing.T) {
+	g := NewWithT(t)
+
+	env := output.NewEnvelope("TestKind", "test-cmd")
+	env.SetStatus(2, 1)
+
+	g.Expect(env.Status).ToNot(BeNil())
+	g.Expect(env.Status.Result).To(Equal(output.StatusFailure))
+	g.Expect(env.Status.Warnings).To(Equal(2))
+	g.Expect(env.Status.Errors).To(Equal(1))
+}

--- a/pkg/util/iostreams/iostreams.go
+++ b/pkg/util/iostreams/iostreams.go
@@ -1,6 +1,7 @@
 package iostreams
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 )
@@ -163,5 +164,53 @@ func (q *QuietWrapper) In() io.Reader {
 
 // ErrOut returns the error output writer from the delegate.
 func (q *QuietWrapper) ErrOut() io.Writer {
+	return q.delegate.ErrOut()
+}
+
+// FullQuietWrapper suppresses stdout output and IOStreams error methods.
+// Out() returns io.Discard; Fprintf/Fprintln/Errorf/Errorln are no-ops.
+// ErrOut() still returns the delegate so Cobra's error handling path works.
+type FullQuietWrapper struct {
+	delegate Interface
+}
+
+// NewFullQuietWrapper creates a wrapper that suppresses all output.
+func NewFullQuietWrapper(delegate Interface) *FullQuietWrapper {
+	return &FullQuietWrapper{delegate: delegate}
+}
+
+// Fprintf is suppressed (no-op) in full quiet mode.
+func (q *FullQuietWrapper) Fprintf(_ string, _ ...any) {}
+
+// Fprintln is suppressed (no-op) in full quiet mode.
+func (q *FullQuietWrapper) Fprintln(_ ...any) {}
+
+// Errorf is suppressed (no-op) in full quiet mode.
+func (q *FullQuietWrapper) Errorf(_ string, _ ...any) {}
+
+// Errorln is suppressed (no-op) in full quiet mode.
+func (q *FullQuietWrapper) Errorln(_ ...any) {}
+
+// Out returns io.Discard so printers writing directly also produce nothing.
+func (q *FullQuietWrapper) Out() io.Writer {
+	return io.Discard
+}
+
+// In returns the input reader from the delegate, or an EOF reader if delegate is nil.
+func (q *FullQuietWrapper) In() io.Reader {
+	if q.delegate == nil {
+		return bytes.NewReader(nil)
+	}
+
+	return q.delegate.In()
+}
+
+// ErrOut returns the error output writer from the delegate, or io.Discard if delegate is nil.
+// Kept functional so Cobra's error handling path can still write errors.
+func (q *FullQuietWrapper) ErrOut() io.Writer {
+	if q.delegate == nil {
+		return io.Discard
+	}
+
 	return q.delegate.ErrOut()
 }

--- a/pkg/util/iostreams/iostreams_test.go
+++ b/pkg/util/iostreams/iostreams_test.go
@@ -141,6 +141,101 @@ func TestIOStreams_Errorln(t *testing.T) {
 	})
 }
 
+// FullQuietWrapper tests
+
+func TestFullQuietWrapper_SuppressesFprintf(t *testing.T) {
+	g := NewWithT(t)
+
+	var out, errOut bytes.Buffer
+	base := iostreams.NewIOStreams(nil, &out, &errOut)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	quiet.Fprintf("should not appear: %s", "test")
+
+	g.Expect(out.String()).To(BeEmpty())
+}
+
+func TestFullQuietWrapper_SuppressesFprintln(t *testing.T) {
+	g := NewWithT(t)
+
+	var out, errOut bytes.Buffer
+	base := iostreams.NewIOStreams(nil, &out, &errOut)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	quiet.Fprintln("should not appear")
+
+	g.Expect(out.String()).To(BeEmpty())
+}
+
+func TestFullQuietWrapper_SuppressesErrorf(t *testing.T) {
+	g := NewWithT(t)
+
+	var out, errOut bytes.Buffer
+	base := iostreams.NewIOStreams(nil, &out, &errOut)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	quiet.Errorf("should not appear: %s", "error")
+
+	g.Expect(errOut.String()).To(BeEmpty())
+}
+
+func TestFullQuietWrapper_SuppressesErrorln(t *testing.T) {
+	g := NewWithT(t)
+
+	var out, errOut bytes.Buffer
+	base := iostreams.NewIOStreams(nil, &out, &errOut)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	quiet.Errorln("should not appear")
+
+	g.Expect(errOut.String()).To(BeEmpty())
+}
+
+func TestFullQuietWrapper_OutReturnsDiscard(t *testing.T) {
+	g := NewWithT(t)
+
+	var out bytes.Buffer
+	base := iostreams.NewIOStreams(nil, &out, nil)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	// Out() should return io.Discard, not the original writer
+	g.Expect(quiet.Out()).ToNot(Equal(&out))
+
+	// Writing directly to Out() should produce nothing
+	_, err := quiet.Out().Write([]byte("direct write"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(out.String()).To(BeEmpty())
+}
+
+func TestFullQuietWrapper_ErrOutPreserved(t *testing.T) {
+	g := NewWithT(t)
+
+	var errOut bytes.Buffer
+	base := iostreams.NewIOStreams(nil, nil, &errOut)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	// ErrOut() returns the real writer so Cobra's error path still works
+	g.Expect(quiet.ErrOut()).To(Equal(&errOut))
+}
+
+func TestFullQuietWrapper_InPreserved(t *testing.T) {
+	g := NewWithT(t)
+
+	var in bytes.Buffer
+	base := iostreams.NewIOStreams(&in, nil, nil)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	g.Expect(quiet.In()).To(Equal(&in))
+}
+
+func TestFullQuietWrapper_ImplementsInterface(t *testing.T) {
+	base := iostreams.NewIOStreams(nil, nil, nil)
+	quiet := iostreams.NewFullQuietWrapper(base)
+
+	// Compile-time interface check
+	var _ iostreams.Interface = quiet
+}
+
 // T008: Test nil writer validation (edge case from spec).
 func TestIOStreams_NilWriterValidation(t *testing.T) {
 	t.Run("nil Out writer should not panic", func(t *testing.T) {


### PR DESCRIPTION
## Description

Add self-describing envelope to JSON/YAML output for `lint`, `deps`, and `components` commands.

```json
{
  "apiVersion": "cli.opendatahub.io/v1",
  "kind": "DiagnosticResultList",
  "metadata": { "generatedAt": "...", "command": "lint", "cliVersion": "..." },
  "status": { "result": "success", "warnings": 0, "errors": 0 },
  "results": [...]
}
```

### Jira Link
https://redhat.atlassian.net/browse/RHOAIENG-54612

### Breaking Changes

- JSON/YAML output now includes envelope fields at top level
- `components describe -o json` nests data under `"component"` key

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Commands gain --verbose/-v and --quiet/-q flags to control output; quiet suppresses normal output, verbose shows extra details where applicable.
  - Outputs (JSON/YAML) now use a standardized envelope that includes apiVersion, kind, metadata (including command and generation time) and a computed status summary.

* **Behavior Changes**
  - Single-item and list responses now return enveloped payloads with aggregated status counts.

* **Tests**
  - Expanded tests cover envelope structure, status computation, and quiet-wrapper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->