### PR TITLE
feat: add component log discovery with multi-container streaming

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -22,23 +22,13 @@ The command auto-discovers pods based on the target name, eliminating the need
 to manually find pod names with kubectl get pods.
 
 Supported targets:
-  operator    ODH/RHOAI operator pod
+  operator     ODH/RHOAI operator pod
+  <component>  Any DSC component (dashboard, kserve, ray, workbenches, etc.)
 
-Examples:
-  # Show operator logs
-  kubectl odh logs operator
+Use tab completion to see all available targets.
 
-  # Follow operator logs (stream new logs as they appear)
-  kubectl odh logs operator -f
-
-  # Show last 100 lines
-  kubectl odh logs operator --tail 100
-
-  # Show logs from the last hour
-  kubectl odh logs operator --since 1h
-
-  # Show previous container logs (useful for crash investigation)
-  kubectl odh logs operator --previous
+For pods with multiple containers, logs from all containers are streamed
+with a [container-name] prefix. Use -c to select a specific container.
 `
 
 const cmdExample = `
@@ -56,6 +46,15 @@ const cmdExample = `
 
   # Show previous container logs (after a crash)
   kubectl odh logs operator --previous
+
+  # Show dashboard component logs
+  kubectl odh logs dashboard
+
+  # Follow kserve logs
+  kubectl odh logs kserve -f
+
+  # Show last 50 lines from ray pods
+  kubectl odh logs ray --tail 50
 `
 
 // AddCommand adds the logs command to the root command.
@@ -78,7 +77,7 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		Args:          cobra.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				return []string{"operator"}, cobra.ShellCompDirectiveNoFileComp
+				return logspkg.ValidTargets, cobra.ShellCompDirectiveNoFileComp
 			}
 
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/pkg/logs/command.go
+++ b/pkg/logs/command.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,11 +18,19 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
 const (
 	targetOperator = "operator"
+
+	// componentLabelSelector finds component pods by their part-of label.
+	// The label value must match the component key in resources.ComponentCRResourceTypes
+	// (e.g., "dashboard", "kserve", "ray"). This contract is set by the ODH/RHOAI operator.
+	componentLabelSelector = "app.kubernetes.io/part-of=%s"
 
 	flagDescFollow    = "Follow log output (stream new logs as they appear)"
 	flagDescTail      = "Lines of recent log file to display (default: all)"
@@ -34,17 +44,24 @@ const (
 	scannerInitialBuffer = 64 * 1024        // 64 KB initial
 	scannerMaxBuffer     = 10 * 1024 * 1024 // 10 MB max
 
-	errMsgUnsupportedTarget  = "unsupported target %q, supported targets: %s"
-	errMsgNoOperatorPod      = "no running operator pod found; checked namespaces: %v"
-	errMsgNoOperatorPodErrs  = "no running operator pod found; errors: %v"
-	errMsgOpenLogStream      = "opening log stream for pod %s/%s: %w"
-	errMsgReadingLogs        = "reading logs: %w"
-	errMsgScanningLogs       = "scanning logs: %w"
-	errMsgStreamingLogs      = "streaming logs: %w"
-	errMsgCreatingClient     = "creating client: %w"
-	errMsgDiscoveringPods    = "discovering operator pods: %w"
-	errMsgNamespaceListError = "namespace %s: %w"
-	errMsgWritingOutput      = "writing output: %w"
+	errMsgUnsupportedTarget   = "unsupported target %q, supported targets: %s"
+	errMsgNoOperatorPod       = "no running operator pod found; checked namespaces: %v"
+	errMsgNoOperatorPodErrs   = "no running operator pod found; errors: %v"
+	errMsgOpenLogStream       = "opening log stream for pod %s/%s: %w"
+	errMsgReadingLogs         = "reading logs: %w"
+	errMsgScanningLogs        = "scanning logs: %w"
+	errMsgStreamingLogs       = "streaming logs: %w"
+	errMsgCreatingClient      = "creating client: %w"
+	errMsgDiscoveringPods     = "discovering operator pods: %w"
+	errMsgNamespaceListError  = "namespace %s: %w"
+	errMsgWritingOutput       = "writing output: %w"
+	errMsgNoComponentPod      = "no running pods found for component %q in namespace %q"
+	errMsgGettingAppNamespace = "getting applications namespace: %w"
+	errMsgListingComponentPod = "listing pods for component %s: %w"
+
+	suggestionNoOperatorPod  = "Verify the ODH/RHOAI operator is installed and running"
+	suggestionNoComponentPod = "Check if the component is enabled in your DataScienceCluster"
+	suggestionInvalidTarget  = "Use 'operator' or a valid component name (dashboard, kserve, ray, etc.)"
 )
 
 // operatorLabelSelector finds ODH/RHOAI operator pods using a single query.
@@ -60,11 +77,38 @@ var operatorNamespaces = []string{
 	"opendatahub-operator-system",
 }
 
+// componentLabelOverrides maps CLI target names to actual part-of label values
+// for components where the label differs from the target name.
+//
+//nolint:gochecknoglobals // Static configuration for label discovery
+var componentLabelOverrides = map[string]string{
+	"aipipelines":   "data-science-pipelines-operator",
+	"modelregistry": "model-registry-operator",
+}
+
+// ValidTargets contains sorted list of valid log targets (operator + components).
+// Built once at init time and reused by Validate() and shell completion.
+//
+//nolint:gochecknoglobals // Static configuration built once at init
+var ValidTargets []string
+
+//nolint:gochecknoinits // One-time initialization of static target list
+func init() {
+	ValidTargets = make([]string, 0, 1+len(resources.ComponentCRResourceTypes))
+	ValidTargets = append(ValidTargets, targetOperator)
+
+	for name := range resources.ComponentCRResourceTypes {
+		ValidTargets = append(ValidTargets, name)
+	}
+
+	sort.Strings(ValidTargets[1:]) // Sort components, keep operator first
+}
+
 // Command implements the logs command.
 type Command struct {
-	Streams genericiooptions.IOStreams
-	Flags   *genericclioptions.ConfigFlags
-	Client  client.Client
+	IO     iostreams.Interface
+	Flags  *genericclioptions.ConfigFlags
+	Client client.Client
 
 	// Args
 	Target string
@@ -83,9 +127,9 @@ type Command struct {
 // NewCommand creates a new logs command.
 func NewCommand(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) *Command {
 	return &Command{
-		Streams: streams,
-		Flags:   flags,
-		Tail:    -1,
+		IO:    iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		Flags: flags,
+		Tail:  -1,
 	}
 }
 
@@ -112,16 +156,33 @@ func (c *Command) Complete() error {
 
 // Validate checks command arguments and flags.
 func (c *Command) Validate() error {
-	if c.Target != targetOperator {
-		return fmt.Errorf(errMsgUnsupportedTarget, c.Target, targetOperator)
+	if c.Target == targetOperator {
+		return nil
 	}
 
-	return nil
+	// Check if target is a valid component
+	if resources.GetComponentCR(c.Target) != nil {
+		return nil
+	}
+
+	return clierrors.NewValidationError(
+		"INVALID_TARGET",
+		fmt.Sprintf(errMsgUnsupportedTarget, c.Target, strings.Join(ValidTargets, ", ")),
+		suggestionInvalidTarget,
+	)
 }
 
 // Run executes the logs command.
 func (c *Command) Run(ctx context.Context) error {
-	pods, err := c.discoverOperatorPods(ctx)
+	var pods []*corev1.Pod
+	var err error
+
+	if c.Target == targetOperator {
+		pods, err = c.discoverOperatorPods(ctx)
+	} else {
+		pods, err = c.discoverComponentPods(ctx)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -173,21 +234,107 @@ func (c *Command) discoverOperatorPods(ctx context.Context) ([]*corev1.Pod, erro
 
 	if len(result) == 0 {
 		if len(errs) > 0 {
-			return nil, fmt.Errorf(errMsgNoOperatorPodErrs, errs)
+			return nil, clierrors.NewValidationError(
+				"NO_OPERATOR_POD",
+				fmt.Sprintf(errMsgNoOperatorPodErrs, errs),
+				suggestionNoOperatorPod,
+			)
 		}
 
-		return nil, fmt.Errorf(errMsgNoOperatorPod, operatorNamespaces)
+		return nil, clierrors.NewValidationError(
+			"NO_OPERATOR_POD",
+			fmt.Sprintf(errMsgNoOperatorPod, operatorNamespaces),
+			suggestionNoOperatorPod,
+		)
 	}
 
 	return result, nil
 }
 
+// getComponentLabelValue returns the part-of label value for a component.
+// Some components have labels that differ from the CLI target name.
+func (c *Command) getComponentLabelValue() string {
+	if override, ok := componentLabelOverrides[c.Target]; ok {
+		return override
+	}
+
+	return c.Target
+}
+
+// discoverComponentPods finds pods for a component using the applications namespace.
+func (c *Command) discoverComponentPods(ctx context.Context) ([]*corev1.Pod, error) {
+	// Get applications namespace where components are deployed
+	ns, err := client.GetApplicationsNamespace(ctx, c.Client)
+	if err != nil {
+		return nil, fmt.Errorf(errMsgGettingAppNamespace, err)
+	}
+
+	// List pods by component label (use override if target name differs from label)
+	labelValue := c.getComponentLabelValue()
+	selector := fmt.Sprintf(componentLabelSelector, labelValue)
+
+	pods, err := c.Client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+		FieldSelector: "status.phase=Running",
+	})
+	if err != nil {
+		return nil, fmt.Errorf(errMsgListingComponentPod, c.Target, err)
+	}
+
+	if len(pods.Items) == 0 {
+		return nil, clierrors.NewValidationError(
+			"NO_COMPONENT_POD",
+			fmt.Sprintf(errMsgNoComponentPod, c.Target, ns),
+			suggestionNoComponentPod,
+		)
+	}
+
+	result := make([]*corev1.Pod, len(pods.Items))
+	for i := range pods.Items {
+		result[i] = &pods.Items[i]
+	}
+
+	return result, nil
+}
+
+// podContainer pairs a pod with a specific container for streaming.
+type podContainer struct {
+	Pod       *corev1.Pod
+	Container string
+	Prefix    string
+}
+
 // streamLogs streams logs from discovered pods.
 func (c *Command) streamLogs(ctx context.Context) error {
+	// Validate -c flag against all pods before streaming
+	if c.Container != "" {
+		for _, pod := range c.Pods {
+			found := false
+
+			for _, ctr := range pod.Spec.Containers {
+				if ctr.Name == c.Container {
+					found = true
+
+					break
+				}
+			}
+
+			if !found {
+				return clierrors.NewValidationError(
+					"INVALID_CONTAINER",
+					fmt.Sprintf("container %q not found in pod %q", c.Container, pod.Name),
+					"Use -c with a container name present in all selected pods",
+				)
+			}
+		}
+	}
+
+	// Build list of pod/container pairs to stream
+	targets := c.buildStreamTargets()
+
 	opts := &corev1.PodLogOptions{
-		Follow:    c.Follow,
-		Previous:  c.Previous,
-		Container: c.Container,
+		Follow:   c.Follow,
+		Previous: c.Previous,
 	}
 
 	if c.Tail >= 0 {
@@ -199,13 +346,48 @@ func (c *Command) streamLogs(ctx context.Context) error {
 		opts.SinceSeconds = &seconds
 	}
 
-	// Single pod: stream directly without prefix
-	if len(c.Pods) == 1 {
-		return c.streamSinglePod(ctx, c.Pods[0], opts)
+	// Single target: stream directly without prefix
+	if len(targets) == 1 {
+		opts.Container = targets[0].Container
+
+		return c.streamSinglePod(ctx, targets[0].Pod, opts)
 	}
 
-	// Multiple pods: stream with prefixes
-	return c.streamMultiplePods(ctx, opts)
+	// Multiple targets: stream with prefixes
+	return c.streamMultipleTargets(ctx, targets, opts)
+}
+
+// buildStreamTargets expands pods into pod/container pairs with computed prefixes.
+// If -c is specified, uses that container for all pods.
+// Otherwise, streams all containers from each pod.
+func (c *Command) buildStreamTargets() []podContainer {
+	var targets []podContainer
+
+	// First pass: collect all targets
+	for _, pod := range c.Pods {
+		if c.Container != "" {
+			targets = append(targets, podContainer{Pod: pod, Container: c.Container})
+		} else if len(pod.Spec.Containers) == 1 {
+			targets = append(targets, podContainer{Pod: pod, Container: pod.Spec.Containers[0].Name})
+		} else {
+			for _, container := range pod.Spec.Containers {
+				targets = append(targets, podContainer{Pod: pod, Container: container.Name})
+			}
+		}
+	}
+
+	// Second pass: compute prefixes based on total target count
+	multiplePods := len(c.Pods) > 1
+
+	for i := range targets {
+		if multiplePods {
+			targets[i].Prefix = fmt.Sprintf("[%s/%s] ", targets[i].Pod.Name, targets[i].Container)
+		} else {
+			targets[i].Prefix = fmt.Sprintf("[%s] ", targets[i].Container)
+		}
+	}
+
+	return targets
 }
 
 // streamSinglePod streams logs from a single pod without prefix.
@@ -218,7 +400,7 @@ func (c *Command) streamSinglePod(ctx context.Context, pod *corev1.Pod, opts *co
 	}
 	defer func() { _ = stream.Close() }()
 
-	_, err = io.Copy(c.Streams.Out, stream)
+	_, err = io.Copy(c.IO.Out(), stream)
 	if err != nil {
 		return fmt.Errorf(errMsgReadingLogs, err)
 	}
@@ -226,9 +408,9 @@ func (c *Command) streamSinglePod(ctx context.Context, pod *corev1.Pod, opts *co
 	return nil
 }
 
-// streamMultiplePods streams logs from multiple pods with [pod-name] prefix.
+// streamMultipleTargets streams logs from multiple pod/container pairs with prefix.
 // Uses channel-based fan-in for better throughput under heavy log volume.
-func (c *Command) streamMultiplePods(ctx context.Context, opts *corev1.PodLogOptions) error {
+func (c *Command) streamMultipleTargets(ctx context.Context, targets []podContainer, opts *corev1.PodLogOptions) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -241,20 +423,21 @@ func (c *Command) streamMultiplePods(ctx context.Context, opts *corev1.PodLogOpt
 	var firstErr error
 
 	// Start producer goroutines
-	for _, pod := range c.Pods {
+	for _, target := range targets {
 		wg.Add(1)
 
-		go func(pod *corev1.Pod) {
+		go func(t podContainer) {
 			defer wg.Done()
 
-			if err := c.streamPodToChannel(ctx, pod, opts, lines); err != nil {
+			if err := c.streamTargetToChannel(ctx, t, opts, lines); err != nil {
 				mu.Lock()
 				if firstErr == nil {
 					firstErr = err
+					cancel() // Signal other producers to stop on first error
 				}
 				mu.Unlock()
 			}
-		}(pod)
+		}(target)
 	}
 
 	// Close channel when all producers are done
@@ -265,7 +448,7 @@ func (c *Command) streamMultiplePods(ctx context.Context, opts *corev1.PodLogOpt
 
 	// Single writer consumes from channel
 	for line := range lines {
-		if _, err := fmt.Fprintln(c.Streams.Out, line); err != nil {
+		if _, err := fmt.Fprintln(c.IO.Out(), line); err != nil {
 			cancel() // Signal producers to stop
 
 			return fmt.Errorf(errMsgWritingOutput, err)
@@ -275,23 +458,25 @@ func (c *Command) streamMultiplePods(ctx context.Context, opts *corev1.PodLogOpt
 	return firstErr
 }
 
-// streamPodToChannel streams logs from a pod to a channel, prefixing each line.
-func (c *Command) streamPodToChannel(ctx context.Context, pod *corev1.Pod, opts *corev1.PodLogOptions, lines chan<- string) error {
-	req := c.Client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, opts)
+// streamTargetToChannel streams logs from a pod/container to a channel, prefixing each line.
+func (c *Command) streamTargetToChannel(ctx context.Context, target podContainer, opts *corev1.PodLogOptions, lines chan<- string) error {
+	targetOpts := *opts
+	targetOpts.Container = target.Container
+
+	req := c.Client.CoreV1().Pods(target.Pod.Namespace).GetLogs(target.Pod.Name, &targetOpts)
 
 	stream, err := req.Stream(ctx)
 	if err != nil {
-		return fmt.Errorf(errMsgOpenLogStream, pod.Namespace, pod.Name, err)
+		return fmt.Errorf(errMsgOpenLogStream, target.Pod.Namespace, target.Pod.Name, err)
 	}
 	defer func() { _ = stream.Close() }()
 
 	scanner := bufio.NewScanner(stream)
 	scanner.Buffer(make([]byte, scannerInitialBuffer), scannerMaxBuffer)
-	prefix := fmt.Sprintf("[%s] ", pod.Name)
 
 	for scanner.Scan() {
 		select {
-		case lines <- prefix + scanner.Text():
+		case lines <- target.Prefix + scanner.Text():
 		case <-ctx.Done():
 			return fmt.Errorf(errMsgStreamingLogs, ctx.Err())
 		}

--- a/pkg/logs/command_internal_test.go
+++ b/pkg/logs/command_internal_test.go
@@ -1,0 +1,108 @@
+package logs
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestBuildStreamTargets(t *testing.T) {
+	t.Run("single pod single container uses container name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &Command{
+			Pods: []*corev1.Pod{
+				makePod("pod-1", "container-a"),
+			},
+		}
+
+		targets := cmd.buildStreamTargets()
+
+		g.Expect(targets).To(HaveLen(1))
+		g.Expect(targets[0].Container).To(Equal("container-a"))
+		g.Expect(targets[0].Prefix).To(Equal("[container-a] "))
+	})
+
+	t.Run("single pod multiple containers expands all with container prefix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &Command{
+			Pods: []*corev1.Pod{
+				makePod("pod-1", "app", "sidecar"),
+			},
+		}
+
+		targets := cmd.buildStreamTargets()
+
+		g.Expect(targets).To(HaveLen(2))
+		g.Expect(targets[0].Prefix).To(Equal("[app] "))
+		g.Expect(targets[1].Prefix).To(Equal("[sidecar] "))
+	})
+
+	t.Run("multiple pods uses pod/container prefix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &Command{
+			Pods: []*corev1.Pod{
+				makePod("pod-1", "app"),
+				makePod("pod-2", "app"),
+			},
+		}
+
+		targets := cmd.buildStreamTargets()
+
+		g.Expect(targets).To(HaveLen(2))
+		g.Expect(targets[0].Prefix).To(Equal("[pod-1/app] "))
+		g.Expect(targets[1].Prefix).To(Equal("[pod-2/app] "))
+	})
+
+	t.Run("container flag overrides automatic selection", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &Command{
+			Container: "specific",
+			Pods: []*corev1.Pod{
+				makePod("pod-1", "app", "sidecar"),
+			},
+		}
+
+		targets := cmd.buildStreamTargets()
+
+		g.Expect(targets).To(HaveLen(1))
+		g.Expect(targets[0].Container).To(Equal("specific"))
+	})
+
+	t.Run("multiple pods with multiple containers", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &Command{
+			Pods: []*corev1.Pod{
+				makePod("pod-1", "app", "sidecar"),
+				makePod("pod-2", "app"),
+			},
+		}
+
+		targets := cmd.buildStreamTargets()
+
+		g.Expect(targets).To(HaveLen(3))
+		g.Expect(targets[0].Prefix).To(Equal("[pod-1/app] "))
+		g.Expect(targets[1].Prefix).To(Equal("[pod-1/sidecar] "))
+		g.Expect(targets[2].Prefix).To(Equal("[pod-2/app] "))
+	})
+}
+
+func makePod(name string, containers ...string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.PodSpec{},
+	}
+
+	for _, c := range containers {
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: c})
+	}
+
+	return pod
+}

--- a/pkg/logs/command_test.go
+++ b/pkg/logs/command_test.go
@@ -1,6 +1,7 @@
 package logs_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -8,6 +9,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/logs"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 
 	. "github.com/onsi/gomega"
 )
@@ -27,6 +29,18 @@ func TestValidate(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
+	t.Run("accepts component targets", func(t *testing.T) {
+		g := NewWithT(t)
+
+		componentTargets := []string{"dashboard", "kserve", "ray", "workbenches"}
+		for _, target := range componentTargets {
+			cmd := &logs.Command{Target: target}
+			err := cmd.Validate()
+
+			g.Expect(err).ToNot(HaveOccurred(), "expected %q to be valid", target)
+		}
+	})
+
 	t.Run("rejects unknown target", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -34,8 +48,26 @@ func TestValidate(t *testing.T) {
 		err := cmd.Validate()
 
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("unsupported target"))
-		g.Expect(err.Error()).To(ContainSubstring("unknown"))
+
+		var structErr *clierrors.StructuredError
+		g.Expect(errors.As(err, &structErr)).To(BeTrue(), "expected StructuredError")
+		g.Expect(structErr.Code).To(Equal("INVALID_TARGET"))
+		g.Expect(structErr.Message).To(ContainSubstring("unsupported target"))
+		g.Expect(structErr.Message).To(ContainSubstring("unknown"))
+	})
+
+	t.Run("error message lists valid targets", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := &logs.Command{Target: "invalid"}
+		err := cmd.Validate()
+
+		g.Expect(err).To(HaveOccurred())
+
+		var structErr *clierrors.StructuredError
+		g.Expect(errors.As(err, &structErr)).To(BeTrue(), "expected StructuredError")
+		g.Expect(structErr.Message).To(ContainSubstring("operator"))
+		g.Expect(structErr.Message).To(ContainSubstring("dashboard"))
 	})
 
 	t.Run("rejects empty target", func(t *testing.T) {
@@ -45,6 +77,10 @@ func TestValidate(t *testing.T) {
 		err := cmd.Validate()
 
 		g.Expect(err).To(HaveOccurred())
+
+		var structErr *clierrors.StructuredError
+		g.Expect(errors.As(err, &structErr)).To(BeTrue(), "expected StructuredError")
+		g.Expect(structErr.Code).To(Equal("INVALID_TARGET"))
 	})
 }
 


### PR DESCRIPTION
## Description

**Jira:** [RHOAIENG-54647](https://redhat.atlassian.net/browse/RHOAIENG-54647)

Add component log discovery to the `logs` command, extending support beyond the operator to all DSC components.

**Features:**
- `kubectl odh logs <component>` - auto-discovers pods by `app.kubernetes.io/part-of` label
- Multi-container streaming - pods with multiple containers stream all with `[container]` prefix
- Multi-pod + multi-container scenarios use `[pod/container]` prefix
- Context-specific error suggestions

**Supported components:**
- dashboard, kserve, ray, workbenches, trustyai, modelregistry, aipipelines, trainer, and more

**Example usage:**
```bash
kubectl odh logs dashboard          # Stream all dashboard containers
kubectl odh logs kserve -f          # Follow kserve logs
kubectl odh logs ray --tail 100     # Last 100 lines from ray
kubectl odh logs dashboard -c app   # Specific container
```

## Testing

- [x] Unit tests pass (`go test ./pkg/logs/... ./cmd/logs/...`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `logs` command to support additional targets (dashboard, kserve, ray) with example usage.
  * Multi-container log streaming now displays source container prefixes for clarity.
  * Improved validation with structured error messages listing supported targets and suggestions.

* **Improvements**
  * Enhanced help text and command examples, including kserve follow mode and ray tailing.
  * Better shell completion support for log targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->