### PR TITLE
feat: add logs command for operator pod aggregation

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -1,0 +1,114 @@
+package logs
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	logspkg "github.com/opendatahub-io/odh-cli/pkg/logs"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	cmdName  = "logs"
+	cmdShort = "Show logs from ODH operator or components"
+)
+
+const cmdLong = `
+Display logs from ODH/RHOAI operator or component pods.
+
+The command auto-discovers pods based on the target name, eliminating the need
+to manually find pod names with kubectl get pods.
+
+Supported targets:
+  operator    ODH/RHOAI operator pod
+
+Examples:
+  # Show operator logs
+  kubectl odh logs operator
+
+  # Follow operator logs (stream new logs as they appear)
+  kubectl odh logs operator -f
+
+  # Show last 100 lines
+  kubectl odh logs operator --tail 100
+
+  # Show logs from the last hour
+  kubectl odh logs operator --since 1h
+
+  # Show previous container logs (useful for crash investigation)
+  kubectl odh logs operator --previous
+`
+
+const cmdExample = `
+  # Show operator logs
+  kubectl odh logs operator
+
+  # Follow operator logs in real-time
+  kubectl odh logs operator -f
+
+  # Show last 100 lines of operator logs
+  kubectl odh logs operator --tail 100
+
+  # Show logs from the last 30 minutes
+  kubectl odh logs operator --since 30m
+
+  # Show previous container logs (after a crash)
+  kubectl odh logs operator --previous
+`
+
+// AddCommand adds the logs command to the root command.
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+	streams := genericiooptions.IOStreams{
+		In:     root.InOrStdin(),
+		Out:    root.OutOrStdout(),
+		ErrOut: root.ErrOrStderr(),
+	}
+
+	command := logspkg.NewCommand(streams, flags)
+
+	cmd := &cobra.Command{
+		Use:           "logs TARGET",
+		Short:         cmdShort,
+		Long:          cmdLong,
+		Example:       cmdExample,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.ExactArgs(1),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return []string{"operator"}, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			command.Target = args[0]
+
+			if err := command.Complete(); err != nil {
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			if err := command.Validate(); err != nil {
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				clierrors.WriteTextError(cmd.ErrOrStderr(), err)
+
+				return clierrors.NewAlreadyHandledError(err)
+			}
+
+			return nil
+		},
+	}
+
+	command.AddFlags(cmd.Flags())
+
+	root.AddCommand(cmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/cmd/deps"
 	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
+	"github.com/opendatahub-io/odh-cli/cmd/logs"
 	"github.com/opendatahub-io/odh-cli/cmd/status"
 	"github.com/opendatahub-io/odh-cli/cmd/version"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
@@ -37,6 +38,7 @@ func main() {
 	deps.AddCommand(cmd, flags)
 	components.AddCommand(cmd, flags)
 	status.AddCommand(cmd, flags)
+	logs.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		if !errors.Is(err, clierrors.ErrAlreadyHandled) {

--- a/pkg/logs/command.go
+++ b/pkg/logs/command.go
@@ -1,0 +1,305 @@
+package logs
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	targetOperator = "operator"
+
+	flagDescFollow    = "Follow log output (stream new logs as they appear)"
+	flagDescTail      = "Lines of recent log file to display (default: all)"
+	flagDescSince     = "Only return logs newer than a relative duration (e.g., 5s, 2m, 3h)"
+	flagDescPrevious  = "Print the logs for the previous instance of the container (for crash debugging)"
+	flagDescContainer = "Container name (if pod has multiple containers)"
+
+	logChannelBuffer = 100
+
+	// Scanner buffer sizes for handling long JSON log lines.
+	scannerInitialBuffer = 64 * 1024        // 64 KB initial
+	scannerMaxBuffer     = 10 * 1024 * 1024 // 10 MB max
+
+	errMsgUnsupportedTarget  = "unsupported target %q, supported targets: %s"
+	errMsgNoOperatorPod      = "no running operator pod found; checked namespaces: %v"
+	errMsgNoOperatorPodErrs  = "no running operator pod found; errors: %v"
+	errMsgOpenLogStream      = "opening log stream for pod %s/%s: %w"
+	errMsgReadingLogs        = "reading logs: %w"
+	errMsgScanningLogs       = "scanning logs: %w"
+	errMsgStreamingLogs      = "streaming logs: %w"
+	errMsgCreatingClient     = "creating client: %w"
+	errMsgDiscoveringPods    = "discovering operator pods: %w"
+	errMsgNamespaceListError = "namespace %s: %w"
+	errMsgWritingOutput      = "writing output: %w"
+)
+
+// operatorLabelSelector finds ODH/RHOAI operator pods using a single query.
+// Uses "in" operator to match both ODH and RHOAI operator names.
+const operatorLabelSelector = "control-plane=controller-manager,name in (opendatahub-operator,rhods-operator)"
+
+// operatorNamespaces contains namespaces where the operator might be installed.
+//
+//nolint:gochecknoglobals // Static configuration for operator discovery
+var operatorNamespaces = []string{
+	"openshift-operators",
+	"redhat-ods-operator",
+	"opendatahub-operator-system",
+}
+
+// Command implements the logs command.
+type Command struct {
+	Streams genericiooptions.IOStreams
+	Flags   *genericclioptions.ConfigFlags
+	Client  client.Client
+
+	// Args
+	Target string
+
+	// Flags
+	Follow    bool
+	Tail      int64
+	Since     time.Duration
+	Previous  bool
+	Container string
+
+	// Resolved state
+	Pods []*corev1.Pod
+}
+
+// NewCommand creates a new logs command.
+func NewCommand(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) *Command {
+	return &Command{
+		Streams: streams,
+		Flags:   flags,
+		Tail:    -1,
+	}
+}
+
+// AddFlags adds command flags.
+func (c *Command) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&c.Follow, "follow", "f", false, flagDescFollow)
+	fs.Int64Var(&c.Tail, "tail", -1, flagDescTail)
+	fs.DurationVar(&c.Since, "since", 0, flagDescSince)
+	fs.BoolVar(&c.Previous, "previous", false, flagDescPrevious)
+	fs.StringVarP(&c.Container, "container", "c", "", flagDescContainer)
+}
+
+// Complete initializes the command state.
+func (c *Command) Complete() error {
+	var err error
+
+	c.Client, err = client.NewClient(c.Flags)
+	if err != nil {
+		return fmt.Errorf(errMsgCreatingClient, err)
+	}
+
+	return nil
+}
+
+// Validate checks command arguments and flags.
+func (c *Command) Validate() error {
+	if c.Target != targetOperator {
+		return fmt.Errorf(errMsgUnsupportedTarget, c.Target, targetOperator)
+	}
+
+	return nil
+}
+
+// Run executes the logs command.
+func (c *Command) Run(ctx context.Context) error {
+	pods, err := c.discoverOperatorPods(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.Pods = pods
+
+	return c.streamLogs(ctx)
+}
+
+// discoverOperatorPods finds all ODH/RHOAI operator pods concurrently across namespaces.
+func (c *Command) discoverOperatorPods(ctx context.Context) ([]*corev1.Pod, error) {
+	coreClient := c.Client.CoreV1()
+
+	var (
+		result []*corev1.Pod
+		errs   []error
+		mu     sync.Mutex
+	)
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, ns := range operatorNamespaces {
+		g.Go(func() error {
+			pods, err := coreClient.Pods(ns).List(ctx, metav1.ListOptions{
+				LabelSelector: operatorLabelSelector,
+				FieldSelector: "status.phase=Running",
+			})
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf(errMsgNamespaceListError, ns, err))
+				mu.Unlock()
+
+				return nil // Continue checking other namespaces
+			}
+
+			mu.Lock()
+			for i := range pods.Items {
+				result = append(result, &pods.Items[i])
+			}
+			mu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf(errMsgDiscoveringPods, err)
+	}
+
+	if len(result) == 0 {
+		if len(errs) > 0 {
+			return nil, fmt.Errorf(errMsgNoOperatorPodErrs, errs)
+		}
+
+		return nil, fmt.Errorf(errMsgNoOperatorPod, operatorNamespaces)
+	}
+
+	return result, nil
+}
+
+// streamLogs streams logs from discovered pods.
+func (c *Command) streamLogs(ctx context.Context) error {
+	opts := &corev1.PodLogOptions{
+		Follow:    c.Follow,
+		Previous:  c.Previous,
+		Container: c.Container,
+	}
+
+	if c.Tail >= 0 {
+		opts.TailLines = &c.Tail
+	}
+
+	if c.Since > 0 {
+		seconds := int64(c.Since.Seconds())
+		opts.SinceSeconds = &seconds
+	}
+
+	// Single pod: stream directly without prefix
+	if len(c.Pods) == 1 {
+		return c.streamSinglePod(ctx, c.Pods[0], opts)
+	}
+
+	// Multiple pods: stream with prefixes
+	return c.streamMultiplePods(ctx, opts)
+}
+
+// streamSinglePod streams logs from a single pod without prefix.
+func (c *Command) streamSinglePod(ctx context.Context, pod *corev1.Pod, opts *corev1.PodLogOptions) error {
+	req := c.Client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, opts)
+
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf(errMsgOpenLogStream, pod.Namespace, pod.Name, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	_, err = io.Copy(c.Streams.Out, stream)
+	if err != nil {
+		return fmt.Errorf(errMsgReadingLogs, err)
+	}
+
+	return nil
+}
+
+// streamMultiplePods streams logs from multiple pods with [pod-name] prefix.
+// Uses channel-based fan-in for better throughput under heavy log volume.
+func (c *Command) streamMultiplePods(ctx context.Context, opts *corev1.PodLogOptions) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	lines := make(chan string, logChannelBuffer)
+
+	var wg sync.WaitGroup
+
+	var mu sync.Mutex
+
+	var firstErr error
+
+	// Start producer goroutines
+	for _, pod := range c.Pods {
+		wg.Add(1)
+
+		go func(pod *corev1.Pod) {
+			defer wg.Done()
+
+			if err := c.streamPodToChannel(ctx, pod, opts, lines); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}(pod)
+	}
+
+	// Close channel when all producers are done
+	go func() {
+		wg.Wait()
+		close(lines)
+	}()
+
+	// Single writer consumes from channel
+	for line := range lines {
+		if _, err := fmt.Fprintln(c.Streams.Out, line); err != nil {
+			cancel() // Signal producers to stop
+
+			return fmt.Errorf(errMsgWritingOutput, err)
+		}
+	}
+
+	return firstErr
+}
+
+// streamPodToChannel streams logs from a pod to a channel, prefixing each line.
+func (c *Command) streamPodToChannel(ctx context.Context, pod *corev1.Pod, opts *corev1.PodLogOptions, lines chan<- string) error {
+	req := c.Client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, opts)
+
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf(errMsgOpenLogStream, pod.Namespace, pod.Name, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	scanner := bufio.NewScanner(stream)
+	scanner.Buffer(make([]byte, scannerInitialBuffer), scannerMaxBuffer)
+	prefix := fmt.Sprintf("[%s] ", pod.Name)
+
+	for scanner.Scan() {
+		select {
+		case lines <- prefix + scanner.Text():
+		case <-ctx.Done():
+			return fmt.Errorf(errMsgStreamingLogs, ctx.Err())
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf(errMsgScanningLogs, err)
+	}
+
+	return nil
+}

--- a/pkg/logs/command_test.go
+++ b/pkg/logs/command_test.go
@@ -1,0 +1,89 @@
+package logs_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/logs"
+
+	. "github.com/onsi/gomega"
+)
+
+// testIOStreams returns a minimal IOStreams for testing.
+func testIOStreams() genericiooptions.IOStreams {
+	return genericiooptions.IOStreams{}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("accepts operator target", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &logs.Command{Target: "operator"}
+		err := cmd.Validate()
+
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("rejects unknown target", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &logs.Command{Target: "unknown"}
+		err := cmd.Validate()
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("unsupported target"))
+		g.Expect(err.Error()).To(ContainSubstring("unknown"))
+	})
+
+	t.Run("rejects empty target", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &logs.Command{Target: ""}
+		err := cmd.Validate()
+
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestAddFlags(t *testing.T) {
+	t.Run("registers all expected flags", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &logs.Command{}
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		g.Expect(fs.Lookup("follow")).ToNot(BeNil())
+		g.Expect(fs.Lookup("tail")).ToNot(BeNil())
+		g.Expect(fs.Lookup("since")).ToNot(BeNil())
+		g.Expect(fs.Lookup("previous")).ToNot(BeNil())
+		g.Expect(fs.Lookup("container")).ToNot(BeNil())
+	})
+
+	t.Run("sets correct default values", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &logs.Command{}
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		tailFlag := fs.Lookup("tail")
+		g.Expect(tailFlag.DefValue).To(Equal("-1"))
+
+		previousFlag := fs.Lookup("previous")
+		g.Expect(previousFlag.DefValue).To(Equal("false"))
+	})
+}
+
+func TestNewCommand(t *testing.T) {
+	t.Run("initializes with default tail value", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := logs.NewCommand(testIOStreams(), nil)
+
+		g.Expect(cmd.Tail).To(Equal(int64(-1)))
+	})
+}

--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
@@ -34,6 +36,7 @@ type defaultClient struct {
 	apiExtensions apiextensionsclientset.Interface
 	olm           olmclientset.Interface
 	metadata      metadata.Interface
+	kubernetes    kubernetes.Interface
 	restMapper    meta.RESTMapper
 
 	olmReader OLMReader
@@ -46,6 +49,13 @@ func (c *defaultClient) Metadata() metadata.Interface                    { retur
 func (c *defaultClient) RESTMapper() meta.RESTMapper                     { return c.restMapper }
 func (c *defaultClient) OLM() OLMReader                                  { return c.olmReader }
 func (c *defaultClient) OLMClient() olmclientset.Interface               { return c.olm }
+func (c *defaultClient) CoreV1() corev1client.CoreV1Interface {
+	if c.kubernetes == nil {
+		panic("CoreV1 called on a client with no kubernetes client configured")
+	}
+
+	return c.kubernetes.CoreV1()
+}
 
 // NewClientWithConfig creates a client from a pre-configured REST config.
 // This allows callers to customize throttling settings before client creation.
@@ -75,6 +85,11 @@ func NewClientWithConfig(restConfig *rest.Config) (Client, error) {
 		return nil, fmt.Errorf("failed to create metadata client: %w", err)
 	}
 
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
 	// Create RESTMapper with caching for efficient GVK->GVR mapping.
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(
 		memory.NewMemCacheClient(discoveryClient),
@@ -86,6 +101,7 @@ func NewClientWithConfig(restConfig *rest.Config) (Client, error) {
 		apiExtensions: apiExtensionsClient,
 		olm:           olmClient,
 		metadata:      metadataClient,
+		kubernetes:    kubeClient,
 		restMapper:    restMapper,
 		olmReader:     newOLMReader(olmClient),
 	}, nil

--- a/pkg/util/client/interfaces.go
+++ b/pkg/util/client/interfaces.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
@@ -112,6 +113,9 @@ type Client interface {
 	// OLMClient returns the full OLM clientset for write operations (subscriptions, CSVs).
 	// Use OLM() from Reader for read-only access.
 	OLMClient() olmclientset.Interface
+
+	// CoreV1 returns the typed CoreV1 client for pod operations like GetLogs.
+	CoreV1() corev1client.CoreV1Interface
 }
 
 // OLMReader provides read-only access to OLM resources.

--- a/pkg/util/client/testing.go
+++ b/pkg/util/client/testing.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 )
 
@@ -17,6 +18,7 @@ type TestClientConfig struct {
 	APIExtensions apiextensionsclientset.Interface
 	OLM           olmclientset.Interface
 	Metadata      metadata.Interface
+	Kubernetes    kubernetes.Interface
 	RESTMapper    meta.RESTMapper
 }
 
@@ -29,6 +31,7 @@ func NewForTesting(cfg TestClientConfig) Client {
 		apiExtensions: cfg.APIExtensions,
 		olm:           cfg.OLM,
 		metadata:      cfg.Metadata,
+		kubernetes:    cfg.Kubernetes,
 		restMapper:    cfg.RESTMapper,
 		olmReader:     newOLMReader(cfg.OLM),
 	}


### PR DESCRIPTION
## Summary

Add `odh logs operator` command that auto-discovers and streams logs from ODH/RHOAI operator pods across multiple namespaces.

- Auto-discovers operator pods using label selectors across `openshift-operators`, `redhat-ods-operator`, and `opendatahub-operator-system` namespaces
- Supports `--tail`, `--since`, `--previous`, and `--container` flags
- Multi-pod aggregation with `[pod-name]` prefix when multiple operator pods exist
- Concurrent namespace discovery for lower latency
- Channel-based streaming for efficient multi-pod log output

## Test plan

- [X] `odh logs operator` - shows operator logs
- [X] `odh logs operator --tail 100` - shows last 100 lines
- [X] `odh logs operator --since 1h` - shows logs from last hour
- [X] `odh logs operator --previous` - shows previous container logs (crash debugging)
- [X] `odh logs unknown` - returns error with supported targets
- [X] Unit tests pass: `go test ./pkg/logs/...`
- [X] Lint passes: `make lint`


## Jira Ticket 
https://redhat.atlassian.net/browse/RHOAIENG-54647
## Follow-up

A follow-up PR will add support for component targets (dashboard, kserve, ray, workbenches, etc.) using DSC-based discovery.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `kubectl odh logs` to stream operator pod logs, auto-discovering operator pods and prefixing multi-pod output with pod names
  * Supports tail, since, previous, and container filtering
  * Shell completion and default target behavior improved

* **Tests**
  * Added unit tests covering logs command validation, flag registration, and initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->