### PR TITLE
feat: enhance status command with table formatting and envelope output

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -36,9 +36,22 @@ Shows the health status of an OpenShift AI / Open Data Hub installation.
 Runs health checks across eight sections and displays a summary table:
   Operator, DSCI, DSC, Nodes, Deployments, Pods, Quotas, Events
 
+Status indicators:
+  ✓  Section healthy (all checks passed)
+  ✗  Section unhealthy (problems found)
+  ?  Section skipped (insufficient permissions)
+
+Sections are grouped into layers:
+  infrastructure: nodes
+  workload:       deployments, pods, events, quotas
+  operator:       operator, dsci, dsc
+
 The applications and operator namespaces are auto-detected from the
 DSCInitialization resource and OLM ClusterServiceVersions. Use
 --apps-namespace and --operator-namespace to override.
+
+By default, also checks required operator dependencies (ServiceMesh,
+Serverless, etc.) and shows which components need them.
 
 Examples:
   # Show platform health summary
@@ -50,8 +63,12 @@ Examples:
   # Check only nodes and deployments
   kubectl odh status --section nodes --section deployments
 
-  # Output full report as JSON
+  # Check only operator-related sections
+  kubectl odh status --layer operator
+
+  # Output full report as JSON or YAML
   kubectl odh status -o json
+  kubectl odh status -o yaml
 `
 
 const cmdExample = `
@@ -64,8 +81,15 @@ const cmdExample = `
   # Filter to specific sections
   kubectl odh status --section operator --section dsci --section dsc
 
-  # JSON output for scripting
+  # Filter by layer (infrastructure, workload, operator)
+  kubectl odh status --layer operator
+
+  # JSON or YAML output for scripting
   kubectl odh status -o json
+  kubectl odh status -o yaml
+
+  # Skip dependency checking
+  kubectl odh status --include-deps=false
 
   # Override namespace detection
   kubectl odh status --apps-namespace my-apps --operator-namespace my-operator

--- a/pkg/deps/check.go
+++ b/pkg/deps/check.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"golang.org/x/sync/errgroup"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,18 +87,26 @@ func (l *DependencyList) computeStatus() {
 }
 
 // CheckDependencies queries the cluster for dependency installation status.
+// Checks run concurrently for improved performance.
 func CheckDependencies(ctx context.Context, olmReader client.OLMReader, manifest *Manifest) ([]DependencyStatus, error) {
 	if !olmReader.Available() {
 		return nil, ErrOLMNotAvailable
 	}
 
 	deps := manifest.GetDependencies()
-	results := make([]DependencyStatus, 0, len(deps))
+	results := make([]DependencyStatus, len(deps))
 
-	for _, dep := range deps {
-		status := checkSingleDependency(ctx, olmReader, dep)
-		results = append(results, status)
+	g, gctx := errgroup.WithContext(ctx)
+
+	for i, dep := range deps {
+		g.Go(func() error {
+			results[i] = checkSingleDependency(gctx, olmReader, dep)
+
+			return nil
+		})
 	}
+
+	_ = g.Wait() // errors are captured in DependencyStatus.Error, not returned
 
 	// Sort by name for consistent output
 	sort.Slice(results, func(i, j int) bool {

--- a/pkg/resources/types_test.go
+++ b/pkg/resources/types_test.go
@@ -1,0 +1,26 @@
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestGVKSyncWithClusterhealth ensures CLI ResourceType definitions stay in sync
+// with clusterhealth library GVKs. If either side changes their GVK definitions,
+// this test will fail and alert developers to the mismatch.
+func TestGVKSyncWithClusterhealth(t *testing.T) {
+	t.Run("DSCInitialization", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(resources.DSCInitialization.GVK()).To(Equal(clusterhealth.DSCInitializationGVK))
+	})
+
+	t.Run("DataScienceCluster", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(resources.DataScienceCluster.GVK()).To(Equal(clusterhealth.DataScienceClusterGVK))
+	})
+}

--- a/pkg/status/errors.go
+++ b/pkg/status/errors.go
@@ -8,17 +8,20 @@ import (
 
 const (
 	errCodeInvalidSection      = "INVALID_SECTION"
+	errCodeInvalidLayer        = "INVALID_LAYER"
 	errCodeInvalidOutputFormat = "INVALID_OUTPUT_FORMAT"
 	errCodeInvalidTimeout      = "INVALID_TIMEOUT"
 	errCodeDSCINotFound        = "DSCI_NOT_FOUND"
 
 	msgInvalidSection      = "invalid section %q"
+	msgInvalidLayer        = "invalid layer %q"
 	msgInvalidOutputFormat = "invalid output format %q"
 	msgInvalidTimeout      = "timeout must be greater than 0"
 	msgDSCINotFound        = "no DSCInitialization found"
 
 	suggestValidSections   = "Valid sections: nodes, deployments, pods, events, quotas, operator, dsci, dsc"
-	suggestValidFormats    = "Use --output with one of: table, json"
+	suggestValidLayers     = "Valid layers: infrastructure, workload, operator"
+	suggestValidFormats    = "Use --output with one of: table, json, yaml"
 	suggestValidTimeout    = "Use --timeout with a positive duration (e.g., 30s, 1m)"
 	suggestInstallODHRHOAI = "Ensure ODH/RHOAI is installed on the cluster"
 )
@@ -31,6 +34,17 @@ func ErrInvalidSection(section string) *clierrors.StructuredError {
 		Category:   clierrors.CategoryValidation,
 		Retriable:  false,
 		Suggestion: suggestValidSections,
+	}
+}
+
+// ErrInvalidLayer creates a structured error for invalid layer names.
+func ErrInvalidLayer(layer string) *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeInvalidLayer,
+		Message:    fmt.Sprintf(msgInvalidLayer, layer),
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: suggestValidLayers,
 	}
 }
 

--- a/pkg/status/export_test.go
+++ b/pkg/status/export_test.go
@@ -1,0 +1,12 @@
+package status
+
+// Export internal functions for testing.
+//
+//nolint:gochecknoglobals // Test exports only compiled in test builds
+var (
+	IsRBACError  = isRBACError
+	StatusSymbol = statusSymbol
+	VisibleLen   = visibleLen
+	PadRight     = padRight
+	Truncate     = truncate
+)

--- a/pkg/status/output.go
+++ b/pkg/status/output.go
@@ -6,17 +6,34 @@ import (
 
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/json"
+	"github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
 )
 
-// renderJSON writes the report as indented JSON to w.
-func renderJSON(w io.Writer, report *clusterhealth.Report) error {
-	renderer := json.NewRenderer[*clusterhealth.Report](
-		json.WithWriter[*clusterhealth.Report](w),
+// renderJSON writes the report as JSON with envelope to w.
+func renderJSON(w io.Writer, report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	statusReport := NewStatusReport(report, depStatuses)
+	renderer := json.NewRenderer[*StatusReport](
+		json.WithWriter[*StatusReport](w),
 	)
 
-	if err := renderer.Render(report); err != nil {
+	if err := renderer.Render(statusReport); err != nil {
 		return fmt.Errorf("rendering JSON report: %w", err)
+	}
+
+	return nil
+}
+
+// renderYAML writes the report as YAML with envelope to w.
+func renderYAML(w io.Writer, report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	statusReport := NewStatusReport(report, depStatuses)
+	renderer := yaml.NewRenderer[*StatusReport](
+		yaml.WithWriter[*StatusReport](w),
+	)
+
+	if err := renderer.Render(statusReport); err != nil {
+		return fmt.Errorf("rendering YAML report: %w", err)
 	}
 
 	return nil

--- a/pkg/status/output_table.go
+++ b/pkg/status/output_table.go
@@ -1,0 +1,653 @@
+package status
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	utilcolor "github.com/opendatahub-io/odh-cli/pkg/util/color"
+)
+
+const (
+	colWidthSection = 12
+	colWidthStatus  = 6
+	maxSummaryLen   = 60
+	maxDetailLen    = 50
+
+	msgInsufficientPerms = "insufficient permissions"
+)
+
+// sectionDisplayOrder defines the order and display names for sections.
+//
+//nolint:gochecknoglobals // Package-level constant data for section ordering
+var sectionDisplayOrder = []struct {
+	key     string
+	display string
+}{
+	{clusterhealth.SectionNodes, "Nodes"},
+	{clusterhealth.SectionDeployments, "Deployments"},
+	{clusterhealth.SectionPods, "Pods"},
+	{clusterhealth.SectionEvents, "Events"},
+	{clusterhealth.SectionQuotas, "Quotas"},
+	{clusterhealth.SectionOperator, "Operator"},
+	{clusterhealth.SectionDSCI, "DSCI"},
+	{clusterhealth.SectionDSC, "DSC"},
+}
+
+// isRBACError checks if the error string indicates a permission/RBAC issue.
+// Allocates once for the lowercased string, then checks all patterns.
+func isRBACError(errStr string) bool {
+	if errStr == "" {
+		return false
+	}
+
+	lower := strings.ToLower(errStr)
+
+	return strings.Contains(lower, "forbidden") ||
+		strings.Contains(lower, "unauthorized") ||
+		strings.Contains(lower, "cannot list") ||
+		strings.Contains(lower, "cannot get")
+}
+
+// statusSymbol returns the appropriate colored symbol for a section.
+func statusSymbol(errStr string) string {
+	if errStr == "" {
+		return utilcolor.StatusPass()
+	}
+	if isRBACError(errStr) {
+		return utilcolor.StatusUnknown()
+	}
+
+	return utilcolor.StatusFail()
+}
+
+// ansiEscapeRegex matches ANSI escape codes for color calculation.
+var ansiEscapeRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// visibleLen returns the visible length of a string, excluding ANSI codes.
+func visibleLen(s string) int {
+	return utf8.RuneCountInString(ansiEscapeRegex.ReplaceAllString(s, ""))
+}
+
+// padRight pads a string to the specified visible width.
+func padRight(s string, width int) string {
+	visible := visibleLen(s)
+	if visible >= width {
+		return s
+	}
+
+	return s + strings.Repeat(" ", width-visible)
+}
+
+// truncate shortens a string to maxLen runes, adding "..." if truncated.
+// Uses rune-aware slicing to avoid corrupting multi-byte UTF-8 characters.
+func truncate(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+
+	if maxLen <= 3 {
+		return "..."
+	}
+
+	return string(runes[:maxLen-3]) + "..."
+}
+
+// renderTableOutput renders the report as a formatted table with symbols.
+func (c *Command) renderTableOutput(report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	w := c.IO.Out()
+
+	// Build section filter set
+	runSet := make(map[string]bool)
+	for _, k := range report.SectionsRun {
+		runSet[k] = true
+	}
+
+	// Print table header
+	if err := writeTableHeader(w); err != nil {
+		return err
+	}
+
+	// Print each section row
+	for _, sec := range sectionDisplayOrder {
+		if len(runSet) > 0 && !runSet[sec.key] {
+			continue
+		}
+
+		errStr, summary := c.getSectionData(report, sec.key)
+		symbol := statusSymbol(errStr)
+
+		if err := writeTableRow(w, sec.display, symbol, summary); err != nil {
+			return err
+		}
+	}
+
+	// Print verbose details if requested
+	if c.Verbose {
+		if err := c.renderVerboseDetails(w, report, runSet); err != nil {
+			return err
+		}
+	}
+
+	// Print dependencies if available
+	if len(depStatuses) > 0 {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return fmt.Errorf("writing newline: %w", err)
+		}
+		if err := c.renderDependenciesTable(w, depStatuses); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeTableHeader(w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%s  %s  SUMMARY\n",
+		padRight("SECTION", colWidthSection),
+		padRight("STATUS", colWidthStatus)); err != nil {
+		return fmt.Errorf("writing table header: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(w, "%s  %s  %s\n",
+		strings.Repeat("-", colWidthSection),
+		strings.Repeat("-", colWidthStatus),
+		"-------"); err != nil {
+		return fmt.Errorf("writing table separator: %w", err)
+	}
+
+	return nil
+}
+
+func writeTableRow(w io.Writer, section, symbol, summary string) error {
+	if _, err := fmt.Fprintf(w, "%s  %s  %s\n",
+		padRight(section, colWidthSection),
+		padRight(symbol, colWidthStatus),
+		summary); err != nil {
+		return fmt.Errorf("writing table row: %w", err)
+	}
+
+	return nil
+}
+
+// getSectionData returns the error string and summary for a section.
+//
+//nolint:nonamedreturns // Named returns would be redundant here
+func (c *Command) getSectionData(report *clusterhealth.Report, key string) (errStr string, summary string) {
+	switch key {
+	case clusterhealth.SectionNodes:
+		return report.Nodes.Error, c.summaryNodes(report)
+	case clusterhealth.SectionDeployments:
+		return report.Deployments.Error, c.summaryDeployments(report)
+	case clusterhealth.SectionPods:
+		return report.Pods.Error, c.summaryPods(report)
+	case clusterhealth.SectionEvents:
+		return report.Events.Error, c.summaryEvents(report)
+	case clusterhealth.SectionQuotas:
+		return report.Quotas.Error, c.summaryQuotas(report)
+	case clusterhealth.SectionOperator:
+		return report.Operator.Error, c.summaryOperator(report)
+	case clusterhealth.SectionDSCI:
+		return report.DSCI.Error, c.summaryDSCI(report)
+	case clusterhealth.SectionDSC:
+		return report.DSC.Error, c.summaryDSC(report)
+	default:
+		return "", ""
+	}
+}
+
+// Section summary functions
+
+func (c *Command) summaryNodes(r *clusterhealth.Report) string {
+	if r.Nodes.Error != "" {
+		if isRBACError(r.Nodes.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.Nodes.Error, maxSummaryLen)
+	}
+
+	n := len(r.Nodes.Data.Nodes)
+	if n == 0 {
+		return "no nodes"
+	}
+
+	unhealthy := 0
+	for _, node := range r.Nodes.Data.Nodes {
+		if node.UnhealthyReason != "" {
+			unhealthy++
+		}
+	}
+	if unhealthy == 0 {
+		return fmt.Sprintf("%d nodes", n)
+	}
+
+	return fmt.Sprintf("%d nodes, %d unhealthy", n, unhealthy)
+}
+
+func (c *Command) summaryDeployments(r *clusterhealth.Report) string {
+	if r.Deployments.Error != "" {
+		if isRBACError(r.Deployments.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.Deployments.Error, maxSummaryLen)
+	}
+
+	byNs := r.Deployments.Data.ByNamespace
+	if len(byNs) == 0 {
+		return "no deployments"
+	}
+
+	total, notReady, nsCount := 0, 0, 0
+	for _, infos := range byNs {
+		if len(infos) > 0 {
+			nsCount++
+		}
+		for _, d := range infos {
+			total++
+			if d.Replicas > 0 && d.Ready != d.Replicas {
+				notReady++
+			}
+		}
+	}
+	if notReady == 0 {
+		return fmt.Sprintf("%d deployments in %d namespaces", total, nsCount)
+	}
+
+	return fmt.Sprintf("%d deployments in %d namespaces, %d not ready", total, nsCount, notReady)
+}
+
+func (c *Command) summaryPods(r *clusterhealth.Report) string {
+	if r.Pods.Error != "" {
+		if isRBACError(r.Pods.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.Pods.Error, maxSummaryLen)
+	}
+
+	byNs := r.Pods.Data.ByNamespace
+	if len(byNs) == 0 {
+		return "no pods"
+	}
+
+	total, notRunning, nsCount := 0, 0, 0
+	for _, infos := range byNs {
+		if len(infos) > 0 {
+			nsCount++
+		}
+		for _, p := range infos {
+			total++
+			if p.Phase != "Running" {
+				notRunning++
+			}
+		}
+	}
+	if notRunning == 0 {
+		return fmt.Sprintf("%d pods in %d namespaces", total, nsCount)
+	}
+
+	return fmt.Sprintf("%d pods in %d namespaces, %d not Running", total, nsCount, notRunning)
+}
+
+func (c *Command) summaryEvents(r *clusterhealth.Report) string {
+	if r.Events.Error != "" {
+		if isRBACError(r.Events.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.Events.Error, maxSummaryLen)
+	}
+
+	n := len(r.Events.Data.Events)
+	if n == 0 {
+		return "no events"
+	}
+
+	return fmt.Sprintf("%d events", n)
+}
+
+func (c *Command) summaryQuotas(r *clusterhealth.Report) string {
+	if r.Quotas.Error != "" {
+		if isRBACError(r.Quotas.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.Quotas.Error, maxSummaryLen)
+	}
+
+	byNs := r.Quotas.Data.ByNamespace
+	if len(byNs) == 0 {
+		return "no quotas"
+	}
+
+	total, exceeded, nsCount := 0, 0, 0
+	for _, infos := range byNs {
+		if len(infos) > 0 {
+			nsCount++
+		}
+		for _, q := range infos {
+			total++
+			if len(q.Exceeded) > 0 {
+				exceeded++
+			}
+		}
+	}
+	if exceeded == 0 {
+		return fmt.Sprintf("%d quotas in %d namespaces", total, nsCount)
+	}
+
+	return fmt.Sprintf("%d quotas in %d namespaces, %d exceeded", total, nsCount, exceeded)
+}
+
+func (c *Command) summaryOperator(r *clusterhealth.Report) string {
+	if r.Operator.Error != "" {
+		if isRBACError(r.Operator.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.Operator.Error, maxSummaryLen)
+	}
+
+	d := r.Operator.Data.Deployment
+	if d == nil {
+		return "no operator deployment"
+	}
+
+	depLine := fmt.Sprintf("%s %d/%d ready", d.Name, d.Ready, d.Replicas)
+	dependents := r.Operator.Data.DependentOperators
+	if len(dependents) == 0 {
+		return depLine
+	}
+
+	notInstalled := 0
+	for _, dep := range dependents {
+		if !dep.Installed {
+			notInstalled++
+		}
+	}
+	if notInstalled == 0 {
+		return fmt.Sprintf("%s, %d dependents", depLine, len(dependents))
+	}
+
+	return fmt.Sprintf("%s, %d dependents (%d not installed)", depLine, len(dependents), notInstalled)
+}
+
+func (c *Command) summaryDSCI(r *clusterhealth.Report) string {
+	if r.DSCI.Error != "" {
+		if isRBACError(r.DSCI.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.DSCI.Error, maxSummaryLen)
+	}
+
+	name := r.DSCI.Data.Name
+	if name == "" {
+		return "no DSCI"
+	}
+
+	n := len(r.DSCI.Data.Conditions)
+	if n == 0 {
+		return name
+	}
+
+	return fmt.Sprintf("%s, %d conditions", name, n)
+}
+
+func (c *Command) summaryDSC(r *clusterhealth.Report) string {
+	if r.DSC.Error != "" {
+		if isRBACError(r.DSC.Error) {
+			return msgInsufficientPerms
+		}
+
+		return truncate(r.DSC.Error, maxSummaryLen)
+	}
+
+	name := r.DSC.Data.Name
+	if name == "" {
+		return "no DSC"
+	}
+
+	n := len(r.DSC.Data.Conditions)
+	if n == 0 {
+		return name
+	}
+
+	return fmt.Sprintf("%s, %d conditions", name, n)
+}
+
+// renderVerboseDetails outputs expanded details for each section.
+func (c *Command) renderVerboseDetails(w io.Writer, report *clusterhealth.Report, runSet map[string]bool) error {
+	if _, err := fmt.Fprintln(w); err != nil {
+		return fmt.Errorf("writing newline: %w", err)
+	}
+	if _, err := fmt.Fprintln(w, "--- Details ---"); err != nil {
+		return fmt.Errorf("writing details header: %w", err)
+	}
+
+	for _, sec := range sectionDisplayOrder {
+		if len(runSet) > 0 && !runSet[sec.key] {
+			continue
+		}
+
+		details := c.getVerboseDetails(report, sec.key)
+		if details != "" {
+			if _, err := fmt.Fprintf(w, "%s:\n%s\n", sec.display, details); err != nil {
+				return fmt.Errorf("writing section details: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Command) getVerboseDetails(r *clusterhealth.Report, key string) string {
+	switch key {
+	case clusterhealth.SectionNodes:
+		return c.verboseNodes(r)
+	case clusterhealth.SectionDeployments:
+		return c.verboseDeployments(r)
+	case clusterhealth.SectionPods:
+		return c.verbosePods(r)
+	case clusterhealth.SectionEvents:
+		return c.verboseEvents(r)
+	case clusterhealth.SectionQuotas:
+		return c.verboseQuotas(r)
+	case clusterhealth.SectionOperator:
+		return c.verboseOperator(r)
+	case clusterhealth.SectionDSCI:
+		return c.verboseCRConditions(r.DSCI.Data.Name, r.DSCI.Data.Conditions, r.DSCI.Error)
+	case clusterhealth.SectionDSC:
+		return c.verboseCRConditions(r.DSC.Data.Name, r.DSC.Data.Conditions, r.DSC.Error)
+	default:
+		return ""
+	}
+}
+
+func (c *Command) verboseNodes(r *clusterhealth.Report) string {
+	if r.Nodes.Error != "" {
+		return "  " + r.Nodes.Error
+	}
+
+	var b strings.Builder
+	for _, n := range r.Nodes.Data.Nodes {
+		nodeStatus := "OK"
+		if n.UnhealthyReason != "" {
+			nodeStatus = n.UnhealthyReason
+		}
+		_, _ = fmt.Fprintf(&b, "  %s: %s\n", n.Name, nodeStatus)
+	}
+
+	return b.String()
+}
+
+func (c *Command) verboseDeployments(r *clusterhealth.Report) string {
+	if r.Deployments.Error != "" {
+		return "  " + r.Deployments.Error
+	}
+
+	var b strings.Builder
+	for ns, infos := range r.Deployments.Data.ByNamespace {
+		for _, d := range infos {
+			_, _ = fmt.Fprintf(&b, "  %s/%s %d/%d ready\n", ns, d.Name, d.Ready, d.Replicas)
+		}
+	}
+
+	return b.String()
+}
+
+func (c *Command) verbosePods(r *clusterhealth.Report) string {
+	if r.Pods.Error != "" {
+		return "  " + r.Pods.Error
+	}
+
+	var b strings.Builder
+	for ns, infos := range r.Pods.Data.ByNamespace {
+		for _, p := range infos {
+			_, _ = fmt.Fprintf(&b, "  %s/%s %s\n", ns, p.Name, p.Phase)
+		}
+	}
+
+	return b.String()
+}
+
+func (c *Command) verboseEvents(r *clusterhealth.Report) string {
+	if r.Events.Error != "" {
+		return "  " + r.Events.Error
+	}
+
+	var b strings.Builder
+	for _, e := range r.Events.Data.Events {
+		_, _ = fmt.Fprintf(&b, "  %s/%s %s: %s\n", e.Namespace, e.Name, e.Reason, truncate(e.Message, maxDetailLen))
+	}
+
+	return b.String()
+}
+
+func (c *Command) verboseQuotas(r *clusterhealth.Report) string {
+	if r.Quotas.Error != "" {
+		return "  " + r.Quotas.Error
+	}
+
+	var b strings.Builder
+	for ns, infos := range r.Quotas.Data.ByNamespace {
+		for _, q := range infos {
+			_, _ = fmt.Fprintf(&b, "  %s/%s", ns, q.Name)
+			if len(q.Exceeded) > 0 {
+				_, _ = fmt.Fprintf(&b, " exceeded: %s", strings.Join(q.Exceeded, ", "))
+			}
+			_, _ = fmt.Fprintln(&b)
+		}
+	}
+
+	return b.String()
+}
+
+func (c *Command) verboseOperator(r *clusterhealth.Report) string {
+	if r.Operator.Error != "" {
+		return "  " + r.Operator.Error
+	}
+
+	var b strings.Builder
+	d := r.Operator.Data.Deployment
+	if d != nil {
+		_, _ = fmt.Fprintf(&b, "  %s %d/%d ready\n", d.Name, d.Ready, d.Replicas)
+	}
+
+	for _, dep := range r.Operator.Data.DependentOperators {
+		_, _ = fmt.Fprintf(&b, "  dependent: %s", dep.Name)
+
+		switch {
+		case !dep.Installed:
+			_, _ = fmt.Fprint(&b, " not installed")
+		case dep.Error != "":
+			_, _ = fmt.Fprintf(&b, " error: %s", dep.Error)
+		case dep.Deployment != nil:
+			_, _ = fmt.Fprintf(&b, " %d/%d ready", dep.Deployment.Ready, dep.Deployment.Replicas)
+		}
+		_, _ = fmt.Fprintln(&b)
+	}
+
+	return b.String()
+}
+
+func (c *Command) verboseCRConditions(name string, conditions []clusterhealth.ConditionSummary, errStr string) string {
+	if errStr != "" {
+		return "  " + errStr
+	}
+	if name == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, cond := range conditions {
+		_, _ = fmt.Fprintf(&b, "  %s: %s", cond.Type, cond.Status)
+		if cond.Message != "" {
+			_, _ = fmt.Fprintf(&b, " (%s)", truncate(cond.Message, maxDetailLen))
+		}
+		_, _ = fmt.Fprintln(&b)
+	}
+
+	return b.String()
+}
+
+// renderDependenciesTable outputs dependency status.
+func (c *Command) renderDependenciesTable(w io.Writer, statuses []deps.DependencyStatus) error {
+	if _, err := fmt.Fprintln(w, "Dependencies:"); err != nil {
+		return fmt.Errorf("writing dependencies header: %w", err)
+	}
+
+	for _, dep := range statuses {
+		var symbol string
+
+		if dep.Error != "" {
+			symbol = utilcolor.StatusWarn()
+		} else {
+			symbol = dependencyStatusSymbol(dep.Status)
+		}
+
+		line := fmt.Sprintf("  %s %s", symbol, dep.DisplayName)
+
+		if dep.Version != "" {
+			line += fmt.Sprintf(" (%s)", dep.Version)
+		}
+
+		if dep.Error != "" {
+			line += " - error: " + dep.Error
+		} else if dep.Status == deps.StatusMissing && len(dep.RequiredBy) > 0 {
+			line += " - required by: " + strings.Join(dep.RequiredBy, ", ")
+		}
+
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return fmt.Errorf("writing dependency line: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// dependencyStatusSymbol returns the appropriate symbol for a dependency status.
+func dependencyStatusSymbol(status deps.Status) string {
+	switch status {
+	case deps.StatusInstalled:
+		return utilcolor.StatusPass()
+	case deps.StatusMissing:
+		return utilcolor.StatusFail()
+	case deps.StatusOptional:
+		return utilcolor.StatusWarn()
+	case deps.StatusUnknown:
+		return utilcolor.StatusUnknown()
+	}
+
+	return utilcolor.StatusUnknown()
+}

--- a/pkg/status/output_table_test.go
+++ b/pkg/status/output_table_test.go
@@ -1,0 +1,128 @@
+package status_test
+
+import (
+	"testing"
+
+	"github.com/fatih/color"
+
+	"github.com/opendatahub-io/odh-cli/pkg/status"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestIsRBACError(t *testing.T) {
+	prev := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = prev })
+
+	tests := []struct {
+		name     string
+		errStr   string
+		expected bool
+	}{
+		{"empty string", "", false},
+		{"generic error", "connection refused", false},
+		{"forbidden lowercase", "forbidden: cannot list nodes", true},
+		{"Forbidden capitalized", "Forbidden: access denied", true},
+		{"FORBIDDEN uppercase", "FORBIDDEN", true},
+		{"unauthorized", "unauthorized: invalid token", true},
+		{"cannot list", "cannot list resource pods", true},
+		{"cannot get", "cannot get resource deployments", true},
+		{"mixed case forbidden", "User is Forbidden from accessing", true},
+		{"unhealthy error", "unhealthy nodes: node-1 (MemoryPressure)", false},
+		{"deployment error", "deployments not ready: 2/3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(status.IsRBACError(tt.errStr)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestStatusSymbol(t *testing.T) {
+	prev := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = prev })
+
+	tests := []struct {
+		name     string
+		errStr   string
+		expected string
+	}{
+		{"no error shows pass", "", "✓"},
+		{"rbac error shows unknown", "forbidden: cannot list", "?"},
+		{"health error shows fail", "unhealthy nodes", "✗"},
+		{"generic error shows fail", "connection timeout", "✗"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(status.StatusSymbol(tt.errStr)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestVisibleLen(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{"plain text", "hello", 5},
+		{"empty", "", 0},
+		{"with ANSI codes", "\x1b[32m✓\x1b[0m", 1},
+		{"unicode", "✓✗?", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(status.VisibleLen(tt.input)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		width    int
+		expected string
+	}{
+		{"shorter than width", "foo", 6, "foo   "},
+		{"equal to width", "foobar", 6, "foobar"},
+		{"longer than width", "foobar", 3, "foobar"},
+		{"empty string", "", 3, "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(status.PadRight(tt.input, tt.width)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"shorter than max", "hello", 10, "hello"},
+		{"equal to max", "hello", 5, "hello"},
+		{"longer than max", "hello world", 8, "hello..."},
+		{"with whitespace", "  hello  ", 10, "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(status.Truncate(tt.input, tt.maxLen)).To(Equal(tt.expected))
+		})
+	}
+}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -2,12 +2,16 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/fatih/color"
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -17,6 +21,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -30,6 +35,7 @@ type OutputFormat string
 const (
 	OutputFormatTable OutputFormat = "table"
 	OutputFormatJSON  OutputFormat = "json"
+	OutputFormatYAML  OutputFormat = "yaml"
 
 	DefaultTimeout = 30 * time.Second
 
@@ -37,22 +43,26 @@ const (
 	defaultRHOAIOperatorName = "rhods-operator"
 
 	// Output format strings.
-	fmtPlatformVersion  = "Platform version: %s\n"
-	fmtOpenShiftVersion = "OpenShift version: %s\n"
+	fmtPlatformStatus   = "PLATFORM STATUS: %s\n"
+	fmtEnvironmentHdr   = "\nEnvironment:\n"
+	fmtPlatformVersion  = "  RHOAI Version:      %s\n"
+	fmtOpenShiftVersion = "  OpenShift Version:  %s\n"
 )
 
 const (
-	flagDescOutput   = `Output format: "table" or "json"`
-	flagDescVerbose  = "Show per-item details for each section"
-	flagDescSection  = "Limit output to specific sections (repeatable): nodes, deployments, pods, events, quotas, operator, dsci, dsc"
-	flagDescNoColor  = "Disable color output"
-	flagDescTimeout  = "Maximum time to wait for health checks to complete"
-	flagDescAppsNS   = "Override the applications namespace (auto-detected from DSCI)"
-	flagDescOperNS   = "Override the operator namespace (auto-detected from OLM/CSV)"
-	flagDescOperName = "Override the operator deployment name (auto-detected from CSV)"
-	flagDescInfra    = "Also scan kube-system for core infrastructure health"
-	flagDescQPS      = "Kubernetes API queries per second"
-	flagDescBurst    = "Kubernetes API burst capacity"
+	flagDescOutput      = `Output format: "table", "json", or "yaml"`
+	flagDescVerbose     = "Show per-item details for each section"
+	flagDescSection     = "Limit output to specific sections (repeatable): nodes, deployments, pods, events, quotas, operator, dsci, dsc"
+	flagDescLayer       = "Limit output to a layer (repeatable): infrastructure (nodes), workload (deployments, pods, events, quotas), operator (operator, dsci, dsc)"
+	flagDescNoColor     = "Disable color output"
+	flagDescTimeout     = "Maximum time to wait for health checks to complete"
+	flagDescAppsNS      = "Override the applications namespace (auto-detected from DSCI)"
+	flagDescOperNS      = "Override the operator namespace (auto-detected from OLM/CSV)"
+	flagDescOperName    = "Override the operator deployment name (auto-detected from CSV)"
+	flagDescInfra       = "Also scan kube-system for core infrastructure health"
+	flagDescIncludeDeps = "Include dependency operator status in output"
+	flagDescQPS         = "Kubernetes API queries per second"
+	flagDescBurst       = "Kubernetes API burst capacity"
 )
 
 // Command contains the status command configuration.
@@ -65,11 +75,13 @@ type Command struct {
 	NoColor      bool
 	Timeout      time.Duration
 	Sections     []string
+	Layers       []string
 
 	AppsNamespace     string
 	OperatorNamespace string
 	OperatorName      string
 	IncludeInfra      bool
+	IncludeDeps       bool
 
 	QPS   float32
 	Burst int
@@ -89,6 +101,7 @@ func NewCommand(
 		ConfigFlags:  configFlags,
 		OutputFormat: OutputFormatTable,
 		Timeout:      DefaultTimeout,
+		IncludeDeps:  true,
 		QPS:          client.DefaultQPS,
 		Burst:        client.DefaultBurst,
 	}
@@ -99,12 +112,14 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescOutput)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.StringArrayVar(&c.Sections, "section", nil, flagDescSection)
+	fs.StringArrayVar(&c.Layers, "layer", nil, flagDescLayer)
 	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
 	fs.StringVar(&c.AppsNamespace, "apps-namespace", "", flagDescAppsNS)
 	fs.StringVar(&c.OperatorNamespace, "operator-namespace", "", flagDescOperNS)
 	fs.StringVar(&c.OperatorName, "operator-name", "", flagDescOperName)
 	fs.BoolVar(&c.IncludeInfra, "include-infra", false, flagDescInfra)
+	fs.BoolVar(&c.IncludeDeps, "include-deps", c.IncludeDeps, flagDescIncludeDeps)
 	fs.Float32Var(&c.QPS, "qps", c.QPS, flagDescQPS)
 	fs.IntVar(&c.Burst, "burst", c.Burst, flagDescBurst)
 }
@@ -125,7 +140,7 @@ func (c *Command) Complete() error {
 
 	c.client = k8sClient
 
-	if c.OutputFormat == OutputFormatJSON {
+	if c.OutputFormat == OutputFormatJSON || c.OutputFormat == OutputFormatYAML {
 		c.NoColor = true
 	}
 
@@ -141,6 +156,10 @@ func (c *Command) Validate() error {
 	}
 
 	if err := validateSections(c.Sections); err != nil {
+		return err
+	}
+
+	if err := validateLayers(c.Layers); err != nil {
 		return err
 	}
 
@@ -199,66 +218,175 @@ func (c *Command) Run(ctx context.Context) error {
 		DSCI:         dsciName,
 		DSC:          dscName,
 		OnlySections: c.Sections,
+		Layers:       c.Layers,
 	}
 
-	report, err := clusterhealth.Run(ctx, cfg)
+	var report *clusterhealth.Report
+	var depStatuses []deps.DependencyStatus
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		report, err = clusterhealth.Run(gctx, cfg)
+		if err != nil {
+			return fmt.Errorf("health checks: %w", err)
+		}
+
+		return nil
+	})
+
+	if c.IncludeDeps {
+		g.Go(func() error {
+			depStatuses = c.checkDependencies(gctx)
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("running status checks: %w", err)
+	}
+
+	return c.output(ctx, report, depStatuses)
+}
+
+// checkDependencies checks operator dependency status.
+// Returns nil slice on error (non-fatal).
+func (c *Command) checkDependencies(ctx context.Context) []deps.DependencyStatus {
+	result, err := deps.GetManifest(ctx, false)
 	if err != nil {
-		return fmt.Errorf("running health checks: %w", err)
+		if c.Verbose || c.IncludeDeps {
+			_, _ = fmt.Fprintf(c.IO.ErrOut(), "Dependencies: skipped (manifest unavailable: %v)\n", err)
+		}
+
+		return nil
 	}
 
-	return c.output(ctx, report)
+	statuses, err := deps.CheckDependencies(ctx, c.client.OLM(), result.Manifest)
+	if err != nil {
+		if c.Verbose || c.IncludeDeps {
+			if errors.Is(err, deps.ErrOLMNotAvailable) {
+				_, _ = fmt.Fprintln(c.IO.ErrOut(), "Dependencies: skipped (OLM not available)")
+			} else {
+				_, _ = fmt.Fprintf(c.IO.ErrOut(), "Dependencies: skipped (check failed: %v)\n", err)
+			}
+		}
+
+		return nil
+	}
+
+	return statuses
 }
 
 // output renders the report in the requested format.
-func (c *Command) output(ctx context.Context, report *clusterhealth.Report) error {
+func (c *Command) output(ctx context.Context, report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
 	switch c.OutputFormat {
 	case OutputFormatTable:
-		return c.outputTable(ctx, report)
+		return c.outputTable(ctx, report, depStatuses)
 	case OutputFormatJSON:
-		return c.outputJSON(report)
+		return c.outputJSON(report, depStatuses)
+	case OutputFormatYAML:
+		return c.outputYAML(report, depStatuses)
 	default:
 		return fmt.Errorf("unsupported output format: %s", c.OutputFormat)
 	}
 }
 
 // outputTable renders the report as a human-readable table.
-func (c *Command) outputTable(ctx context.Context, report *clusterhealth.Report) error {
+func (c *Command) outputTable(ctx context.Context, report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
 	w := c.IO.Out()
 
-	ver, err := version.Detect(ctx, c.client)
-	if err == nil && ver != nil {
-		if _, err := fmt.Fprintf(w, fmtPlatformVersion, ver.String()); err != nil {
-			return fmt.Errorf("writing platform version: %w", err)
+	// Detect versions concurrently
+	var ver, ocpVer *semver.Version
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		v, err := version.Detect(gctx, c.client)
+		if err == nil {
+			ver = v
 		}
+
+		return nil
+	})
+
+	g.Go(func() error {
+		v, err := version.DetectOpenShiftVersion(gctx, c.client)
+		if err == nil {
+			ocpVer = v
+		}
+
+		return nil
+	})
+
+	_ = g.Wait()
+
+	// Print PLATFORM STATUS header
+	if _, err := fmt.Fprintf(w, fmtPlatformStatus, formatPlatformStatus(report)); err != nil {
+		return fmt.Errorf("writing platform status: %w", err)
 	}
 
-	ocpVer, err := version.DetectOpenShiftVersion(ctx, c.client)
-	if err == nil && ocpVer != nil {
-		if _, err := fmt.Fprintf(w, fmtOpenShiftVersion, ocpVer.String()); err != nil {
-			return fmt.Errorf("writing OpenShift version: %w", err)
-		}
+	// Print Environment section
+	if err := c.writeEnvironmentSection(w, ver, ocpVer); err != nil {
+		return err
 	}
 
 	if _, err := fmt.Fprintln(w); err != nil {
 		return fmt.Errorf("writing newline: %w", err)
 	}
 
-	if _, err := fmt.Fprint(w, report.PrettyPrint(c.Verbose)); err != nil {
-		return fmt.Errorf("writing health report: %w", err)
+	return c.renderTableOutput(report, depStatuses)
+}
+
+// formatPlatformStatus returns colored "Healthy" or "Unhealthy" based on report state.
+func formatPlatformStatus(report *clusterhealth.Report) string {
+	if report.Healthy() {
+		return color.GreenString("Healthy")
+	}
+
+	return color.RedString("Unhealthy")
+}
+
+// writeEnvironmentSection writes the Environment header and version info if available.
+func (c *Command) writeEnvironmentSection(w io.Writer, ver, ocpVer *semver.Version) error {
+	if ver == nil && ocpVer == nil {
+		return nil
+	}
+
+	if _, err := fmt.Fprint(w, fmtEnvironmentHdr); err != nil {
+		return fmt.Errorf("writing environment header: %w", err)
+	}
+
+	if ver != nil {
+		if _, err := fmt.Fprintf(w, fmtPlatformVersion, ver.String()); err != nil {
+			return fmt.Errorf("writing platform version: %w", err)
+		}
+	}
+
+	if ocpVer != nil {
+		if _, err := fmt.Fprintf(w, fmtOpenShiftVersion, ocpVer.String()); err != nil {
+			return fmt.Errorf("writing OpenShift version: %w", err)
+		}
 	}
 
 	return nil
 }
 
-// outputJSON renders the report as JSON.
-func (c *Command) outputJSON(report *clusterhealth.Report) error {
-	return renderJSON(c.IO.Out(), report)
+// outputJSON renders the report as JSON with envelope.
+func (c *Command) outputJSON(report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	return renderJSON(c.IO.Out(), report, depStatuses)
+}
+
+// outputYAML renders the report as YAML with envelope.
+func (c *Command) outputYAML(report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	return renderYAML(c.IO.Out(), report, depStatuses)
 }
 
 // Validate checks if the output format is valid.
 func (o OutputFormat) Validate() error {
 	switch o {
-	case OutputFormatTable, OutputFormatJSON:
+	case OutputFormatTable, OutputFormatJSON, OutputFormatYAML:
 		return nil
 	default:
 		return ErrInvalidOutputFormat(string(o))
@@ -285,6 +413,27 @@ func validateSections(sections []string) error {
 	for _, s := range sections {
 		if !isValidSection(s) {
 			return ErrInvalidSection(s)
+		}
+	}
+
+	return nil
+}
+
+func isValidLayer(layer string) bool {
+	switch layer {
+	case clusterhealth.LayerInfrastructure,
+		clusterhealth.LayerWorkload,
+		clusterhealth.LayerOperator:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateLayers(layers []string) error {
+	for _, l := range layers {
+		if !isValidLayer(l) {
+			return ErrInvalidLayer(l)
 		}
 	}
 

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -15,6 +15,7 @@ func TestCommandValidate_OutputFormat(t *testing.T) {
 	}{
 		{"table format", status.OutputFormatTable, false},
 		{"json format", status.OutputFormatJSON, false},
+		{"yaml format", status.OutputFormatYAML, false},
 		{"invalid format", status.OutputFormat("xml"), true},
 		{"empty format", status.OutputFormat(""), true},
 	}
@@ -83,6 +84,37 @@ func TestCommandValidate_Timeout(t *testing.T) {
 			err := cmd.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Command.Validate() with timeout %v error = %v, wantErr %v", tt.timeout, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_Layers(t *testing.T) {
+	tests := []struct {
+		name    string
+		layers  []string
+		wantErr bool
+	}{
+		{"nil layers", nil, false},
+		{"empty layers", []string{}, false},
+		{"infrastructure layer", []string{"infrastructure"}, false},
+		{"workload layer", []string{"workload"}, false},
+		{"operator layer", []string{"operator"}, false},
+		{"all layers", []string{"infrastructure", "workload", "operator"}, false},
+		{"invalid layer", []string{"invalid"}, true},
+		{"mixed valid and invalid", []string{"infrastructure", "invalid"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &status.Command{
+				OutputFormat: status.OutputFormatTable,
+				Timeout:      30 * time.Second,
+				Layers:       tt.layers,
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() with layers %v error = %v, wantErr %v", tt.layers, err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/status/types.go
+++ b/pkg/status/types.go
@@ -1,0 +1,99 @@
+package status
+
+import (
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	"github.com/opendatahub-io/odh-cli/pkg/output"
+)
+
+// StatusReport wraps the cluster health report with a standard envelope.
+type StatusReport struct {
+	output.Envelope
+
+	Report       *clusterhealth.Report   `json:"report"                 yaml:"report"`
+	Dependencies []deps.DependencyStatus `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+}
+
+// NewStatusReport creates a new StatusReport with envelope fields populated.
+func NewStatusReport(report *clusterhealth.Report, depStatuses []deps.DependencyStatus) *StatusReport {
+	sr := &StatusReport{
+		Envelope:     output.NewEnvelope("StatusReport", "status"),
+		Report:       report,
+		Dependencies: depStatuses,
+	}
+	sr.computeStatus()
+
+	return sr
+}
+
+// computeStatus calculates warnings/errors from the report sections and dependencies.
+func (sr *StatusReport) computeStatus() {
+	errors := sr.countSectionErrors()
+	warnings := 0
+
+	// Count dependency issues
+	for _, dep := range sr.Dependencies {
+		if dep.Error != "" {
+			errors++
+
+			continue
+		}
+
+		switch dep.Status {
+		case deps.StatusMissing:
+			errors++
+		case deps.StatusUnknown:
+			warnings++
+		case deps.StatusInstalled, deps.StatusOptional:
+			// No action needed
+		}
+	}
+
+	sr.SetStatus(warnings, errors)
+}
+
+// countSectionErrors counts the number of sections with errors.
+// Uses direct field access to avoid allocating a temporary slice.
+func (sr *StatusReport) countSectionErrors() int {
+	if sr.Report == nil {
+		return 0
+	}
+
+	count := 0
+	r := sr.Report
+
+	if r.Nodes.Error != "" {
+		count++
+	}
+
+	if r.Deployments.Error != "" {
+		count++
+	}
+
+	if r.Pods.Error != "" {
+		count++
+	}
+
+	if r.Events.Error != "" {
+		count++
+	}
+
+	if r.Quotas.Error != "" {
+		count++
+	}
+
+	if r.Operator.Error != "" {
+		count++
+	}
+
+	if r.DSCI.Error != "" {
+		count++
+	}
+
+	if r.DSC.Error != "" {
+		count++
+	}
+
+	return count
+}

--- a/pkg/status/types_test.go
+++ b/pkg/status/types_test.go
@@ -1,0 +1,136 @@
+package status_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	"github.com/opendatahub-io/odh-cli/pkg/output"
+	"github.com/opendatahub-io/odh-cli/pkg/status"
+
+	. "github.com/onsi/gomega"
+)
+
+// fixedTestTime provides a deterministic timestamp for test data.
+//
+//nolint:gochecknoglobals // Test data constant
+var fixedTestTime = time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+func TestNewStatusReport_EnvelopeFields(t *testing.T) {
+	g := NewWithT(t)
+
+	report := &clusterhealth.Report{
+		CollectedAt: fixedTestTime,
+	}
+
+	sr := status.NewStatusReport(report, nil)
+
+	g.Expect(sr.APIVersion).To(Equal(output.APIVersion))
+	g.Expect(sr.Kind).To(Equal("StatusReport"))
+	g.Expect(sr.Metadata.Command).To(Equal("status"))
+	g.Expect(sr.Report).To(Equal(report))
+}
+
+func TestNewStatusReport_ComputeStatus_Healthy(t *testing.T) {
+	g := NewWithT(t)
+
+	report := &clusterhealth.Report{
+		CollectedAt: fixedTestTime,
+		Nodes:       clusterhealth.SectionResult[clusterhealth.NodesSection]{},
+		Deployments: clusterhealth.SectionResult[clusterhealth.DeploymentsSection]{},
+		Pods:        clusterhealth.SectionResult[clusterhealth.PodsSection]{},
+		Events:      clusterhealth.SectionResult[clusterhealth.EventsSection]{},
+		Quotas:      clusterhealth.SectionResult[clusterhealth.QuotasSection]{},
+		Operator:    clusterhealth.SectionResult[clusterhealth.OperatorSection]{},
+		DSCI:        clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{},
+		DSC:         clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{},
+	}
+
+	sr := status.NewStatusReport(report, nil)
+
+	g.Expect(sr.Status).NotTo(BeNil())
+	g.Expect(sr.Status.Result).To(Equal(output.StatusSuccess))
+	g.Expect(sr.Status.Errors).To(Equal(0))
+	g.Expect(sr.Status.Warnings).To(Equal(0))
+}
+
+func TestNewStatusReport_ComputeStatus_WithSectionErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	report := &clusterhealth.Report{
+		CollectedAt: fixedTestTime,
+		Nodes:       clusterhealth.SectionResult[clusterhealth.NodesSection]{Error: "unhealthy nodes"},
+		Deployments: clusterhealth.SectionResult[clusterhealth.DeploymentsSection]{Error: "deployments not ready"},
+		Pods:        clusterhealth.SectionResult[clusterhealth.PodsSection]{},
+		Events:      clusterhealth.SectionResult[clusterhealth.EventsSection]{},
+		Quotas:      clusterhealth.SectionResult[clusterhealth.QuotasSection]{},
+		Operator:    clusterhealth.SectionResult[clusterhealth.OperatorSection]{},
+		DSCI:        clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{},
+		DSC:         clusterhealth.SectionResult[clusterhealth.CRConditionsSection]{},
+	}
+
+	sr := status.NewStatusReport(report, nil)
+
+	g.Expect(sr.Status).NotTo(BeNil())
+	g.Expect(sr.Status.Result).To(Equal(output.StatusFailure))
+	g.Expect(sr.Status.Errors).To(Equal(2))
+}
+
+func TestNewStatusReport_ComputeStatus_WithDependencyErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	report := &clusterhealth.Report{
+		CollectedAt: fixedTestTime,
+	}
+
+	depStatuses := []deps.DependencyStatus{
+		{Name: "servicemesh", Status: deps.StatusInstalled},
+		{Name: "serverless", Status: deps.StatusMissing},
+		{Name: "authorino", Status: deps.StatusUnknown},
+	}
+
+	sr := status.NewStatusReport(report, depStatuses)
+
+	g.Expect(sr.Status).NotTo(BeNil())
+	g.Expect(sr.Status.Errors).To(Equal(1), "missing dep should count as error")
+	g.Expect(sr.Status.Warnings).To(Equal(1), "unknown dep should count as warning")
+}
+
+func TestNewStatusReport_ComputeStatus_WithDependencyAPIError(t *testing.T) {
+	g := NewWithT(t)
+
+	report := &clusterhealth.Report{
+		CollectedAt: fixedTestTime,
+	}
+
+	depStatuses := []deps.DependencyStatus{
+		{Name: "servicemesh", Status: deps.StatusInstalled},
+		{Name: "serverless", Status: deps.StatusUnknown, Error: "get subscription failed"},
+	}
+
+	sr := status.NewStatusReport(report, depStatuses)
+
+	g.Expect(sr.Status).NotTo(BeNil())
+	g.Expect(sr.Status.Errors).To(Equal(1), "dep.Error should count as error")
+	g.Expect(sr.Status.Warnings).To(Equal(0), "dep.Error should not count as warning")
+}
+
+func TestNewStatusReport_IncludesDependencies(t *testing.T) {
+	g := NewWithT(t)
+
+	report := &clusterhealth.Report{
+		CollectedAt: fixedTestTime,
+	}
+
+	depStatuses := []deps.DependencyStatus{
+		{Name: "servicemesh", DisplayName: "Service Mesh", Status: deps.StatusInstalled},
+		{Name: "serverless", DisplayName: "Serverless", Status: deps.StatusMissing},
+	}
+
+	sr := status.NewStatusReport(report, depStatuses)
+
+	g.Expect(sr.Dependencies).To(HaveLen(2))
+	g.Expect(sr.Dependencies[0].Name).To(Equal("servicemesh"))
+}

--- a/pkg/util/color/symbols.go
+++ b/pkg/util/color/symbols.go
@@ -32,6 +32,11 @@ func StatusFail() string {
 	return red.Sprint("✗")
 }
 
+// StatusUnknown returns a yellow question mark for permission/unknown errors.
+func StatusUnknown() string {
+	return yellow.Sprint("?")
+}
+
 // Severity level formatting.
 
 // SeverityCritical returns "critical" in red.


### PR DESCRIPTION
## Description

Enhances `./bin/kubectl-odh status` with improved formatting and structured output.

**Changes:**
- Add `PLATFORM STATUS: Healthy/Unhealthy` header with Environment section
- Add status symbols: `✓` (healthy), `✗` (unhealthy), `?` (permission error)
- Add YAML output format (`-o yaml`)
- Add `StatusReport` envelope for JSON/YAML output
- Add `--include-deps` flag for dependency status

## Jira Link
https://redhat.atlassian.net/browse/RHOAIENG-58858

**Example:**
```
PLATFORM STATUS: Healthy

Environment:
  RHOAI Version:      2.25.0
  OpenShift Version:  4.16.3

SECTION       STATUS  SUMMARY
------------  ------  -------
Nodes         ✓       3 nodes
Deployments   ✓       18 deployments in 2 namespaces
Pods          ✓       32 pods in 2 namespaces
Operator      ✓       opendatahub-operator 1/1 ready
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --layer filter and --include-deps flag (deps checked by default)
  * YAML output support (-o yaml) and enhanced JSON/YAML rendering
  * Table output now shows dependency status and richer section summaries
  * Help text updated with legend, layer explanation, and expanded examples

* **Performance**
  * Dependency checks run concurrently

* **Tests**
  * New unit tests covering status report envelope, table helpers, and layer validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->