### PR TITLE
Enable odh-cli for ppc64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN set -e; \
     case "$ARCH" in \
         amd64) KUBE_ARCH="amd64" ;; \
         arm64) KUBE_ARCH="arm64" ;; \
+        ppc64le) KUBE_ARCH="ppc64le" ;; \
         *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     echo "Installing kubectl for architecture: $KUBE_ARCH"; \
@@ -89,6 +90,7 @@ RUN set -e; \
     case "$ARCH" in \
         amd64) OC_ARCH="amd64" ;; \
         arm64) OC_ARCH="arm64" ;; \
+        ppc64le) OC_ARCH="ppc64le" ;; \
         *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     echo "Installing oc for architecture: $OC_ARCH"; \
@@ -105,6 +107,7 @@ RUN set -e; \
     case "$ARCH" in \
         amd64) YQ_ARCH="amd64" ;; \
         arm64) YQ_ARCH="arm64" ;; \
+        ppc64le) YQ_ARCH="ppc64le" ;; \
         *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac; \
     echo "Installing yq for architecture: $YQ_ARCH"; \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LINT_TIMEOUT := 10m
 # Container registry configuration
 CONTAINER_REGISTRY ?= quay.io
 CONTAINER_REPO ?= $(CONTAINER_REGISTRY)/rhoai/rhoai-upgrade-helpers-rhel9
-CONTAINER_PLATFORMS ?= linux/amd64,linux/arm64
+CONTAINER_PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le
 CONTAINER_TAGS ?= $(VERSION)
 
 # Platform for cross-compilation (defaults to current platform)


### PR DESCRIPTION
## Description
Enable odh-cli for ppc64le



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for ppc64le (PowerPC 64-bit little-endian) architecture. Container images can now be built and deployed on ppc64le platforms alongside existing amd64 and arm64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->