### PR TITLE
RHOAIENG-61428: Wire migrate command framework into rhai-cli

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
 	"github.com/opendatahub-io/odh-cli/cmd/logs"
+	"github.com/opendatahub-io/odh-cli/cmd/migrate"
 	"github.com/opendatahub-io/odh-cli/cmd/status"
 	"github.com/opendatahub-io/odh-cli/cmd/version"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
@@ -41,6 +42,7 @@ func main() {
 	status.AddCommand(cmd, flags)
 	logs.AddCommand(cmd, flags)
 	completion.AddCommand(cmd, flags)
+	migrate.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		exitCode := int(clierrors.ExitCodeFromError(err))

--- a/cmd/migrate/list/list.go
+++ b/cmd/migrate/list/list.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 )
 
 const (
@@ -27,6 +28,9 @@ migrations without version filtering, or --target-version to filter by applicabi
 const cmdExample = `
   # List applicable migrations for version 3.0
   kubectl odh migrate list --target-version 3.0.0
+
+  # List only pre-upgrade migrations
+  kubectl odh migrate list --target-version 3.0.0 --phase pre-upgrade
 
   # List all migrations without version filtering
   kubectl odh migrate list --all
@@ -66,5 +70,12 @@ func AddCommand(
 	}
 
 	command.AddFlags(cmd.Flags())
+
+	_ = cmd.RegisterFlagCompletionFunc("phase",
+		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return action.PhaseValues(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+
 	parent.AddCommand(cmd)
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -37,6 +37,9 @@ const cmdExample = `
   # List available migrations for version 3.0
   kubectl odh migrate list --target-version 3.0.0
 
+  # List only pre-upgrade migrations
+  kubectl odh migrate list --target-version 3.0.0 --phase pre-upgrade
+
   # List all migrations including non-applicable ones
   kubectl odh migrate list --all
 
@@ -45,6 +48,9 @@ const cmdExample = `
 
   # Run a migration with confirmation prompts
   kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0
+
+  # Run all pre-upgrade migrations
+  kubectl odh migrate run --phase pre-upgrade --target-version 3.0.0
 
   # Run migration in dry-run mode (preview changes only)
   kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --dry-run

--- a/cmd/migrate/prepare/prepare.go
+++ b/cmd/migrate/prepare/prepare.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 )
 
 const (
@@ -31,6 +32,9 @@ Use --output-dir to specify where backups should be written.
 const cmdExample = `
   # Prepare for a single migration (creates timestamped backup directory)
   kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0
+
+  # Prepare all pre-upgrade migrations
+  kubectl odh migrate prepare --phase pre-upgrade --target-version 3.0.0
 
   # Prepare with custom backup directory
   kubectl odh migrate prepare --migration kueue.rhbok.migrate --target-version 3.0.0 --output-dir /path/to/backups
@@ -76,5 +80,18 @@ func AddCommand(
 	}
 
 	command.AddFlags(cmd.Flags())
+
+	_ = cmd.RegisterFlagCompletionFunc("phase",
+		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return action.PhaseValues(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+
+	_ = cmd.RegisterFlagCompletionFunc("migration",
+		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return command.ActionIDs(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+
 	parent.AddCommand(cmd)
 }

--- a/cmd/migrate/run/run.go
+++ b/cmd/migrate/run/run.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 )
 
 const (
@@ -33,6 +34,9 @@ const cmdExample = `
 
   # Run migration without confirmation prompts
   kubectl odh migrate run --migration kueue.rhbok.migrate --target-version 3.0.0 --yes
+
+  # Run all pre-upgrade migrations (auto-selects applicable actions)
+  kubectl odh migrate run --phase pre-upgrade --target-version 3.0.0
 
   # Run multiple migrations sequentially
   kubectl odh migrate run -m kueue.rhbok.migrate -m other.migration --target-version 3.0.0
@@ -73,5 +77,18 @@ func AddCommand(
 	}
 
 	command.AddFlags(cmd.Flags())
+
+	_ = cmd.RegisterFlagCompletionFunc("phase",
+		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return action.PhaseValues(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+
+	_ = cmd.RegisterFlagCompletionFunc("migration",
+		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return command.ActionIDs(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+
 	parent.AddCommand(cmd)
 }

--- a/pkg/migrate/action/action.go
+++ b/pkg/migrate/action/action.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/blang/semver/v4"
 
@@ -18,6 +19,31 @@ const (
 	GroupValidation ActionGroup = "validation"
 )
 
+type ActionPhase string
+
+const (
+	PhasePreUpgrade    ActionPhase = "pre-upgrade"
+	PhasePostUpgrade   ActionPhase = "post-upgrade"
+	PhasePreEnablement ActionPhase = "pre-enablement"
+)
+
+func PhaseValues() []string {
+	return []string{
+		string(PhasePreUpgrade),
+		string(PhasePostUpgrade),
+		string(PhasePreEnablement),
+	}
+}
+
+func (p ActionPhase) Validate() error {
+	switch p {
+	case PhasePreUpgrade, PhasePostUpgrade, PhasePreEnablement, "":
+		return nil
+	default:
+		return fmt.Errorf("invalid phase %q: must be one of: pre-upgrade, post-upgrade, pre-enablement", p)
+	}
+}
+
 // Task represents a single executable phase (prepare or run) with validation and execution.
 type Task interface {
 	Validate(ctx context.Context, target Target) (*result.ActionResult, error)
@@ -29,6 +55,7 @@ type Action interface {
 	Name() string
 	Description() string
 	Group() ActionGroup
+	Phase() ActionPhase
 
 	// CanApply returns whether this action should run for the given target context.
 	// Actions can use target.CurrentVersion, target.TargetVersion, or target.Client for filtering.

--- a/pkg/migrate/action/action_test.go
+++ b/pkg/migrate/action/action_test.go
@@ -1,0 +1,38 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestActionPhase_Validate(t *testing.T) {
+	t.Run("should accept pre-upgrade", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(action.PhasePreUpgrade.Validate()).ToNot(HaveOccurred())
+	})
+
+	t.Run("should accept post-upgrade", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(action.PhasePostUpgrade.Validate()).ToNot(HaveOccurred())
+	})
+
+	t.Run("should accept pre-enablement", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(action.PhasePreEnablement.Validate()).ToNot(HaveOccurred())
+	})
+
+	t.Run("should accept empty string", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(action.ActionPhase("").Validate()).ToNot(HaveOccurred())
+	})
+
+	t.Run("should reject invalid phase", func(t *testing.T) {
+		g := NewWithT(t)
+		err := action.ActionPhase("invalid").Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid phase"))
+	})
+}

--- a/pkg/migrate/action/executor.go
+++ b/pkg/migrate/action/executor.go
@@ -37,8 +37,9 @@ func (e *Executor) ExecuteSelective(
 	target Target,
 	pattern string,
 	group ActionGroup,
+	phase ActionPhase,
 ) ([]ActionExecution, error) {
-	actions, err := e.registry.ListByPattern(pattern, group)
+	actions, err := e.registry.ListByFilter(pattern, group, phase)
 	if err != nil {
 		return nil, fmt.Errorf("selecting actions: %w", err)
 	}

--- a/pkg/migrate/action/executor_test.go
+++ b/pkg/migrate/action/executor_test.go
@@ -1,0 +1,150 @@
+package action_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExecutor_ExecuteAll(t *testing.T) {
+	t.Run("should return empty for empty registry", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+		executor := action.NewExecutor(registry)
+
+		results := executor.ExecuteAll(context.Background(), action.Target{})
+		g.Expect(results).To(BeEmpty())
+	})
+
+	t.Run("should skip actions where CanApply returns false", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{
+			id:       "skip.action",
+			canApply: false,
+			runTask:  &mockTask{result: result.New("migration", "skip", "Skip", "")},
+		})
+
+		executor := action.NewExecutor(registry)
+		results := executor.ExecuteAll(context.Background(), action.Target{})
+		g.Expect(results).To(BeEmpty())
+	})
+
+	t.Run("should execute applicable actions", func(t *testing.T) {
+		g := NewWithT(t)
+		actionResult := result.New("migration", "test", "Test", "")
+		actionResult.Status.Completed = true
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{
+			id:       "test.action",
+			canApply: true,
+			runTask:  &mockTask{result: actionResult},
+		})
+
+		executor := action.NewExecutor(registry)
+		results := executor.ExecuteAll(context.Background(), action.Target{})
+		g.Expect(results).To(HaveLen(1))
+		g.Expect(results[0].Error).ToNot(HaveOccurred())
+		g.Expect(results[0].Result.Status.Completed).To(BeTrue())
+	})
+
+	t.Run("should handle action with nil run task", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{
+			id:       "nil.task",
+			canApply: true,
+			runTask:  nil,
+		})
+
+		executor := action.NewExecutor(registry)
+		results := executor.ExecuteAll(context.Background(), action.Target{})
+		g.Expect(results).To(HaveLen(1))
+		g.Expect(results[0].Error).To(HaveOccurred())
+		g.Expect(results[0].Error.Error()).To(ContainSubstring("no run task"))
+	})
+
+	t.Run("should handle task execution error", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{
+			id:       "error.action",
+			canApply: true,
+			runTask:  &mockTask{err: errors.New("execution failed")},
+		})
+
+		executor := action.NewExecutor(registry)
+		results := executor.ExecuteAll(context.Background(), action.Target{})
+		g.Expect(results).To(HaveLen(1))
+		g.Expect(results[0].Error).To(HaveOccurred())
+		g.Expect(results[0].Result.Status.Error).To(ContainSubstring("execution failed"))
+	})
+}
+
+func TestExecutor_ExecuteSelective(t *testing.T) {
+	t.Run("should filter by pattern", func(t *testing.T) {
+		g := NewWithT(t)
+		actionResult := result.New("migration", "test", "Test", "")
+		actionResult.Status.Completed = true
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{
+			id:       "kueue.migrate",
+			canApply: true,
+			runTask:  &mockTask{result: actionResult},
+		})
+		registry.MustRegister(&mockAction{
+			id:       "other.migrate",
+			canApply: true,
+			runTask:  &mockTask{result: actionResult},
+		})
+
+		executor := action.NewExecutor(registry)
+		results, err := executor.ExecuteSelective(context.Background(), action.Target{}, "kueue.*", "", "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(results).To(HaveLen(1))
+		g.Expect(results[0].Action.ID()).To(Equal("kueue.migrate"))
+	})
+
+	t.Run("should filter by phase", func(t *testing.T) {
+		g := NewWithT(t)
+		actionResult := result.New("migration", "test", "Test", "")
+		actionResult.Status.Completed = true
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{
+			id:       "pre.action",
+			phase:    action.PhasePreUpgrade,
+			canApply: true,
+			runTask:  &mockTask{result: actionResult},
+		})
+		registry.MustRegister(&mockAction{
+			id:       "post.action",
+			phase:    action.PhasePostUpgrade,
+			canApply: true,
+			runTask:  &mockTask{result: actionResult},
+		})
+
+		executor := action.NewExecutor(registry)
+		results, err := executor.ExecuteSelective(context.Background(), action.Target{}, "*", "", action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(results).To(HaveLen(1))
+		g.Expect(results[0].Action.ID()).To(Equal("pre.action"))
+	})
+
+	t.Run("should return error for invalid pattern", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "test.action", canApply: true})
+		executor := action.NewExecutor(registry)
+
+		_, err := executor.ExecuteSelective(context.Background(), action.Target{}, "[invalid", "", "")
+		g.Expect(err).To(HaveOccurred())
+	})
+}

--- a/pkg/migrate/action/registry.go
+++ b/pkg/migrate/action/registry.go
@@ -47,6 +47,17 @@ func (r *ActionRegistry) Get(id string) (Action, bool) {
 	return action, ok
 }
 
+func (r *ActionRegistry) ActionIDs() []string {
+	actions := r.ListAll()
+	ids := make([]string, 0, len(actions))
+
+	for _, a := range actions {
+		ids = append(ids, a.ID())
+	}
+
+	return ids
+}
+
 func (r *ActionRegistry) ListAll() []Action {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -67,6 +78,33 @@ func (r *ActionRegistry) ListByPattern(
 	pattern string,
 	group ActionGroup,
 ) ([]Action, error) {
+	return r.ListByFilter(pattern, group, "")
+}
+
+func (r *ActionRegistry) ListByPhase(phase ActionPhase) []Action {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var filtered []Action
+
+	for _, action := range r.actions {
+		if action.Phase() == phase {
+			filtered = append(filtered, action)
+		}
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].ID() < filtered[j].ID()
+	})
+
+	return filtered
+}
+
+func (r *ActionRegistry) ListByFilter(
+	pattern string,
+	group ActionGroup,
+	phase ActionPhase,
+) ([]Action, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -74,6 +112,10 @@ func (r *ActionRegistry) ListByPattern(
 
 	for id, action := range r.actions {
 		if group != "" && action.Group() != group {
+			continue
+		}
+
+		if phase != "" && action.Phase() != phase {
 			continue
 		}
 

--- a/pkg/migrate/action/registry_test.go
+++ b/pkg/migrate/action/registry_test.go
@@ -1,0 +1,271 @@
+package action_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+
+	. "github.com/onsi/gomega"
+)
+
+type mockAction struct {
+	id          string
+	name        string
+	description string
+	group       action.ActionGroup
+	phase       action.ActionPhase
+	canApply    bool
+	runTask     action.Task
+}
+
+func (m *mockAction) ID() string                    { return m.id }
+func (m *mockAction) Name() string                  { return m.name }
+func (m *mockAction) Description() string           { return m.description }
+func (m *mockAction) Group() action.ActionGroup     { return m.group }
+func (m *mockAction) Phase() action.ActionPhase     { return m.phase }
+func (m *mockAction) CanApply(_ action.Target) bool { return m.canApply }
+func (m *mockAction) Prepare() action.Task          { return nil }
+func (m *mockAction) Run() action.Task              { return m.runTask }
+
+type mockTask struct {
+	result *result.ActionResult
+	err    error
+}
+
+func (m *mockTask) Validate(_ context.Context, _ action.Target) (*result.ActionResult, error) {
+	return m.result, m.err
+}
+
+func (m *mockTask) Execute(_ context.Context, _ action.Target) (*result.ActionResult, error) {
+	return m.result, m.err
+}
+
+func TestRegistry_Register(t *testing.T) {
+	t.Run("should register and retrieve an action", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		act := &mockAction{id: "test.action", name: "Test"}
+
+		err := registry.Register(act)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		retrieved, ok := registry.Get("test.action")
+		g.Expect(ok).To(BeTrue())
+		g.Expect(retrieved.ID()).To(Equal("test.action"))
+	})
+
+	t.Run("should return error for duplicate registration", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		act := &mockAction{id: "test.action", name: "Test"}
+
+		err := registry.Register(act)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = registry.Register(act)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("already registered"))
+	})
+}
+
+func TestRegistry_MustRegister(t *testing.T) {
+	t.Run("should panic on duplicate registration", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		act := &mockAction{id: "test.action", name: "Test"}
+
+		registry.MustRegister(act)
+
+		g.Expect(func() {
+			registry.MustRegister(act)
+		}).To(Panic())
+	})
+}
+
+func TestRegistry_Get(t *testing.T) {
+	t.Run("should return false for unknown ID", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+
+		_, ok := registry.Get("nonexistent")
+		g.Expect(ok).To(BeFalse())
+	})
+}
+
+func TestRegistry_ListAll(t *testing.T) {
+	t.Run("should return empty list for empty registry", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		actions := registry.ListAll()
+		g.Expect(actions).To(BeEmpty())
+	})
+
+	t.Run("should return all actions sorted by ID", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "z.action"})
+		registry.MustRegister(&mockAction{id: "a.action"})
+		registry.MustRegister(&mockAction{id: "m.action"})
+
+		actions := registry.ListAll()
+		g.Expect(actions).To(HaveLen(3))
+		g.Expect(actions[0].ID()).To(Equal("a.action"))
+		g.Expect(actions[1].ID()).To(Equal("m.action"))
+		g.Expect(actions[2].ID()).To(Equal("z.action"))
+	})
+}
+
+func TestRegistry_ListByPattern(t *testing.T) {
+	t.Run("should match by glob pattern", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "kueue.rhbok.migrate", group: action.GroupMigration})
+		registry.MustRegister(&mockAction{id: "kueue.other.migrate", group: action.GroupMigration})
+		registry.MustRegister(&mockAction{id: "other.action", group: action.GroupBackup})
+
+		matched, err := registry.ListByPattern("kueue.*", "")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(matched).To(HaveLen(2))
+		g.Expect(matched[0].ID()).To(Equal("kueue.other.migrate"))
+		g.Expect(matched[1].ID()).To(Equal("kueue.rhbok.migrate"))
+	})
+
+	t.Run("should filter by group", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "a.action", group: action.GroupMigration})
+		registry.MustRegister(&mockAction{id: "b.action", group: action.GroupBackup})
+
+		matched, err := registry.ListByPattern("*", action.GroupMigration)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(matched).To(HaveLen(1))
+		g.Expect(matched[0].ID()).To(Equal("a.action"))
+	})
+
+	t.Run("should return error for invalid pattern", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "test.action"})
+
+		_, err := registry.ListByPattern("[invalid", "")
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestRegistry_ListByPhase(t *testing.T) {
+	t.Run("should filter by phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "pre.action", phase: action.PhasePreUpgrade})
+		registry.MustRegister(&mockAction{id: "post.action", phase: action.PhasePostUpgrade})
+		registry.MustRegister(&mockAction{id: "enable.action", phase: action.PhasePreEnablement})
+
+		preActions := registry.ListByPhase(action.PhasePreUpgrade)
+		g.Expect(preActions).To(HaveLen(1))
+		g.Expect(preActions[0].ID()).To(Equal("pre.action"))
+
+		postActions := registry.ListByPhase(action.PhasePostUpgrade)
+		g.Expect(postActions).To(HaveLen(1))
+		g.Expect(postActions[0].ID()).To(Equal("post.action"))
+	})
+
+	t.Run("should return empty for unmatched phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "pre.action", phase: action.PhasePreUpgrade})
+
+		postActions := registry.ListByPhase(action.PhasePostUpgrade)
+		g.Expect(postActions).To(BeEmpty())
+	})
+
+	t.Run("should return sorted by ID", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "z.pre", phase: action.PhasePreUpgrade})
+		registry.MustRegister(&mockAction{id: "a.pre", phase: action.PhasePreUpgrade})
+
+		actions := registry.ListByPhase(action.PhasePreUpgrade)
+		g.Expect(actions).To(HaveLen(2))
+		g.Expect(actions[0].ID()).To(Equal("a.pre"))
+		g.Expect(actions[1].ID()).To(Equal("z.pre"))
+	})
+}
+
+func TestRegistry_ListByFilter(t *testing.T) {
+	t.Run("should filter by pattern, group, and phase combined", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "kueue.migrate", group: action.GroupMigration, phase: action.PhasePreUpgrade})
+		registry.MustRegister(&mockAction{id: "kueue.backup", group: action.GroupBackup, phase: action.PhasePreUpgrade})
+		registry.MustRegister(&mockAction{id: "other.migrate", group: action.GroupMigration, phase: action.PhasePostUpgrade})
+
+		matched, err := registry.ListByFilter("kueue.*", action.GroupMigration, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(matched).To(HaveLen(1))
+		g.Expect(matched[0].ID()).To(Equal("kueue.migrate"))
+	})
+
+	t.Run("should apply only phase filter when group and pattern are wildcards", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&mockAction{id: "a.action", phase: action.PhasePreUpgrade})
+		registry.MustRegister(&mockAction{id: "b.action", phase: action.PhasePostUpgrade})
+
+		matched, err := registry.ListByFilter("*", "", action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(matched).To(HaveLen(1))
+		g.Expect(matched[0].ID()).To(Equal("a.action"))
+	})
+}
+
+func TestRegistry_ConcurrentRegistration(t *testing.T) {
+	g := NewWithT(t)
+
+	registry := action.NewActionRegistry()
+
+	var wg sync.WaitGroup
+
+	const numGoroutines = 50
+
+	errors := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			act := &mockAction{id: "concurrent.action"}
+			errors[idx] = registry.Register(act)
+		}(i)
+	}
+
+	wg.Wait()
+
+	successes := 0
+
+	for _, err := range errors {
+		if err == nil {
+			successes++
+		}
+	}
+
+	g.Expect(successes).To(Equal(1))
+}

--- a/pkg/migrate/action/result/result.go
+++ b/pkg/migrate/action/result/result.go
@@ -71,6 +71,24 @@ func New(
 	}
 }
 
+func (r *ActionResult) HasSkippedSteps() bool {
+	return hasSkipped(r.Status.Steps)
+}
+
+func hasSkipped(steps []ActionStep) bool {
+	for _, s := range steps {
+		if s.Status == StepSkipped {
+			return true
+		}
+
+		if hasSkipped(s.Children) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func NewStep(
 	name string,
 	description string,

--- a/pkg/migrate/action/result/result_test.go
+++ b/pkg/migrate/action/result/result_test.go
@@ -1,0 +1,63 @@
+package result_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHasSkippedSteps(t *testing.T) {
+	t.Run("should return false when no steps", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		g.Expect(r.HasSkippedSteps()).To(BeFalse())
+	})
+
+	t.Run("should return false when all steps completed", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		r.Status.Steps = []result.ActionStep{
+			result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+			result.NewStep("step2", "Step 2", result.StepCompleted, "done"),
+		}
+		g.Expect(r.HasSkippedSteps()).To(BeFalse())
+	})
+
+	t.Run("should return true when top-level step is skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		r.Status.Steps = []result.ActionStep{
+			result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+			result.NewStep("step2", "Step 2", result.StepSkipped, "user cancelled"),
+		}
+		g.Expect(r.HasSkippedSteps()).To(BeTrue())
+	})
+
+	t.Run("should return true when nested child step is skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+
+		parent := result.NewStep("parent", "Parent", result.StepCompleted, "done")
+		parent.Children = []result.ActionStep{
+			result.NewStep("child", "Child", result.StepSkipped, "skipped"),
+		}
+
+		r.Status.Steps = []result.ActionStep{parent}
+		g.Expect(r.HasSkippedSteps()).To(BeTrue())
+	})
+
+	t.Run("should return false when children are all completed", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+
+		parent := result.NewStep("parent", "Parent", result.StepCompleted, "done")
+		parent.Children = []result.ActionStep{
+			result.NewStep("child", "Child", result.StepCompleted, "done"),
+		}
+
+		r.Status.Steps = []result.ActionStep{parent}
+		g.Expect(r.HasSkippedSteps()).To(BeFalse())
+	})
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok.go
@@ -71,6 +71,10 @@ func (a *RHBOKMigrationAction) Group() action.ActionGroup {
 	return action.GroupMigration
 }
 
+func (a *RHBOKMigrationAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
 func (a *RHBOKMigrationAction) CanApply(target action.Target) bool {
 	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
 }
@@ -92,7 +96,7 @@ func (a *RHBOKMigrationAction) checkKueueManaged(
 		"Check if Kueue is managed by DataScienceCluster",
 	)
 
-	dsc, err := target.Client.Dynamic().Resource(resources.DataScienceCluster.GVR()).
+	dsc, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
 		Namespace("").
 		Get(ctx, "default-dsc", metav1.GetOptions{})
 
@@ -265,7 +269,7 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 		"Update DataScienceCluster Kueue managementState",
 	)
 
-	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 	if err != nil {
 		step.Complete(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
 
@@ -305,7 +309,7 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 		Steps:    retryMaxSteps,
 	}, func() (bool, error) {
 		// Get latest version
-		latestDSC, err := client.GetDataScienceCluster(ctx, target.Client)
+		latestDSC, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 		if err != nil {
 			return false, fmt.Errorf("failed to get DataScienceCluster: %w", err)
 		}
@@ -316,7 +320,7 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 		}
 
 		// Attempt update
-		_, err = target.Client.Dynamic().Resource(resources.DataScienceCluster.GVR()).
+		_, err = target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
 			Update(ctx, latestDSC, metav1.UpdateOptions{})
 		if err != nil {
 			// Retry on conflict errors

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
@@ -22,7 +22,7 @@ func (a *RHBOKMigrationAction) checkCurrentKueueState(
 		"Verify current Kueue state",
 	)
 
-	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			step.Complete(result.StepFailed, "DataScienceCluster not found - OpenShift AI may not be installed")

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -25,8 +25,9 @@ var _ cmd.Command = (*ListCommand)(nil)
 type migrationRow struct {
 	ID          string
 	Name        string
-	Description string
+	Phase       string
 	Applicable  string
+	Description string
 }
 
 type ListCommand struct {
@@ -34,6 +35,7 @@ type ListCommand struct {
 
 	TargetVersion string
 	ShowAll       bool
+	Phase         string
 
 	parsedTargetVersion *semver.Version
 
@@ -60,6 +62,7 @@ func (c *ListCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescListVerbose)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescListTargetVersion)
 	fs.BoolVar(&c.ShowAll, "all", false, flagDescListAll)
+	fs.StringVar(&c.Phase, "phase", "", flagDescListPhase)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
@@ -100,6 +103,10 @@ func (c *ListCommand) Validate() error {
 		return errors.New("--target-version flag is required")
 	}
 
+	if err := action.ActionPhase(c.Phase).Validate(); err != nil {
+		return fmt.Errorf("validating phase: %w", err)
+	}
+
 	return nil
 }
 
@@ -122,9 +129,49 @@ func (c *ListCommand) Run(ctx context.Context) error {
 		return nil
 	}
 
+	allActions = filterByPhase(allActions, action.ActionPhase(c.Phase))
+
+	if len(allActions) == 0 {
+		c.IO.Errorf("No migrations found for phase %q", c.Phase)
+
+		return nil
+	}
+
+	rows := c.buildRows(allActions, currentVersion)
+
+	if len(rows) == 0 {
+		c.IO.Errorf("no migrations applicable for version %s", c.TargetVersion)
+
+		return nil
+	}
+
+	if err := c.printRows(rows); err != nil {
+		return err
+	}
+
+	c.printPhaseHint(currentVersion)
+
+	return nil
+}
+
+func (c *ListCommand) printPhaseHint(currentVersion *semver.Version) {
+	if c.Phase != "" || currentVersion == nil || c.OutputFormat != OutputFormatTable {
+		return
+	}
+
+	detectedPhase, err := DetectPhase(currentVersion, c.parsedTargetVersion)
+	if err != nil {
+		return
+	}
+
+	c.IO.Fprintf("\nNote: 'migrate run' will auto-detect phase as %q for this cluster.\n", string(detectedPhase))
+	c.IO.Fprintf("Use --phase to filter the list by lifecycle phase.\n")
+}
+
+func (c *ListCommand) buildRows(actions []action.Action, currentVersion *semver.Version) []migrationRow {
 	rows := make([]migrationRow, 0)
 
-	for _, act := range allActions {
+	for _, act := range actions {
 		var applicableStr string
 
 		if c.ShowAll && c.parsedTargetVersion == nil {
@@ -152,17 +199,16 @@ func (c *ListCommand) Run(ctx context.Context) error {
 		rows = append(rows, migrationRow{
 			ID:          act.ID(),
 			Name:        act.Name(),
-			Description: act.Description(),
+			Phase:       string(act.Phase()),
 			Applicable:  applicableStr,
+			Description: act.Description(),
 		})
 	}
 
-	if len(rows) == 0 {
-		c.IO.Errorf("no migrations applicable for version %s", c.TargetVersion)
+	return rows
+}
 
-		return nil
-	}
-
+func (c *ListCommand) printRows(rows []migrationRow) error {
 	switch c.OutputFormat {
 	case OutputFormatTable:
 		return c.printTable(rows)
@@ -178,7 +224,7 @@ func (c *ListCommand) Run(ctx context.Context) error {
 func (c *ListCommand) printTable(rows []migrationRow) error {
 	renderer := table.NewRenderer(
 		table.WithWriter[migrationRow](c.IO.Out()),
-		table.WithHeaders[migrationRow]("ID", "NAME", "APPLICABLE", "DESCRIPTION"),
+		table.WithHeaders[migrationRow]("ID", "NAME", "PHASE", "APPLICABLE", "DESCRIPTION"),
 		table.WithTableOptions[migrationRow](table.DefaultTableOptions...),
 	)
 

--- a/pkg/migrate/command_list_internal_test.go
+++ b/pkg/migrate/command_list_internal_test.go
@@ -1,0 +1,151 @@
+package migrate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+
+	. "github.com/onsi/gomega"
+)
+
+func newTestListCommand() (*ListCommand, *bytes.Buffer) {
+	outBuf := &bytes.Buffer{}
+	streams := genericiooptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    outBuf,
+		ErrOut: &bytes.Buffer{},
+	}
+
+	cmd := &ListCommand{
+		SharedOptions: NewSharedOptions(streams),
+		registry:      action.NewActionRegistry(),
+	}
+
+	return cmd, outBuf
+}
+
+func TestBuildRows(t *testing.T) {
+	current := semver.MustParse("2.25.0")
+	target := semver.MustParse("3.0.0")
+
+	t.Run("should include applicable actions", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestListCommand()
+		cmd.parsedTargetVersion = &target
+
+		actions := []action.Action{
+			&stubAction{id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true},
+		}
+
+		rows := cmd.buildRows(actions, &current)
+		g.Expect(rows).To(HaveLen(1))
+		g.Expect(rows[0].ID).To(Equal("test.migrate"))
+		g.Expect(rows[0].Applicable).To(Equal("Yes"))
+		g.Expect(rows[0].Phase).To(Equal("pre-upgrade"))
+	})
+
+	t.Run("should exclude non-applicable actions when ShowAll is false", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestListCommand()
+		cmd.parsedTargetVersion = &target
+
+		actions := []action.Action{
+			&stubAction{id: "applicable", phase: action.PhasePreUpgrade, canApply: true},
+			&stubAction{id: "not-applicable", phase: action.PhasePreUpgrade, canApply: false},
+		}
+
+		rows := cmd.buildRows(actions, &current)
+		g.Expect(rows).To(HaveLen(1))
+		g.Expect(rows[0].ID).To(Equal("applicable"))
+	})
+
+	t.Run("should include non-applicable actions when ShowAll is true", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestListCommand()
+		cmd.ShowAll = true
+		cmd.parsedTargetVersion = &target
+
+		actions := []action.Action{
+			&stubAction{id: "applicable", phase: action.PhasePreUpgrade, canApply: true},
+			&stubAction{id: "not-applicable", phase: action.PhasePreUpgrade, canApply: false},
+		}
+
+		rows := cmd.buildRows(actions, &current)
+		g.Expect(rows).To(HaveLen(2))
+		g.Expect(rows[0].Applicable).To(Equal("Yes"))
+		g.Expect(rows[1].Applicable).To(Equal("No"))
+	})
+
+	t.Run("should show N/A when ShowAll with no target version", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestListCommand()
+		cmd.ShowAll = true
+		cmd.parsedTargetVersion = nil
+
+		actions := []action.Action{
+			&stubAction{id: "test.migrate", phase: action.PhasePostUpgrade, canApply: false},
+		}
+
+		rows := cmd.buildRows(actions, nil)
+		g.Expect(rows).To(HaveLen(1))
+		g.Expect(rows[0].Applicable).To(Equal("N/A"))
+	})
+}
+
+func TestPrintPhaseHint(t *testing.T) {
+	current := semver.MustParse("2.25.0")
+	target := semver.MustParse("3.0.0")
+
+	t.Run("should show phase hint when phase is empty and format is table", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, outBuf := newTestListCommand()
+		cmd.Phase = ""
+		cmd.OutputFormat = OutputFormatTable
+		cmd.parsedTargetVersion = &target
+
+		cmd.printPhaseHint(&current)
+
+		g.Expect(outBuf.String()).To(ContainSubstring("auto-detect phase as \"pre-upgrade\""))
+	})
+
+	t.Run("should not show phase hint when phase is explicitly set", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, outBuf := newTestListCommand()
+		cmd.Phase = "pre-upgrade"
+		cmd.OutputFormat = OutputFormatTable
+		cmd.parsedTargetVersion = &target
+
+		cmd.printPhaseHint(&current)
+
+		g.Expect(outBuf.String()).To(BeEmpty())
+	})
+
+	t.Run("should not show phase hint for JSON output", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, outBuf := newTestListCommand()
+		cmd.Phase = ""
+		cmd.OutputFormat = OutputFormatJSON
+		cmd.parsedTargetVersion = &target
+
+		cmd.printPhaseHint(&current)
+
+		g.Expect(outBuf.String()).To(BeEmpty())
+	})
+
+	t.Run("should not show phase hint when currentVersion is nil", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, outBuf := newTestListCommand()
+		cmd.Phase = ""
+		cmd.OutputFormat = OutputFormatTable
+		cmd.parsedTargetVersion = &target
+
+		cmd.printPhaseHint(nil)
+
+		g.Expect(outBuf.String()).To(BeEmpty())
+	})
+}

--- a/pkg/migrate/command_list_test.go
+++ b/pkg/migrate/command_list_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestListCommand_Validate(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("should require target version when all is false", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = ""
 		cmd.ShowAll = false
@@ -24,6 +24,8 @@ func TestListCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should not require target version when all is true", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = ""
 		cmd.ShowAll = true
@@ -33,6 +35,8 @@ func TestListCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should reject both all and target-version together", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 		cmd.ShowAll = true
@@ -46,6 +50,8 @@ func TestListCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should validate successfully with target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 
@@ -57,10 +63,55 @@ func TestListCommand_Validate(t *testing.T) {
 	})
 }
 
-func TestListCommand_Complete(t *testing.T) {
-	g := NewWithT(t)
+func TestListCommand_Validate_Phase(t *testing.T) {
+	t.Run("should accept valid phase", func(t *testing.T) {
+		g := NewWithT(t)
 
+		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "pre-upgrade"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("should reject invalid phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "invalid"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid phase"))
+	})
+
+	t.Run("should accept empty phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = ""
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestListCommand_Complete(t *testing.T) {
 	t.Run("should parse valid target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 
@@ -69,6 +120,8 @@ func TestListCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should reject invalid target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewListCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "invalid"
 

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -28,8 +29,10 @@ type PrepareCommand struct {
 	OutputDir     string
 	MigrationIDs  []string
 	TargetVersion string
+	Phase         string
 
 	parsedTargetVersion *semver.Version
+	parsedPhase         action.ActionPhase
 
 	// registry is the action registry for this command instance.
 	// Explicitly populated to avoid global state and enable test isolation.
@@ -49,6 +52,10 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	}
 }
 
+func (c *PrepareCommand) ActionIDs() []string {
+	return c.registry.ActionIDs()
+}
+
 func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescPrepareVerbose)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescPrepareTimeout)
@@ -57,6 +64,7 @@ func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.OutputDir, "output-dir", "", flagDescPrepareOutputDir)
 	fs.StringArrayVarP(&c.MigrationIDs, "migration", "m", []string{}, flagDescPrepareMigration)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescPrepareTargetVersion)
+	fs.StringVar(&c.Phase, "phase", "", flagDescPreparePhase)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
@@ -70,6 +78,11 @@ func (c *PrepareCommand) Complete() error {
 
 	// Always enable verbose for migrate prepare
 	c.Verbose = true
+
+	c.parsedPhase = ""
+	if c.Phase != "" {
+		c.parsedPhase = action.ActionPhase(c.Phase)
+	}
 
 	if c.TargetVersion != "" {
 		// Use ParseTolerant to accept partial versions (e.g., "3.0" → "3.0.0")
@@ -94,12 +107,16 @@ func (c *PrepareCommand) Validate() error {
 		return fmt.Errorf("validating shared options: %w", err)
 	}
 
-	if len(c.MigrationIDs) == 0 {
-		return errors.New("--migration flag is required")
+	if len(c.MigrationIDs) == 0 && c.Phase == "" {
+		return errors.New("--migration flag is required (or use --phase to prepare all actions for a lifecycle phase)")
 	}
 
 	if c.TargetVersion == "" {
 		return errors.New("--target-version flag is required")
+	}
+
+	if err := c.parsedPhase.Validate(); err != nil {
+		return fmt.Errorf("validating phase: %w", err)
 	}
 
 	return nil
@@ -114,8 +131,37 @@ func (c *PrepareCommand) Run(ctx context.Context) error {
 		return fmt.Errorf("detecting cluster version: %w", err)
 	}
 
+	effectivePhase, resolvedIDs, err := resolvePhaseAndMigrations(phaseResolverInput{
+		ParsedPhase:    c.parsedPhase,
+		MigrationIDs:   c.MigrationIDs,
+		CurrentVersion: currentVersion,
+		TargetVersion:  c.parsedTargetVersion,
+		Registry:       c.registry,
+		Client:         c.Client,
+		IO:             c.IO,
+	})
+	if err != nil {
+		return err
+	}
+
+	c.MigrationIDs = resolvedIDs
+
+	if len(c.MigrationIDs) == 0 {
+		return fmt.Errorf("no applicable migrations found for phase %s", string(effectivePhase))
+	}
+
+	return c.runPrepareMode(ctx, currentVersion, c.parsedTargetVersion, effectivePhase)
+}
+
+func (c *PrepareCommand) runPrepareMode(
+	ctx context.Context,
+	currentVersion *semver.Version,
+	targetVersion *semver.Version,
+	effectivePhase action.ActionPhase,
+) error {
 	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
-	c.IO.Errorf("Target OpenShift AI version: %s", c.parsedTargetVersion.String())
+	c.IO.Errorf("Target OpenShift AI version: %s", targetVersion.String())
+	c.IO.Errorf("Phase: %s", string(effectivePhase))
 	c.IO.Errorf("Backup directory: %s\n", c.OutputDir)
 
 	for idx, migrationID := range c.MigrationIDs {
@@ -126,6 +172,11 @@ func (c *PrepareCommand) Run(ctx context.Context) error {
 		selectedAction, ok := c.registry.Get(migrationID)
 		if !ok {
 			return fmt.Errorf("migration %q not found", migrationID)
+		}
+
+		if selectedAction.Phase() != effectivePhase {
+			c.IO.Errorf("WARNING: migration %s has phase %s but effective phase is %s; proceeding because --migration was explicit",
+				migrationID, string(selectedAction.Phase()), string(effectivePhase))
 		}
 
 		prepareTask := selectedAction.Prepare()
@@ -142,7 +193,7 @@ func (c *PrepareCommand) Run(ctx context.Context) error {
 		target := action.Target{
 			Client:         c.Client,
 			CurrentVersion: currentVersion,
-			TargetVersion:  c.parsedTargetVersion,
+			TargetVersion:  targetVersion,
 			DryRun:         c.DryRun,
 			SkipConfirm:    c.Yes,
 			OutputDir:      c.OutputDir,
@@ -174,7 +225,16 @@ func (c *PrepareCommand) Run(ctx context.Context) error {
 		c.IO.Errorf("Dry-run complete. Run without --dry-run to create backups.")
 	} else {
 		c.IO.Errorf("All preparations completed successfully!")
-		c.IO.Errorf("Backups saved to: %s", c.OutputDir)
+
+		entries, err := os.ReadDir(c.OutputDir)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			c.IO.Errorf("Warning: could not read backup directory: %v", err)
+		} else if len(entries) > 0 {
+			c.IO.Errorf("Backups saved to: %s", c.OutputDir)
+		} else {
+			c.IO.Errorf("No backups were created — all backup steps were skipped (see output above for details).")
+		}
+
 		c.IO.Errorf("\nRun 'migrate run' to execute the migration.")
 	}
 

--- a/pkg/migrate/command_prepare_internal_test.go
+++ b/pkg/migrate/command_prepare_internal_test.go
@@ -1,0 +1,188 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+
+	. "github.com/onsi/gomega"
+)
+
+func newTestPrepareCommand(t *testing.T) (*PrepareCommand, *bytes.Buffer) {
+	t.Helper()
+
+	errBuf := &bytes.Buffer{}
+	streams := genericiooptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &bytes.Buffer{},
+		ErrOut: errBuf,
+	}
+
+	cmd := &PrepareCommand{
+		SharedOptions: NewSharedOptions(streams),
+		registry:      action.NewActionRegistry(),
+		OutputDir:     filepath.Join(t.TempDir(), "backup-test"),
+	}
+
+	return cmd, errBuf
+}
+
+func TestRunPrepareMode(t *testing.T) {
+	current := semver.MustParse("2.25.0")
+	target := semver.MustParse("3.0.0")
+
+	t.Run("should execute prepare task successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestPrepareCommand(t)
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task,
+		})
+		cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task.execCount).To(Equal(1))
+	})
+
+	t.Run("should skip action with nil prepare task", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestPrepareCommand(t)
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "no.prepare", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: nil,
+		})
+		cmd.MigrationIDs = []string{"no.prepare"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(errBuf.String()).To(ContainSubstring("no prepare phase"))
+	})
+
+	t.Run("should warn and proceed when phase does not match explicit migration", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestPrepareCommand(t)
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "pre.action", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task,
+		})
+		cmd.MigrationIDs = []string{"pre.action"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePostUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task.execCount).To(Equal(1))
+		g.Expect(errBuf.String()).To(ContainSubstring("WARNING"))
+		g.Expect(errBuf.String()).To(ContainSubstring("proceeding because --migration was explicit"))
+	})
+
+	t.Run("should return error for unknown migration ID", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestPrepareCommand(t)
+		cmd.MigrationIDs = []string{"nonexistent"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	t.Run("should return error when task execution fails", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestPrepareCommand(t)
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "fail.action", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: &stubTask{err: errors.New("prepare failed")},
+		})
+		cmd.MigrationIDs = []string{"fail.action"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("preparation failed"))
+	})
+
+	t.Run("should show no backups message when output dir does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestPrepareCommand(t)
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task,
+		})
+		cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(errBuf.String()).To(ContainSubstring("No backups were created"))
+	})
+
+	t.Run("should show backups saved message when output dir has files", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestPrepareCommand(t)
+
+		g.Expect(os.MkdirAll(cmd.OutputDir, 0o750)).To(Succeed())
+		g.Expect(os.WriteFile(filepath.Join(cmd.OutputDir, "backup.yaml"), []byte("data"), 0o600)).To(Succeed())
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task,
+		})
+		cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(errBuf.String()).To(ContainSubstring("Backups saved to"))
+	})
+
+	t.Run("should return error when preparation is incomplete", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestPrepareCommand(t)
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "incomplete.action", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: &stubTask{result: newIncompleteResult()},
+		})
+		cmd.MigrationIDs = []string{"incomplete.action"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("preparation halted"))
+	})
+
+	t.Run("should execute multiple preparations", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestPrepareCommand(t)
+
+		task1 := &stubTask{result: newSuccessResult()}
+		task2 := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "first.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task1,
+		})
+		cmd.registry.MustRegister(&stubAction{
+			id: "second.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task2,
+		})
+		cmd.MigrationIDs = []string{"first.migrate", "second.migrate"}
+
+		err := cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task1.execCount).To(Equal(1))
+		g.Expect(task2.execCount).To(Equal(1))
+	})
+}

--- a/pkg/migrate/command_prepare_test.go
+++ b/pkg/migrate/command_prepare_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestPrepareCommand_Validate(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("should require migration ID", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{}
 		cmd.TargetVersion = "3.0.0"
@@ -24,6 +24,8 @@ func TestPrepareCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should require target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = ""
@@ -34,6 +36,8 @@ func TestPrepareCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should validate successfully with required fields", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = "3.0.0"
@@ -46,6 +50,8 @@ func TestPrepareCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should accept multiple migration IDs", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{"migration1", "migration2", "migration3"}
 		cmd.TargetVersion = "3.0.0"
@@ -59,10 +65,71 @@ func TestPrepareCommand_Validate(t *testing.T) {
 	})
 }
 
-func TestPrepareCommand_Complete(t *testing.T) {
-	g := NewWithT(t)
+func TestPrepareCommand_Validate_Phase(t *testing.T) {
+	t.Run("should accept valid phase", func(t *testing.T) {
+		g := NewWithT(t)
 
+		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{"test.migration"}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "pre-upgrade"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("should reject invalid phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{"test.migration"}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "invalid"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid phase"))
+	})
+
+	t.Run("should accept phase without migration IDs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "pre-upgrade"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("should require migration or phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = ""
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--migration"))
+	})
+}
+
+func TestPrepareCommand_Complete(t *testing.T) {
 	t.Run("should parse valid target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 
@@ -71,6 +138,8 @@ func TestPrepareCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should reject invalid target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "invalid"
 
@@ -80,6 +149,8 @@ func TestPrepareCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should accept partial version format", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0"
 
@@ -88,6 +159,8 @@ func TestPrepareCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should set default output directory with timestamp", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 		cmd.OutputDir = ""
@@ -99,6 +172,8 @@ func TestPrepareCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should preserve custom output directory", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 		cmd.OutputDir = "/custom/path"
@@ -109,6 +184,8 @@ func TestPrepareCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should always enable verbose mode", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 		cmd.Verbose = false

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -25,8 +25,10 @@ type RunCommand struct {
 	Yes           bool
 	MigrationIDs  []string
 	TargetVersion string
+	Phase         string
 
 	parsedTargetVersion *semver.Version
+	parsedPhase         action.ActionPhase
 
 	// registry is the action registry for this command instance.
 	// Explicitly populated to avoid global state and enable test isolation.
@@ -46,6 +48,10 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	}
 }
 
+func (c *RunCommand) ActionIDs() []string {
+	return c.registry.ActionIDs()
+}
+
 func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescRunVerbose)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescRunTimeout)
@@ -53,6 +59,7 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.Yes, "yes", "y", false, flagDescRunYes)
 	fs.StringArrayVarP(&c.MigrationIDs, "migration", "m", []string{}, flagDescRunMigration)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescRunTargetVersion)
+	fs.StringVar(&c.Phase, "phase", "", flagDescRunPhase)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
@@ -66,6 +73,11 @@ func (c *RunCommand) Complete() error {
 
 	// Always enable verbose for migrate run (both dry-run and actual execution)
 	c.Verbose = true
+
+	c.parsedPhase = ""
+	if c.Phase != "" {
+		c.parsedPhase = action.ActionPhase(c.Phase)
+	}
 
 	if c.TargetVersion != "" {
 		// Use ParseTolerant to accept partial versions (e.g., "3.0" → "3.0.0")
@@ -84,12 +96,16 @@ func (c *RunCommand) Validate() error {
 		return fmt.Errorf("validating shared options: %w", err)
 	}
 
-	if len(c.MigrationIDs) == 0 {
-		return errors.New("--migration flag is required")
+	if len(c.MigrationIDs) == 0 && c.Phase == "" {
+		return errors.New("--migration flag is required (or use --phase to run all actions for a lifecycle phase)")
 	}
 
 	if c.TargetVersion == "" {
 		return errors.New("--target-version flag is required")
+	}
+
+	if err := c.parsedPhase.Validate(); err != nil {
+		return fmt.Errorf("validating phase: %w", err)
 	}
 
 	return nil
@@ -104,26 +120,53 @@ func (c *RunCommand) Run(ctx context.Context) error {
 		return fmt.Errorf("detecting cluster version: %w", err)
 	}
 
-	return c.runMigrationMode(ctx, currentVersion, c.parsedTargetVersion, c.registry)
+	effectivePhase, resolvedIDs, err := resolvePhaseAndMigrations(phaseResolverInput{
+		ParsedPhase:    c.parsedPhase,
+		MigrationIDs:   c.MigrationIDs,
+		CurrentVersion: currentVersion,
+		TargetVersion:  c.parsedTargetVersion,
+		Registry:       c.registry,
+		Client:         c.Client,
+		IO:             c.IO,
+	})
+	if err != nil {
+		return err
+	}
+
+	c.MigrationIDs = resolvedIDs
+
+	if len(c.MigrationIDs) == 0 {
+		return fmt.Errorf("no applicable migrations found for phase %s", string(effectivePhase))
+	}
+
+	return c.runMigrationMode(ctx, currentVersion, c.parsedTargetVersion, effectivePhase)
 }
 
 func (c *RunCommand) runMigrationMode(
 	ctx context.Context,
 	currentVersion *semver.Version,
 	targetVersion *semver.Version,
-	registry *action.ActionRegistry,
+	effectivePhase action.ActionPhase,
 ) error {
 	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
-	c.IO.Errorf("Target OpenShift AI version: %s\n", targetVersion.String())
+	c.IO.Errorf("Target OpenShift AI version: %s", targetVersion.String())
+	c.IO.Errorf("Phase: %s\n", string(effectivePhase))
+
+	hasSkips := false
 
 	for idx, migrationID := range c.MigrationIDs {
 		if len(c.MigrationIDs) > 1 {
 			c.IO.Errorf("\n=== Migration %d/%d: %s ===\n", idx+1, len(c.MigrationIDs), migrationID)
 		}
 
-		selectedAction, ok := registry.Get(migrationID)
+		selectedAction, ok := c.registry.Get(migrationID)
 		if !ok {
 			return fmt.Errorf("migration %q not found", migrationID)
+		}
+
+		if selectedAction.Phase() != effectivePhase {
+			c.IO.Errorf("WARNING: migration %s has phase %s but effective phase is %s; proceeding because --migration was explicit",
+				migrationID, string(selectedAction.Phase()), string(effectivePhase))
 		}
 
 		// Use verbose recorder for real-time streaming output
@@ -165,11 +208,22 @@ func (c *RunCommand) runMigrationMode(
 
 			return fmt.Errorf("migration halted: %s", migrationID)
 		}
-		c.IO.Errorf("Migration %s completed successfully!", migrationID)
+		if actionResult.HasSkippedSteps() {
+			c.IO.Errorf("Migration %s completed with skipped steps", migrationID)
+
+			hasSkips = true
+		} else {
+			c.IO.Errorf("Migration %s completed successfully!", migrationID)
+		}
 	}
 
 	c.IO.Fprintln()
-	c.IO.Errorf("All migrations completed successfully!")
+
+	if hasSkips {
+		c.IO.Errorf("All migrations completed (some steps were skipped).")
+	} else {
+		c.IO.Errorf("All migrations completed successfully!")
+	}
 
 	return nil
 }

--- a/pkg/migrate/command_run_internal_test.go
+++ b/pkg/migrate/command_run_internal_test.go
@@ -1,0 +1,223 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+
+	. "github.com/onsi/gomega"
+)
+
+type stubTask struct {
+	result    *result.ActionResult
+	err       error
+	execCount int
+}
+
+func (s *stubTask) Validate(_ context.Context, _ action.Target) (*result.ActionResult, error) {
+	return s.result, s.err
+}
+
+func (s *stubTask) Execute(_ context.Context, _ action.Target) (*result.ActionResult, error) {
+	s.execCount++
+
+	return s.result, s.err
+}
+
+func newSuccessResult() *result.ActionResult {
+	r := result.New("migration", "test", "Test", "")
+	r.Status.Completed = true
+
+	return r
+}
+
+func newResultWithSkippedSteps() *result.ActionResult {
+	r := result.New("migration", "test", "Test", "")
+	r.Status.Completed = true
+	r.Status.Steps = []result.ActionStep{
+		result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+		result.NewStep("step2", "Step 2", result.StepSkipped, "user cancelled"),
+	}
+
+	return r
+}
+
+func newIncompleteResult() *result.ActionResult {
+	r := result.New("migration", "test", "Test", "")
+	r.Status.Completed = false
+
+	return r
+}
+
+func newTestRunCommand() (*RunCommand, *bytes.Buffer) {
+	errBuf := &bytes.Buffer{}
+	streams := genericiooptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &bytes.Buffer{},
+		ErrOut: errBuf,
+	}
+
+	cmd := &RunCommand{
+		SharedOptions: NewSharedOptions(streams),
+		registry:      action.NewActionRegistry(),
+	}
+
+	return cmd, errBuf
+}
+
+func TestRunMigrationMode(t *testing.T) {
+	current := semver.MustParse("2.25.0")
+	target := semver.MustParse("3.0.0")
+
+	t.Run("should execute a single migration successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task,
+		})
+		cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task.execCount).To(Equal(1))
+	})
+
+	t.Run("should return error for unknown migration ID", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+		cmd.MigrationIDs = []string{"nonexistent"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	t.Run("should warn and proceed when phase does not match explicit migration", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestRunCommand()
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "pre.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task,
+		})
+		cmd.MigrationIDs = []string{"pre.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePostUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task.execCount).To(Equal(1))
+		g.Expect(errBuf.String()).To(ContainSubstring("WARNING"))
+		g.Expect(errBuf.String()).To(ContainSubstring("proceeding because --migration was explicit"))
+	})
+
+	t.Run("should return error when task execution fails", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "fail.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{err: errors.New("task failed")},
+		})
+		cmd.MigrationIDs = []string{"fail.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("migration failed"))
+	})
+
+	t.Run("should return error when migration is incomplete", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "incomplete.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newIncompleteResult()},
+		})
+		cmd.MigrationIDs = []string{"incomplete.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("migration halted"))
+	})
+
+	t.Run("should return error when action has nil run task", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "nil.task", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: nil,
+		})
+		cmd.MigrationIDs = []string{"nil.task"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("no run task"))
+	})
+
+	t.Run("should execute multiple migrations", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+
+		task1 := &stubTask{result: newSuccessResult()}
+		task2 := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "first.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task1,
+		})
+		cmd.registry.MustRegister(&stubAction{
+			id: "second.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task2,
+		})
+		cmd.MigrationIDs = []string{"first.migrate", "second.migrate"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task1.execCount).To(Equal(1))
+		g.Expect(task2.execCount).To(Equal(1))
+	})
+
+	t.Run("should report skipped steps in output", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "skip.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newResultWithSkippedSteps()},
+		})
+		cmd.MigrationIDs = []string{"skip.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(errBuf.String()).To(ContainSubstring("completed with skipped steps"))
+		g.Expect(errBuf.String()).To(ContainSubstring("some steps were skipped"))
+		g.Expect(errBuf.String()).ToNot(ContainSubstring("completed successfully"))
+	})
+
+	t.Run("should execute migration when explicit --migration matches --phase", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, _ := newTestRunCommand()
+
+		task := &stubTask{result: newSuccessResult()}
+		cmd.registry.MustRegister(&stubAction{
+			id: "pre.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task,
+		})
+		cmd.MigrationIDs = []string{"pre.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(task.execCount).To(Equal(1))
+	})
+}

--- a/pkg/migrate/command_run_test.go
+++ b/pkg/migrate/command_run_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestRunCommand_Validate(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("should require migration ID", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{}
 		cmd.TargetVersion = "3.0.0"
@@ -24,6 +24,8 @@ func TestRunCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should require target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = ""
@@ -34,6 +36,8 @@ func TestRunCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should validate successfully with required fields", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{"test.migration"}
 		cmd.TargetVersion = "3.0.0"
@@ -46,6 +50,8 @@ func TestRunCommand_Validate(t *testing.T) {
 	})
 
 	t.Run("should accept multiple migration IDs", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.MigrationIDs = []string{"migration1", "migration2", "migration3"}
 		cmd.TargetVersion = "3.0.0"
@@ -59,10 +65,71 @@ func TestRunCommand_Validate(t *testing.T) {
 	})
 }
 
-func TestRunCommand_Complete(t *testing.T) {
-	g := NewWithT(t)
+func TestRunCommand_Validate_Phase(t *testing.T) {
+	t.Run("should accept valid phase", func(t *testing.T) {
+		g := NewWithT(t)
 
+		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{"test.migration"}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "pre-upgrade"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("should reject invalid phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{"test.migration"}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "invalid"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid phase"))
+	})
+
+	t.Run("should accept phase without migration IDs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = "pre-upgrade"
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("should require migration or phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd.MigrationIDs = []string{}
+		cmd.TargetVersion = "3.0.0"
+		cmd.Phase = ""
+
+		err := cmd.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--migration"))
+	})
+}
+
+func TestRunCommand_Complete(t *testing.T) {
 	t.Run("should parse valid target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "3.0.0"
 
@@ -71,6 +138,8 @@ func TestRunCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should reject invalid target version", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.TargetVersion = "invalid"
 
@@ -80,6 +149,8 @@ func TestRunCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should enable verbose when dry-run is true", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.DryRun = true
 		cmd.Verbose = false
@@ -90,6 +161,8 @@ func TestRunCommand_Complete(t *testing.T) {
 	})
 
 	t.Run("should enable verbose when dry-run is false", func(t *testing.T) {
+		g := NewWithT(t)
+
 		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
 		cmd.DryRun = false
 		cmd.Verbose = false

--- a/pkg/migrate/constants.go
+++ b/pkg/migrate/constants.go
@@ -6,6 +6,7 @@ const (
 	flagDescListVerbose       = "Show detailed information"
 	flagDescListTargetVersion = "Target version for migration filtering (required unless --all is specified)"
 	flagDescListAll           = "Show all migrations, not just applicable ones"
+	flagDescListPhase         = "Filter migrations by lifecycle phase (pre-upgrade|post-upgrade|pre-enablement)"
 )
 
 // Flag descriptions for the migrate run command.
@@ -16,6 +17,7 @@ const (
 	flagDescRunYes           = "Skip confirmation prompts"
 	flagDescRunMigration     = "Migration ID to execute (can be specified multiple times)"
 	flagDescRunTargetVersion = "Target version for migration (required)"
+	flagDescRunPhase         = "Lifecycle phase to execute (pre-upgrade|post-upgrade|pre-enablement). Auto-detected from version comparison if not specified"
 )
 
 // Flag descriptions for the migrate prepare command.
@@ -27,4 +29,5 @@ const (
 	flagDescPrepareOutputDir     = "Output directory for backups (default: ./backup-<timestamp>/)"
 	flagDescPrepareMigration     = "Migration ID to prepare (can be specified multiple times)"
 	flagDescPrepareTargetVersion = "Target version for migration (required)"
+	flagDescPreparePhase         = "Filter preparations by lifecycle phase (pre-upgrade|post-upgrade|pre-enablement)"
 )

--- a/pkg/migrate/phase.go
+++ b/pkg/migrate/phase.go
@@ -1,0 +1,93 @@
+package migrate
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+// DetectPhase determines the migration phase based on version comparison.
+// If current < target: pre-upgrade (cluster hasn't been upgraded yet).
+// If current >= target: post-upgrade (cluster has been upgraded).
+func DetectPhase(current, target *semver.Version) (action.ActionPhase, error) {
+	if current == nil {
+		return "", errors.New("current version is required for phase detection")
+	}
+
+	if target == nil {
+		return "", errors.New("target version is required for phase detection")
+	}
+
+	if current.LT(*target) {
+		return action.PhasePreUpgrade, nil
+	}
+
+	return action.PhasePostUpgrade, nil
+}
+
+type phaseResolverInput struct {
+	ParsedPhase    action.ActionPhase
+	MigrationIDs   []string
+	CurrentVersion *semver.Version
+	TargetVersion  *semver.Version
+	Registry       *action.ActionRegistry
+	Client         client.Client
+	IO             iostreams.Interface
+}
+
+// resolvePhaseAndMigrations determines the effective phase and populates migration IDs
+// when they aren't explicitly provided. Returns the effective phase and the migration IDs.
+//
+// When --migration is explicit, phase filtering is bypassed: the migration runs
+// regardless of phase mismatch, with a warning emitted by the caller.
+func resolvePhaseAndMigrations(in phaseResolverInput) (action.ActionPhase, []string, error) {
+	effectivePhase := in.ParsedPhase
+	if effectivePhase == "" {
+		detected, err := DetectPhase(in.CurrentVersion, in.TargetVersion)
+		if err != nil {
+			return "", nil, fmt.Errorf("detecting phase: %w", err)
+		}
+
+		effectivePhase = detected
+		in.IO.Errorf("Auto-detected phase: %s", string(effectivePhase))
+	}
+
+	migrationIDs := in.MigrationIDs
+	if len(migrationIDs) == 0 {
+		allActions := in.Registry.ListAll()
+		allActions = filterByPhase(allActions, effectivePhase)
+
+		for _, act := range allActions {
+			if act.CanApply(action.Target{
+				Client:         in.Client,
+				CurrentVersion: in.CurrentVersion,
+				TargetVersion:  in.TargetVersion,
+			}) {
+				migrationIDs = append(migrationIDs, act.ID())
+			}
+		}
+	}
+
+	return effectivePhase, migrationIDs, nil
+}
+
+func filterByPhase(actions []action.Action, phase action.ActionPhase) []action.Action {
+	if phase == "" {
+		return actions
+	}
+
+	var filtered []action.Action
+
+	for _, a := range actions {
+		if a.Phase() == phase {
+			filtered = append(filtered, a)
+		}
+	}
+
+	return filtered
+}

--- a/pkg/migrate/phase_internal_test.go
+++ b/pkg/migrate/phase_internal_test.go
@@ -1,0 +1,191 @@
+package migrate
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+type stubAction struct {
+	id          string
+	phase       action.ActionPhase
+	canApply    bool
+	runTask     action.Task
+	prepareTask action.Task
+}
+
+func (s *stubAction) ID() string                    { return s.id }
+func (s *stubAction) Name() string                  { return s.id }
+func (s *stubAction) Description() string           { return "" }
+func (s *stubAction) Group() action.ActionGroup     { return action.GroupMigration }
+func (s *stubAction) Phase() action.ActionPhase     { return s.phase }
+func (s *stubAction) CanApply(_ action.Target) bool { return s.canApply }
+func (s *stubAction) Prepare() action.Task          { return s.prepareTask }
+func (s *stubAction) Run() action.Task              { return s.runTask }
+
+func TestFilterByPhase(t *testing.T) {
+	t.Run("should return all actions when phase is empty", func(t *testing.T) {
+		g := NewWithT(t)
+
+		actions := []action.Action{
+			&stubAction{id: "pre", phase: action.PhasePreUpgrade},
+			&stubAction{id: "post", phase: action.PhasePostUpgrade},
+		}
+
+		result := filterByPhase(actions, "")
+		g.Expect(result).To(HaveLen(2))
+	})
+
+	t.Run("should filter to matching phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		actions := []action.Action{
+			&stubAction{id: "pre", phase: action.PhasePreUpgrade},
+			&stubAction{id: "post", phase: action.PhasePostUpgrade},
+			&stubAction{id: "enable", phase: action.PhasePreEnablement},
+		}
+
+		result := filterByPhase(actions, action.PhasePreUpgrade)
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].ID()).To(Equal("pre"))
+	})
+
+	t.Run("should return empty when no actions match", func(t *testing.T) {
+		g := NewWithT(t)
+
+		actions := []action.Action{
+			&stubAction{id: "pre", phase: action.PhasePreUpgrade},
+		}
+
+		result := filterByPhase(actions, action.PhasePostUpgrade)
+		g.Expect(result).To(BeEmpty())
+	})
+
+	t.Run("should handle nil input", func(t *testing.T) {
+		g := NewWithT(t)
+
+		result := filterByPhase(nil, action.PhasePreUpgrade)
+		g.Expect(result).To(BeEmpty())
+	})
+}
+
+func newTestIO() iostreams.Interface {
+	return iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+}
+
+func TestResolvePhaseAndMigrations(t *testing.T) {
+	t.Run("should use explicit phase when provided", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		io := newTestIO()
+
+		phase, ids, err := resolvePhaseAndMigrations(phaseResolverInput{
+			ParsedPhase:  action.PhasePostUpgrade,
+			MigrationIDs: []string{"some.id"},
+			Registry:     registry,
+			IO:           io,
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePostUpgrade))
+		g.Expect(ids).To(ConsistOf("some.id"))
+	})
+
+	t.Run("should auto-detect phase when not provided", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("2.25.0")
+		target := semver.MustParse("3.0.0")
+		registry := action.NewActionRegistry()
+		io := newTestIO()
+
+		phase, _, err := resolvePhaseAndMigrations(phaseResolverInput{
+			MigrationIDs:   []string{"some.id"},
+			CurrentVersion: &current,
+			TargetVersion:  &target,
+			Registry:       registry,
+			IO:             io,
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePreUpgrade))
+	})
+
+	t.Run("should preserve explicit migration IDs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&stubAction{id: "other.action", phase: action.PhasePreUpgrade, canApply: true})
+		io := newTestIO()
+
+		_, ids, err := resolvePhaseAndMigrations(phaseResolverInput{
+			ParsedPhase:  action.PhasePreUpgrade,
+			MigrationIDs: []string{"explicit.id"},
+			Registry:     registry,
+			IO:           io,
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ids).To(ConsistOf("explicit.id"))
+	})
+
+	t.Run("should resolve IDs from registry when none provided", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&stubAction{id: "pre.action", phase: action.PhasePreUpgrade, canApply: true})
+		registry.MustRegister(&stubAction{id: "post.action", phase: action.PhasePostUpgrade, canApply: true})
+		io := newTestIO()
+
+		_, ids, err := resolvePhaseAndMigrations(phaseResolverInput{
+			ParsedPhase: action.PhasePreUpgrade,
+			Registry:    registry,
+			IO:          io,
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ids).To(ConsistOf("pre.action"))
+	})
+
+	t.Run("should filter by CanApply when resolving IDs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&stubAction{id: "applicable", phase: action.PhasePreUpgrade, canApply: true})
+		registry.MustRegister(&stubAction{id: "not-applicable", phase: action.PhasePreUpgrade, canApply: false})
+		io := newTestIO()
+
+		_, ids, err := resolvePhaseAndMigrations(phaseResolverInput{
+			ParsedPhase: action.PhasePreUpgrade,
+			Registry:    registry,
+			IO:          io,
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ids).To(ConsistOf("applicable"))
+	})
+
+	t.Run("should return empty when no actions match phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		registry := action.NewActionRegistry()
+		registry.MustRegister(&stubAction{id: "post.only", phase: action.PhasePostUpgrade, canApply: true})
+		io := newTestIO()
+
+		_, ids, err := resolvePhaseAndMigrations(phaseResolverInput{
+			ParsedPhase: action.PhasePreUpgrade,
+			Registry:    registry,
+			IO:          io,
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ids).To(BeEmpty())
+	})
+}

--- a/pkg/migrate/phase_test.go
+++ b/pkg/migrate/phase_test.go
@@ -1,0 +1,96 @@
+package migrate_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDetectPhase(t *testing.T) {
+	t.Run("should return pre-upgrade when current < target", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("2.25.0")
+		target := semver.MustParse("3.0.0")
+
+		phase, err := migrate.DetectPhase(&current, &target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePreUpgrade))
+	})
+
+	t.Run("should return post-upgrade when current == target", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("3.0.0")
+		target := semver.MustParse("3.0.0")
+
+		phase, err := migrate.DetectPhase(&current, &target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePostUpgrade))
+	})
+
+	t.Run("should return post-upgrade when current > target", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("3.5.0")
+		target := semver.MustParse("3.0.0")
+
+		phase, err := migrate.DetectPhase(&current, &target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePostUpgrade))
+	})
+
+	t.Run("should return error when current is nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		target := semver.MustParse("3.0.0")
+
+		_, err := migrate.DetectPhase(nil, &target)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("current version"))
+	})
+
+	t.Run("should return error when target is nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("2.25.0")
+
+		_, err := migrate.DetectPhase(&current, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("target version"))
+	})
+
+	t.Run("should return error when both are nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := migrate.DetectPhase(nil, nil)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("should handle major version crossing", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("2.25.0")
+		target := semver.MustParse("3.5.0")
+
+		phase, err := migrate.DetectPhase(&current, &target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePreUpgrade))
+	})
+
+	t.Run("should handle minor version difference", func(t *testing.T) {
+		g := NewWithT(t)
+
+		current := semver.MustParse("3.0.0")
+		target := semver.MustParse("3.5.0")
+
+		phase, err := migrate.DetectPhase(&current, &target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(phase).To(Equal(action.PhasePreUpgrade))
+	})
+}

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -77,10 +77,18 @@ func (r ResourceType) Unstructured() unstructured.Unstructured {
 //
 //nolint:gochecknoglobals // Required by Constitution Principle VIII - centralized GVK/GVR definitions
 var (
-	// DataScienceCluster is the OpenShift AI DataScienceCluster resource.
+	// DataScienceCluster is the OpenShift AI DataScienceCluster resource (v2, served by RHOAI 3.x).
 	DataScienceCluster = ResourceType{
 		Group:    "datasciencecluster.opendatahub.io",
 		Version:  "v2",
+		Kind:     "DataScienceCluster",
+		Resource: "datascienceclusters",
+	}
+
+	// DataScienceClusterV1 is the v1 API version, served by RHOAI 2.x clusters.
+	DataScienceClusterV1 = ResourceType{
+		Group:    "datasciencecluster.opendatahub.io",
+		Version:  "v1",
 		Kind:     "DataScienceCluster",
 		Resource: "datascienceclusters",
 	}


### PR DESCRIPTION
Register the migrate command (list, prepare, run) in the CLI entry point and add lifecycle phase support for migration actions.

- Wire migrate command into cmd/main.go
- Add ActionPhase type (pre-upgrade, post-upgrade, pre-enablement) with Phase() method on the Action interface
- Add --phase flag to list, run, and prepare subcommands
- Auto-detect phase from cluster version comparison when --phase is omitted
- Add phase column to migrate list table output
- Add phase filtering to ActionRegistry and Executor
- Add shell completion for --phase and --migration flags
- Add DataScienceClusterV1 resource type for 2.x cluster compat
- Return non-zero exit when no migrations match
- Report skipped steps in final output when user declines prompts
- Show phase auto-detection hint in list output

## Description

<!-- What does this PR do? -->

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top-level migrate subcommand and full --phase support (pre-upgrade, post-upgrade, pre-enablement) with auto-detection, phase-aware list/run/prepare behavior, new PHASE column, improved help/examples, and shell tab-completion for phase and migration IDs.
  * Added phase-aware action lifecycle APIs, detection behavior, skipped-steps reporting, and improved backup/no-backup output.
  * Improved Kueue-related cluster resource handling and added v1 resource type.

* **Tests**
  * Broadened unit test coverage across phase detection, action registry, executor, results, and migrate commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->