### PR TITLE
feat: add events command for listing ODH events

### DIFF
--- a/cmd/events/events.go
+++ b/cmd/events/events.go
@@ -1,0 +1,95 @@
+package events
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	eventspkg "github.com/opendatahub-io/odh-cli/pkg/events"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+// handleErr writes the error in structured or text format and returns an already-handled error.
+//
+//nolint:wrapcheck // NewAlreadyHandledError is a sentinel, not meant to be wrapped
+func handleErr(w io.Writer, err error, outputFormat string) error {
+	if clierrors.WriteStructuredError(w, err, outputFormat) {
+		return clierrors.NewAlreadyHandledError(err)
+	}
+
+	clierrors.WriteTextError(w, err)
+
+	return clierrors.NewAlreadyHandledError(err)
+}
+
+const (
+	cmdName  = "events"
+	cmdShort = "Show events for ODH resources"
+)
+
+const cmdLong = `
+Shows Kubernetes events related to Open Data Hub / OpenShift AI resources.
+
+Events are fetched from ODH namespaces (applications, operator, monitoring)
+using the clusterhealth library. The namespaces are auto-detected from the
+DSCInitialization resource.
+`
+
+const cmdExample = `
+  # Show recent events
+  kubectl odh events
+
+  # Show events from the last 30 minutes
+  kubectl odh events --since 30m
+
+  # Show only warnings
+  kubectl odh events --type Warning
+
+  # All ODH namespaces, YAML output
+  kubectl odh events -A -o yaml
+`
+
+// AddCommand adds the events command to the root command.
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+	streams := genericiooptions.IOStreams{
+		In:     root.InOrStdin(),
+		Out:    root.OutOrStdout(),
+		ErrOut: root.ErrOrStderr(),
+	}
+
+	command := eventspkg.NewCommand(streams, flags)
+
+	cmd := &cobra.Command{
+		Use:           cmdName,
+		Short:         cmdShort,
+		Long:          cmdLong,
+		Example:       cmdExample,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			errOut := cmd.ErrOrStderr()
+			outputFormat := command.OutputFormat
+
+			if err := command.Complete(); err != nil {
+				return handleErr(errOut, err, outputFormat)
+			}
+
+			if err := command.Validate(); err != nil {
+				return handleErr(errOut, err, outputFormat)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				return handleErr(errOut, err, outputFormat)
+			}
+
+			return nil
+		},
+	}
+
+	command.AddFlags(cmd.Flags())
+
+	root.AddCommand(cmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/cmd/completion"
 	"github.com/opendatahub-io/odh-cli/cmd/components"
 	"github.com/opendatahub-io/odh-cli/cmd/deps"
+	"github.com/opendatahub-io/odh-cli/cmd/events"
 	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
 	"github.com/opendatahub-io/odh-cli/cmd/logs"
@@ -43,6 +44,7 @@ func main() {
 	logs.AddCommand(cmd, flags)
 	completion.AddCommand(cmd, flags)
 	migrate.AddCommand(cmd, flags)
+	events.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		exitCode := int(clierrors.ExitCodeFromError(err))

--- a/pkg/deps/fetch.go
+++ b/pkg/deps/fetch.go
@@ -54,9 +54,7 @@ type ManifestResult struct {
 
 // GetManifest returns the parsed manifest and version, using embedded data by default.
 // If refresh is true, fetches the latest manifest from GitHub.
-//
-//nolint:revive // flag-parameter: refresh is intentional API design for CLI command
-func GetManifest(ctx context.Context, refresh bool) (*ManifestResult, error) {
+func GetManifest(ctx context.Context, refresh bool) (*ManifestResult, error) { //nolint:revive // flag-parameter: refresh is intentional API design
 	if refresh {
 		return fetchAndParseManifest(ctx, gitopsBaseURL)
 	}

--- a/pkg/events/command.go
+++ b/pkg/events/command.go
@@ -1,0 +1,223 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+var _ cmd.Command = (*Command)(nil)
+
+const (
+	outputFormatTable = "table"
+	outputFormatJSON  = "json"
+	outputFormatYAML  = "yaml"
+
+	namespaceDiscoveryTimeout = 15 * time.Second
+	defaultSinceDuration      = 5 * time.Minute
+	maxSinceDuration          = 24 * time.Hour
+)
+
+// Command contains the events command configuration.
+type Command struct {
+	IO          iostreams.Interface
+	ConfigFlags *genericclioptions.ConfigFlags
+	Client      client.Client
+
+	// Flags
+	EventType          string
+	Since              time.Duration
+	AllNamespaces      bool
+	OutputFormat       string
+	OperatorNSOverride string
+
+	// Resolved fields (populated during Complete)
+	Namespace         string
+	NamespaceExplicit bool // true if user explicitly passed -n flag
+	ApplicationsNS    string
+	OperatorNS        string
+	MonitoringNS      string
+
+	// Clusterhealth integration
+	crClient crclient.Client
+}
+
+// NewCommand creates a new events Command with defaults.
+func NewCommand(
+	streams genericiooptions.IOStreams,
+	configFlags *genericclioptions.ConfigFlags,
+) *Command {
+	return &Command{
+		IO:           iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		ConfigFlags:  configFlags,
+		OutputFormat: outputFormatTable,
+		OperatorNS:   client.DefaultRHOAIOperatorNamespace,
+	}
+}
+
+// AddFlags registers command-specific flags.
+func (c *Command) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&c.EventType, "type", "", "Filter events by type (Warning or Normal)")
+	fs.DurationVar(&c.Since, "since", defaultSinceDuration, "Only show events newer than this duration (e.g., 5m, 1h, 30s)")
+	fs.BoolVarP(&c.AllNamespaces, "all-namespaces", "A", false, "List events across all ODH namespaces")
+	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	fs.StringVar(&c.OperatorNSOverride, "operator-namespace", "", "Override the operator namespace (auto-detected from OLM/CSV)")
+}
+
+// Complete resolves derived fields after flag parsing.
+func (c *Command) Complete() error {
+	restConfig, err := client.NewRESTConfig(c.ConfigFlags, client.DefaultQPS, client.DefaultBurst)
+	if err != nil {
+		return clierrors.ErrConfigFailed(err)
+	}
+
+	k8sClient, err := client.NewClientWithConfig(restConfig)
+	if err != nil {
+		return clierrors.ErrClientFailed(err)
+	}
+
+	c.Client = k8sClient
+
+	crClient, err := client.NewControllerRuntimeClient(restConfig)
+	if err != nil {
+		return clierrors.ErrCRClientFailed(err)
+	}
+
+	c.crClient = crClient
+
+	// Check if user explicitly passed -n flag (vs namespace from kubeconfig)
+	c.NamespaceExplicit = c.ConfigFlags.Namespace != nil && *c.ConfigFlags.Namespace != ""
+
+	if !c.AllNamespaces {
+		ns, _, err := c.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return clierrors.ErrNamespaceFailed(err)
+		}
+
+		c.Namespace = ns
+	}
+
+	return nil
+}
+
+// Validate checks that all options are valid before execution.
+func (c *Command) Validate() error {
+	if c.AllNamespaces && c.ConfigFlags.Namespace != nil && *c.ConfigFlags.Namespace != "" {
+		return clierrors.NewValidationError(
+			"INVALID_FLAGS",
+			"--all-namespaces and --namespace are mutually exclusive",
+			"Use either -A or -n <namespace>, not both",
+		)
+	}
+
+	switch c.OutputFormat {
+	case outputFormatTable, outputFormatJSON, outputFormatYAML:
+	default:
+		return clierrors.NewValidationError(
+			"INVALID_OUTPUT_FORMAT",
+			fmt.Sprintf("invalid output format %q", c.OutputFormat),
+			"Use one of: table, json, yaml",
+		)
+	}
+
+	if c.EventType != "" && c.EventType != "Warning" && c.EventType != "Normal" {
+		return clierrors.NewValidationError(
+			"INVALID_EVENT_TYPE",
+			fmt.Sprintf("invalid event type %q", c.EventType),
+			"Use --type Warning or --type Normal",
+		)
+	}
+
+	if c.Since < 0 {
+		return clierrors.NewValidationError(
+			"INVALID_DURATION",
+			"--since must be a non-negative duration",
+			"Use 0 or a positive value like --since 5m or --since 1h",
+		)
+	}
+
+	if c.Since > maxSinceDuration {
+		return clierrors.NewValidationError(
+			"INVALID_DURATION",
+			fmt.Sprintf("--since duration %v exceeds maximum of 24h", c.Since),
+			"Use --since with values like 5m, 1h, or 24h",
+		)
+	}
+
+	return nil
+}
+
+// Run executes the events command.
+func (c *Command) Run(ctx context.Context) error {
+	if err := c.discoverNamespaces(ctx); err != nil {
+		return err
+	}
+
+	return c.listEvents(ctx)
+}
+
+// discoverNamespaces resolves ODH namespaces using centralized discovery helpers.
+// Called from Run() so it respects the command context for cancellation.
+func (c *Command) discoverNamespaces(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, namespaceDiscoveryTimeout)
+	defer cancel()
+
+	// Use combined helper for single API call
+	namespaces, err := client.GetDSCINamespaces(ctx, c.Client)
+	if err != nil && !apierrors.IsNotFound(err) {
+		_, _ = fmt.Fprintf(c.IO.ErrOut(), "Warning: failed to get DSCI namespaces: %v\n", err)
+	}
+
+	c.ApplicationsNS = namespaces.Applications
+	c.MonitoringNS = namespaces.Monitoring
+
+	if c.OperatorNSOverride != "" {
+		c.OperatorNS = c.OperatorNSOverride
+
+		return nil
+	}
+
+	operatorNS, err := client.DiscoverOperatorNamespace(ctx, c.Client)
+	if err == nil {
+		c.OperatorNS = operatorNS
+
+		return nil
+	}
+
+	// Check if this is a "not found" error (operator not installed) vs RBAC/other errors
+	var structured *clierrors.StructuredError
+	if !errors.As(err, &structured) || structured.Category != clierrors.CategoryNotFound {
+		// Forbidden/RBAC errors should fail - user can use --operator-namespace
+		return fmt.Errorf("discovering operator namespace: %w", err)
+	}
+
+	_, _ = fmt.Fprint(c.IO.ErrOut(), "Warning: operator namespace not found, using default\n")
+	c.OperatorNS = client.DefaultRHOAIOperatorNamespace
+
+	return nil
+}
+
+// listEvents fetches and displays events.
+func (c *Command) listEvents(ctx context.Context) error {
+	events, err := c.fetchEvents(ctx)
+	if err != nil {
+		return err
+	}
+
+	sortEventsByTime(events)
+
+	return c.renderOutput(events)
+}

--- a/pkg/events/command_test.go
+++ b/pkg/events/command_test.go
@@ -1,0 +1,156 @@
+package events_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/events"
+)
+
+func TestCommandValidate_OutputFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		wantErr bool
+	}{
+		{"table format", "table", false},
+		{"json format", "json", false},
+		{"yaml format", "yaml", false},
+		{"invalid format", "xml", true},
+		{"empty format", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &events.Command{
+				OutputFormat: tt.format,
+				ConfigFlags:  genericclioptions.NewConfigFlags(true),
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() with format %q error = %v, wantErr %v",
+					tt.format, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_EventType(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		wantErr   bool
+	}{
+		{"empty type", "", false},
+		{"warning type", "Warning", false},
+		{"normal type", "Normal", false},
+		{"invalid type", "Error", true},
+		{"lowercase warning", "warning", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &events.Command{
+				OutputFormat: "table",
+				EventType:    tt.eventType,
+				ConfigFlags:  genericclioptions.NewConfigFlags(true),
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() with eventType %q error = %v, wantErr %v",
+					tt.eventType, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_Since(t *testing.T) {
+	tests := []struct {
+		name    string
+		since   time.Duration
+		wantErr bool
+	}{
+		{"zero duration", 0, false},
+		{"positive duration", 5 * time.Minute, false},
+		{"negative duration", -1 * time.Minute, true},
+		{"max duration", 24 * time.Hour, false},
+		{"exceeds max duration", 25 * time.Hour, true},
+		{"way over max", 1000 * time.Hour, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &events.Command{
+				OutputFormat: "table",
+				Since:        tt.since,
+				ConfigFlags:  genericclioptions.NewConfigFlags(true),
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() with since %v error = %v, wantErr %v",
+					tt.since, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_AllNamespacesAndNamespace(t *testing.T) {
+	ns := "test-namespace"
+
+	tests := []struct {
+		name          string
+		allNamespaces bool
+		namespace     *string
+		wantErr       bool
+	}{
+		{"all namespaces only", true, nil, false},
+		{"namespace only", false, &ns, false},
+		{"both set", true, &ns, true},
+		{"neither set", false, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := genericclioptions.NewConfigFlags(true)
+			flags.Namespace = tt.namespace
+
+			cmd := &events.Command{
+				OutputFormat:  "table",
+				AllNamespaces: tt.allNamespaces,
+				ConfigFlags:   flags,
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() allNamespaces=%v, namespace=%v error = %v, wantErr %v",
+					tt.allNamespaces, tt.namespace, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewCommand(t *testing.T) {
+	streams := genericclioptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	cmd := events.NewCommand(streams, flags)
+
+	if cmd == nil {
+		t.Fatal("NewCommand() returned nil")
+	}
+
+	if cmd.OutputFormat != "table" {
+		t.Errorf("NewCommand() OutputFormat = %q, expected %q",
+			cmd.OutputFormat, "table")
+	}
+
+	if cmd.OperatorNS != "redhat-ods-operator" {
+		t.Errorf("NewCommand() OperatorNS = %q, expected %q",
+			cmd.OperatorNS, "redhat-ods-operator")
+	}
+
+	if cmd.ConfigFlags != flags {
+		t.Error("NewCommand() ConfigFlags not set correctly")
+	}
+}

--- a/pkg/events/discover_test.go
+++ b/pkg/events/discover_test.go
@@ -1,0 +1,249 @@
+//nolint:testpackage // Tests internal implementation (discoverNamespaces)
+package events
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	mockclient "github.com/opendatahub-io/odh-cli/pkg/util/test/mocks/client"
+
+	. "github.com/onsi/gomega"
+)
+
+// dsciNotFoundErr creates a proper Kubernetes NotFound error for DSCI.
+func dsciNotFoundErr() error {
+	return apierrors.NewNotFound(schema.GroupResource{
+		Group:    resources.DSCInitialization.Group,
+		Resource: resources.DSCInitialization.Resource,
+	}, "")
+}
+
+// forbiddenErr creates a proper Kubernetes Forbidden error.
+func forbiddenErr(resource, name string) error {
+	return apierrors.NewForbidden(schema.GroupResource{Resource: resource}, name, errors.New("forbidden"))
+}
+
+// createDSCI creates a test DSCInitialization object.
+func createDSCI(appNS, monitoringNS string) *unstructured.Unstructured {
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"spec": map[string]any{},
+		},
+	}
+
+	if appNS != "" {
+		spec := dsci.Object["spec"].(map[string]any)
+		spec["applicationsNamespace"] = appNS
+	}
+
+	if monitoringNS != "" {
+		spec := dsci.Object["spec"].(map[string]any)
+		spec["monitoring"] = map[string]any{
+			"namespace": monitoringNS,
+		}
+	}
+
+	return dsci
+}
+
+// setupCommand creates a Command with mock client and IO streams.
+func setupCommand(mockClient *mockclient.MockClient) (*Command, *bytes.Buffer) {
+	var errBuf bytes.Buffer
+	streams := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &errBuf)
+
+	cmd := &Command{
+		IO:          streams,
+		ConfigFlags: genericclioptions.NewConfigFlags(true),
+		Client:      mockClient,
+	}
+
+	return cmd, &errBuf
+}
+
+func TestDiscoverNamespaces_DSCINotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+
+	// Both GetApplicationsNamespace and GetMonitoringNamespace call List for DSCI
+	// Both return NotFound - this is handled gracefully
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return(nil, dsciNotFoundErr())
+
+	// Operator discovery - found in first namespace (no OLM needed)
+	mockClient.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
+		Return(&unstructured.Unstructured{}, nil).Once()
+
+	cmd, _ := setupCommand(mockClient)
+	err := cmd.discoverNamespaces(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd.ApplicationsNS).To(BeEmpty())
+	g.Expect(cmd.MonitoringNS).To(BeEmpty())
+	g.Expect(cmd.OperatorNS).To(Equal(client.DefaultRHOAIOperatorNamespace))
+	mockClient.AssertExpectations(t)
+}
+
+func TestDiscoverNamespaces_DSCIForbidden(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+
+	// DSCI returns Forbidden error - warns but continues
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return(nil, forbiddenErr("dscinitialization", ""))
+
+	// Operator discovery still proceeds
+	mockClient.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
+		Return(&unstructured.Unstructured{}, nil).Once()
+
+	cmd, errBuf := setupCommand(mockClient)
+	err := cmd.discoverNamespaces(ctx)
+
+	// Now warns instead of erroring - permissive error handling
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(errBuf.String()).To(ContainSubstring("Warning"))
+	g.Expect(cmd.ApplicationsNS).To(BeEmpty())
+	mockClient.AssertExpectations(t)
+}
+
+func TestDiscoverNamespaces_DSCIWithAllFields(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+
+	dsci := createDSCI("redhat-ods-applications", "redhat-ods-monitoring")
+	// Both helpers call List for DSCI
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return([]*unstructured.Unstructured{dsci}, nil)
+
+	// Operator discovery - found in first namespace (no OLM needed)
+	mockClient.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
+		Return(&unstructured.Unstructured{}, nil).Once()
+
+	cmd, _ := setupCommand(mockClient)
+	err := cmd.discoverNamespaces(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd.ApplicationsNS).To(Equal("redhat-ods-applications"))
+	g.Expect(cmd.MonitoringNS).To(Equal("redhat-ods-monitoring"))
+	g.Expect(cmd.OperatorNS).To(Equal(client.DefaultRHOAIOperatorNamespace))
+	mockClient.AssertExpectations(t)
+}
+
+func TestDiscoverNamespaces_DSCIWithoutMonitoring(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+
+	dsci := createDSCI("redhat-ods-applications", "")
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return([]*unstructured.Unstructured{dsci}, nil)
+
+	// Operator discovery - found in first namespace (no OLM needed)
+	mockClient.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
+		Return(&unstructured.Unstructured{}, nil).Once()
+
+	cmd, _ := setupCommand(mockClient)
+	err := cmd.discoverNamespaces(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd.ApplicationsNS).To(Equal("redhat-ods-applications"))
+	g.Expect(cmd.MonitoringNS).To(Equal("redhat-ods-applications")) // Falls back to apps NS
+	mockClient.AssertExpectations(t)
+}
+
+func TestDiscoverNamespaces_OperatorOverride(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+
+	// DSCI found
+	dsci := createDSCI("redhat-ods-applications", "")
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return([]*unstructured.Unstructured{dsci}, nil)
+
+	// No operator discovery calls expected - override is set
+
+	cmd, _ := setupCommand(mockClient)
+	cmd.OperatorNSOverride = "custom-operator-ns"
+	err := cmd.discoverNamespaces(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd.OperatorNS).To(Equal("custom-operator-ns"))
+	mockClient.AssertExpectations(t)
+}
+
+func TestDiscoverNamespaces_OperatorNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(false)
+	mockClient.On("OLM").Return(mockOLM)
+
+	// DSCI found
+	dsci := createDSCI("redhat-ods-applications", "")
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return([]*unstructured.Unstructured{dsci}, nil)
+
+	// Operator not found in any namespace - all GetResource calls return NotFound
+	mockClient.On("GetResource", mock.Anything, resources.Deployment, mock.Anything, mock.Anything).
+		Return(nil, apierrors.NewNotFound(schema.GroupResource{Resource: "deployments"}, ""))
+
+	cmd, errBuf := setupCommand(mockClient)
+	err := cmd.discoverNamespaces(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd.OperatorNS).To(Equal(client.DefaultRHOAIOperatorNamespace))
+	g.Expect(errBuf.String()).To(ContainSubstring("Warning"))
+	mockClient.AssertExpectations(t)
+}
+
+func TestDiscoverNamespaces_OperatorForbidden(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	mockClient := &mockclient.MockClient{}
+	mockOLM := &mockclient.MockOLMReader{}
+	mockOLM.On("Available").Return(false)
+	mockClient.On("OLM").Return(mockOLM)
+
+	// DSCI found
+	dsci := createDSCI("redhat-ods-applications", "")
+	mockClient.On("List", mock.Anything, resources.DSCInitialization, mock.Anything).
+		Return([]*unstructured.Unstructured{dsci}, nil)
+
+	// Operator discovery returns Forbidden
+	mockClient.On("GetResource", mock.Anything, resources.Deployment, mock.Anything, mock.Anything).
+		Return(nil, forbiddenErr("deployments", "rhods-operator"))
+
+	cmd, _ := setupCommand(mockClient)
+	err := cmd.discoverNamespaces(ctx)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("discovering operator namespace"))
+	mockClient.AssertExpectations(t)
+}

--- a/pkg/events/filter.go
+++ b/pkg/events/filter.go
@@ -1,0 +1,80 @@
+package events
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const eventFetchTimeout = 30 * time.Second
+
+// fetchEvents retrieves events using the clusterhealth library.
+func (c *Command) fetchEvents(ctx context.Context) ([]clusterhealth.EventInfo, error) {
+	namespaces, err := c.getTargetNamespaces()
+	if err != nil {
+		return nil, err
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, eventFetchTimeout)
+	defer cancel()
+
+	cfg := clusterhealth.RecentEventsConfig{
+		Client:     c.crClient,
+		Namespaces: namespaces,
+		Since:      c.Since,
+		EventType:  c.EventType,
+	}
+
+	events, err := clusterhealth.RunRecentEvents(fetchCtx, cfg)
+	if err != nil {
+		return nil, clierrors.ErrEventsFetchFailed(err)
+	}
+
+	return events, nil
+}
+
+// getTargetNamespaces returns the namespaces to query for events.
+// For -n <namespace>, returns ONLY that namespace (exclusive scope like kubectl).
+// For --all-namespaces or no flags, returns ODH namespaces (apps, operator, monitoring).
+// Returns ErrNoNamespacesDiscovered if no namespaces could be determined.
+func (c *Command) getTargetNamespaces() ([]string, error) {
+	// If user explicitly passed -n <namespace>, return ONLY that namespace (exclusive)
+	// Note: NamespaceExplicit distinguishes "odh events -n foo" from "odh events" (no flags)
+	if c.NamespaceExplicit && c.Namespace != "" {
+		return []string{c.Namespace}, nil
+	}
+
+	// Otherwise return ODH namespaces (for -A or no flags)
+	seen := make(map[string]bool)
+	var namespaces []string
+
+	add := func(ns string) {
+		if ns != "" && !seen[ns] {
+			seen[ns] = true
+			namespaces = append(namespaces, ns)
+		}
+	}
+
+	add(c.ApplicationsNS)
+	add(c.OperatorNS)
+	add(c.MonitoringNS)
+
+	if len(namespaces) == 0 {
+		return nil, clierrors.ErrNoNamespacesDiscovered()
+	}
+
+	return namespaces, nil
+}
+
+// sortEventsByTime sorts events in place by timestamp, most recent first.
+// Uses stable sort to preserve original order for events with identical timestamps.
+func sortEventsByTime(events []clusterhealth.EventInfo) {
+	slices.SortStableFunc(events, func(a, b clusterhealth.EventInfo) int {
+		return cmp.Compare(b.LastTime.UnixNano(), a.LastTime.UnixNano())
+	})
+}

--- a/pkg/events/filter_test.go
+++ b/pkg/events/filter_test.go
@@ -1,0 +1,189 @@
+//nolint:testpackage // Tests internal implementation (unexported functions)
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+)
+
+func TestGetTargetNamespaces(t *testing.T) {
+	tests := []struct {
+		name          string
+		cmd           *Command
+		wantNamespace []string
+		wantErr       bool
+	}{
+		{
+			name: "all namespaces with ODH namespaces",
+			cmd: &Command{
+				AllNamespaces:  true,
+				ApplicationsNS: "redhat-ods-applications",
+				OperatorNS:     "redhat-ods-operator",
+				MonitoringNS:   "redhat-ods-monitoring",
+			},
+			wantNamespace: []string{
+				"redhat-ods-applications",
+				"redhat-ods-operator",
+				"redhat-ods-monitoring",
+			},
+		},
+		{
+			name: "explicit -n flag is exclusive",
+			cmd: &Command{
+				NamespaceExplicit: true,
+				Namespace:         "my-project",
+				ApplicationsNS:    "redhat-ods-applications",
+				OperatorNS:        "redhat-ods-operator",
+				MonitoringNS:      "redhat-ods-applications",
+			},
+			wantNamespace: []string{
+				"my-project",
+			},
+		},
+		{
+			name: "no flags uses ODH namespaces (not kubeconfig namespace)",
+			cmd: &Command{
+				NamespaceExplicit: false,
+				Namespace:         "default", // from kubeconfig, should be ignored
+				ApplicationsNS:    "redhat-ods-applications",
+				OperatorNS:        "redhat-ods-operator",
+				MonitoringNS:      "redhat-ods-monitoring",
+			},
+			wantNamespace: []string{
+				"redhat-ods-applications",
+				"redhat-ods-operator",
+				"redhat-ods-monitoring",
+			},
+		},
+		{
+			name: "deduplicates ODH namespaces",
+			cmd: &Command{
+				AllNamespaces:  true,
+				ApplicationsNS: "redhat-ods-applications",
+				OperatorNS:     "redhat-ods-operator",
+				MonitoringNS:   "redhat-ods-applications",
+			},
+			wantNamespace: []string{
+				"redhat-ods-applications",
+				"redhat-ods-operator",
+			},
+		},
+		{
+			name: "empty namespaces returns error",
+			cmd: &Command{
+				AllNamespaces: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "skips empty namespace strings",
+			cmd: &Command{
+				AllNamespaces:  true,
+				ApplicationsNS: "",
+				OperatorNS:     "redhat-ods-operator",
+				MonitoringNS:   "",
+			},
+			wantNamespace: []string{"redhat-ods-operator"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.cmd.getTargetNamespaces()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("getTargetNamespaces() expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("getTargetNamespaces() unexpected error: %v", err)
+
+				return
+			}
+
+			if len(result) != len(tt.wantNamespace) {
+				t.Errorf("getTargetNamespaces() returned %d namespaces, expected %d\nGot: %v\nExpected: %v",
+					len(result), len(tt.wantNamespace), result, tt.wantNamespace)
+
+				return
+			}
+
+			resultSet := make(map[string]bool)
+			for _, ns := range result {
+				resultSet[ns] = true
+			}
+
+			for _, want := range tt.wantNamespace {
+				if !resultSet[want] {
+					t.Errorf("getTargetNamespaces() missing namespace %q\nGot: %v", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSortEventsByTime(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		events []clusterhealth.EventInfo
+		want   []string
+	}{
+		{
+			name:   "empty events",
+			events: []clusterhealth.EventInfo{},
+			want:   []string{},
+		},
+		{
+			name: "single event",
+			events: []clusterhealth.EventInfo{
+				{Name: "event1", LastTime: now},
+			},
+			want: []string{"event1"},
+		},
+		{
+			name: "multiple events sorted by time descending",
+			events: []clusterhealth.EventInfo{
+				{Name: "old", LastTime: now.Add(-1 * time.Hour)},
+				{Name: "newest", LastTime: now},
+				{Name: "middle", LastTime: now.Add(-30 * time.Minute)},
+			},
+			want: []string{"newest", "middle", "old"},
+		},
+		{
+			name: "events with zero time",
+			events: []clusterhealth.EventInfo{
+				{Name: "no-time", LastTime: time.Time{}},
+				{Name: "has-time", LastTime: now},
+			},
+			want: []string{"has-time", "no-time"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortEventsByTime(tt.events)
+
+			if len(tt.events) != len(tt.want) {
+				t.Errorf("sortEventsByTime() resulted in %d events, expected %d",
+					len(tt.events), len(tt.want))
+
+				return
+			}
+
+			for i, event := range tt.events {
+				if event.Name != tt.want[i] {
+					t.Errorf("sortEventsByTime()[%d] = %q, expected %q",
+						i, event.Name, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/events/output.go
+++ b/pkg/events/output.go
@@ -1,0 +1,193 @@
+package events
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"regexp"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
+	printeryaml "github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	maxMessageLen    = 80
+	hoursPerDay      = 24
+	tabwriterPadding = 2
+
+	msgNoEventsFound  = "No events found."
+	tableHeader       = "LAST SEEN\tTYPE\tREASON\tOBJECT\tCOUNT\tMESSAGE\n"
+	tableHeaderWithNS = "NAMESPACE\tLAST SEEN\tTYPE\tREASON\tOBJECT\tCOUNT\tMESSAGE\n"
+)
+
+// formatAge converts a time.Time to a human-readable relative time.
+func formatAge(t time.Time) string {
+	return formatAgeFrom(t, time.Now())
+}
+
+// formatAgeFrom formats a duration relative to a reference time.
+// Extracted for deterministic testing without clock drift.
+func formatAgeFrom(t time.Time, now time.Time) string {
+	if t.IsZero() {
+		return "<unknown>"
+	}
+
+	d := now.Sub(t)
+	if d < 0 {
+		return "0s"
+	}
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(math.Floor(d.Hours()/hoursPerDay)))
+	}
+}
+
+// truncateMessage truncates long messages for table display.
+// Uses rune-safe truncation to avoid splitting multibyte UTF-8 characters.
+func truncateMessage(msg string) string {
+	r := []rune(msg)
+	if len(r) <= maxMessageLen {
+		return msg
+	}
+
+	return string(r[:maxMessageLen-3]) + "..."
+}
+
+// ansiEscapeRegex matches ANSI escape sequences (CSI sequences like \x1b[31m).
+var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// sanitizeForTerminal removes ANSI escape sequences and control characters
+// from untrusted input to prevent terminal escape sequence injection (CWE-150).
+func sanitizeForTerminal(s string) string {
+	// First strip full ANSI sequences (e.g., \x1b[31m) to avoid bracket remnants
+	s = ansiEscapeRegex.ReplaceAllString(s, "")
+
+	// Then strip any remaining control characters
+	return strings.Map(func(r rune) rune {
+		// Keep printable characters and tabs
+		if r >= 32 || r == '\t' {
+			return r
+		}
+		// Drop control characters including bare ESC (\x1b)
+		return -1
+	}, s)
+}
+
+// renderOutput dispatches to the appropriate output formatter.
+func (c *Command) renderOutput(events []clusterhealth.EventInfo) error {
+	switch c.OutputFormat {
+	case outputFormatJSON:
+		return outputJSON(c.IO.Out(), events)
+	case outputFormatYAML:
+		return outputYAML(c.IO.Out(), events)
+	default:
+		return outputTable(c.IO.Out(), events, c.AllNamespaces)
+	}
+}
+
+// outputTable renders events as a formatted table.
+// When showNamespace is true, adds a NAMESPACE column (like kubectl -A).
+//
+//nolint:revive // flag-parameter: showNamespace mirrors kubectl -A behavior
+func outputTable(w io.Writer, events []clusterhealth.EventInfo, showNamespace bool) error {
+	if len(events) == 0 {
+		if _, err := fmt.Fprintln(w, msgNoEventsFound); err != nil {
+			return clierrors.ErrRenderFailed("table", err)
+		}
+
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, tabwriterPadding, ' ', 0)
+
+	if showNamespace {
+		if _, err := fmt.Fprint(tw, tableHeaderWithNS); err != nil {
+			return clierrors.ErrRenderFailed("table", err)
+		}
+	} else {
+		if _, err := fmt.Fprint(tw, tableHeader); err != nil {
+			return clierrors.ErrRenderFailed("table", err)
+		}
+	}
+
+	for _, e := range events {
+		age := formatAge(e.LastTime)
+		// Sanitize all rendered fields for consistency (CWE-150)
+		eventType := sanitizeForTerminal(e.Type)
+		kind := sanitizeForTerminal(e.Kind)
+		name := sanitizeForTerminal(e.Name)
+		reason := sanitizeForTerminal(e.Reason)
+		message := truncateMessage(sanitizeForTerminal(e.Message))
+		object := fmt.Sprintf("%s/%s", kind, name)
+
+		if showNamespace {
+			namespace := sanitizeForTerminal(e.Namespace)
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n", namespace, age, eventType, reason, object, e.Count, message); err != nil {
+				return clierrors.ErrRenderFailed("table", err)
+			}
+		} else {
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%s\n", age, eventType, reason, object, e.Count, message); err != nil {
+				return clierrors.ErrRenderFailed("table", err)
+			}
+		}
+	}
+
+	if err := tw.Flush(); err != nil {
+		return clierrors.ErrRenderFailed("table", err)
+	}
+
+	return nil
+}
+
+// outputJSON renders events as JSON.
+func outputJSON(w io.Writer, events []clusterhealth.EventInfo) error {
+	output := toEventOutputList(events)
+
+	renderer := printerjson.NewRenderer[any](
+		printerjson.WithWriter[any](w),
+	)
+
+	if err := renderer.Render(output); err != nil {
+		return clierrors.ErrRenderFailed("JSON", err)
+	}
+
+	return nil
+}
+
+// outputYAML renders events as YAML.
+func outputYAML(w io.Writer, events []clusterhealth.EventInfo) error {
+	output := toEventOutputList(events)
+
+	renderer := printeryaml.NewRenderer[any](
+		printeryaml.WithWriter[any](w),
+	)
+
+	if err := renderer.Render(output); err != nil {
+		return clierrors.ErrRenderFailed("YAML", err)
+	}
+
+	return nil
+}
+
+// toEventOutputList converts EventInfo slice to a structure suitable for JSON/YAML rendering.
+// Always returns consistent EventList shape for stable machine consumption.
+func toEventOutputList(events []clusterhealth.EventInfo) any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "EventList",
+		"items":      events,
+	}
+}

--- a/pkg/events/output_test.go
+++ b/pkg/events/output_test.go
@@ -1,0 +1,320 @@
+//nolint:testpackage // Tests internal implementation (unexported functions)
+package events
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+)
+
+func TestFormatAge(t *testing.T) {
+	// Use a fixed reference time for deterministic tests (no clock drift).
+	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		time     time.Time
+		expected string
+	}{
+		{"zero time", time.Time{}, "<unknown>"},
+		{"25 seconds ago", now.Add(-25 * time.Second), "25s"},
+		{"5 minutes ago", now.Add(-5 * time.Minute), "5m"},
+		{"2 hours ago", now.Add(-2 * time.Hour), "2h"},
+		{"3 days ago", now.Add(-3 * 24 * time.Hour), "3d"},
+		{"future time", now.Add(1 * time.Hour), "0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatAgeFrom(tt.time, now)
+			if result != tt.expected {
+				t.Errorf("formatAgeFrom() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTruncateMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{"short message", "Hello", "Hello"},
+		{"exact length", strings.Repeat("a", 80), strings.Repeat("a", 80)},
+		{"long message", strings.Repeat("a", 100), strings.Repeat("a", 77) + "..."},
+		{"empty message", "", ""},
+		{"multibyte runes short", "café résumé", "café résumé"},
+		{"multibyte runes long", strings.Repeat("é", 100), strings.Repeat("é", 77) + "..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateMessage(tt.message)
+			if result != tt.expected {
+				t.Errorf("truncateMessage() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeForTerminal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"with tab", "hello\tworld", "hello\tworld"},
+		{"ANSI escape", "hello\x1b[31mred\x1b[0m", "hellored"},
+		{"newline", "hello\nworld", "helloworld"},
+		{"carriage return", "hello\rworld", "helloworld"},
+		{"null byte", "hello\x00world", "helloworld"},
+		{"bell", "hello\x07world", "helloworld"},
+		{"mixed control chars", "\x1b[2J\x1b[HMalicious", "Malicious"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeForTerminal(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeForTerminal() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOutputTable(t *testing.T) {
+	tests := []struct {
+		name          string
+		events        []clusterhealth.EventInfo
+		showNamespace bool
+		wantContains  []string
+	}{
+		{
+			name:          "empty events",
+			events:        []clusterhealth.EventInfo{},
+			showNamespace: false,
+			wantContains:  []string{msgNoEventsFound},
+		},
+		{
+			name: "single event",
+			events: []clusterhealth.EventInfo{
+				{
+					Kind:    "Pod",
+					Name:    "test-pod",
+					Type:    "Warning",
+					Reason:  "BackOff",
+					Message: "Back-off pulling image",
+					Count:   3,
+				},
+			},
+			showNamespace: false,
+			wantContains: []string{
+				"LAST SEEN",
+				"TYPE",
+				"REASON",
+				"OBJECT",
+				"COUNT",
+				"MESSAGE",
+				"Pod/test-pod",
+				"Warning",
+				"BackOff",
+				"3",
+				"Back-off pulling image",
+			},
+		},
+		{
+			name: "multiple events",
+			events: []clusterhealth.EventInfo{
+				{Kind: "Pod", Name: "pod1", Type: "Warning", Reason: "BackOff"},
+				{Kind: "Deployment", Name: "deploy1", Type: "Normal", Reason: "Scaled"},
+			},
+			showNamespace: false,
+			wantContains: []string{
+				"Pod/pod1",
+				"Deployment/deploy1",
+			},
+		},
+		{
+			name: "shows namespace column when requested",
+			events: []clusterhealth.EventInfo{
+				{
+					Namespace: "redhat-ods-applications",
+					Kind:      "Pod",
+					Name:      "test-pod",
+					Type:      "Warning",
+					Reason:    "BackOff",
+					Count:     5,
+				},
+			},
+			showNamespace: true,
+			wantContains: []string{
+				"NAMESPACE",
+				"COUNT",
+				"redhat-ods-applications",
+				"Pod/test-pod",
+				"5",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := outputTable(&buf, tt.events, tt.showNamespace)
+			if err != nil {
+				t.Fatalf("outputTable() error = %v", err)
+			}
+
+			result := buf.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("outputTable() output missing %q\nGot: %s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestOutputJSON(t *testing.T) {
+	tests := []struct {
+		name         string
+		events       []clusterhealth.EventInfo
+		wantContains []string
+	}{
+		{
+			name:   "empty events",
+			events: []clusterhealth.EventInfo{},
+			wantContains: []string{
+				`"kind": "EventList"`,
+				`"items": []`,
+			},
+		},
+		{
+			name: "single event returns list",
+			events: []clusterhealth.EventInfo{
+				{Kind: "Pod", Name: "test-pod", Type: "Warning"},
+			},
+			wantContains: []string{
+				`"kind": "EventList"`,
+				`"items":`,
+				`"name": "test-pod"`,
+			},
+		},
+		{
+			name: "multiple events returns list",
+			events: []clusterhealth.EventInfo{
+				{Kind: "Pod", Name: "pod1"},
+				{Kind: "Pod", Name: "pod2"},
+			},
+			wantContains: []string{
+				`"kind": "EventList"`,
+				`"items":`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := outputJSON(&buf, tt.events)
+			if err != nil {
+				t.Fatalf("outputJSON() error = %v", err)
+			}
+
+			result := buf.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("outputJSON() output missing %q\nGot: %s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestOutputYAML(t *testing.T) {
+	tests := []struct {
+		name         string
+		events       []clusterhealth.EventInfo
+		wantContains []string
+	}{
+		{
+			name:   "empty events",
+			events: []clusterhealth.EventInfo{},
+			wantContains: []string{
+				"kind: EventList",
+				"items: []",
+			},
+		},
+		{
+			name: "single event returns list",
+			events: []clusterhealth.EventInfo{
+				{Kind: "Pod", Name: "test-pod"},
+			},
+			wantContains: []string{
+				"kind: EventList",
+				"name: test-pod",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := outputYAML(&buf, tt.events)
+			if err != nil {
+				t.Fatalf("outputYAML() error = %v", err)
+			}
+
+			result := buf.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("outputYAML() output missing %q\nGot: %s", want, result)
+				}
+			}
+		})
+	}
+}
+
+func TestToEventOutputList(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []clusterhealth.EventInfo
+	}{
+		{
+			name:   "empty returns list",
+			events: []clusterhealth.EventInfo{},
+		},
+		{
+			name: "single event returns list",
+			events: []clusterhealth.EventInfo{
+				{Kind: "Pod"},
+			},
+		},
+		{
+			name: "multiple events returns list",
+			events: []clusterhealth.EventInfo{
+				{Kind: "Pod"},
+				{Kind: "Pod"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toEventOutputList(tt.events)
+			m, ok := result.(map[string]any)
+			if !ok {
+				t.Fatal("toEventOutputList() should always return map[string]any")
+			}
+			if m["kind"] != "EventList" {
+				t.Errorf("toEventOutputList() kind = %v, expected EventList", m["kind"])
+			}
+		})
+	}
+}

--- a/pkg/status/errors.go
+++ b/pkg/status/errors.go
@@ -80,14 +80,3 @@ func ErrNoDSCIFound() *clierrors.StructuredError {
 		Suggestion: suggestInstallODHRHOAI,
 	}
 }
-
-// ErrOperatorNamespaceNotFound creates a structured error when operator namespace cannot be discovered.
-func ErrOperatorNamespaceNotFound() *clierrors.StructuredError {
-	return &clierrors.StructuredError{
-		Code:       "OPERATOR_NAMESPACE_NOT_FOUND",
-		Message:    "could not discover operator namespace",
-		Category:   clierrors.CategoryNotFound,
-		Retriable:  false,
-		Suggestion: "Use --operator-namespace to specify the operator namespace",
-	}
-}

--- a/pkg/status/namespace.go
+++ b/pkg/status/namespace.go
@@ -3,28 +3,12 @@ package status
 import (
 	"context"
 	"fmt"
-	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
-
-const (
-	// Well-known operator namespace defaults.
-	defaultRHOAIOperatorNamespace = "redhat-ods-operator"
-	defaultODHOperatorNamespace   = "opendatahub"
-	defaultOpenShiftOperatorsNS   = "openshift-operators"
-)
-
-// operatorInfo holds operator namespace and deployment name discovered from OLM.
-type operatorInfo struct {
-	Namespace      string
-	DeploymentName string
-}
 
 // namespaceConfig holds the three namespaces required by clusterhealth.Config.
 type namespaceConfig struct {
@@ -36,14 +20,14 @@ type namespaceConfig struct {
 // discoverNamespaces resolves the apps, operator, and monitoring namespaces.
 // Flag overrides take priority over auto-detection from cluster resources.
 // If dsci is provided, it will be reused instead of fetching again.
-// Also returns operatorInfo for reuse in operator name discovery.
+// Also returns OperatorInfo for reuse in operator name discovery.
 func discoverNamespaces(
 	ctx context.Context,
 	c client.Client,
 	dsci *unstructured.Unstructured,
 	appsNSOverride string,
 	operatorNSOverride string,
-) (*namespaceConfig, *operatorInfo, error) {
+) (*namespaceConfig, *client.OperatorInfo, error) {
 	cfg := &namespaceConfig{}
 
 	appsNS, err := discoverAppsNamespace(dsci, appsNSOverride)
@@ -53,8 +37,22 @@ func discoverNamespaces(
 
 	cfg.Apps = appsNS
 
-	// Fetch operator info from OLM once, reuse for namespace and name discovery
-	opInfo := discoverOperatorFromOLM(ctx, c)
+	// Fetch operator info from OLM once, reuse for namespace and name discovery.
+	// When operatorNSOverride is set, make OLM lookup best-effort so users with
+	// explicit --operator-namespace don't need cluster-wide CSV list RBAC.
+	var opInfo *client.OperatorInfo
+
+	if operatorNSOverride == "" {
+		var olmErr error
+
+		opInfo, olmErr = client.DiscoverOperatorFromOLM(ctx, c)
+		if olmErr != nil {
+			return nil, nil, fmt.Errorf("discovering operator from OLM: %w", olmErr)
+		}
+	} else {
+		// Best-effort when override is set - ignore errors
+		opInfo, _ = client.DiscoverOperatorFromOLM(ctx, c)
+	}
 
 	operatorNS, err := discoverOperatorNamespace(ctx, c, opInfo, operatorNSOverride)
 	if err != nil {
@@ -90,79 +88,22 @@ func discoverAppsNamespace(dsci *unstructured.Unstructured, override string) (st
 // discoverOperatorNamespace returns the operator namespace.
 // Uses the flag override if set, otherwise uses pre-fetched info from OLM,
 // falling back to well-known defaults.
-func discoverOperatorNamespace(ctx context.Context, c client.Reader, info *operatorInfo, override string) (string, error) {
+func discoverOperatorNamespace(ctx context.Context, c client.Reader, info *client.OperatorInfo, override string) (string, error) {
 	if override != "" {
 		return override, nil
 	}
 
-	if info != nil && info.Namespace != "" {
-		return info.Namespace, nil
-	}
-
-	return discoverOperatorNamespaceFromDefaults(ctx, c)
-}
-
-// discoverOperatorFromOLM searches for the operator CSV across all namespaces.
-// Finds CSVs by name prefix (rhods-operator or opendatahub-operator) and returns
-// both the namespace and deployment name from a single API call.
-func discoverOperatorFromOLM(ctx context.Context, c client.Reader) *operatorInfo {
-	if !c.OLM().Available() {
-		return nil
-	}
-
-	csvList, err := c.OLM().ClusterServiceVersions("").List(ctx, metav1.ListOptions{})
+	ns, err := client.DiscoverOperatorNamespaceWithInfo(ctx, c, info)
 	if err != nil {
-		return nil
+		return "", fmt.Errorf("discovering operator namespace: %w", err)
 	}
 
-	for _, csv := range csvList.Items {
-		name := csv.GetName()
-		if strings.HasPrefix(name, "rhods-operator.") || strings.HasPrefix(name, "opendatahub-operator.") {
-			info := &operatorInfo{}
-
-			// Get namespace - use original namespace from olm.copiedFrom if this is a copy
-			if copiedFrom, ok := csv.GetLabels()["olm.copiedFrom"]; ok && copiedFrom != "" {
-				info.Namespace = copiedFrom
-			} else {
-				info.Namespace = csv.GetNamespace()
-			}
-
-			// Get deployment name from install strategy
-			deployments := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
-			if len(deployments) > 0 {
-				info.DeploymentName = deployments[0].Name
-			}
-
-			return info
-		}
-	}
-
-	return nil
-}
-
-// discoverOperatorNamespaceFromDefaults tries well-known operator namespaces
-// by checking if the specific operator deployment exists there.
-func discoverOperatorNamespaceFromDefaults(ctx context.Context, c client.Reader) (string, error) {
-	operatorDeploymentNames := []string{
-		"rhods-operator",
-		"opendatahub-operator-controller-manager",
-	}
-
-	for _, ns := range []string{defaultRHOAIOperatorNamespace, defaultODHOperatorNamespace, defaultOpenShiftOperatorsNS} {
-		for _, name := range operatorDeploymentNames {
-			_, err := c.GetResource(ctx, resources.Deployment, name, client.InNamespace(ns))
-			if err == nil {
-				return ns, nil
-			}
-		}
-	}
-
-	return "", ErrOperatorNamespaceNotFound()
+	return ns, nil
 }
 
 // discoverOperatorName returns the operator deployment name.
 // Uses the override if set, otherwise uses pre-fetched info or falls back to defaults.
-func discoverOperatorName(info *operatorInfo, override string) string {
+func discoverOperatorName(info *client.OperatorInfo, override string) string {
 	if override != "" {
 		return override
 	}

--- a/pkg/status/namespace_test.go
+++ b/pkg/status/namespace_test.go
@@ -8,14 +8,22 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/mock"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	mockclient "github.com/opendatahub-io/odh-cli/pkg/util/test/mocks/client"
 
 	. "github.com/onsi/gomega"
 )
+
+// notFoundErr creates a proper Kubernetes NotFound error for deployment lookups.
+func notFoundErr(name string) error {
+	return apierrors.NewNotFound(schema.GroupResource{Resource: "deployments"}, name)
+}
 
 func TestDiscoverAppsNamespace(t *testing.T) {
 	t.Run("override takes priority", func(t *testing.T) {
@@ -133,7 +141,7 @@ func TestDiscoverOperatorName(t *testing.T) {
 	t.Run("override takes priority", func(t *testing.T) {
 		g := NewWithT(t)
 
-		name := discoverOperatorName(&operatorInfo{DeploymentName: "from-olm"}, "my-override")
+		name := discoverOperatorName(&client.OperatorInfo{DeploymentName: "from-olm"}, "my-override")
 
 		g.Expect(name).To(Equal("my-override"))
 	})
@@ -141,7 +149,7 @@ func TestDiscoverOperatorName(t *testing.T) {
 	t.Run("uses operator info deployment name", func(t *testing.T) {
 		g := NewWithT(t)
 
-		name := discoverOperatorName(&operatorInfo{DeploymentName: "opendatahub-operator-controller-manager"}, "")
+		name := discoverOperatorName(&client.OperatorInfo{DeploymentName: "opendatahub-operator-controller-manager"}, "")
 
 		g.Expect(name).To(Equal("opendatahub-operator-controller-manager"))
 	})
@@ -157,7 +165,7 @@ func TestDiscoverOperatorName(t *testing.T) {
 	t.Run("returns default when deployment name is empty", func(t *testing.T) {
 		g := NewWithT(t)
 
-		name := discoverOperatorName(&operatorInfo{}, "")
+		name := discoverOperatorName(&client.OperatorInfo{}, "")
 
 		g.Expect(name).To(Equal(defaultRHOAIOperatorName))
 	})
@@ -180,7 +188,7 @@ func TestDiscoverOperatorNamespace(t *testing.T) {
 
 		mockReader := &mockclient.MockReader{}
 
-		ns, err := discoverOperatorNamespace(t.Context(), mockReader, &operatorInfo{Namespace: "openshift-operators"}, "")
+		ns, err := discoverOperatorNamespace(t.Context(), mockReader, &client.OperatorInfo{Namespace: "openshift-operators"}, "")
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(ns).To(Equal("openshift-operators"))
@@ -196,12 +204,12 @@ func TestDiscoverOperatorNamespace(t *testing.T) {
 		ns, err := discoverOperatorNamespace(t.Context(), mockReader, nil, "")
 
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(ns).To(Equal(defaultRHOAIOperatorNamespace))
+		g.Expect(ns).To(Equal(client.DefaultRHOAIOperatorNamespace))
 		mockReader.AssertExpectations(t)
 	})
 }
 
-func TestDiscoverOperatorNamespaceFromDefaults(t *testing.T) {
+func TestDiscoverOperatorNamespaceWithInfoFallback(t *testing.T) {
 	t.Run("finds rhods-operator in redhat-ods-operator namespace", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -209,10 +217,10 @@ func TestDiscoverOperatorNamespaceFromDefaults(t *testing.T) {
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
 			Return(&unstructured.Unstructured{}, nil).Once()
 
-		ns, err := discoverOperatorNamespaceFromDefaults(t.Context(), mockReader)
+		ns, err := client.DiscoverOperatorNamespaceWithInfo(t.Context(), mockReader, nil)
 
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(ns).To(Equal(defaultRHOAIOperatorNamespace))
+		g.Expect(ns).To(Equal(client.DefaultRHOAIOperatorNamespace))
 		mockReader.AssertExpectations(t)
 	})
 
@@ -221,16 +229,16 @@ func TestDiscoverOperatorNamespaceFromDefaults(t *testing.T) {
 
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
-			Return(nil, errors.New("not found")).Times(2)
+			Return(nil, notFoundErr("rhods-operator")).Times(2)
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "opendatahub-operator-controller-manager", mock.Anything).
-			Return(nil, errors.New("not found")).Once()
+			Return(nil, notFoundErr("opendatahub-operator-controller-manager")).Once()
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "opendatahub-operator-controller-manager", mock.Anything).
 			Return(&unstructured.Unstructured{}, nil).Once()
 
-		ns, err := discoverOperatorNamespaceFromDefaults(t.Context(), mockReader)
+		ns, err := client.DiscoverOperatorNamespaceWithInfo(t.Context(), mockReader, nil)
 
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(ns).To(Equal(defaultODHOperatorNamespace))
+		g.Expect(ns).To(Equal(client.DefaultODHOperatorNamespace))
 		mockReader.AssertExpectations(t)
 	})
 
@@ -239,16 +247,16 @@ func TestDiscoverOperatorNamespaceFromDefaults(t *testing.T) {
 
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "rhods-operator", mock.Anything).
-			Return(nil, errors.New("not found")).Times(3)
+			Return(nil, notFoundErr("rhods-operator")).Times(3)
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "opendatahub-operator-controller-manager", mock.Anything).
-			Return(nil, errors.New("not found")).Times(2)
+			Return(nil, notFoundErr("opendatahub-operator-controller-manager")).Times(2)
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, "opendatahub-operator-controller-manager", mock.Anything).
 			Return(&unstructured.Unstructured{}, nil).Once()
 
-		ns, err := discoverOperatorNamespaceFromDefaults(t.Context(), mockReader)
+		ns, err := client.DiscoverOperatorNamespaceWithInfo(t.Context(), mockReader, nil)
 
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(ns).To(Equal(defaultOpenShiftOperatorsNS))
+		g.Expect(ns).To(Equal(client.DefaultOpenShiftOperatorsNS))
 		mockReader.AssertExpectations(t)
 	})
 
@@ -257,9 +265,9 @@ func TestDiscoverOperatorNamespaceFromDefaults(t *testing.T) {
 
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("GetResource", mock.Anything, resources.Deployment, mock.Anything, mock.Anything).
-			Return(nil, errors.New("not found"))
+			Return(nil, notFoundErr("operator"))
 
-		ns, err := discoverOperatorNamespaceFromDefaults(t.Context(), mockReader)
+		ns, err := client.DiscoverOperatorNamespaceWithInfo(t.Context(), mockReader, nil)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(ns).To(BeEmpty())
@@ -277,13 +285,14 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(info).To(BeNil())
 		mockOLM.AssertExpectations(t)
 	})
 
-	t.Run("returns nil when CSV list fails", func(t *testing.T) {
+	t.Run("returns error when CSV list fails", func(t *testing.T) {
 		g := NewWithT(t)
 
 		mockCSVReader := &mockclient.MockCSVReader{}
@@ -297,8 +306,9 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).To(HaveOccurred())
 		g.Expect(info).To(BeNil())
 		mockReader.AssertExpectations(t)
 		mockOLM.AssertExpectations(t)
@@ -328,8 +338,9 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(info).To(BeNil())
 		mockReader.AssertExpectations(t)
 		mockOLM.AssertExpectations(t)
@@ -368,8 +379,9 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(info).ToNot(BeNil())
 		g.Expect(info.Namespace).To(Equal("redhat-ods-operator"))
 		g.Expect(info.DeploymentName).To(Equal("rhods-operator"))
@@ -410,8 +422,9 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(info).ToNot(BeNil())
 		g.Expect(info.Namespace).To(Equal("openshift-operators"))
 		g.Expect(info.DeploymentName).To(Equal("opendatahub-operator-controller-manager"))
@@ -455,8 +468,9 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(info).ToNot(BeNil())
 		g.Expect(info.Namespace).To(Equal("redhat-ods-operator"))
 		g.Expect(info.DeploymentName).To(Equal("rhods-operator"))
@@ -495,8 +509,9 @@ func TestDiscoverOperatorFromOLM(t *testing.T) {
 		mockReader := &mockclient.MockReader{}
 		mockReader.On("OLM").Return(mockOLM)
 
-		info := discoverOperatorFromOLM(t.Context(), mockReader)
+		info, err := client.DiscoverOperatorFromOLM(t.Context(), mockReader)
 
+		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(info).ToNot(BeNil())
 		g.Expect(info.Namespace).To(Equal("redhat-ods-operator"))
 		g.Expect(info.DeploymentName).To(BeEmpty())

--- a/pkg/util/client/discovery.go
+++ b/pkg/util/client/discovery.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+// Well-known operator namespace defaults.
+const (
+	DefaultRHOAIOperatorNamespace = "redhat-ods-operator"
+	DefaultODHOperatorNamespace   = "opendatahub"
+	DefaultOpenShiftOperatorsNS   = "openshift-operators"
+)
+
+// OperatorInfo holds operator namespace and deployment name discovered from OLM.
+type OperatorInfo struct {
+	Namespace      string
+	DeploymentName string
+}
+
+// DiscoverOperatorFromOLM searches for the operator CSV across all namespaces.
+// Finds CSVs by name prefix (rhods-operator or opendatahub-operator) and returns
+// both the namespace and deployment name from a single API call.
+// Returns (nil, nil) if OLM is not available or no matching CSV is found.
+// Returns (nil, error) for actual failures like Forbidden/RBAC issues.
+func DiscoverOperatorFromOLM(ctx context.Context, c Reader) (*OperatorInfo, error) {
+	if !c.OLM().Available() {
+		return nil, nil
+	}
+
+	csvList, err := c.OLM().ClusterServiceVersions("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// Propagate non-NotFound errors (e.g., Forbidden) so RBAC issues are visible
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("listing ClusterServiceVersions: %w", err)
+		}
+
+		return nil, nil
+	}
+
+	for _, csv := range csvList.Items {
+		name := csv.GetName()
+		if strings.HasPrefix(name, "rhods-operator.") || strings.HasPrefix(name, "opendatahub-operator.") {
+			info := &OperatorInfo{}
+
+			// Get namespace - use original namespace from olm.copiedFrom if this is a copy
+			if copiedFrom, ok := csv.GetLabels()["olm.copiedFrom"]; ok && copiedFrom != "" {
+				info.Namespace = copiedFrom
+			} else {
+				info.Namespace = csv.GetNamespace()
+			}
+
+			// Get deployment name from install strategy
+			deployments := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
+			if len(deployments) > 0 {
+				info.DeploymentName = deployments[0].Name
+			}
+
+			return info, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// DiscoverOperatorNamespace finds the operator namespace using well-known defaults
+// with fallback to OLM discovery. Returns an error if no operator is found.
+// Propagates non-NotFound errors (e.g., Forbidden) so RBAC issues are visible.
+func DiscoverOperatorNamespace(ctx context.Context, c Reader) (string, error) {
+	// Try well-known defaults first (fast - max 6 API calls)
+	ns, defaultsErr := discoverOperatorNamespaceFromDefaults(ctx, c)
+	if defaultsErr == nil {
+		return ns, nil
+	}
+
+	// Fall back to OLM-based discovery (slower but comprehensive)
+	info, olmErr := DiscoverOperatorFromOLM(ctx, c)
+	if olmErr != nil {
+		// OLM discovery failed with an error (e.g., Forbidden) - propagate it
+		return "", olmErr
+	}
+
+	if info != nil && info.Namespace != "" {
+		return info.Namespace, nil
+	}
+
+	// Return the original error from defaults (Forbidden, timeout, or NotFound)
+	// so RBAC issues propagate to the user instead of being masked
+	return "", defaultsErr
+}
+
+// DiscoverOperatorNamespaceWithInfo finds the operator namespace using pre-fetched
+// OLM info, falling back to well-known defaults if info is nil or incomplete.
+func DiscoverOperatorNamespaceWithInfo(ctx context.Context, c Reader, info *OperatorInfo) (string, error) {
+	if info != nil && info.Namespace != "" {
+		return info.Namespace, nil
+	}
+
+	return discoverOperatorNamespaceFromDefaults(ctx, c)
+}
+
+// discoverOperatorNamespaceFromDefaults tries well-known operator namespaces
+// by checking if the specific operator deployment exists there.
+// Returns the first namespace where the operator is found, or an error.
+// NotFound errors are silently skipped; other errors (Forbidden, timeout) are returned.
+func discoverOperatorNamespaceFromDefaults(ctx context.Context, c Reader) (string, error) {
+	operatorDeploymentNames := []string{
+		"rhods-operator",
+		"opendatahub-operator-controller-manager",
+	}
+
+	namespaces := []string{
+		DefaultRHOAIOperatorNamespace,
+		DefaultODHOperatorNamespace,
+		DefaultOpenShiftOperatorsNS,
+	}
+
+	var firstNonNotFoundErr error
+
+	for _, ns := range namespaces {
+		for _, name := range operatorDeploymentNames {
+			_, err := c.GetResource(ctx, resources.Deployment, name, InNamespace(ns))
+			if err == nil {
+				return ns, nil
+			}
+
+			// Only skip NotFound errors; capture other errors (Forbidden, timeout, etc.)
+			if !apierrors.IsNotFound(err) && firstNonNotFoundErr == nil {
+				if classified := clierrors.Classify(err); classified != nil {
+					firstNonNotFoundErr = classified
+				} else {
+					firstNonNotFoundErr = err
+				}
+			}
+		}
+	}
+
+	// If we encountered a non-NotFound error, return it
+	if firstNonNotFoundErr != nil {
+		return "", firstNonNotFoundErr
+	}
+
+	return "", clierrors.ErrOperatorNamespaceNotFound()
+}

--- a/pkg/util/client/discovery_test.go
+++ b/pkg/util/client/discovery_test.go
@@ -1,0 +1,701 @@
+//nolint:testpackage // Tests internal implementation
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util"
+
+	. "github.com/onsi/gomega"
+)
+
+// --- Mock OLM Reader ---
+
+type mockOLMReader struct {
+	available bool
+	csvReader *mockCSVReader
+}
+
+func (m *mockOLMReader) Available() bool {
+	return m.available
+}
+
+func (m *mockOLMReader) Subscriptions(_ string) SubscriptionReader {
+	return nil
+}
+
+func (m *mockOLMReader) ClusterServiceVersions(_ string) CSVReader {
+	return m.csvReader
+}
+
+// mockCSVReader implements CSVReader for testing.
+type mockCSVReader struct {
+	csvList *operatorsv1alpha1.ClusterServiceVersionList
+	listErr error
+}
+
+func (m *mockCSVReader) List(_ context.Context, _ metav1.ListOptions) (*operatorsv1alpha1.ClusterServiceVersionList, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+
+	return m.csvList, nil
+}
+
+func (m *mockCSVReader) Get(_ context.Context, _ string, _ metav1.GetOptions) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+	return nil, nil
+}
+
+// --- Mock Reader for discovery tests ---
+
+// namespaceName tracks a queried namespace/deployment pair.
+type namespaceName struct {
+	namespace string
+	name      string
+}
+
+type mockDiscoveryReader struct {
+	olmReader    OLMReader
+	deployments  map[string]map[string]bool // namespace -> deployment name -> exists
+	getErr       error                      // error to return for all Get calls
+	forbiddenNS  map[string]bool            // namespaces that return Forbidden
+	queriedPairs []namespaceName            // tracks namespace/name pairs queried
+}
+
+func (m *mockDiscoveryReader) OLM() OLMReader {
+	return m.olmReader
+}
+
+func (m *mockDiscoveryReader) GetResource(
+	_ context.Context,
+	resourceType resources.ResourceType,
+	name string,
+	opts ...GetOption,
+) (*unstructured.Unstructured, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+
+	// Only handle Deployment resources
+	if resourceType != resources.Deployment {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "unknown"}, name)
+	}
+
+	// Extract namespace from options
+	cfg := &GetConfig{}
+	util.ApplyOptions(cfg, opts...)
+
+	ns := cfg.Namespace
+
+	// Track the query
+	m.queriedPairs = append(m.queriedPairs, namespaceName{namespace: ns, name: name})
+
+	// Check if namespace returns Forbidden
+	if m.forbiddenNS != nil && m.forbiddenNS[ns] {
+		return nil, apierrors.NewForbidden(schema.GroupResource{Resource: "deployments"}, name, errors.New("forbidden"))
+	}
+
+	// Check if deployment exists
+	if m.deployments != nil {
+		if nsDeployments, ok := m.deployments[ns]; ok {
+			if nsDeployments[name] {
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]any{
+							"name":      name,
+							"namespace": ns,
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "deployments"}, name)
+}
+
+// Implement remaining Reader interface methods (unused in discovery tests).
+func (m *mockDiscoveryReader) List(_ context.Context, _ resources.ResourceType, _ ...ListResourcesOption) ([]*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryReader) ListMetadata(_ context.Context, _ resources.ResourceType, _ ...ListResourcesOption) ([]*metav1.PartialObjectMetadata, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryReader) ListResources(_ context.Context, _ schema.GroupVersionResource, _ ...ListResourcesOption) ([]*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryReader) Get(_ context.Context, _ schema.GroupVersionResource, _ string, _ ...GetOption) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryReader) GetResourceMetadata(_ context.Context, _ resources.ResourceType, _ string, _ ...GetOption) (*metav1.PartialObjectMetadata, error) {
+	return nil, nil
+}
+
+// Compile-time check that mockDiscoveryReader implements Reader.
+var _ Reader = (*mockDiscoveryReader)(nil)
+
+// --- Tests for DiscoverOperatorFromOLM ---
+
+func TestDiscoverOperatorFromOLM_OLMNotAvailable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+	}
+
+	info, err := DiscoverOperatorFromOLM(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info).To(BeNil())
+}
+
+func TestDiscoverOperatorFromOLM_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{
+			available: true,
+			csvReader: &mockCSVReader{
+				listErr: errors.New("list failed"),
+			},
+		},
+	}
+
+	info, err := DiscoverOperatorFromOLM(ctx, reader)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(info).To(BeNil())
+}
+
+func TestDiscoverOperatorFromOLM_NoMatchingCSV(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{
+			available: true,
+			csvReader: &mockCSVReader{
+				csvList: &operatorsv1alpha1.ClusterServiceVersionList{
+					Items: []operatorsv1alpha1.ClusterServiceVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "some-other-operator.v1.0.0",
+								Namespace: "some-namespace",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	info, err := DiscoverOperatorFromOLM(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info).To(BeNil())
+}
+
+func TestDiscoverOperatorFromOLM_RHODSOperatorFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{
+			available: true,
+			csvReader: &mockCSVReader{
+				csvList: &operatorsv1alpha1.ClusterServiceVersionList{
+					Items: []operatorsv1alpha1.ClusterServiceVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "rhods-operator.v2.10.0",
+								Namespace: "redhat-ods-operator",
+							},
+							Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+								InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+									StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+										DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+											{Name: "rhods-operator"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	info, err := DiscoverOperatorFromOLM(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.Namespace).To(Equal("redhat-ods-operator"))
+	g.Expect(info.DeploymentName).To(Equal("rhods-operator"))
+}
+
+func TestDiscoverOperatorFromOLM_ODHOperatorFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{
+			available: true,
+			csvReader: &mockCSVReader{
+				csvList: &operatorsv1alpha1.ClusterServiceVersionList{
+					Items: []operatorsv1alpha1.ClusterServiceVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "opendatahub-operator.v2.10.0",
+								Namespace: "opendatahub",
+							},
+							Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+								InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+									StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+										DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+											{Name: "opendatahub-operator-controller-manager"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	info, err := DiscoverOperatorFromOLM(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.Namespace).To(Equal("opendatahub"))
+	g.Expect(info.DeploymentName).To(Equal("opendatahub-operator-controller-manager"))
+}
+
+func TestDiscoverOperatorFromOLM_CopiedFromLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{
+			available: true,
+			csvReader: &mockCSVReader{
+				csvList: &operatorsv1alpha1.ClusterServiceVersionList{
+					Items: []operatorsv1alpha1.ClusterServiceVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "rhods-operator.v2.10.0",
+								Namespace: "redhat-ods-applications", // copied CSV
+								Labels: map[string]string{
+									"olm.copiedFrom": "redhat-ods-operator", // original namespace
+								},
+							},
+							Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+								InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+									StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+										DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+											{Name: "rhods-operator"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	info, err := DiscoverOperatorFromOLM(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.Namespace).To(Equal("redhat-ods-operator")) // should use copiedFrom
+	g.Expect(info.DeploymentName).To(Equal("rhods-operator"))
+}
+
+// --- Tests for DiscoverOperatorNamespace ---
+
+func TestDiscoverOperatorNamespace_UsesOLMDiscovery(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{
+			available: true,
+			csvReader: &mockCSVReader{
+				csvList: &operatorsv1alpha1.ClusterServiceVersionList{
+					Items: []operatorsv1alpha1.ClusterServiceVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "rhods-operator.v2.10.0",
+								Namespace: "redhat-ods-operator",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ns, err := DiscoverOperatorNamespace(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal("redhat-ods-operator"))
+}
+
+func TestDiscoverOperatorNamespace_FallsBackToDefaults(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultODHOperatorNamespace: {
+				"opendatahub-operator-controller-manager": true,
+			},
+		},
+	}
+
+	ns, err := DiscoverOperatorNamespace(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultODHOperatorNamespace))
+}
+
+// --- Tests for DiscoverOperatorNamespaceWithInfo ---
+
+func TestDiscoverOperatorNamespaceWithInfo_UsesProvidedInfo(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+	}
+
+	info := &OperatorInfo{
+		Namespace:      "custom-operator-ns",
+		DeploymentName: "my-operator",
+	}
+
+	ns, err := DiscoverOperatorNamespaceWithInfo(ctx, reader, info)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal("custom-operator-ns"))
+}
+
+func TestDiscoverOperatorNamespaceWithInfo_FallsBackWhenInfoNil(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultRHOAIOperatorNamespace: {
+				"rhods-operator": true,
+			},
+		},
+	}
+
+	ns, err := DiscoverOperatorNamespaceWithInfo(ctx, reader, nil)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultRHOAIOperatorNamespace))
+}
+
+func TestDiscoverOperatorNamespaceWithInfo_FallsBackWhenNamespaceEmpty(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultRHOAIOperatorNamespace: {
+				"rhods-operator": true,
+			},
+		},
+	}
+
+	info := &OperatorInfo{
+		Namespace:      "", // empty
+		DeploymentName: "some-deployment",
+	}
+
+	ns, err := DiscoverOperatorNamespaceWithInfo(ctx, reader, info)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultRHOAIOperatorNamespace))
+}
+
+// --- Tests for discoverOperatorNamespaceFromDefaults ---
+
+func TestDiscoverOperatorNamespaceFromDefaults_FindsRHOAIOperator(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultRHOAIOperatorNamespace: {
+				"rhods-operator": true,
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultRHOAIOperatorNamespace))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_FindsODHOperator(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultODHOperatorNamespace: {
+				"opendatahub-operator-controller-manager": true,
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultODHOperatorNamespace))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_FindsInOpenShiftOperators(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultOpenShiftOperatorsNS: {
+				"rhods-operator": true,
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultOpenShiftOperatorsNS))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_NotFoundError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader:   &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{}, // no deployments
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("could not discover operator namespace"))
+	g.Expect(ns).To(BeEmpty())
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_ReturnsForbiddenError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		forbiddenNS: map[string]bool{
+			DefaultRHOAIOperatorNamespace: true,
+		},
+		deployments: map[string]map[string]bool{}, // no deployments found in other namespaces
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsForbidden(err) || err.Error() != "").To(BeTrue())
+	g.Expect(ns).To(BeEmpty())
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_SkipsNotFoundContinuesSearch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// First two namespaces return NotFound, third has the deployment
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			// DefaultRHOAIOperatorNamespace: not found
+			// DefaultODHOperatorNamespace: not found
+			DefaultOpenShiftOperatorsNS: {
+				"opendatahub-operator-controller-manager": true,
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultOpenShiftOperatorsNS))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_FirstHitCancelsSearch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Deployment exists in first namespace - should stop searching immediately
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultRHOAIOperatorNamespace: {
+				"rhods-operator": true,
+			},
+			// Also has deployment in other namespaces - should NOT be queried
+			DefaultODHOperatorNamespace: {
+				"opendatahub-operator-controller-manager": true,
+			},
+			DefaultOpenShiftOperatorsNS: {
+				"rhods-operator": true,
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultRHOAIOperatorNamespace))
+
+	// Verify only one query was made (first hit cancels)
+	g.Expect(reader.queriedPairs).To(HaveLen(1))
+	g.Expect(reader.queriedPairs[0].namespace).To(Equal(DefaultRHOAIOperatorNamespace))
+	g.Expect(reader.queriedPairs[0].name).To(Equal("rhods-operator"))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_AllNotFoundExhaustiveSearch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// No deployments anywhere - should try all combinations
+	reader := &mockDiscoveryReader{
+		olmReader:   &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(ns).To(BeEmpty())
+
+	// Verify all 6 combinations were tried (3 namespaces × 2 deployment names)
+	// Order: for each namespace, try both deployment names
+	expectedQueries := []namespaceName{
+		{DefaultRHOAIOperatorNamespace, "rhods-operator"},
+		{DefaultRHOAIOperatorNamespace, "opendatahub-operator-controller-manager"},
+		{DefaultODHOperatorNamespace, "rhods-operator"},
+		{DefaultODHOperatorNamespace, "opendatahub-operator-controller-manager"},
+		{DefaultOpenShiftOperatorsNS, "rhods-operator"},
+		{DefaultOpenShiftOperatorsNS, "opendatahub-operator-controller-manager"},
+	}
+
+	g.Expect(reader.queriedPairs).To(HaveLen(6))
+	g.Expect(reader.queriedPairs).To(Equal(expectedQueries))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_ForbiddenThenFoundReturnsSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// First namespace returns Forbidden, but deployment exists in second namespace
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		forbiddenNS: map[string]bool{
+			DefaultRHOAIOperatorNamespace: true, // Forbidden here
+		},
+		deployments: map[string]map[string]bool{
+			DefaultODHOperatorNamespace: {
+				"opendatahub-operator-controller-manager": true, // Found here
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	// Should succeed despite Forbidden in first namespace
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultODHOperatorNamespace))
+
+	// Verify search continued past Forbidden namespace
+	g.Expect(len(reader.queriedPairs)).To(BeNumerically(">", 2))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_ForbiddenCapturedWhenNothingFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// First namespace returns Forbidden, nothing found in other namespaces
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		forbiddenNS: map[string]bool{
+			DefaultRHOAIOperatorNamespace: true,
+		},
+		deployments: map[string]map[string]bool{}, // Nothing found anywhere
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	// Should return the Forbidden error (not ErrOperatorNamespaceNotFound)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(ns).To(BeEmpty())
+
+	// The error should be related to Forbidden, not "not found"
+	g.Expect(err.Error()).ToNot(ContainSubstring("could not discover operator namespace"))
+}
+
+func TestDiscoverOperatorNamespaceFromDefaults_SecondDeploymentNameInSameNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// First deployment name not found, but second deployment name exists in first namespace
+	reader := &mockDiscoveryReader{
+		olmReader: &mockOLMReader{available: false},
+		deployments: map[string]map[string]bool{
+			DefaultRHOAIOperatorNamespace: {
+				// "rhods-operator": not found
+				"opendatahub-operator-controller-manager": true, // Found on second try
+			},
+		},
+	}
+
+	ns, err := discoverOperatorNamespaceFromDefaults(ctx, reader)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(Equal(DefaultRHOAIOperatorNamespace))
+
+	// Should have tried both deployment names in first namespace
+	g.Expect(reader.queriedPairs).To(HaveLen(2))
+	g.Expect(reader.queriedPairs[0].name).To(Equal("rhods-operator"))
+	g.Expect(reader.queriedPairs[1].name).To(Equal("opendatahub-operator-controller-manager"))
+}

--- a/pkg/util/client/helpers.go
+++ b/pkg/util/client/helpers.go
@@ -387,6 +387,47 @@ func GetApplicationsNamespace(ctx context.Context, r Reader) (string, error) {
 	return namespace, nil
 }
 
+// DSCINamespaces contains namespaces extracted from DSCInitialization.
+type DSCINamespaces struct {
+	Applications string
+	Monitoring   string
+}
+
+// GetDSCINamespaces retrieves both applications and monitoring namespaces from DSCInitialization
+// in a single API call. Returns empty strings for namespaces that are not set.
+// Returns NotFound error if DSCI doesn't exist. Returns error for jq query failures
+// other than missing fields.
+func GetDSCINamespaces(ctx context.Context, r Reader) (DSCINamespaces, error) {
+	dsci, err := GetDSCInitialization(ctx, r)
+	if err != nil {
+		return DSCINamespaces{}, err
+	}
+
+	var result DSCINamespaces
+
+	// Get applications namespace
+	appNS, err := jq.Query[string](dsci, ".spec.applicationsNamespace")
+	if err != nil && !errors.Is(err, jq.ErrNotFound) {
+		return DSCINamespaces{}, fmt.Errorf("querying applicationsNamespace: %w", err)
+	}
+
+	result.Applications = appNS
+
+	// Get monitoring namespace, fall back to applications namespace
+	monNS, err := jq.Query[string](dsci, ".spec.monitoring.namespace")
+	if err != nil && !errors.Is(err, jq.ErrNotFound) {
+		return DSCINamespaces{}, fmt.Errorf("querying monitoring namespace: %w", err)
+	}
+
+	if monNS != "" {
+		result.Monitoring = monNS
+	} else {
+		result.Monitoring = result.Applications
+	}
+
+	return result, nil
+}
+
 // List lists resources of the given type, applies an optional filter, and returns matching items.
 // CRD-not-found errors are treated as an empty list. Pass nil filter to return all.
 // T must be *unstructured.Unstructured (dispatches to Reader.List) or *metav1.PartialObjectMetadata

--- a/pkg/util/client/helpers_test.go
+++ b/pkg/util/client/helpers_test.go
@@ -512,6 +512,108 @@ func TestGetApplicationsNamespace_EmptyNamespace(t *testing.T) {
 	g.Expect(namespace).To(BeEmpty())
 }
 
+// createDSCInitializationWithMonitoring creates a DSCI with both applications and monitoring namespaces.
+func createDSCInitializationWithMonitoring(applicationsNS, monitoringNS string) runtime.Object {
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"spec": map[string]any{},
+		},
+	}
+
+	spec := dsci.Object["spec"].(map[string]any)
+	if applicationsNS != "" {
+		spec["applicationsNamespace"] = applicationsNS
+	}
+	if monitoringNS != "" {
+		spec["monitoring"] = map[string]any{
+			"namespace": monitoringNS,
+		}
+	}
+
+	return dsci
+}
+
+func TestGetDSCINamespaces_BothNamespacesSet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsci := createDSCInitializationWithMonitoring("redhat-ods-applications", "redhat-ods-monitoring")
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, dsci)
+	metadataClient := metadatafake.NewSimpleMetadataClient(scheme, dsci)
+
+	client := &defaultClient{
+		dynamic:   dynamicClient,
+		metadata:  metadataClient,
+		olmReader: newOLMReader(nil),
+	}
+
+	namespaces, err := GetDSCINamespaces(ctx, client)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(namespaces.Applications).To(Equal("redhat-ods-applications"))
+	g.Expect(namespaces.Monitoring).To(Equal("redhat-ods-monitoring"))
+}
+
+func TestGetDSCINamespaces_MonitoringFallsBackToApplications(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// DSCI with only applications namespace set
+	dsci := createDSCInitializationWithMonitoring("redhat-ods-applications", "")
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, dsci)
+	metadataClient := metadatafake.NewSimpleMetadataClient(scheme, dsci)
+
+	client := &defaultClient{
+		dynamic:   dynamicClient,
+		metadata:  metadataClient,
+		olmReader: newOLMReader(nil),
+	}
+
+	namespaces, err := GetDSCINamespaces(ctx, client)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(namespaces.Applications).To(Equal("redhat-ods-applications"))
+	g.Expect(namespaces.Monitoring).To(Equal("redhat-ods-applications"))
+}
+
+func TestGetDSCINamespaces_DSCINotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	gvrListMap := map[schema.GroupVersionResource]string{
+		resources.DSCInitialization.GVR(): "DSCInitializationList",
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrListMap)
+	metadataClient := metadatafake.NewSimpleMetadataClient(scheme)
+
+	client := &defaultClient{
+		dynamic:   dynamicClient,
+		metadata:  metadataClient,
+		olmReader: newOLMReader(nil),
+	}
+
+	namespaces, err := GetDSCINamespaces(ctx, client)
+
+	g.Expect(err).To(Satisfy(apierrors.IsNotFound))
+	g.Expect(namespaces.Applications).To(BeEmpty())
+	g.Expect(namespaces.Monitoring).To(BeEmpty())
+}
+
 // --- List[T] tests ---
 
 func configMapResourceType() resources.ResourceType {

--- a/pkg/util/errors/common.go
+++ b/pkg/util/errors/common.go
@@ -1,0 +1,110 @@
+package errors
+
+import "fmt"
+
+// Common error codes.
+const (
+	CodeConfigFailed    = "CONFIG_FAILED"
+	CodeClientFailed    = "CLIENT_FAILED"
+	CodeNamespaceFailed = "NAMESPACE_FAILED"
+	CodeDSCIFailed      = "DSCI_FAILED"
+	CodeNotFound        = "NOT_FOUND"
+	CodeRenderFailed    = "RENDER_FAILED"
+)
+
+// Common suggestions.
+const (
+	SuggestCheckKubeconfig = "Verify your kubeconfig is valid and the cluster is reachable"
+	SuggestCheckCluster    = "Ensure the cluster is running and accessible"
+	SuggestCheckODH        = "Ensure ODH/RHOAI is properly installed"
+	SuggestRetry           = "Try again; if the problem persists, check cluster connectivity"
+)
+
+// classifyOrWrap attempts to classify the error. If classification succeeds,
+// it prepends the context message. Otherwise, it creates a new StructuredError.
+// Returns a copy to avoid mutating the original error in the chain.
+func classifyOrWrap(err error, code, context, suggestion string, category ErrorCategory, retriable bool) *StructuredError {
+	if classified := Classify(err); classified != nil {
+		wrapped := *classified
+		wrapped.Message = fmt.Sprintf("%s: %s", context, classified.Message)
+
+		return &wrapped
+	}
+
+	return &StructuredError{
+		Code:       code,
+		Message:    fmt.Sprintf("%s: %s", context, err.Error()),
+		Category:   category,
+		Retriable:  retriable,
+		Suggestion: suggestion,
+	}
+}
+
+// ErrConfigFailed creates a structured error for REST config creation failures.
+func ErrConfigFailed(err error) *StructuredError {
+	return classifyOrWrap(err, CodeConfigFailed, "failed to create REST config",
+		SuggestCheckKubeconfig, CategoryValidation, false)
+}
+
+// ErrClientFailed creates a structured error for Kubernetes client creation failures.
+func ErrClientFailed(err error) *StructuredError {
+	return classifyOrWrap(err, CodeClientFailed, "failed to create Kubernetes client",
+		SuggestCheckCluster, CategoryConnection, true)
+}
+
+// ErrCRClientFailed creates a structured error for controller-runtime client creation failures.
+func ErrCRClientFailed(err error) *StructuredError {
+	return classifyOrWrap(err, CodeClientFailed, "failed to create controller-runtime client",
+		SuggestCheckCluster, CategoryConnection, true)
+}
+
+// ErrNamespaceFailed creates a structured error for namespace determination failures.
+func ErrNamespaceFailed(err error) *StructuredError {
+	return classifyOrWrap(err, CodeNamespaceFailed, "failed to determine namespace from kubeconfig",
+		SuggestCheckKubeconfig, CategoryValidation, false)
+}
+
+// ErrDSCIFailed creates a structured error for DSCInitialization retrieval failures.
+func ErrDSCIFailed(err error) *StructuredError {
+	return classifyOrWrap(err, CodeDSCIFailed, "failed to get DSCInitialization",
+		SuggestCheckODH, CategoryInternal, true)
+}
+
+// ErrNoNamespacesDiscovered creates a structured error when no ODH namespaces could be found.
+func ErrNoNamespacesDiscovered() *StructuredError {
+	return &StructuredError{
+		Code:       CodeNotFound,
+		Message:    "no ODH namespaces discovered",
+		Category:   CategoryNotFound,
+		Retriable:  false,
+		Suggestion: SuggestCheckODH,
+	}
+}
+
+// ErrOperatorNamespaceNotFound creates a structured error when operator namespace cannot be discovered.
+func ErrOperatorNamespaceNotFound() *StructuredError {
+	return &StructuredError{
+		Code:       CodeNotFound,
+		Message:    "could not discover operator namespace",
+		Category:   CategoryNotFound,
+		Retriable:  false,
+		Suggestion: "Use --operator-namespace to specify the operator namespace",
+	}
+}
+
+// ErrRenderFailed creates a structured error for output rendering failures.
+func ErrRenderFailed(format string, err error) *StructuredError {
+	return &StructuredError{
+		Code:       CodeRenderFailed,
+		Message:    fmt.Sprintf("failed to render %s output: %s", format, err.Error()),
+		Category:   CategoryInternal,
+		Retriable:  false,
+		Suggestion: SuggestRetry,
+	}
+}
+
+// ErrEventsFetchFailed creates a structured error when fetching events fails.
+func ErrEventsFetchFailed(err error) *StructuredError {
+	return classifyOrWrap(err, "EVENTS_FETCH_FAILED", "failed to fetch events",
+		SuggestRetry, CategoryInternal, true)
+}

--- a/pkg/util/test/mocks/client/client.go
+++ b/pkg/util/test/mocks/client/client.go
@@ -1,0 +1,190 @@
+package client
+
+import (
+	"context"
+
+	olmclientset "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/stretchr/testify/mock"
+
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/metadata"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// MockClient is a mock implementation of client.Client using testify/mock.
+type MockClient struct {
+	mock.Mock
+}
+
+var _ client.Client = (*MockClient)(nil)
+
+// Reader methods
+
+func (m *MockClient) List(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	opts ...client.ListResourcesOption,
+) ([]*unstructured.Unstructured, error) {
+	args := m.Called(ctx, resourceType, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).([]*unstructured.Unstructured)
+
+	return result, args.Error(1)
+}
+
+func (m *MockClient) ListMetadata(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	opts ...client.ListResourcesOption,
+) ([]*metav1.PartialObjectMetadata, error) {
+	args := m.Called(ctx, resourceType, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).([]*metav1.PartialObjectMetadata)
+
+	return result, args.Error(1)
+}
+
+func (m *MockClient) ListResources(
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	opts ...client.ListResourcesOption,
+) ([]*unstructured.Unstructured, error) {
+	args := m.Called(ctx, gvr, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).([]*unstructured.Unstructured)
+
+	return result, args.Error(1)
+}
+
+func (m *MockClient) Get(
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	name string,
+	opts ...client.GetOption,
+) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, gvr, name, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*unstructured.Unstructured)
+
+	return result, args.Error(1)
+}
+
+func (m *MockClient) GetResource(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	name string,
+	opts ...client.GetOption,
+) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, resourceType, name, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*unstructured.Unstructured)
+
+	return result, args.Error(1)
+}
+
+func (m *MockClient) GetResourceMetadata(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	name string,
+	opts ...client.GetOption,
+) (*metav1.PartialObjectMetadata, error) {
+	args := m.Called(ctx, resourceType, name, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*metav1.PartialObjectMetadata)
+
+	return result, args.Error(1)
+}
+
+func (m *MockClient) OLM() client.OLMReader {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+
+	result, _ := args.Get(0).(client.OLMReader)
+
+	return result
+}
+
+// Writer methods
+
+func (m *MockClient) Patch(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	name string,
+	pt types.PatchType,
+	data []byte,
+	opts ...client.PatchOption,
+) (*unstructured.Unstructured, error) {
+	args := m.Called(ctx, resourceType, name, pt, data, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	result, _ := args.Get(0).(*unstructured.Unstructured)
+
+	return result, args.Error(1)
+}
+
+// Client-specific methods (return nil for mocks)
+
+func (m *MockClient) Dynamic() dynamic.Interface {
+	return nil
+}
+
+func (m *MockClient) Discovery() discovery.DiscoveryInterface {
+	return nil
+}
+
+func (m *MockClient) APIExtensions() apiextensionsclientset.Interface {
+	return nil
+}
+
+func (m *MockClient) Metadata() metadata.Interface {
+	return nil
+}
+
+func (m *MockClient) RESTMapper() meta.RESTMapper {
+	return nil
+}
+
+func (m *MockClient) OLMClient() olmclientset.Interface {
+	return nil
+}
+
+func (m *MockClient) CoreV1() corev1client.CoreV1Interface {
+	return nil
+}
+
+func (m *MockClient) AuthorizationV1() authorizationv1client.AuthorizationV1Interface {
+	return nil
+}


### PR DESCRIPTION
## Description

This PR introduces the `odh events` command that provides visibility into Kubernetes events related to Open Data Hub / OpenShift AI resources.

**Key implementation details:**
- Uses `clusterhealth.RunRecentEvents()` for event collection
- Auto-discovers ODH namespaces from DSCInitialization CR
- Concurrent operator namespace discovery (checks multiple locations in parallel)
- Proper validation errors with actionable suggestions

##### Jira link :- https://redhat.atlassian.net/browse/RHOAIENG-54646


**Usage examples:**
```bash
kubectl odh events                    # Recent events (default: 5m)
kubectl odh events --since 1h         # Last hour
kubectl odh events --type Warning     # Warnings only
kubectl odh events -A -o json         # All ODH namespaces, JSON output
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests


## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed

## Follow-up

A follow-up PR will add:
- `--component`: filter events by component (e.g., kserve, dashboard, workbenches)
- `--follow` / `-f`: stream new events as they occur


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `events` subcommand to list and filter cluster events.
  * Supports filtering by event type (Warning/Normal), time range (up to 24 hours), and namespaces.
  * Output formats: table, JSON, and YAML.
  * Events sorted by recency with relative timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->