### PR TITLE
RHOAIENG-60450 - odh-cli check for llamastackoperator to ogx migratio…

### DIFF
--- a/pkg/lint/checks/components/llamastack/llamastack.go
+++ b/pkg/lint/checks/components/llamastack/llamastack.go
@@ -1,0 +1,57 @@
+package llamastack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const kind = "llamastackoperator"
+
+// RemovalCheck validates that LlamaStack Operator is disabled before upgrading from 3.4 to 3.5.
+type RemovalCheck struct {
+	check.BaseCheck
+}
+
+func NewRemovalCheck() *RemovalCheck {
+	return &RemovalCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupComponent,
+			Kind:             kind,
+			Type:             check.CheckTypeRemoval,
+			CheckID:          "components.llamastackoperator.removal",
+			CheckName:        "Components :: LlamaStack Operator :: Removal (3.5)",
+			CheckDescription: "Validates that LlamaStack Operator is disabled before upgrading from RHOAI 3.4 to 3.5 (component is replaced by ogx)",
+			CheckRemediation: "Disable LlamaStack Operator by setting managementState to 'Removed' in DataScienceCluster before upgrading",
+		},
+	}
+}
+
+// CanApply returns whether this check should run for the given target.
+// This check only applies when upgrading FROM 3.4.x TO 3.5.x and LlamaStack Operator is Managed.
+func (c *RemovalCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom34To35(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, kind, constants.ManagementStateManaged), nil
+}
+
+func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	return validate.Component(c, target).
+		Run(ctx, validate.Removal("LlamaStack Operator is enabled (state: %s) but is replaced by ogx in RHOAI %s",
+			check.WithImpact(result.ImpactBlocking),
+			check.WithRemediation(c.CheckRemediation)))
+}

--- a/pkg/lint/checks/components/llamastack/llamastack_test.go
+++ b/pkg/lint/checks/components/llamastack/llamastack_test.go
@@ -1,0 +1,216 @@
+package llamastack_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/llamastack"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals // Test fixture - shared across test functions
+var listKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func TestLlamaStackRemovalCheck_CanApply_NoDSC(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_NotConfigured(t *testing.T) {
+	g := NewWithT(t)
+
+	// DSC without llamastackoperator component — should not apply
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"dashboard": "Managed"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_ManagedBlocking(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Create DataScienceCluster with llamastackoperator Managed (blocking upgrade)
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Managed"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	llamastackCheck := llamastack.NewRemovalCheck()
+	result, err := llamastackCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonVersionIncompatible),
+		"Message": And(ContainSubstring("enabled"), ContainSubstring("replaced by ogx in RHOAI 3.5")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(And(
+		HaveKeyWithValue("component.opendatahub.io/management-state", "Managed"),
+		HaveKeyWithValue("check.opendatahub.io/target-version", "3.5.0"),
+	))
+}
+
+func TestLlamaStackRemovalCheck_CanApply_Unmanaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Unmanaged"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_Removed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Removed"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Managed"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_NotUpgrade(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Managed"})},
+		TargetVersion: "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_WrongVersion_35To36(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Managed"})},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_From33To35(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Managed"})},
+		CurrentVersion: "3.3.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_CanApply_From2xTo35(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"llamastackoperator": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestLlamaStackRemovalCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	llamastackCheck := llamastack.NewRemovalCheck()
+
+	g.Expect(llamastackCheck.ID()).To(Equal("components.llamastackoperator.removal"))
+	g.Expect(llamastackCheck.Name()).To(Equal("Components :: LlamaStack Operator :: Removal (3.5)"))
+	g.Expect(llamastackCheck.Group()).To(Equal(check.GroupComponent))
+	g.Expect(llamastackCheck.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kserve"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kueue"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/llamastack"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/modelmesh"
 	raycomponent "github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/ray"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
@@ -100,7 +101,7 @@ func NewCommand(
 	registry.MustRegister(dscinitialization.NewDSCInitializationReadinessCheck())
 	registry.MustRegister(datasciencecluster.NewDataScienceClusterReadinessCheck())
 
-	// Components (12)
+	// Components (13)
 	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
 	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
 	registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())
@@ -113,6 +114,7 @@ func NewCommand(
 	registry.MustRegister(kueue.NewManagementStateCheck())
 	// Deferred: re-enable when a future 3.3.x release supports Unmanaged + Red Hat build of Kueue Operator.
 	// registry.MustRegister(kueue.NewOperatorInstalledCheck())
+	registry.MustRegister(llamastack.NewRemovalCheck())
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())
 

--- a/pkg/util/version/helpers.go
+++ b/pkg/util/version/helpers.go
@@ -65,3 +65,14 @@ func IsVersionAtLeast(
 
 	return version.Major == major && version.Minor >= minor
 }
+
+// IsUpgradeFrom34To35 checks if the versions represent an upgrade from 3.4.x to 3.5.x specifically.
+// This is used for checks that only apply to the llamastackoperator -> ogx migration.
+// Returns false if either version is nil.
+func IsUpgradeFrom34To35(from *semver.Version, to *semver.Version) bool {
+	if from == nil || to == nil {
+		return false
+	}
+
+	return from.Major == 3 && from.Minor == 4 && to.Major == 3 && to.Minor == 5
+}

--- a/pkg/util/version/helpers_test.go
+++ b/pkg/util/version/helpers_test.go
@@ -312,6 +312,98 @@ func TestMajorMinorLabel(t *testing.T) {
 	}
 }
 
+func TestIsUpgradeFrom34To35(t *testing.T) {
+	tests := []struct {
+		name           string
+		from           *semver.Version
+		to             *semver.Version
+		expectedResult bool
+	}{
+		{
+			name:           "nil from version returns false",
+			from:           nil,
+			to:             toVersionPtr("3.5.0"),
+			expectedResult: false,
+		},
+		{
+			name:           "nil to version returns false",
+			from:           toVersionPtr("3.4.0"),
+			to:             nil,
+			expectedResult: false,
+		},
+		{
+			name:           "both nil returns false",
+			from:           nil,
+			to:             nil,
+			expectedResult: false,
+		},
+		{
+			name:           "upgrade from 3.4 to 3.5 returns true",
+			from:           toVersionPtr("3.4.0"),
+			to:             toVersionPtr("3.5.0"),
+			expectedResult: true,
+		},
+		{
+			name:           "upgrade from 3.4.1 to 3.5.0 returns true",
+			from:           toVersionPtr("3.4.1"),
+			to:             toVersionPtr("3.5.0"),
+			expectedResult: true,
+		},
+		{
+			name:           "upgrade from 3.4.0 to 3.5.1 returns true",
+			from:           toVersionPtr("3.4.0"),
+			to:             toVersionPtr("3.5.1"),
+			expectedResult: true,
+		},
+		{
+			name:           "upgrade from 3.3 to 3.5 returns false",
+			from:           toVersionPtr("3.3.0"),
+			to:             toVersionPtr("3.5.0"),
+			expectedResult: false,
+		},
+		{
+			name:           "upgrade from 3.4 to 3.6 returns false",
+			from:           toVersionPtr("3.4.0"),
+			to:             toVersionPtr("3.6.0"),
+			expectedResult: false,
+		},
+		{
+			name:           "upgrade from 2.17 to 3.5 returns false",
+			from:           toVersionPtr("2.17.0"),
+			to:             toVersionPtr("3.5.0"),
+			expectedResult: false,
+		},
+		{
+			name:           "upgrade from 3.5 to 3.6 returns false",
+			from:           toVersionPtr("3.5.0"),
+			to:             toVersionPtr("3.6.0"),
+			expectedResult: false,
+		},
+		{
+			name:           "upgrade from 3.5 to 3.5 returns false",
+			from:           toVersionPtr("3.5.0"),
+			to:             toVersionPtr("3.5.0"),
+			expectedResult: false,
+		},
+		{
+			name:           "upgrade from 3.4 to 4.0 returns false",
+			from:           toVersionPtr("3.4.0"),
+			to:             toVersionPtr("4.0.0"),
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := version.IsUpgradeFrom34To35(tt.from, tt.to)
+
+			g.Expect(result).To(Equal(tt.expectedResult))
+		})
+	}
+}
+
 func toVersionPtr(versionStr string) *semver.Version {
 	v := semver.MustParse(versionStr)
 


### PR DESCRIPTION
…n within DSC

## Description

JIRA: [RHOAIENG-60450](https://redhat.atlassian.net/browse/RHOAIENG-60450)

Adding check to remove llamastack when upgrading from 3.4 to 3.5.

```
odh-cli % ./bin/kubectl-odh lint --target-version 3.5

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ STATUS  KIND                GROUP       CHECK                IMPACT    MESSAGE                                                                                  │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✓       cert-manager        dependency  installed            info      cert-manager Operator for Red Hat OpenShift installed: cert-manager-operator.v1.19.0     │
│ ✓       openshift-platform  dependency  version-requirement  info      OpenShift 4.21.8 meets RHOAI 3.5 minimum version requirement (4.19.9+)                   │
│ ✓       dsc                 platform    readiness            info      DataScienceCluster is ready                                                              │
│ ✓       dsci                platform    readiness            info      DSCInitialization is ready                                                               │
│ ✗       llamastackoperator  component   removal              critical  LlamaStack Operator is enabled (state: Managed) but is replaced by ogx in RHOAI 3.5      │
│ ✓       kserve              workload    config-migration     info      No InferenceServices found with legacy hardware profile annotation - no migration needed │
│ ✓       notebook            workload    config-migration     info      No Notebooks found with legacy hardware profile annotation - no migration needed         │
│ ✓       notebook            workload    config-migration     info      No Notebooks found with container name mismatch                                          │
│ ✓       notebook            workload    data-integrity       info      All Notebooks reference existing HardwareProfiles                                        │
│ ✓       notebook            workload    data-integrity       info      All Notebook connections reference existing Secrets                                      │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Environment:
  OpenShift AI version: 3.4.0 -> 3.5
  OpenShift version:    4.21.8

Summary:
  Total: 10 | Passed: 9 | Warnings: 0 | Failed: 1 | Prohibited: 0

Result:
  FAIL - blocking findings detected

=====
# Change llamastackoperator to Removed
=====

odh-cli % ./bin/kubectl-odh lint --target-version 3.5  

┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ STATUS  KIND                GROUP       CHECK                IMPACT  MESSAGE                                                                                  │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✓       cert-manager        dependency  installed            info    cert-manager Operator for Red Hat OpenShift installed: cert-manager-operator.v1.19.0     │
│ ✓       openshift-platform  dependency  version-requirement  info    OpenShift 4.21.8 meets RHOAI 3.5 minimum version requirement (4.19.9+)                   │
│ ✓       dsc                 platform    readiness            info    DataScienceCluster is ready                                                              │
│ ✓       dsci                platform    readiness            info    DSCInitialization is ready                                                               │
│ ✓       kserve              workload    config-migration     info    No InferenceServices found with legacy hardware profile annotation - no migration needed │
│ ✓       notebook            workload    config-migration     info    No Notebooks found with legacy hardware profile annotation - no migration needed         │
│ ✓       notebook            workload    config-migration     info    No Notebooks found with container name mismatch                                          │
│ ✓       notebook            workload    data-integrity       info    All Notebook connections reference existing Secrets                                      │
│ ✓       notebook            workload    data-integrity       info    All Notebooks reference existing HardwareProfiles                                        │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Environment:
  OpenShift AI version: 3.4.0 -> 3.5
  OpenShift version:    4.21.8

Summary:
  Total: 9 | Passed: 9 | Warnings: 0 | Failed: 0 | Prohibited: 0

Result:
  PASS - all checks passed
```

Environment:
  OpenShift AI version: 3.4.0 -> 3.5
  OpenShift version:    4.21.8

Summary:
  Total: 9 | Passed: 9 | Warnings: 0 | Failed: 0 | Prohibited: 0

Result:
  PASS - all checks passed`



## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests






## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lint check that validates the LlamaStack Operator during upgrades from RHOAI 3.4.x to 3.5.x and emits a blocking diagnostic if still enabled.

* **Integration**
  * Registered the new lint check with the checks registry so it runs as part of component validations.

* **Tests**
  * Added comprehensive unit tests covering applicability, validation behavior, metadata, and version-comparison scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->