### PR TITLE
[RHOAIENG-61436] Port TrustyAI Scripts to Go Actions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     wrapcheck:
       ignore-package-globs:
         - github.com/opendatahub-io/odh-cli/pkg/lint/check/validate
+        - github.com/opendatahub-io/odh-cli/pkg/migrate/action
     cyclop:
       max-complexity: 15  # Increased from default 10
     gocognit:

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,9 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	k8s.io/apiserver v0.35.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -89,6 +91,8 @@ github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef h1:xpF9fUHpoIrrjX24DU
 github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -113,6 +117,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -125,6 +131,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=

--- a/pkg/migrate/action/action.go
+++ b/pkg/migrate/action/action.go
@@ -2,10 +2,13 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/pflag"
+
+	"k8s.io/client-go/rest"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -77,9 +80,20 @@ type ActionConfigurer interface {
 	AddFlags(fs *pflag.FlagSet)
 }
 
+// BuildResult extracts the final ActionResult from the target's recorder.
+func BuildResult(target Target) (*result.ActionResult, error) {
+	rootRecorder, ok := target.Recorder.(RootRecorder)
+	if !ok {
+		return nil, errors.New("recorder is not a RootRecorder")
+	}
+
+	return rootRecorder.Build(), nil
+}
+
 // Target holds all context needed for executing migration actions.
 type Target struct {
 	Client         client.Client
+	RESTConfig     *rest.Config    // Low-level K8s config for actions needing auth tokens or pod exec
 	CurrentVersion *semver.Version // Version being migrated FROM
 	TargetVersion  *semver.Version // Version being migrated TO
 	DryRun         bool

--- a/pkg/migrate/actions/modelserving/add_owner_references.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references.go
@@ -224,7 +224,7 @@ func (t *addOwnerRefsRunTask) Validate(
 	_ context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *addOwnerRefsRunTask) Execute(
@@ -233,5 +233,5 @@ func (t *addOwnerRefsRunTask) Execute(
 ) (*result.ActionResult, error) {
 	t.action.addOwnerReferences(ctx, target)
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }

--- a/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist.go
+++ b/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist.go
@@ -239,7 +239,7 @@ func (t *hpIgnorelistPrepareTask) Validate(
 	_ context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *hpIgnorelistPrepareTask) Execute(
@@ -255,13 +255,13 @@ func (t *hpIgnorelistPrepareTask) Execute(
 	if err != nil {
 		step.Completef(result.StepFailed, msgGetAppNamespaceFailed, err)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	if target.DryRun {
 		step.Completef(result.StepSkipped, "Would backup ConfigMap %s from namespace %s", inferenceServiceConfigName, namespace)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
@@ -272,7 +272,7 @@ func (t *hpIgnorelistPrepareTask) Execute(
 			step.Completef(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
 		}
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	outputDir := filepath.Join(target.OutputDir, namespace)
@@ -283,7 +283,7 @@ func (t *hpIgnorelistPrepareTask) Execute(
 		step.Completef(result.StepCompleted, "Backed up ConfigMap %s to %s", inferenceServiceConfigName, outputDir)
 	}
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 // --- Run Task ---
@@ -296,7 +296,7 @@ func (t *hpIgnorelistRunTask) Validate(
 	_ context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *hpIgnorelistRunTask) Execute(
@@ -308,11 +308,11 @@ func (t *hpIgnorelistRunTask) Execute(
 		step := target.Recorder.Child("get-namespace", "Get applications namespace")
 		step.Completef(result.StepFailed, msgGetAppNamespaceFailed, err)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	t.action.updateConfigMap(ctx, target, namespace)
 	t.action.restartKServeController(ctx, target, namespace)
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }

--- a/pkg/migrate/actions/modelserving/managed_isvc_config.go
+++ b/pkg/migrate/actions/modelserving/managed_isvc_config.go
@@ -123,7 +123,7 @@ func (t *managedISVCConfigRunTask) Validate(
 	_ context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *managedISVCConfigRunTask) Execute(
@@ -135,7 +135,7 @@ func (t *managedISVCConfigRunTask) Execute(
 		step := target.Recorder.Child("get-namespace", "Get applications namespace")
 		step.Completef(result.StepFailed, msgGetAppNamespaceFailed, err)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	changed := t.action.setManagedTrue(ctx, target, namespace)
@@ -145,5 +145,5 @@ func (t *managedISVCConfigRunTask) Execute(
 		restartDeployment(ctx, target, namespace, kserveControllerDeployment, restartStep)
 	}
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
@@ -199,7 +199,7 @@ func (t *modelMeshToRawPrepareTask) Validate(
 	_ context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *modelMeshToRawPrepareTask) Execute(
@@ -216,19 +216,19 @@ func (t *modelMeshToRawPrepareTask) Execute(
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	if len(isvcs) == 0 {
 		step.Completef(result.StepSkipped, msgModelMeshNoISVCs)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	if target.DryRun {
 		step.Completef(result.StepSkipped, "Would backup %d ModelMesh InferenceServices and associated ServingRuntimes", len(isvcs))
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	// Backup ISVCs grouped by namespace
@@ -239,7 +239,7 @@ func (t *modelMeshToRawPrepareTask) Execute(
 		if err := backup.WriteResourcesToDir(outputDir, resources.InferenceService.GVR(), nsISVCs); err != nil {
 			step.Completef(result.StepFailed, "Failed to backup InferenceServices in namespace %s: %v", ns, err)
 
-			return buildResult(target)
+			return action.BuildResult(target)
 		}
 	}
 
@@ -252,7 +252,7 @@ func (t *modelMeshToRawPrepareTask) Execute(
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to list ServingRuntimes: %v", err)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	for ns, nsSRs := range groupByNamespace(servingRuntimes) {
@@ -260,13 +260,13 @@ func (t *modelMeshToRawPrepareTask) Execute(
 		if writeErr := backup.WriteResourcesToDir(outputDir, resources.ServingRuntime.GVR(), nsSRs); writeErr != nil {
 			step.Completef(result.StepFailed, "Failed to backup ServingRuntimes in namespace %s: %v", ns, writeErr)
 
-			return buildResult(target)
+			return action.BuildResult(target)
 		}
 	}
 
 	step.Completef(result.StepCompleted, msgModelMeshBackupDone, len(isvcs), target.OutputDir)
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 // --- Run Task ---
@@ -290,7 +290,7 @@ func (t *modelMeshToRawRunTask) Validate(
 		step.Completef(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeModelMesh)
 	}
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *modelMeshToRawRunTask) Execute(
@@ -299,5 +299,5 @@ func (t *modelMeshToRawRunTask) Execute(
 ) (*result.ActionResult, error) {
 	t.action.convertISVCs(ctx, target)
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }

--- a/pkg/migrate/actions/modelserving/serverless_to_raw.go
+++ b/pkg/migrate/actions/modelserving/serverless_to_raw.go
@@ -129,7 +129,7 @@ func (t *serverlessToRawPrepareTask) Validate(
 	_ context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *serverlessToRawPrepareTask) Execute(
@@ -145,19 +145,19 @@ func (t *serverlessToRawPrepareTask) Execute(
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	if len(isvcs) == 0 {
 		step.Completef(result.StepSkipped, msgServerlessNoISVCs)
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	if target.DryRun {
 		step.Completef(result.StepSkipped, "Would backup %d Serverless InferenceServices", len(isvcs))
 
-		return buildResult(target)
+		return action.BuildResult(target)
 	}
 
 	// Group ISVCs by namespace for backup
@@ -168,13 +168,13 @@ func (t *serverlessToRawPrepareTask) Execute(
 		if err := backup.WriteResourcesToDir(outputDir, resources.InferenceService.GVR(), nsISVCs); err != nil {
 			step.Completef(result.StepFailed, "Failed to write InferenceServices backup for namespace %s: %v", ns, err)
 
-			return buildResult(target)
+			return action.BuildResult(target)
 		}
 	}
 
 	step.Completef(result.StepCompleted, msgServerlessBackupDone, len(isvcs), target.OutputDir)
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 // --- Run Task ---
@@ -198,7 +198,7 @@ func (t *serverlessToRawRunTask) Validate(
 		step.Completef(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeServerless)
 	}
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }
 
 func (t *serverlessToRawRunTask) Execute(
@@ -207,5 +207,5 @@ func (t *serverlessToRawRunTask) Execute(
 ) (*result.ActionResult, error) {
 	t.action.convertISVCs(ctx, target)
 
-	return buildResult(target)
+	return action.BuildResult(target)
 }

--- a/pkg/migrate/actions/modelserving/support.go
+++ b/pkg/migrate/actions/modelserving/support.go
@@ -440,16 +440,6 @@ func ensureRoleBinding(
 	step.Recordf("create-rolebinding", "Created RoleBinding %s/%s", result.StepCompleted, namespace, name)
 }
 
-// buildResult extracts the RootRecorder from target and builds the ActionResult.
-func buildResult(target action.Target) (*result.ActionResult, error) {
-	rootRecorder, ok := target.Recorder.(action.RootRecorder)
-	if !ok {
-		return nil, errors.New("recorder is not a RootRecorder")
-	}
-
-	return rootRecorder.Build(), nil
-}
-
 // groupByNamespace groups unstructured objects by their namespace.
 func groupByNamespace(objs []*unstructured.Unstructured) map[string][]*unstructured.Unstructured {
 	grouped := make(map[string][]*unstructured.Unstructured)

--- a/pkg/migrate/actions/trustyai/data/data.go
+++ b/pkg/migrate/actions/trustyai/data/data.go
@@ -1,0 +1,52 @@
+package data
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+)
+
+const (
+	actionID          = "trustyai.data"
+	actionName        = "Backup and restore TrustyAI data storage"
+	actionDescription = "Backup and restore TrustyAI PVC files or MariaDB database"
+)
+
+type DataAction struct {
+	BackupDir   string
+	BackupFile  string
+	ServiceName string
+}
+
+func (a *DataAction) ID() string          { return actionID }
+func (a *DataAction) Name() string        { return actionName }
+func (a *DataAction) Description() string { return actionDescription }
+
+func (a *DataAction) Group() action.ActionGroup {
+	return action.GroupBackup
+}
+
+func (a *DataAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *DataAction) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&a.BackupDir, "data-dir", "/tmp/rhoai-upgrade-backup/trustyai",
+		"Directory to write data backup files")
+	fs.StringVar(&a.BackupFile, "data-file", "",
+		"Backup directory to restore from (used with migrate run)")
+	fs.StringVar(&a.ServiceName, "data-service-name", "",
+		"TrustyAIService CR name (auto-detected if omitted)")
+}
+
+func (a *DataAction) CanApply(_ action.Target) bool {
+	return true
+}
+
+func (a *DataAction) Prepare() action.Task {
+	return &prepareTask{action: a}
+}
+
+func (a *DataAction) Run() action.Task {
+	return &runTask{action: a}
+}

--- a/pkg/migrate/actions/trustyai/data/discovery.go
+++ b/pkg/migrate/actions/trustyai/data/discovery.go
@@ -1,0 +1,602 @@
+package data
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	podexec "github.com/opendatahub-io/odh-cli/pkg/util/exec"
+)
+
+const (
+	trustyaiContainer     = "trustyai-service"
+	mariadbContainer      = "mariadb"
+	storageFormatPVC      = "PVC"
+	storageFormatDatabase = "DATABASE"
+	metadataFileName      = "metadata.json"
+	dumpFileName          = "dump.sql"
+	dataSubDir            = "data"
+	operatorVolumeName    = "volume"
+	backupDirPermission   = 0o755
+	backupFilePermission  = 0o644
+)
+
+//nolint:gochecknoglobals // Static key lists for credential extraction; Go has no const slices.
+var (
+	usernameKeys = []string{
+		"databaseUsername", "databaseUser", "database-username", "database-user",
+		"MYSQL_USER", "DB_USER", "user", "username",
+	}
+	passwordKeys = []string{
+		"databasePassword", "database-password",
+		"MYSQL_PASSWORD", "DB_PASSWORD", "password",
+	}
+	databaseKeys = []string{
+		"databaseName", "database-name",
+		"MYSQL_DATABASE", "DB_NAME", "database",
+	}
+	serviceHostKeys = []string{
+		"databaseService", "database-service", "DB_HOST",
+	}
+)
+
+type serviceInfo struct {
+	name          string
+	namespace     string
+	storageFormat string
+	cr            *unstructured.Unstructured
+}
+
+type mountInfo struct {
+	mountPath string
+	pvcName   string
+}
+
+type dbCredentials struct {
+	secretName string
+	username   string
+	password   string
+	database   string
+}
+
+// DataBackupMetadata captures all parameters of a data backup for use during restore.
+type DataBackupMetadata struct {
+	Timestamp         string `json:"timestamp"`
+	Namespace         string `json:"namespace"`
+	TrustyAIService   string `json:"trustyaiService"`
+	StorageFormat     string `json:"storageFormat"`
+	PVCName           string `json:"pvcName,omitempty"`
+	MountPath         string `json:"mountPath,omitempty"`
+	SourcePod         string `json:"sourcePod,omitempty"`
+	FileCount         int    `json:"fileCount,omitempty"`
+	MariaDBPod        string `json:"mariadbPod,omitempty"`
+	CredentialsSecret string `json:"credentialsSecret,omitempty"`
+	DatabaseName      string `json:"databaseName,omitempty"`
+	DatabaseUser      string `json:"databaseUser,omitempty"`
+	DumpCommand       string `json:"dumpCommand,omitempty"`
+	DumpLines         int    `json:"dumpLines,omitempty"`
+}
+
+func discoverTrustyAIServices(ctx context.Context, target action.Target, serviceName string) ([]serviceInfo, error) {
+	if serviceName != "" {
+		services, err := target.Client.List(ctx, resources.TrustyAIService)
+		if err != nil {
+			return nil, fmt.Errorf("listing TrustyAIService resources: %w", err)
+		}
+
+		var filtered []serviceInfo
+
+		for _, svc := range services {
+			if svc.GetName() == serviceName {
+				format, _, _ := unstructured.NestedString(svc.Object, "spec", "storage", "format")
+				filtered = append(filtered, serviceInfo{
+					name:          svc.GetName(),
+					namespace:     svc.GetNamespace(),
+					storageFormat: normalizeStorageFormat(format),
+					cr:            svc,
+				})
+			}
+		}
+
+		return filtered, nil
+	}
+
+	services, err := target.Client.List(ctx, resources.TrustyAIService)
+	if err != nil {
+		return nil, fmt.Errorf("listing TrustyAIService resources: %w", err)
+	}
+
+	var result []serviceInfo
+
+	for _, svc := range services {
+		format, _, _ := unstructured.NestedString(svc.Object, "spec", "storage", "format")
+		result = append(result, serviceInfo{
+			name:          svc.GetName(),
+			namespace:     svc.GetNamespace(),
+			storageFormat: normalizeStorageFormat(format),
+			cr:            svc,
+		})
+	}
+
+	return result, nil
+}
+
+func normalizeStorageFormat(format string) string {
+	switch strings.ToUpper(format) {
+	case storageFormatPVC, "":
+		return storageFormatPVC
+	case storageFormatDatabase, "DB":
+		return storageFormatDatabase
+	default:
+		return format
+	}
+}
+
+func findServicePod(ctx context.Context, target action.Target, namespace, serviceName string) (*corev1.Pod, error) {
+	labels := []string{
+		"app=" + serviceName,
+		"app.kubernetes.io/name=" + serviceName,
+		"app.kubernetes.io/part-of=trustyai",
+	}
+
+	for _, label := range labels {
+		pod, err := findRunningPodByLabel(ctx, target, namespace, label)
+		if err != nil {
+			return nil, err
+		}
+
+		if pod != nil {
+			return pod, nil
+		}
+	}
+
+	pod, err := findRunningPodByName(ctx, target, namespace, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	if pod != nil {
+		return pod, nil
+	}
+
+	return nil, fmt.Errorf("no running TrustyAI pod found in namespace %q for service %q", namespace, serviceName)
+}
+
+func findMariaDBPod(ctx context.Context, target action.Target, namespace, serviceName string, secretData map[string][]byte) (*corev1.Pod, error) {
+	patterns := []string{
+		"mariadb-" + serviceName,
+		"mariadb",
+		"mysql",
+	}
+
+	for _, pattern := range patterns {
+		pod, err := findRunningPodByName(ctx, target, namespace, pattern)
+		if err != nil {
+			return nil, err
+		}
+
+		if pod != nil {
+			return pod, nil
+		}
+	}
+
+	svcHost := trySecretKeys(secretData, serviceHostKeys)
+	if svcHost != "" {
+		pod, err := findRunningPodByName(ctx, target, namespace, svcHost)
+		if err != nil {
+			return nil, err
+		}
+
+		if pod != nil {
+			return pod, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no running MariaDB pod found in namespace %q", namespace)
+}
+
+func findRunningPodByLabel(ctx context.Context, target action.Target, namespace, label string) (*corev1.Pod, error) {
+	pods, err := target.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: label,
+		FieldSelector: "status.phase=Running",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing pods with label %q: %w", label, err)
+	}
+
+	if len(pods.Items) == 0 {
+		return nil, nil
+	}
+
+	return &pods.Items[0], nil
+}
+
+func findRunningPodByName(ctx context.Context, target action.Target, namespace, namePattern string) (*corev1.Pod, error) {
+	pods, err := target.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "status.phase=Running",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing running pods: %w", err)
+	}
+
+	lowerPattern := strings.ToLower(namePattern)
+
+	for i := range pods.Items {
+		if strings.Contains(strings.ToLower(pods.Items[i].Name), lowerPattern) {
+			return &pods.Items[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+func findMountPath(pod *corev1.Pod, cr *unstructured.Unstructured, serviceName string) (*mountInfo, error) {
+	if info := findMountByVolumeName(pod, operatorVolumeName); info != nil {
+		return info, nil
+	}
+
+	if info := findMountByPVCName(pod, serviceName); info != nil {
+		return info, nil
+	}
+
+	if cr != nil {
+		folder, found, _ := unstructured.NestedString(cr.Object, "spec", "storage", "folder")
+		if found && folder != "" {
+			return &mountInfo{
+				mountPath: folder,
+				pvcName:   serviceName + "-pvc",
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not determine PVC mount path for pod %q", pod.Name)
+}
+
+func findMountByVolumeName(pod *corev1.Pod, volumeName string) *mountInfo { //nolint:unparam // volumeName is parameterised for testability
+	var pvcName string
+
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == volumeName && pod.Spec.Volumes[i].PersistentVolumeClaim != nil {
+			pvcName = pod.Spec.Volumes[i].PersistentVolumeClaim.ClaimName
+
+			break
+		}
+	}
+
+	for i := range pod.Spec.Containers {
+		for j := range pod.Spec.Containers[i].VolumeMounts {
+			if pod.Spec.Containers[i].VolumeMounts[j].Name == volumeName {
+				return &mountInfo{
+					mountPath: pod.Spec.Containers[i].VolumeMounts[j].MountPath,
+					pvcName:   pvcName,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func findMountByPVCName(pod *corev1.Pod, serviceName string) *mountInfo {
+	lowerName := strings.ToLower(serviceName)
+
+	for i := range pod.Spec.Volumes {
+		vol := &pod.Spec.Volumes[i]
+		if vol.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		if !strings.Contains(strings.ToLower(vol.PersistentVolumeClaim.ClaimName), lowerName) {
+			continue
+		}
+
+		for j := range pod.Spec.Containers {
+			for k := range pod.Spec.Containers[j].VolumeMounts {
+				if pod.Spec.Containers[j].VolumeMounts[k].Name == vol.Name {
+					return &mountInfo{
+						mountPath: pod.Spec.Containers[j].VolumeMounts[k].MountPath,
+						pvcName:   vol.PersistentVolumeClaim.ClaimName,
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func findDBCredentials(ctx context.Context, target action.Target, namespace string, cr *unstructured.Unstructured, serviceName string) (*dbCredentials, error) {
+	secretName, err := findCredentialsSecret(ctx, target, namespace, cr, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	secretObj, err := target.Client.GetResource(ctx, resources.Secret, secretName,
+		client.InNamespace(namespace))
+	if err != nil {
+		return nil, fmt.Errorf("getting secret %q: %w", secretName, err)
+	}
+
+	secretData := extractSecretData(secretObj)
+
+	username := trySecretKeys(secretData, usernameKeys)
+	if username == "" {
+		return nil, fmt.Errorf("could not find username in secret %q", secretName)
+	}
+
+	password := trySecretKeys(secretData, passwordKeys)
+	if password == "" {
+		return nil, fmt.Errorf("could not find password in secret %q", secretName)
+	}
+
+	database := trySecretKeys(secretData, databaseKeys)
+	if database == "" {
+		return nil, fmt.Errorf("could not find database name in secret %q", secretName)
+	}
+
+	return &dbCredentials{
+		secretName: secretName,
+		username:   username,
+		password:   password,
+		database:   database,
+	}, nil
+}
+
+func findCredentialsSecret(ctx context.Context, target action.Target, namespace string, cr *unstructured.Unstructured, serviceName string) (string, error) {
+	if cr != nil {
+		name, found, _ := unstructured.NestedString(cr.Object, "spec", "storage", "databaseConfigurations")
+		if found && name != "" {
+			if secretExists(ctx, target, namespace, name) {
+				return name, nil
+			}
+		}
+	}
+
+	conventionName := serviceName + "-db-credentials"
+	if secretExists(ctx, target, namespace, conventionName) {
+		return conventionName, nil
+	}
+
+	name, err := findSecretByPattern(ctx, target, namespace, "db-credentials")
+	if err != nil {
+		return "", err
+	}
+
+	if name != "" {
+		return name, nil
+	}
+
+	name, err = findSecretByPattern(ctx, target, namespace, "mariadb")
+	if err != nil {
+		return "", err
+	}
+
+	if name != "" {
+		return name, nil
+	}
+
+	return "", fmt.Errorf("no database credentials secret found in namespace %q", namespace)
+}
+
+func secretExists(ctx context.Context, target action.Target, namespace, name string) bool {
+	_, err := target.Client.GetResource(ctx, resources.Secret, name, client.InNamespace(namespace))
+
+	return err == nil
+}
+
+func findSecretByPattern(ctx context.Context, target action.Target, namespace, pattern string) (string, error) {
+	secrets, err := target.Client.List(ctx, resources.Secret, client.WithNamespace(namespace))
+	if err != nil {
+		return "", fmt.Errorf("listing secrets: %w", err)
+	}
+
+	lowerPattern := strings.ToLower(pattern)
+
+	for _, s := range secrets {
+		if strings.Contains(strings.ToLower(s.GetName()), lowerPattern) {
+			return s.GetName(), nil
+		}
+	}
+
+	return "", nil
+}
+
+func extractSecretData(secret *unstructured.Unstructured) map[string][]byte {
+	dataField, found, _ := unstructured.NestedMap(secret.Object, "data")
+	if !found {
+		return nil
+	}
+
+	result := make(map[string][]byte, len(dataField))
+
+	for k, v := range dataField {
+		strVal, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(strVal)
+		if err != nil {
+			continue
+		}
+
+		result[k] = decoded
+	}
+
+	return result
+}
+
+func trySecretKeys(data map[string][]byte, keys []string) string {
+	for _, key := range keys {
+		if val, ok := data[key]; ok && len(val) > 0 {
+			return strings.TrimSpace(string(val))
+		}
+	}
+
+	return ""
+}
+
+func detectDumpCommand(ctx context.Context, executor podexec.Executor, namespace string, pod *corev1.Pod) (string, error) {
+	commands := []string{"mariadb-dump", "mysqldump"}
+
+	for _, name := range commands {
+		if commandExistsInPod(ctx, executor, namespace, pod, name) {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("neither mariadb-dump nor mysqldump found in pod %q", pod.Name)
+}
+
+func detectClientCommand(ctx context.Context, executor podexec.Executor, namespace string, pod *corev1.Pod) (string, error) {
+	commands := []string{"mariadb", "mysql"}
+
+	for _, name := range commands {
+		if commandExistsInPod(ctx, executor, namespace, pod, name) {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("neither mariadb nor mysql client found in pod %q", pod.Name)
+}
+
+func commandExistsInPod(ctx context.Context, executor podexec.Executor, namespace string, pod *corev1.Pod, command string) bool {
+	var stderr bytes.Buffer
+
+	err := executor.Exec(ctx, podexec.ExecOptions{
+		Namespace:     namespace,
+		PodName:       pod.Name,
+		ContainerName: mariadbContainer,
+		Command:       []string{"which", command},
+		Stdout:        io.Discard,
+		Stderr:        &stderr,
+	})
+
+	return err == nil
+}
+
+func writeMetadata(backupPath string, metadata DataBackupMetadata) error {
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling metadata: %w", err)
+	}
+
+	metaPath := filepath.Join(backupPath, metadataFileName)
+
+	if err := os.WriteFile(metaPath, data, backupFilePermission); err != nil {
+		return fmt.Errorf("writing metadata file: %w", err)
+	}
+
+	return nil
+}
+
+func countFiles(dir string) (int, error) {
+	count := 0
+
+	err := filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			count++
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, fmt.Errorf("walking directory: %w", err)
+	}
+
+	return count, nil
+}
+
+func countLines(filePath string) (int, error) {
+	f, err := os.Open(filePath) //nolint:gosec // Path from controlled backup directory.
+	if err != nil {
+		return 0, fmt.Errorf("opening file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	count := 0
+
+	r := bufio.NewReader(f)
+	for {
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			count++
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return 0, fmt.Errorf("reading file: %w", err)
+		}
+	}
+
+	return count, nil
+}
+
+func detectBackupType(backupFile string) (string, error) {
+	metadataPath := filepath.Join(backupFile, metadataFileName)
+	if data, err := os.ReadFile(metadataPath); err == nil { //nolint:gosec // Path from validated backup dir.
+		var meta DataBackupMetadata
+		if jsonErr := json.Unmarshal(data, &meta); jsonErr == nil && meta.StorageFormat != "" {
+			return normalizeStorageFormat(meta.StorageFormat), nil
+		}
+	}
+
+	dataDir := filepath.Join(backupFile, dataSubDir)
+	if info, err := os.Stat(dataDir); err == nil && info.IsDir() {
+		return storageFormatPVC, nil
+	}
+
+	dumpFile := filepath.Join(backupFile, dumpFileName)
+	if _, err := os.Stat(dumpFile); err == nil {
+		return storageFormatDatabase, nil
+	}
+
+	return "", fmt.Errorf("cannot determine backup type from %q (expected data/ directory or dump.sql file)", backupFile)
+}
+
+func loadMetadata(backupFile string) *DataBackupMetadata {
+	metadataPath := filepath.Join(backupFile, metadataFileName)
+
+	data, err := os.ReadFile(metadataPath) //nolint:gosec // Path from validated backup dir.
+	if err != nil {
+		return nil
+	}
+
+	var meta DataBackupMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil
+	}
+
+	return &meta
+}
+
+func containsSQLError(output string) bool {
+	for line := range strings.SplitSeq(output, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "ERROR") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/migrate/actions/trustyai/data/discovery_test.go
+++ b/pkg/migrate/actions/trustyai/data/discovery_test.go
@@ -1,0 +1,1247 @@
+//nolint:testpackage // Tests internal implementation
+package data
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	podexec "github.com/opendatahub-io/odh-cli/pkg/util/exec"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+func newTestClient(scheme *runtime.Scheme, k8sObjects []runtime.Object, dynamicObjects ...runtime.Object) client.Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.TrustyAIService.GVR(): resources.TrustyAIService.ListKind(),
+		resources.Secret.GVR():          resources.Secret.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dynamicObjects...)
+	k8sClient := k8sfake.NewSimpleClientset(k8sObjects...) //nolint:staticcheck // NewClientset requires generated apply configs
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:    dynamicClient,
+		Kubernetes: k8sClient,
+	})
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func newTrustyAIService(name, namespace, storageFormat string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.TrustyAIService.APIVersion(),
+			"kind":       resources.TrustyAIService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"storage": map[string]any{
+					"format": storageFormat,
+				},
+			},
+		},
+	}
+}
+
+func newSecret(name, namespace string, data map[string]string) *unstructured.Unstructured {
+	encodedData := make(map[string]any, len(data))
+	for k, v := range data {
+		encodedData[k] = base64.StdEncoding.EncodeToString([]byte(v))
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Secret.APIVersion(),
+			"kind":       resources.Secret.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"data": encodedData,
+		},
+	}
+}
+
+func newRunningPod(name, namespace string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+}
+
+func newPodWithVolumes(name, namespace string, volumes []corev1.Volume, mounts []corev1.VolumeMount) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:         trustyaiContainer,
+					VolumeMounts: mounts,
+				},
+			},
+			Volumes: volumes,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// normalizeStorageFormat
+// ---------------------------------------------------------------------------
+
+func TestNormalizeStorageFormat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"PVC", "PVC"},
+		{"pvc", "PVC"},
+		{"", "PVC"},
+		{"DATABASE", "DATABASE"},
+		{"database", "DATABASE"},
+		{"DB", "DATABASE"},
+		{"db", "DATABASE"},
+		{"UNKNOWN", "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q->%s", tt.input, tt.expected), func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(normalizeStorageFormat(tt.input)).To(Equal(tt.expected))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// containsSQLError
+// ---------------------------------------------------------------------------
+
+func TestContainsSQLError(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected bool
+	}{
+		{"no error", "some output\nall good", false},
+		{"error line", "ERROR 1045 (28000): Access denied", true},
+		{"error with whitespace", "  ERROR at line 1", true},
+		{"error in middle", "warning\nERROR something\ndone", true},
+		{"empty", "", false},
+		{"lowercase error", "error is not sql error", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(containsSQLError(tt.output)).To(Equal(tt.expected))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// trySecretKeys
+// ---------------------------------------------------------------------------
+
+func TestTrySecretKeys(t *testing.T) {
+	g := NewWithT(t)
+
+	data := map[string][]byte{
+		"databaseUser":     []byte("admin"),
+		"databasePassword": []byte("secret"),
+	}
+
+	g.Expect(trySecretKeys(data, usernameKeys)).To(Equal("admin"))
+	g.Expect(trySecretKeys(data, passwordKeys)).To(Equal("secret"))
+	g.Expect(trySecretKeys(data, databaseKeys)).To(Equal(""))
+	g.Expect(trySecretKeys(nil, usernameKeys)).To(Equal(""))
+}
+
+func TestTrySecretKeys_TrimsWhitespace(t *testing.T) {
+	g := NewWithT(t)
+
+	data := map[string][]byte{
+		"user": []byte("  admin  \n"),
+	}
+
+	g.Expect(trySecretKeys(data, usernameKeys)).To(Equal("admin"))
+}
+
+// ---------------------------------------------------------------------------
+// extractSecretData
+// ---------------------------------------------------------------------------
+
+func TestExtractSecretData(t *testing.T) {
+	g := NewWithT(t)
+
+	secret := newSecret("test", "ns1", map[string]string{
+		"username": "admin",
+		"password": "s3cret",
+	})
+
+	result := extractSecretData(secret)
+	g.Expect(result).To(HaveKeyWithValue("username", []byte("admin")))
+	g.Expect(result).To(HaveKeyWithValue("password", []byte("s3cret")))
+}
+
+func TestExtractSecretData_NoDataField(t *testing.T) {
+	g := NewWithT(t)
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata":   map[string]any{"name": "test", "namespace": "ns1"},
+		},
+	}
+
+	g.Expect(extractSecretData(secret)).To(BeNil())
+}
+
+func TestExtractSecretData_InvalidBase64(t *testing.T) {
+	g := NewWithT(t)
+
+	secret := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata":   map[string]any{"name": "test", "namespace": "ns1"},
+			"data": map[string]any{
+				"valid":   base64.StdEncoding.EncodeToString([]byte("ok")),
+				"invalid": "not-valid-base64!!!",
+			},
+		},
+	}
+
+	result := extractSecretData(secret)
+	g.Expect(result).To(HaveKeyWithValue("valid", []byte("ok")))
+	g.Expect(result).ToNot(HaveKey("invalid"))
+}
+
+// ---------------------------------------------------------------------------
+// countFiles / countLines
+// ---------------------------------------------------------------------------
+
+func TestCountFiles(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	_ = os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o600)
+	_ = os.WriteFile(filepath.Join(dir, "b.txt"), []byte("world"), 0o600)
+	_ = os.MkdirAll(filepath.Join(dir, "sub"), 0o750)
+	_ = os.WriteFile(filepath.Join(dir, "sub", "c.txt"), []byte("nested"), 0o600)
+
+	count, err := countFiles(dir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(3))
+}
+
+func TestCountFiles_EmptyDir(t *testing.T) {
+	g := NewWithT(t)
+
+	count, err := countFiles(t.TempDir())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(0))
+}
+
+func TestCountLines(t *testing.T) {
+	g := NewWithT(t)
+	f := filepath.Join(t.TempDir(), "dump.sql")
+	_ = os.WriteFile(f, []byte("line1\nline2\nline3\n"), 0o600)
+
+	count, err := countLines(f)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(3))
+}
+
+func TestCountLines_LongLine(t *testing.T) {
+	g := NewWithT(t)
+	f := filepath.Join(t.TempDir(), "dump.sql")
+
+	longLine := strings.Repeat("x", 128*1024) // 128KB — exceeds bufio.MaxScanTokenSize (64KB)
+	content := "line1\n" + longLine + "\nline3\n"
+	_ = os.WriteFile(f, []byte(content), 0o600)
+
+	count, err := countLines(f)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(3))
+}
+
+func TestCountLines_NoTrailingNewline(t *testing.T) {
+	g := NewWithT(t)
+	f := filepath.Join(t.TempDir(), "dump.sql")
+	_ = os.WriteFile(f, []byte("line1\nline2"), 0o600)
+
+	count, err := countLines(f)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(count).To(Equal(2))
+}
+
+func TestCountLines_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := countLines("/nonexistent/file")
+	g.Expect(err).To(HaveOccurred())
+}
+
+// ---------------------------------------------------------------------------
+// writeMetadata / loadMetadata / detectBackupType
+// ---------------------------------------------------------------------------
+
+func TestWriteAndLoadMetadata(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	meta := DataBackupMetadata{
+		Timestamp:       "20250605-120000",
+		Namespace:       "ns1",
+		TrustyAIService: "trustyai-service",
+		StorageFormat:   "PVC",
+		PVCName:         "my-pvc",
+		MountPath:       "/data",
+		SourcePod:       "pod-abc",
+		FileCount:       42,
+	}
+
+	err := writeMetadata(dir, meta)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	loaded := loadMetadata(dir)
+	g.Expect(loaded).ToNot(BeNil())
+	g.Expect(loaded.Namespace).To(Equal("ns1"))
+	g.Expect(loaded.StorageFormat).To(Equal("PVC"))
+	g.Expect(loaded.FileCount).To(Equal(42))
+}
+
+func TestLoadMetadata_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(loadMetadata(t.TempDir())).To(BeNil())
+}
+
+func TestDetectBackupType_FromMetadata(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+
+	_ = writeMetadata(dir, DataBackupMetadata{StorageFormat: "DATABASE"})
+
+	storageFormat, err := detectBackupType(dir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(storageFormat).To(Equal("DATABASE"))
+}
+
+func TestDetectBackupType_FromDataDir(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, dataSubDir), 0o750)
+
+	storageFormat, err := detectBackupType(dir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(storageFormat).To(Equal("PVC"))
+}
+
+func TestDetectBackupType_FromDumpSQL(t *testing.T) {
+	g := NewWithT(t)
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, dumpFileName), []byte("SQL"), 0o600)
+
+	storageFormat, err := detectBackupType(dir)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(storageFormat).To(Equal("DATABASE"))
+}
+
+func TestDetectBackupType_Unknown(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := detectBackupType(t.TempDir())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("cannot determine backup type"))
+}
+
+// ---------------------------------------------------------------------------
+// findMountByVolumeName / findMountByPVCName / findMountPath
+// ---------------------------------------------------------------------------
+
+func TestFindMountByVolumeName(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "trustyai-pvc",
+					},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: operatorVolumeName, MountPath: "/data"},
+		},
+	)
+
+	info := findMountByVolumeName(pod, operatorVolumeName)
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.mountPath).To(Equal("/data"))
+	g.Expect(info.pvcName).To(Equal("trustyai-pvc"))
+}
+
+func TestFindMountByVolumeName_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1", nil, nil)
+	g.Expect(findMountByVolumeName(pod, operatorVolumeName)).To(BeNil())
+}
+
+func TestFindMountByVolumeName_NoContainers(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: operatorVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "pvc1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(findMountByVolumeName(pod, operatorVolumeName)).To(BeNil())
+}
+
+func TestFindMountByVolumeName_SidecarBeforeApp(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "istio-proxy"},
+				{
+					Name:         trustyaiContainer,
+					VolumeMounts: []corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: operatorVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "trustyai-pvc"},
+					},
+				},
+			},
+		},
+	}
+
+	info := findMountByVolumeName(pod, operatorVolumeName)
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.mountPath).To(Equal("/data"))
+	g.Expect(info.pvcName).To(Equal("trustyai-pvc"))
+}
+
+func TestFindMountByPVCName_SidecarBeforeApp(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "istio-proxy"},
+				{
+					Name:         trustyaiContainer,
+					VolumeMounts: []corev1.VolumeMount{{Name: "data-vol", MountPath: "/opt/data"}},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "data-vol",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "trustyai-service-pvc"},
+					},
+				},
+			},
+		},
+	}
+
+	info := findMountByPVCName(pod, "trustyai-service")
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.mountPath).To(Equal("/opt/data"))
+	g.Expect(info.pvcName).To(Equal("trustyai-service-pvc"))
+}
+
+func TestFindMountByPVCName(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1",
+		[]corev1.Volume{
+			{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "trustyai-service-pvc",
+					},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: "data-vol", MountPath: "/opt/data"},
+		},
+	)
+
+	info := findMountByPVCName(pod, "trustyai-service")
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.mountPath).To(Equal("/opt/data"))
+	g.Expect(info.pvcName).To(Equal("trustyai-service-pvc"))
+}
+
+func TestFindMountByPVCName_NonPVCVolume(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1",
+		[]corev1.Volume{
+			{
+				Name:         "config-vol",
+				VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"}}},
+			},
+			{
+				Name: "data-vol",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "trustyai-pvc",
+					},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: "config-vol", MountPath: "/config"},
+			{Name: "data-vol", MountPath: "/data"},
+		},
+	)
+
+	info := findMountByPVCName(pod, "trustyai")
+	g.Expect(info).ToNot(BeNil())
+	g.Expect(info.mountPath).To(Equal("/data"))
+}
+
+func TestFindMountByPVCName_NoMatch(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1",
+		[]corev1.Volume{
+			{
+				Name: "other-vol",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "other-pvc",
+					},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: "other-vol", MountPath: "/other"},
+		},
+	)
+
+	g.Expect(findMountByPVCName(pod, "trustyai")).To(BeNil())
+}
+
+func TestFindMountPath_ByVolumeName(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "trustyai-pvc",
+					},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: operatorVolumeName, MountPath: "/data"},
+		},
+	)
+
+	info, err := findMountPath(pod, nil, "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info.mountPath).To(Equal("/data"))
+}
+
+func TestFindMountPath_FallbackToCR(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1", nil, nil)
+	cr := newTrustyAIService("trustyai", "ns1", "PVC")
+
+	_ = unstructured.SetNestedField(cr.Object, "/custom/path", "spec", "storage", "folder")
+
+	info, err := findMountPath(pod, cr, "trustyai")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info.mountPath).To(Equal("/custom/path"))
+}
+
+func TestFindMountPath_ByPVCName(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1",
+		[]corev1.Volume{
+			{
+				Name: "custom-vol",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "trustyai-service-pvc",
+					},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: "custom-vol", MountPath: "/storage"},
+		},
+	)
+
+	info, err := findMountPath(pod, nil, "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(info.mountPath).To(Equal("/storage"))
+	g.Expect(info.pvcName).To(Equal("trustyai-service-pvc"))
+}
+
+func TestFindMountPath_NoMatch(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := newPodWithVolumes("pod1", "ns1", nil, nil)
+
+	_, err := findMountPath(pod, nil, "trustyai")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("could not determine PVC mount path"))
+}
+
+// ---------------------------------------------------------------------------
+// findRunningPodByLabel / findRunningPodByName
+// ---------------------------------------------------------------------------
+
+func TestFindRunningPodByLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("trustyai-pod", "ns1", map[string]string{
+		"app": "trustyai-service",
+	})
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findRunningPodByLabel(ctx, target, "ns1", "app=trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found).ToNot(BeNil())
+	g.Expect(found.Name).To(Equal("trustyai-pod"))
+}
+
+func TestFindRunningPodByLabel_NoPods(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	found, err := findRunningPodByLabel(ctx, target, "ns1", "app=trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found).To(BeNil())
+}
+
+func TestFindRunningPodByName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("mariadb-trustyai-abc", "ns1", nil)
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findRunningPodByName(ctx, target, "ns1", "mariadb")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found).ToNot(BeNil())
+	g.Expect(found.Name).To(Equal("mariadb-trustyai-abc"))
+}
+
+func TestFindRunningPodByName_NoMatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("other-pod", "ns1", nil)
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findRunningPodByName(ctx, target, "ns1", "mariadb")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found).To(BeNil())
+}
+
+func TestFindRunningPodByName_CaseInsensitive(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("MariaDB-Pod-123", "ns1", nil)
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findRunningPodByName(ctx, target, "ns1", "mariadb")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found).ToNot(BeNil())
+}
+
+// ---------------------------------------------------------------------------
+// findServicePod
+// ---------------------------------------------------------------------------
+
+func TestFindServicePod_ByLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("trustyai-abc", "ns1", map[string]string{
+		"app": "trustyai-service",
+	})
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findServicePod(ctx, target, "ns1", "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("trustyai-abc"))
+}
+
+func TestFindServicePod_ByName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("trustyai-service-xyz", "ns1", nil)
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findServicePod(ctx, target, "ns1", "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("trustyai-service-xyz"))
+}
+
+func TestFindServicePod_BySecondLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("trustyai-pod", "ns1", map[string]string{
+		"app.kubernetes.io/name": "trustyai-service",
+	})
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findServicePod(ctx, target, "ns1", "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("trustyai-pod"))
+}
+
+func TestFindServicePod_ByThirdLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("trustyai-pod", "ns1", map[string]string{
+		"app.kubernetes.io/part-of": "trustyai",
+	})
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findServicePod(ctx, target, "ns1", "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("trustyai-pod"))
+}
+
+func TestFindServicePod_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	_, err := findServicePod(ctx, target, "ns1", "trustyai-service")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no running TrustyAI pod found"))
+}
+
+// ---------------------------------------------------------------------------
+// findMariaDBPod
+// ---------------------------------------------------------------------------
+
+func TestFindMariaDBPod_ByPattern(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("mariadb-trustyai-service-xyz", "ns1", nil)
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	found, err := findMariaDBPod(ctx, target, "ns1", "trustyai-service", nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("mariadb-trustyai-service-xyz"))
+}
+
+func TestFindMariaDBPod_BySecretHost(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("custom-db-host-pod", "ns1", nil)
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	secretData := map[string][]byte{
+		"databaseService": []byte("custom-db-host"),
+	}
+
+	found, err := findMariaDBPod(ctx, target, "ns1", "trustyai", secretData)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("custom-db-host-pod"))
+}
+
+func TestFindMariaDBPod_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	_, err := findMariaDBPod(ctx, target, "ns1", "trustyai", nil)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no running MariaDB pod found"))
+}
+
+// ---------------------------------------------------------------------------
+// secretExists / findSecretByPattern
+// ---------------------------------------------------------------------------
+
+func TestSecretExists(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("my-secret", "ns1", map[string]string{"key": "val"})
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	g.Expect(secretExists(ctx, target, "ns1", "my-secret")).To(BeTrue())
+	g.Expect(secretExists(ctx, target, "ns1", "nonexistent")).To(BeFalse())
+}
+
+func TestFindSecretByPattern(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{"key": "val"})
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	name, err := findSecretByPattern(ctx, target, "ns1", "db-credentials")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(name).To(Equal("trustyai-db-credentials"))
+}
+
+func TestFindSecretByPattern_NoMatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	name, err := findSecretByPattern(ctx, target, "ns1", "db-credentials")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(name).To(Equal(""))
+}
+
+// ---------------------------------------------------------------------------
+// findCredentialsSecret
+// ---------------------------------------------------------------------------
+
+func TestFindCredentialsSecret_FromCR(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	cr := newTrustyAIService("trustyai", "ns1", "DATABASE")
+	_ = unstructured.SetNestedField(cr.Object, "my-db-secret", "spec", "storage", "databaseConfigurations")
+
+	secret := newSecret("my-db-secret", "ns1", map[string]string{"key": "val"})
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	name, err := findCredentialsSecret(ctx, target, "ns1", cr, "trustyai")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(name).To(Equal("my-db-secret"))
+}
+
+func TestFindCredentialsSecret_ByConvention(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{"key": "val"})
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	name, err := findCredentialsSecret(ctx, target, "ns1", nil, "trustyai")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(name).To(Equal("trustyai-db-credentials"))
+}
+
+func TestFindCredentialsSecret_ByPattern(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("some-db-credentials-thing", "ns1", map[string]string{"key": "val"})
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	name, err := findCredentialsSecret(ctx, target, "ns1", nil, "nonexistent-svc")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(name).To(Equal("some-db-credentials-thing"))
+}
+
+func TestFindCredentialsSecret_ByMariaDBPattern(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("some-mariadb-secret", "ns1", map[string]string{"key": "val"})
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	name, err := findCredentialsSecret(ctx, target, "ns1", nil, "nonexistent-svc")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(name).To(Equal("some-mariadb-secret"))
+}
+
+func TestFindCredentialsSecret_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	_, err := findCredentialsSecret(ctx, target, "ns1", nil, "trustyai")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no database credentials secret found"))
+}
+
+// ---------------------------------------------------------------------------
+// findDBCredentials
+// ---------------------------------------------------------------------------
+
+func TestFindDBCredentials(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret123",
+		"databaseName":     "trustyai_db",
+	})
+
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	creds, err := findDBCredentials(ctx, target, "ns1", nil, "trustyai")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(creds.username).To(Equal("admin"))
+	g.Expect(creds.password).To(Equal("secret123"))
+	g.Expect(creds.database).To(Equal("trustyai_db"))
+	g.Expect(creds.secretName).To(Equal("trustyai-db-credentials"))
+}
+
+func TestFindDBCredentials_MissingPassword(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databaseName":     "trustyai_db",
+	})
+
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	_, err := findDBCredentials(ctx, target, "ns1", nil, "trustyai")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("could not find password"))
+}
+
+func TestFindDBCredentials_MissingUsername(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	_, err := findDBCredentials(ctx, target, "ns1", nil, "trustyai")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("could not find username"))
+}
+
+func TestFindDBCredentials_MissingDatabase(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+	})
+
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+
+	_, err := findDBCredentials(ctx, target, "ns1", nil, "trustyai")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("could not find database name"))
+}
+
+// ---------------------------------------------------------------------------
+// discoverTrustyAIServices
+// ---------------------------------------------------------------------------
+
+func TestDiscoverTrustyAIServices(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc1 := newTrustyAIService("svc1", "ns1", "PVC")
+	svc2 := newTrustyAIService("svc2", "ns2", "DATABASE")
+
+	target := newTarget(newTestClient(newScheme(), nil, svc1, svc2))
+
+	services, err := discoverTrustyAIServices(ctx, target, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(services).To(HaveLen(2))
+}
+
+func TestDiscoverTrustyAIServices_WithFilter(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc1 := newTrustyAIService("svc1", "ns1", "PVC")
+	svc2 := newTrustyAIService("svc2", "ns2", "DATABASE")
+
+	target := newTarget(newTestClient(newScheme(), nil, svc1, svc2))
+
+	services, err := discoverTrustyAIServices(ctx, target, "svc2")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(services).To(HaveLen(1))
+	g.Expect(services[0].name).To(Equal("svc2"))
+	g.Expect(services[0].storageFormat).To(Equal("DATABASE"))
+}
+
+func TestDiscoverTrustyAIServices_NoneFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	services, err := discoverTrustyAIServices(ctx, target, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(services).To(BeEmpty())
+}
+
+func TestDiscoverTrustyAIServices_NormalizesFormat(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("svc1", "ns1", "db")
+	target := newTarget(newTestClient(newScheme(), nil, svc))
+
+	services, err := discoverTrustyAIServices(ctx, target, "")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(services).To(HaveLen(1))
+	g.Expect(services[0].storageFormat).To(Equal("DATABASE"))
+}
+
+// ---------------------------------------------------------------------------
+// commandExistsInPod / detectDumpCommand / detectClientCommand
+// ---------------------------------------------------------------------------
+
+func TestCommandExistsInPod(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[1] == "mariadb-dump" {
+				return nil
+			}
+
+			return errors.New("not found")
+		},
+	}
+
+	g.Expect(commandExistsInPod(ctx, executor, "ns1", pod, "mariadb-dump")).To(BeTrue())
+	g.Expect(commandExistsInPod(ctx, executor, "ns1", pod, "mysqldump")).To(BeFalse())
+}
+
+func TestDetectDumpCommand_MariaDB(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[1] == "mariadb-dump" {
+				return nil
+			}
+
+			return errors.New("not found")
+		},
+	}
+
+	cmd, err := detectDumpCommand(ctx, executor, "ns1", pod)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd).To(Equal("mariadb-dump"))
+}
+
+func TestDetectDumpCommand_MySQL(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[1] == "mysqldump" {
+				return nil
+			}
+
+			return errors.New("not found")
+		},
+	}
+
+	cmd, err := detectDumpCommand(ctx, executor, "ns1", pod)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd).To(Equal("mysqldump"))
+}
+
+func TestDetectDumpCommand_NoneFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, _ podexec.ExecOptions) error {
+			return errors.New("not found")
+		},
+	}
+
+	_, err := detectDumpCommand(ctx, executor, "ns1", pod)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("neither mariadb-dump nor mysqldump"))
+}
+
+func TestDetectClientCommand_MariaDB(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[1] == "mariadb" {
+				return nil
+			}
+
+			return errors.New("not found")
+		},
+	}
+
+	cmd, err := detectClientCommand(ctx, executor, "ns1", pod)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd).To(Equal("mariadb"))
+}
+
+func TestDetectClientCommand_MySQL(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[1] == "mysql" {
+				return nil
+			}
+
+			return errors.New("not found")
+		},
+	}
+
+	cmd, err := detectClientCommand(ctx, executor, "ns1", pod)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd).To(Equal("mysql"))
+}
+
+func TestDetectClientCommand_NoneFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "db-pod", Namespace: "ns1"}}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, _ podexec.ExecOptions) error {
+			return errors.New("not found")
+		},
+	}
+
+	_, err := detectClientCommand(ctx, executor, "ns1", pod)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("neither mariadb nor mysql"))
+}

--- a/pkg/migrate/actions/trustyai/data/prepare_task.go
+++ b/pkg/migrate/actions/trustyai/data/prepare_task.go
@@ -1,0 +1,300 @@
+package data
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	podexec "github.com/opendatahub-io/odh-cli/pkg/util/exec"
+)
+
+const backupTimestampFmt = "20060102-150405"
+
+type prepareTask struct {
+	action *DataAction
+}
+
+func (t *prepareTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("check-trustyai-data", "Check TrustyAI data services")
+
+	services, err := discoverTrustyAIServices(ctx, target, t.action.ServiceName)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover TrustyAI services: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(services) == 0 {
+		step.Completef(result.StepSkipped, "No TrustyAIService CRs found")
+	} else {
+		step.Completef(result.StepCompleted, "Found %d TrustyAIService(s)", len(services))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("backup-trustyai-data", "Backup TrustyAI data storage")
+
+	services, err := discoverTrustyAIServices(ctx, target, t.action.ServiceName)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover TrustyAI services: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(services) == 0 {
+		step.Completef(result.StepSkipped, "No TrustyAIService CRs found")
+
+		return action.BuildResult(target)
+	}
+
+	var executor podexec.Executor
+	if target.RESTConfig != nil {
+		executor = podexec.NewSPDYExecutor(target.RESTConfig, target.Client.CoreV1())
+	}
+
+	outputDir := t.action.BackupDir
+	if target.OutputDir != "" {
+		outputDir = filepath.Join(target.OutputDir, "trustyai-data")
+	}
+
+	for _, svc := range services {
+		svcStep := step.Child(
+			fmt.Sprintf("backup-%s-%s", svc.namespace, svc.name),
+			fmt.Sprintf("Backup %s/%s (%s)", svc.namespace, svc.name, svc.storageFormat),
+		)
+
+		switch svc.storageFormat {
+		case storageFormatPVC:
+			t.backupPVC(ctx, target, executor, svc, outputDir, svcStep)
+		case storageFormatDatabase:
+			t.backupDatabase(ctx, target, executor, svc, outputDir, svcStep)
+		default:
+			svcStep.Completef(result.StepSkipped, "Unsupported storage format %q", svc.storageFormat)
+		}
+	}
+
+	step.Completef(result.StepCompleted, "Data backup complete")
+
+	return action.BuildResult(target)
+}
+
+func (t *prepareTask) backupPVC(
+	ctx context.Context,
+	target action.Target,
+	executor podexec.Executor,
+	svc serviceInfo,
+	outputDir string,
+	step action.StepRecorder,
+) {
+	pod, err := findServicePod(ctx, target, svc.namespace, svc.name)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find TrustyAI pod: %v", err)
+
+		return
+	}
+
+	mount, err := findMountPath(pod, svc.cr, svc.name)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find mount path: %v", err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would backup PVC data from %s:%s", pod.Name, mount.mountPath)
+
+		return
+	}
+
+	if executor == nil {
+		step.Completef(result.StepFailed, "No SPDY executor available (RESTConfig not set)")
+
+		return
+	}
+
+	timestamp := time.Now().Format(backupTimestampFmt)
+	backupDirName := fmt.Sprintf("trustyai-data-%s-%s", svc.namespace, timestamp)
+	backupPath := filepath.Join(outputDir, backupDirName)
+	dataPath := filepath.Join(backupPath, dataSubDir)
+
+	if err := os.MkdirAll(dataPath, backupDirPermission); err != nil {
+		step.Completef(result.StepFailed, "Failed to create backup directory: %v", err)
+
+		return
+	}
+
+	if err := podexec.CopyFromPod(ctx, executor, podexec.CopyOptions{
+		Namespace:     svc.namespace,
+		PodName:       pod.Name,
+		ContainerName: trustyaiContainer,
+		PodPath:       mount.mountPath,
+		LocalPath:     dataPath,
+	}); err != nil {
+		step.Completef(result.StepFailed, "Failed to copy data from pod: %v", err)
+
+		return
+	}
+
+	fileCount, _ := countFiles(dataPath)
+
+	metadata := DataBackupMetadata{
+		Timestamp:       timestamp,
+		Namespace:       svc.namespace,
+		TrustyAIService: svc.name,
+		StorageFormat:   storageFormatPVC,
+		PVCName:         mount.pvcName,
+		MountPath:       mount.mountPath,
+		SourcePod:       pod.Name,
+		FileCount:       fileCount,
+	}
+
+	if err := writeMetadata(backupPath, metadata); err != nil {
+		step.Completef(result.StepFailed, "Failed to write backup metadata: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Backed up %d file(s) to %s", fileCount, backupPath)
+}
+
+func (t *prepareTask) backupDatabase(
+	ctx context.Context,
+	target action.Target,
+	executor podexec.Executor,
+	svc serviceInfo,
+	outputDir string,
+	step action.StepRecorder,
+) {
+	creds, err := findDBCredentials(ctx, target, svc.namespace, svc.cr, svc.name)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find DB credentials: %v", err)
+
+		return
+	}
+
+	secretObj, err := target.Client.GetResource(ctx, resources.Secret, creds.secretName,
+		client.InNamespace(svc.namespace))
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to get secret: %v", err)
+
+		return
+	}
+
+	secretData := extractSecretData(secretObj)
+
+	mariadbPod, err := findMariaDBPod(ctx, target, svc.namespace, svc.name, secretData)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find MariaDB pod: %v", err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would dump database %s from pod %s", creds.database, mariadbPod.Name)
+
+		return
+	}
+
+	if executor == nil {
+		step.Completef(result.StepFailed, "No SPDY executor available (RESTConfig not set)")
+
+		return
+	}
+
+	dumpCmd, err := detectDumpCommand(ctx, executor, svc.namespace, mariadbPod)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to detect dump command: %v", err)
+
+		return
+	}
+
+	timestamp := time.Now().Format(backupTimestampFmt)
+	backupDirName := fmt.Sprintf("trustyai-db-%s-%s", svc.namespace, timestamp)
+	backupPath := filepath.Join(outputDir, backupDirName)
+
+	if err := os.MkdirAll(backupPath, backupDirPermission); err != nil {
+		step.Completef(result.StepFailed, "Failed to create backup directory: %v", err)
+
+		return
+	}
+
+	dumpPath := filepath.Join(backupPath, dumpFileName)
+
+	dumpFile, err := os.Create(dumpPath) //nolint:gosec // Path built from controlled backupDir + timestamp.
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to create dump file: %v", err)
+
+		return
+	}
+
+	var stderrBuf bytes.Buffer
+
+	execErr := executor.Exec(ctx, podexec.ExecOptions{
+		Namespace:     svc.namespace,
+		PodName:       mariadbPod.Name,
+		ContainerName: mariadbContainer,
+		Command: []string{
+			dumpCmd, "--skip-lock-tables",
+			"-u" + creds.username,
+			"-p" + creds.password,
+			creds.database,
+		},
+		Stdout: dumpFile,
+		Stderr: &stderrBuf,
+	})
+
+	if closeErr := dumpFile.Close(); closeErr != nil {
+		step.Completef(result.StepFailed, "Failed to close dump file: %v", closeErr)
+
+		return
+	}
+
+	if execErr != nil {
+		fi, statErr := os.Stat(dumpPath)
+		if statErr != nil || fi.Size() == 0 {
+			_ = os.RemoveAll(backupPath)
+			step.Completef(result.StepFailed, "Database dump failed: %v", execErr)
+
+			return
+		}
+	}
+
+	dumpLines, _ := countLines(dumpPath)
+
+	if dumpLines <= 1 {
+		_ = os.RemoveAll(backupPath)
+		step.Completef(result.StepFailed, "Database dump appears empty")
+
+		return
+	}
+
+	metadata := DataBackupMetadata{
+		Timestamp:         timestamp,
+		Namespace:         svc.namespace,
+		TrustyAIService:   svc.name,
+		StorageFormat:     storageFormatDatabase,
+		MariaDBPod:        mariadbPod.Name,
+		CredentialsSecret: creds.secretName,
+		DatabaseName:      creds.database,
+		DatabaseUser:      creds.username,
+		DumpCommand:       dumpCmd,
+		DumpLines:         dumpLines,
+	}
+
+	if err := writeMetadata(backupPath, metadata); err != nil {
+		step.Completef(result.StepFailed, "Failed to write backup metadata: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Dumped %d lines from database %s to %s", dumpLines, creds.database, backupPath)
+}

--- a/pkg/migrate/actions/trustyai/data/prepare_task_test.go
+++ b/pkg/migrate/actions/trustyai/data/prepare_task_test.go
@@ -1,0 +1,1441 @@
+//nolint:testpackage // Tests internal implementation
+package data
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	podexec "github.com/opendatahub-io/odh-cli/pkg/util/exec"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+// ---------------------------------------------------------------------------
+// DataAction metadata
+// ---------------------------------------------------------------------------
+
+func TestDataAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &DataAction{}
+
+	g.Expect(a.ID()).To(Equal("trustyai.data"))
+	g.Expect(a.Name()).To(Equal("Backup and restore TrustyAI data storage"))
+	g.Expect(a.Description()).To(ContainSubstring("TrustyAI"))
+	g.Expect(a.Group()).To(Equal(action.GroupBackup))
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.CanApply(action.Target{})).To(BeTrue())
+	g.Expect(a.Prepare()).ToNot(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestDataAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &DataAction{}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	g.Expect(fs.Lookup("data-dir")).ToNot(BeNil())
+	g.Expect(fs.Lookup("data-file")).ToNot(BeNil())
+	g.Expect(fs.Lookup("data-service-name")).ToNot(BeNil())
+}
+
+// ---------------------------------------------------------------------------
+// prepareTask.Validate
+// ---------------------------------------------------------------------------
+
+func TestPrepareTask_Validate_NoServices(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{}
+	result, err := a.Prepare().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Validate_WithServices(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("trustyai", "ns1", "PVC")
+	target := newTarget(newTestClient(newScheme(), nil, svc))
+
+	a := &DataAction{}
+	result, err := a.Prepare().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// prepareTask.Execute
+// ---------------------------------------------------------------------------
+
+func TestPrepareTask_Execute_NoServices(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_UnsupportedFormat(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("trustyai", "ns1", "UNKNOWN_FORMAT")
+	target := newTarget(newTestClient(newScheme(), nil, svc))
+
+	a := &DataAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// runTask.Validate
+// ---------------------------------------------------------------------------
+
+func TestRunTask_Validate_NoBackupFile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_FileNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{BackupFile: "/nonexistent/path"}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_NotDirectory(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	f := filepath.Join(t.TempDir(), "not-a-dir.txt")
+	_ = os.WriteFile(f, []byte("nope"), 0o600)
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{BackupFile: f}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_Ready(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(backupDir, dataSubDir), 0o750)
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{BackupFile: backupDir}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// runTask.Execute
+// ---------------------------------------------------------------------------
+
+func TestRunTask_Execute_NoBackupFile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_CannotDetectType(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{BackupFile: t.TempDir()}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoServicesForRestore(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(backupDir, dataSubDir), 0o750)
+
+	target := newTarget(newTestClient(newScheme(), nil))
+
+	a := &DataAction{BackupFile: backupDir}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DryRun_PVC(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "test.csv"), []byte("data"), 0o600)
+
+	_ = writeMetadata(backupDir, DataBackupMetadata{
+		Namespace:     "ns1",
+		StorageFormat: storageFormatPVC,
+		MountPath:     "/data",
+		PVCName:       "trustyai-pvc",
+	})
+
+	svc := newTrustyAIService("trustyai", "ns1", "PVC")
+	pod := newRunningPod("trustyai-service-pod", "ns1", map[string]string{"app": "trustyai"})
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, svc),
+		func(t *action.Target) { t.DryRun = true },
+	)
+
+	stderrBuf := target.IO.ErrOut().(*bytes.Buffer)
+
+	a := &DataAction{BackupFile: backupDir}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+	_ = stderrBuf
+}
+
+func TestRunTask_Execute_DryRun_Database(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+	_ = writeMetadata(backupDir, DataBackupMetadata{
+		Namespace:     "ns1",
+		StorageFormat: storageFormatDatabase,
+		MariaDBPod:    "mariadb-pod",
+		DatabaseName:  "trustyai_db",
+	})
+
+	svc := newTrustyAIService("trustyai", "ns1", "DATABASE")
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, svc, secret),
+		func(t *action.Target) { t.DryRun = true },
+	)
+
+	a := &DataAction{BackupFile: backupDir}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_UnsupportedBackupType(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = writeMetadata(backupDir, DataBackupMetadata{
+		Namespace:     "ns1",
+		StorageFormat: "UNKNOWN",
+	})
+
+	svc := newTrustyAIService("trustyai", "ns1", "PVC")
+	target := newTarget(newTestClient(newScheme(), nil, svc))
+
+	a := &DataAction{BackupFile: backupDir}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// resolveMariaDBPod
+// ---------------------------------------------------------------------------
+
+func TestResolveMariaDBPod_FromMetadata(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("mariadb-specific", "ns1", nil)
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	meta := &DataBackupMetadata{MariaDBPod: "mariadb-specific"}
+
+	task := &runTask{action: &DataAction{}}
+	found, err := task.resolveMariaDBPod(ctx, target, svc, meta, nil)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("mariadb-specific"))
+}
+
+func TestResolveMariaDBPod_FallbackToDiscovery(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newRunningPod("mariadb-trustyai-xyz", "ns1", nil)
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+
+	meta := &DataBackupMetadata{MariaDBPod: "old-deleted-pod"}
+
+	task := &runTask{action: &DataAction{}}
+	found, err := task.resolveMariaDBPod(ctx, target, svc, meta, nil)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(found.Name).To(Equal("mariadb-trustyai-xyz"))
+}
+
+// ---------------------------------------------------------------------------
+// backupPVC (internal method, tested via prepareTask)
+// ---------------------------------------------------------------------------
+
+func writeTarToWriter(w io.Writer, files map[string]string) {
+	tw := tar.NewWriter(w)
+	defer func() { _ = tw.Close() }()
+
+	for name, content := range files {
+		_ = tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o600,
+			Size: int64(len(content)),
+		})
+		_, _ = tw.Write([]byte(content))
+	}
+}
+
+func TestBackupPVC(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	outputDir := t.TempDir()
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[0] == "tar" && opts.Stdout != nil {
+				writeTarToWriter(opts.Stdout, map[string]string{
+					"file1.csv": "data1",
+					"file2.csv": "data2",
+				})
+			}
+
+			return nil
+		},
+	}
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatPVC,
+		cr:            newTrustyAIService("trustyai", "ns1", "PVC"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+	step := target.Recorder.Child("test-backup-pvc", "Test backup PVC")
+
+	task := &prepareTask{action: &DataAction{BackupDir: outputDir}}
+	task.backupPVC(ctx, target, executor, svc, outputDir, step)
+
+	entries, _ := os.ReadDir(outputDir)
+	g.Expect(entries).ToNot(BeEmpty())
+}
+
+func TestBackupPVC_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: operatorVolumeName, MountPath: "/data"},
+		},
+	)
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatPVC,
+		cr:            newTrustyAIService("trustyai", "ns1", "PVC"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}),
+		func(t *action.Target) { t.DryRun = true },
+	)
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupPVC(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupPVC_NoPodFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatPVC,
+	}
+
+	target := newTarget(newTestClient(newScheme(), nil))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupPVC(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupPVC_NoMountPath(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1", nil, nil)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatPVC,
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupPVC(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupPVC_NoExecutor(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{
+			{Name: operatorVolumeName, MountPath: "/data"},
+		},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatPVC,
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupPVC(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// backupDatabase
+// ---------------------------------------------------------------------------
+
+func TestBackupDatabase_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, secret),
+		func(t *action.Target) { t.DryRun = true },
+	)
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupDatabase_NoCreds(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+	}
+
+	target := newTarget(newTestClient(newScheme(), nil))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupDatabase_NoMariaDBPod(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupDatabase_NoExecutor(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, nil, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupDatabase_NoDumpCommandFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, _ podexec.ExecOptions) error {
+			return errors.New("not found")
+		},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, executor, svc, t.TempDir(), step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestBackupDatabase_Success(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	outputDir := t.TempDir()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if len(opts.Command) > 0 && opts.Command[0] == "which" {
+				if opts.Command[1] == "mariadb-dump" {
+					return nil
+				}
+
+				return errors.New("not found")
+			}
+			if opts.Stdout != nil {
+				_, _ = fmt.Fprintln(opts.Stdout, "-- MariaDB dump")
+				_, _ = fmt.Fprintln(opts.Stdout, "INSERT INTO metrics VALUES (1, 'spd');")
+				_, _ = fmt.Fprintln(opts.Stdout, "INSERT INTO metrics VALUES (2, 'dir');")
+			}
+
+			return nil
+		},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, executor, svc, outputDir, step)
+
+	entries, _ := os.ReadDir(outputDir)
+	g.Expect(entries).ToNot(BeEmpty())
+}
+
+func TestBackupDatabase_EmptyDump(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	outputDir := t.TempDir()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if len(opts.Command) > 0 && opts.Command[0] == "which" {
+				return nil
+			}
+			if opts.Stdout != nil {
+				_, _ = fmt.Fprintln(opts.Stdout, "-- empty dump")
+			}
+
+			return nil
+		},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, executor, svc, outputDir, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// restorePVC
+// ---------------------------------------------------------------------------
+
+func TestRestorePVC_EmptyBackup(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(backupDir, dataSubDir), 0o750)
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+	target := newTarget(newTestClient(newScheme(), nil))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestorePVC_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "file.csv"), []byte("data"), 0o600)
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}),
+		func(t *action.Target) { t.DryRun = true },
+	)
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestorePVC_WithMetadata(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "file.csv"), []byte("data"), 0o600)
+
+	pod := newRunningPod("trustyai-pod", "ns1", map[string]string{"app": "trustyai"})
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+	meta := &DataBackupMetadata{MountPath: "/data", PVCName: "pvc1"}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Stdin != nil {
+				_, _ = io.Copy(io.Discard, opts.Stdin)
+			}
+
+			return nil
+		},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, executor, svc, meta, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestorePVC_NoExecutor(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "file.csv"), []byte("data"), 0o600)
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// restoreDatabase
+// ---------------------------------------------------------------------------
+
+func TestRestoreDatabase_EmptyDump(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte(""), 0o600)
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+	target := newTarget(newTestClient(newScheme(), nil))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[0] == "which" && opts.Command[1] == "mariadb" {
+				return nil
+			}
+
+			return errors.New("not found")
+		},
+	}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, secret),
+		func(t *action.Target) { t.DryRun = true },
+	)
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_Success(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[0] == "which" {
+				return nil
+			}
+			if opts.Stdin != nil {
+				_, _ = io.Copy(io.Discard, opts.Stdin)
+			}
+
+			return nil
+		},
+	}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_SQLError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[0] == "which" {
+				return nil
+			}
+			if opts.Stdin != nil {
+				_, _ = io.Copy(io.Discard, opts.Stdin)
+			}
+			if opts.Stderr != nil {
+				_, _ = fmt.Fprintln(opts.Stderr, "ERROR 1045 (28000): Access denied")
+			}
+
+			return errors.New("command failed")
+		},
+	}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_WarningsOnly(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[0] == "which" {
+				return nil
+			}
+			if opts.Stdin != nil {
+				_, _ = io.Copy(io.Discard, opts.Stdin)
+			}
+			if opts.Stderr != nil {
+				_, _ = fmt.Fprintln(opts.Stderr, "Warning: some deprecation notice")
+			}
+
+			return errors.New("non-zero exit")
+		},
+	}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "trustyai.opendatahub.io/v1alpha1",
+			"kind":       "TrustyAIService",
+			"metadata":   map[string]any{"name": "trustyai", "namespace": "ns1"},
+		}},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_NoExecutor(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_NoClientCommand(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, _ podexec.ExecOptions) error {
+			return errors.New("not found")
+		},
+	}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// restorePVC - additional error paths
+// ---------------------------------------------------------------------------
+
+func TestRestorePVC_NoPodFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "file.csv"), []byte("data"), 0o600)
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+	target := newTarget(newTestClient(newScheme(), nil))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestorePVC_CopyToPodError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "file.csv"), []byte("data"), 0o600)
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, _ podexec.ExecOptions) error {
+			return errors.New("connection refused")
+		},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestorePVC_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	dataDir := filepath.Join(backupDir, dataSubDir)
+	_ = os.MkdirAll(dataDir, 0o750)
+	_ = os.WriteFile(filepath.Join(dataDir, "file.csv"), []byte("data"), 0o600)
+
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	svc := serviceInfo{name: "trustyai", namespace: "ns1"}
+	meta := &DataBackupMetadata{MountPath: "/data", PVCName: "pvc1"}
+
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}),
+		func(t *action.Target) {
+			t.SkipConfirm = false
+			t.IO = io
+			t.Recorder = action.NewVerboseRootRecorder(io)
+		},
+	)
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restorePVC(ctx, target, nil, svc, meta, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// restoreDatabase - additional error paths
+// ---------------------------------------------------------------------------
+
+func TestRestoreDatabase_NoCreds(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), nil))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if opts.Command[0] == "which" {
+				return nil
+			}
+
+			return nil
+		},
+	}
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, secret),
+		func(t *action.Target) {
+			t.SkipConfirm = false
+			t.IO = io
+			t.Recorder = action.NewVerboseRootRecorder(io)
+		},
+	)
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, executor, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestRestoreDatabase_NoMariaDBPod(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(backupDir, dumpFileName), []byte("-- dump\nINSERT INTO foo;\n"), 0o600)
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		cr: newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	target := newTarget(newTestClient(newScheme(), nil, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &runTask{action: &DataAction{BackupFile: backupDir}}
+	task.restoreDatabase(ctx, target, nil, svc, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// backupDatabase - exec error with partial output
+// ---------------------------------------------------------------------------
+
+func TestBackupDatabase_ExecErrorWithPartialDump(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	outputDir := t.TempDir()
+
+	svc := serviceInfo{
+		name: "trustyai", namespace: "ns1",
+		storageFormat: storageFormatDatabase,
+		cr:            newTrustyAIService("trustyai", "ns1", "DATABASE"),
+	}
+
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	executor := &podexec.MockExecutor{
+		ExecFn: func(_ context.Context, opts podexec.ExecOptions) error {
+			if len(opts.Command) > 0 && opts.Command[0] == "which" {
+				return nil
+			}
+			if opts.Stdout != nil {
+				_, _ = fmt.Fprintln(opts.Stdout, "-- partial dump")
+				_, _ = fmt.Fprintln(opts.Stdout, "INSERT INTO foo;")
+				_, _ = fmt.Fprintln(opts.Stdout, "INSERT INTO bar;")
+			}
+
+			return errors.New("connection lost")
+		},
+	}
+
+	target := newTarget(newTestClient(newScheme(), []runtime.Object{pod}, secret))
+	step := target.Recorder.Child("test", "test")
+
+	task := &prepareTask{action: &DataAction{}}
+	task.backupDatabase(ctx, target, executor, svc, outputDir, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// prepareTask.Execute with PVC storage - end-to-end
+// ---------------------------------------------------------------------------
+
+func TestPrepareTask_Execute_PVC_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("trustyai", "ns1", "PVC")
+	pod := newPodWithVolumes("trustyai-pod", "ns1",
+		[]corev1.Volume{
+			{
+				Name: operatorVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc1"},
+				},
+			},
+		},
+		[]corev1.VolumeMount{{Name: operatorVolumeName, MountPath: "/data"}},
+	)
+	pod.Labels = map[string]string{"app": "trustyai"}
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, svc),
+		func(t *action.Target) { t.DryRun = true },
+	)
+
+	a := &DataAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_Database_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("trustyai", "ns1", "DATABASE")
+	secret := newSecret("trustyai-db-credentials", "ns1", map[string]string{
+		"databaseUsername": "admin",
+		"databasePassword": "secret",
+		"databaseName":     "trustyai_db",
+	})
+	pod := newRunningPod("mariadb-trustyai-pod", "ns1", nil)
+
+	target := newTarget(
+		newTestClient(newScheme(), []runtime.Object{pod}, svc, secret),
+		func(t *action.Target) { t.DryRun = true },
+	)
+
+	a := &DataAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}

--- a/pkg/migrate/actions/trustyai/data/run_task.go
+++ b/pkg/migrate/actions/trustyai/data/run_task.go
@@ -1,0 +1,368 @@
+package data
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+	podexec "github.com/opendatahub-io/odh-cli/pkg/util/exec"
+)
+
+type runTask struct {
+	action *DataAction
+}
+
+func (t *runTask) Validate(_ context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("check-data-restore", "Check data restore readiness")
+
+	if t.action.BackupFile == "" {
+		step.Completef(result.StepSkipped, "No --data-file specified; nothing to restore")
+
+		return action.BuildResult(target)
+	}
+
+	info, err := os.Stat(t.action.BackupFile)
+	if err != nil {
+		step.Completef(result.StepFailed, "Backup path %s not found: %v", t.action.BackupFile, err)
+
+		return action.BuildResult(target)
+	}
+
+	if !info.IsDir() {
+		step.Completef(result.StepFailed, "Backup path %s is not a directory", t.action.BackupFile)
+
+		return action.BuildResult(target)
+	}
+
+	storageFormat, err := detectBackupType(t.action.BackupFile)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to detect backup type: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	step.Completef(result.StepCompleted, "Ready to restore %s backup from %s", storageFormat, t.action.BackupFile)
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("restore-trustyai-data", "Restore TrustyAI data storage")
+
+	if t.action.BackupFile == "" {
+		step.Completef(result.StepSkipped, "No --data-file specified; nothing to restore")
+
+		return action.BuildResult(target)
+	}
+
+	storageFormat, err := detectBackupType(t.action.BackupFile)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to detect backup type: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	var executor podexec.Executor
+	if target.RESTConfig != nil {
+		executor = podexec.NewSPDYExecutor(target.RESTConfig, target.Client.CoreV1())
+	}
+
+	meta := loadMetadata(t.action.BackupFile)
+
+	namespace := ""
+	if meta != nil {
+		namespace = meta.Namespace
+	}
+
+	targetSvc, err := resolveTargetService(ctx, target, t.action.ServiceName, meta, namespace)
+	if err != nil {
+		step.Completef(result.StepFailed, "%v", err)
+
+		return action.BuildResult(target)
+	}
+
+	switch storageFormat {
+	case storageFormatPVC:
+		t.restorePVC(ctx, target, executor, *targetSvc, meta, step)
+	case storageFormatDatabase:
+		t.restoreDatabase(ctx, target, executor, *targetSvc, meta, step)
+	default:
+		step.Completef(result.StepFailed, "Unsupported backup type %q", storageFormat)
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) restorePVC(
+	ctx context.Context,
+	target action.Target,
+	executor podexec.Executor,
+	svc serviceInfo,
+	meta *DataBackupMetadata,
+	step action.StepRecorder,
+) {
+	dataDir := filepath.Join(t.action.BackupFile, dataSubDir)
+
+	fileCount, err := countFiles(dataDir)
+	if err != nil || fileCount == 0 {
+		step.Completef(result.StepSkipped, "Backup directory is empty, nothing to restore")
+
+		return
+	}
+
+	pod, err := findServicePod(ctx, target, svc.namespace, svc.name)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find TrustyAI pod: %v", err)
+
+		return
+	}
+
+	var mount *mountInfo
+
+	if meta != nil && meta.MountPath != "" {
+		mount = &mountInfo{mountPath: meta.MountPath, pvcName: meta.PVCName}
+	} else {
+		mount, err = findMountPath(pod, svc.cr, svc.name)
+		if err != nil {
+			step.Completef(result.StepFailed, "Failed to find mount path: %v", err)
+
+			return
+		}
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would restore %d file(s) to %s:%s", fileCount, pod.Name, mount.mountPath)
+
+		return
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to restore %d file(s) to pod %s at %s", fileCount, pod.Name, mount.mountPath)
+
+		if !confirmation.Prompt(target.IO, "Proceed with PVC restore?") {
+			step.Completef(result.StepSkipped, "User cancelled PVC restore")
+
+			return
+		}
+	}
+
+	if executor == nil {
+		step.Completef(result.StepFailed, "No SPDY executor available (RESTConfig not set)")
+
+		return
+	}
+
+	if err := podexec.CopyToPod(ctx, executor, podexec.CopyOptions{
+		Namespace:     svc.namespace,
+		PodName:       pod.Name,
+		ContainerName: trustyaiContainer,
+		PodPath:       mount.mountPath,
+		LocalPath:     dataDir,
+	}); err != nil {
+		step.Completef(result.StepFailed, "Failed to copy data to pod: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Restored %d file(s) to %s:%s", fileCount, pod.Name, mount.mountPath)
+}
+
+func (t *runTask) restoreDatabase(
+	ctx context.Context,
+	target action.Target,
+	executor podexec.Executor,
+	svc serviceInfo,
+	meta *DataBackupMetadata,
+	step action.StepRecorder,
+) {
+	dumpPath := filepath.Join(t.action.BackupFile, dumpFileName)
+
+	dumpLines, err := countLines(dumpPath)
+	if err != nil || dumpLines <= 1 {
+		step.Completef(result.StepFailed, "Dump file appears empty or unreadable")
+
+		return
+	}
+
+	creds, err := findDBCredentials(ctx, target, svc.namespace, svc.cr, svc.name)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find DB credentials: %v", err)
+
+		return
+	}
+
+	secretObj, err := target.Client.GetResource(ctx, resources.Secret, creds.secretName,
+		client.InNamespace(svc.namespace))
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to get secret: %v", err)
+
+		return
+	}
+
+	secretData := extractSecretData(secretObj)
+
+	mariadbPod, err := t.resolveMariaDBPod(ctx, target, svc, meta, secretData)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to find MariaDB pod: %v", err)
+
+		return
+	}
+
+	if executor == nil {
+		step.Completef(result.StepFailed, "No SPDY executor available (RESTConfig not set)")
+
+		return
+	}
+
+	clientCmd, err := detectClientCommand(ctx, executor, svc.namespace, mariadbPod)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to detect client command: %v", err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would restore %d-line dump to database %s via %s",
+			dumpLines, creds.database, mariadbPod.Name)
+
+		return
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to restore %d-line SQL dump to database %s via %s",
+			dumpLines, creds.database, mariadbPod.Name)
+
+		if !confirmation.Prompt(target.IO, "Proceed with database restore?") {
+			step.Completef(result.StepSkipped, "User cancelled database restore")
+
+			return
+		}
+	}
+
+	dumpFile, err := os.Open(dumpPath) //nolint:gosec // Path from validated backup dir.
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to open dump file: %v", err)
+
+		return
+	}
+	defer func() { _ = dumpFile.Close() }()
+
+	var stderrBuf bytes.Buffer
+
+	execErr := executor.Exec(ctx, podexec.ExecOptions{
+		Namespace:     svc.namespace,
+		PodName:       mariadbPod.Name,
+		ContainerName: mariadbContainer,
+		Command: []string{
+			clientCmd,
+			"-u" + creds.username,
+			"-p" + creds.password,
+			creds.database,
+		},
+		Stdin:  dumpFile,
+		Stderr: &stderrBuf,
+	})
+
+	if execErr != nil {
+		if containsSQLError(stderrBuf.String()) {
+			step.Completef(result.StepFailed, "SQL error during restore: %s", stderrBuf.String())
+
+			return
+		}
+
+		target.IO.Errorf("WARNING: restore completed with warnings: %s", stderrBuf.String())
+	}
+
+	step.Completef(result.StepCompleted, "Restored %d-line dump to database %s via %s",
+		dumpLines, creds.database, mariadbPod.Name)
+}
+
+func (t *runTask) resolveMariaDBPod(
+	ctx context.Context,
+	target action.Target,
+	svc serviceInfo,
+	meta *DataBackupMetadata,
+	secretData map[string][]byte,
+) (*corev1.Pod, error) {
+	if meta != nil && meta.MariaDBPod != "" {
+		pod, _ := findRunningPodByName(ctx, target, svc.namespace, meta.MariaDBPod)
+		if pod != nil {
+			return pod, nil
+		}
+	}
+
+	return findMariaDBPod(ctx, target, svc.namespace, svc.name, secretData)
+}
+
+func resolveTargetService(
+	ctx context.Context,
+	target action.Target,
+	serviceName string,
+	meta *DataBackupMetadata,
+	namespace string,
+) (*serviceInfo, error) {
+	services, err := discoverTrustyAIServices(ctx, target, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover TrustyAI services: %w", err)
+	}
+
+	if svc := matchServiceByMeta(services, meta, namespace); svc != nil {
+		return svc, nil
+	}
+
+	if svc := matchServiceByNamespace(services, namespace); svc != nil {
+		return svc, nil
+	}
+
+	if len(services) > 0 {
+		return &services[0], nil
+	}
+
+	return nil, errors.New("no TrustyAIService found for restore")
+}
+
+func matchServiceByMeta(services []serviceInfo, meta *DataBackupMetadata, namespace string) *serviceInfo {
+	if meta == nil || meta.TrustyAIService == "" {
+		return nil
+	}
+
+	for i := range services {
+		if services[i].name != meta.TrustyAIService {
+			continue
+		}
+
+		if namespace != "" && services[i].namespace != namespace {
+			continue
+		}
+
+		return &services[i]
+	}
+
+	return nil
+}
+
+func matchServiceByNamespace(services []serviceInfo, namespace string) *serviceInfo {
+	if namespace == "" {
+		return nil
+	}
+
+	for i := range services {
+		if services[i].namespace == namespace {
+			return &services[i]
+		}
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/trustyai/deadlock/deadlock.go
+++ b/pkg/migrate/actions/trustyai/deadlock/deadlock.go
@@ -1,0 +1,37 @@
+package deadlock
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+)
+
+const (
+	actionID          = "trustyai.break-gpu-deadlock"
+	actionName        = "Break GPU deployment deadlocks"
+	actionDescription = "Detect and fix GPU deployment deadlocks caused by TrustyAI patching InferenceServices"
+)
+
+type BreakGPUDeadlockAction struct{}
+
+func (a *BreakGPUDeadlockAction) ID() string          { return actionID }
+func (a *BreakGPUDeadlockAction) Name() string        { return actionName }
+func (a *BreakGPUDeadlockAction) Description() string { return actionDescription }
+
+func (a *BreakGPUDeadlockAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *BreakGPUDeadlockAction) Phase() action.ActionPhase {
+	return action.PhasePostUpgrade
+}
+
+func (a *BreakGPUDeadlockAction) CanApply(_ action.Target) bool {
+	return true
+}
+
+func (a *BreakGPUDeadlockAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *BreakGPUDeadlockAction) Run() action.Task {
+	return &runTask{action: a}
+}

--- a/pkg/migrate/actions/trustyai/deadlock/run_task.go
+++ b/pkg/migrate/actions/trustyai/deadlock/run_task.go
@@ -1,0 +1,189 @@
+package deadlock
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+const (
+	predictorLabel = "component=predictor"
+	isvcLabel      = "serving.kserve.io/inferenceservice"
+)
+
+type deadlockInfo struct {
+	namespace        string
+	inferenceService string
+	runningPod       string
+	pendingPod       string
+}
+
+type runTask struct {
+	action *BreakGPUDeadlockAction
+}
+
+func (t *runTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("detect-deadlocks", "Detect GPU deployment deadlocks")
+
+	deadlocks, err := detectDeadlocks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to detect deadlocks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(deadlocks) == 0 {
+		step.Completef(result.StepCompleted, "No GPU deadlocks detected")
+	} else {
+		step.Completef(result.StepCompleted, "Found %d GPU deadlock(s) across cluster", len(deadlocks))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("break-gpu-deadlocks", "Break GPU deployment deadlocks")
+
+	deadlocks, err := detectDeadlocks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to detect deadlocks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(deadlocks) == 0 {
+		step.Completef(result.StepSkipped, "No GPU deadlocks detected")
+
+		return action.BuildResult(target)
+	}
+
+	step.Recordf("detect", "Found %d GPU deadlock(s)", result.StepCompleted, len(deadlocks))
+
+	for _, dl := range deadlocks {
+		step.AddDetail(fmt.Sprintf("%s/%s", dl.namespace, dl.inferenceService), map[string]string{
+			"runningPod": dl.runningPod,
+			"pendingPod": dl.pendingPod,
+		})
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would delete %d Running pod(s) to resolve deadlocks", len(deadlocks))
+
+		return action.BuildResult(target)
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to delete %d Running pod(s) to resolve GPU deadlocks", len(deadlocks))
+
+		if !confirmation.Prompt(target.IO, "Proceed with pod deletion?") {
+			step.Completef(result.StepSkipped, "User cancelled deadlock resolution")
+
+			return action.BuildResult(target)
+		}
+	}
+
+	fixedCount := 0
+
+	for _, dl := range deadlocks {
+		fixStep := step.Child(
+			fmt.Sprintf("fix-%s-%s", dl.namespace, dl.inferenceService),
+			fmt.Sprintf("Delete Running pod for %s/%s", dl.namespace, dl.inferenceService),
+		)
+
+		err := target.Client.CoreV1().Pods(dl.namespace).Delete(ctx, dl.runningPod, metav1.DeleteOptions{})
+		if err != nil {
+			fixStep.Completef(result.StepFailed, "Failed to delete pod %s: %v", dl.runningPod, err)
+
+			continue
+		}
+
+		fixStep.Completef(result.StepCompleted, "Deleted pod %s for InferenceService %s", dl.runningPod, dl.inferenceService)
+
+		fixedCount++
+	}
+
+	step.Completef(result.StepCompleted, "Resolved %d/%d GPU deadlock(s)", fixedCount, len(deadlocks))
+
+	return action.BuildResult(target)
+}
+
+func detectDeadlocks(ctx context.Context, target action.Target) ([]deadlockInfo, error) {
+	pods, err := target.Client.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		LabelSelector: predictorLabel,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing predictor pods: %w", err)
+	}
+
+	type isvcPods struct {
+		namespace string
+		running   string
+		pending   string
+	}
+
+	type isvcKey struct {
+		namespace string
+		name      string
+	}
+
+	byISVC := make(map[isvcKey]*isvcPods)
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		isvcName := pod.Labels[isvcLabel]
+		if isvcName == "" {
+			continue
+		}
+
+		key := isvcKey{namespace: pod.Namespace, name: isvcName}
+
+		entry, ok := byISVC[key]
+		if !ok {
+			entry = &isvcPods{namespace: pod.Namespace}
+			byISVC[key] = entry
+		}
+
+		switch pod.Status.Phase { //nolint:exhaustive // only Running and Pending are relevant
+		case corev1.PodRunning:
+			if entry.running == "" {
+				entry.running = pod.Name
+			}
+		case corev1.PodPending:
+			if entry.pending == "" {
+				entry.pending = pod.Name
+			}
+		}
+	}
+
+	var deadlocks []deadlockInfo
+
+	for key, pods := range byISVC {
+		if pods.running != "" && pods.pending != "" {
+			deadlocks = append(deadlocks, deadlockInfo{
+				namespace:        key.namespace,
+				inferenceService: key.name,
+				runningPod:       pods.running,
+				pendingPod:       pods.pending,
+			})
+		}
+	}
+
+	sort.Slice(deadlocks, func(i, j int) bool {
+		if deadlocks[i].namespace != deadlocks[j].namespace {
+			return deadlocks[i].namespace < deadlocks[j].namespace
+		}
+
+		return deadlocks[i].inferenceService < deadlocks[j].inferenceService
+	})
+
+	return deadlocks, nil
+}

--- a/pkg/migrate/actions/trustyai/deadlock/run_task_test.go
+++ b/pkg/migrate/actions/trustyai/deadlock/run_task_test.go
@@ -1,0 +1,292 @@
+//nolint:testpackage // Tests internal implementation
+package deadlock
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newTestClient(objects ...runtime.Object) client.Client {
+	k8sClient := k8sfake.NewSimpleClientset(objects...) //nolint:staticcheck // NewClientset requires generated apply configs
+
+	return client.NewForTesting(client.TestClientConfig{
+		Kubernetes: k8sClient,
+	})
+}
+
+func newPredictorPod(name, namespace, isvc string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"component":                          "predictor",
+				"serving.kserve.io/inferenceservice": isvc,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func TestBreakGPUDeadlockAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &BreakGPUDeadlockAction{}
+
+	g.Expect(a.ID()).To(Equal("trustyai.break-gpu-deadlock"))
+	g.Expect(a.Name()).To(Equal("Break GPU deployment deadlocks"))
+	g.Expect(a.Description()).To(ContainSubstring("GPU"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
+	g.Expect(a.Prepare()).To(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestBreakGPUDeadlockAction_CanApply(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &BreakGPUDeadlockAction{}
+	g.Expect(a.CanApply(action.Target{})).To(BeTrue())
+}
+
+func TestRunTask_Validate_NoPods(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient())
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_WithDeadlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(
+		newPredictorPod("model-a-running", "ns1", "model-a", corev1.PodRunning),
+		newPredictorPod("model-a-pending", "ns1", "model-a", corev1.PodPending),
+	))
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoDeadlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(
+		newPredictorPod("model-a-running", "ns1", "model-a", corev1.PodRunning),
+	))
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_FixesDeadlocks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := k8sfake.NewSimpleClientset( //nolint:staticcheck // NewClientset requires generated apply configs
+		newPredictorPod("model-a-running", "ns1", "model-a", corev1.PodRunning),
+		newPredictorPod("model-a-pending", "ns1", "model-a", corev1.PodPending),
+	)
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Kubernetes: k8sClient,
+	})
+	target := newTarget(testClient)
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	pods, err := k8sClient.CoreV1().Pods("ns1").List(ctx, metav1.ListOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(pods.Items).To(HaveLen(1))
+	g.Expect(pods.Items[0].Name).To(Equal("model-a-pending"))
+}
+
+func TestRunTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := k8sfake.NewSimpleClientset( //nolint:staticcheck // NewClientset requires generated apply configs
+		newPredictorPod("model-a-running", "ns1", "model-a", corev1.PodRunning),
+		newPredictorPod("model-a-pending", "ns1", "model-a", corev1.PodPending),
+	)
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Kubernetes: k8sClient,
+	})
+	target := newTarget(testClient, withDryRun)
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	pods, err := k8sClient.CoreV1().Pods("ns1").List(ctx, metav1.ListOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(pods.Items).To(HaveLen(2))
+}
+
+func TestRunTask_Execute_MultiNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := k8sfake.NewSimpleClientset( //nolint:staticcheck // NewClientset requires generated apply configs
+		newPredictorPod("model-a-running", "ns1", "model-a", corev1.PodRunning),
+		newPredictorPod("model-a-pending", "ns1", "model-a", corev1.PodPending),
+		newPredictorPod("model-b-running", "ns2", "model-b", corev1.PodRunning),
+		newPredictorPod("model-b-pending", "ns2", "model-b", corev1.PodPending),
+		newPredictorPod("model-c-running", "ns2", "model-c", corev1.PodRunning),
+	)
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Kubernetes: k8sClient,
+	})
+	target := newTarget(testClient)
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	ns1Pods, _ := k8sClient.CoreV1().Pods("ns1").List(ctx, metav1.ListOptions{})
+	g.Expect(ns1Pods.Items).To(HaveLen(1))
+	g.Expect(ns1Pods.Items[0].Name).To(Equal("model-a-pending"))
+
+	ns2Pods, _ := k8sClient.CoreV1().Pods("ns2").List(ctx, metav1.ListOptions{})
+	g.Expect(ns2Pods.Items).To(HaveLen(2))
+}
+
+func TestRunTask_Execute_PodWithoutISVCLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	podNoLabel := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphan-pod",
+			Namespace: "ns1",
+			Labels: map[string]string{
+				"component": "predictor",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	target := newTarget(newTestClient(podNoLabel))
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_OnlyPending(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newTestClient(
+		newPredictorPod("model-a-pending", "ns1", "model-a", corev1.PodPending),
+	))
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client: newTestClient(
+			newPredictorPod("model-a-running", "ns1", "model-a", corev1.PodRunning),
+			newPredictorPod("model-a-pending", "ns1", "model-a", corev1.PodPending),
+		),
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    false,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	a := &BreakGPUDeadlockAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.HasSkippedSteps()).To(BeTrue())
+}

--- a/pkg/migrate/actions/trustyai/guardrails/guardrails.go
+++ b/pkg/migrate/actions/trustyai/guardrails/guardrails.go
@@ -1,0 +1,49 @@
+package guardrails
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+)
+
+const (
+	actionID          = "trustyai.patch-guardrails"
+	actionName        = "Patch GuardrailsOrchestrator readinessProbe"
+	actionDescription = "Add readinessProbe to GuardrailsOrchestrator deployments for RHOAI 2.5 to 3.3 upgrades"
+)
+
+type PatchGuardrailsAction struct {
+	GorchName string
+}
+
+func (a *PatchGuardrailsAction) ID() string          { return actionID }
+func (a *PatchGuardrailsAction) Name() string        { return actionName }
+func (a *PatchGuardrailsAction) Description() string { return actionDescription }
+
+func (a *PatchGuardrailsAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *PatchGuardrailsAction) Phase() action.ActionPhase {
+	return action.PhasePostUpgrade
+}
+
+func (a *PatchGuardrailsAction) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&a.GorchName, "gorch-name", "", "Filter to a specific GuardrailsOrchestrator CR name (optional; default: check all)")
+}
+
+func (a *PatchGuardrailsAction) CanApply(target action.Target) bool {
+	if target.CurrentVersion == nil || target.TargetVersion == nil {
+		return false
+	}
+
+	return target.CurrentVersion.Major == 2 && target.TargetVersion.Major >= 3
+}
+
+func (a *PatchGuardrailsAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *PatchGuardrailsAction) Run() action.Task {
+	return &runTask{action: a}
+}

--- a/pkg/migrate/actions/trustyai/guardrails/run_task.go
+++ b/pkg/migrate/actions/trustyai/guardrails/run_task.go
@@ -1,0 +1,314 @@
+package guardrails
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+const (
+	expectedProbePath        = "/health"
+	expectedProbePort        = int64(8034)
+	probeInitialDelaySeconds = 10
+	probeTimeoutSeconds      = 10
+	probePeriodSeconds       = 20
+	probeSuccessThreshold    = 1
+	probeFailureThreshold    = 3
+)
+
+type probeStatus string
+
+const (
+	probeOK         probeStatus = "OK"
+	probeNeedsPatch probeStatus = "NEEDS_PATCH"
+)
+
+type runTask struct {
+	action *PatchGuardrailsAction
+}
+
+func (t *runTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("check-guardrails-probe", "Check GuardrailsOrchestrator readinessProbe")
+
+	gorchs, err := t.discoverGorchs(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list GuardrailsOrchestrators: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(gorchs) == 0 {
+		step.Completef(result.StepSkipped, "No GuardrailsOrchestrator CRs found")
+
+		return action.BuildResult(target)
+	}
+
+	needsPatch := 0
+
+	for _, gorch := range gorchs {
+		name := gorch.GetName()
+		ns := gorch.GetNamespace()
+
+		deployment, err := target.Client.GetResource(ctx, resources.Deployment, name, client.InNamespace(ns))
+		if err != nil {
+			continue
+		}
+
+		status := checkProbe(deployment, name)
+		if status == probeNeedsPatch {
+			needsPatch++
+		}
+	}
+
+	if needsPatch == 0 {
+		step.Completef(result.StepCompleted, "All %d GuardrailsOrchestrator deployment(s) have correct readinessProbe", len(gorchs))
+	} else {
+		step.Completef(result.StepCompleted, "Found %d/%d deployment(s) needing readinessProbe patch", needsPatch, len(gorchs))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("patch-guardrails-probe", "Patch GuardrailsOrchestrator readinessProbe")
+
+	gorchs, err := t.discoverGorchs(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list GuardrailsOrchestrators: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(gorchs) == 0 {
+		step.Completef(result.StepSkipped, "No GuardrailsOrchestrator CRs found")
+
+		return action.BuildResult(target)
+	}
+
+	step.Recordf("discover", "Found %d GuardrailsOrchestrator CR(s)", result.StepCompleted, len(gorchs))
+
+	type patchCandidate struct {
+		name      string
+		namespace string
+		patch     []byte
+	}
+
+	var candidates []patchCandidate
+
+	for _, gorch := range gorchs {
+		name := gorch.GetName()
+		ns := gorch.GetNamespace()
+
+		deployStep := step.Child(
+			fmt.Sprintf("check-%s-%s", ns, name),
+			fmt.Sprintf("Check %s/%s", ns, name),
+		)
+
+		deployment, err := target.Client.GetResource(ctx, resources.Deployment, name, client.InNamespace(ns))
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				deployStep.Completef(result.StepSkipped, "Deployment %s/%s not found", ns, name)
+
+				continue
+			}
+
+			deployStep.Completef(result.StepFailed, "Failed to get deployment %s/%s: %v", ns, name, err)
+
+			return action.BuildResult(target)
+		}
+
+		status := checkProbe(deployment, name)
+		if status == probeOK {
+			deployStep.Completef(result.StepSkipped, "%s/%s: readinessProbe already configured", ns, name)
+
+			continue
+		}
+
+		patchBytes, err := buildReadinessProbePatch(name)
+		if err != nil {
+			deployStep.Completef(result.StepFailed, "Failed to build patch for %s/%s: %v", ns, name, err)
+
+			continue
+		}
+
+		deployStep.Completef(result.StepCompleted, "%s/%s needs readinessProbe patch", ns, name)
+
+		candidates = append(candidates, patchCandidate{name: name, namespace: ns, patch: patchBytes})
+	}
+
+	if len(candidates) == 0 {
+		step.Completef(result.StepCompleted, "No deployments need readinessProbe patching")
+
+		return action.BuildResult(target)
+	}
+
+	if target.DryRun {
+		for _, cand := range candidates {
+			target.IO.Fprintln()
+			target.IO.Fprintf("DRY RUN: Would apply readinessProbe patch to %s/%s:", cand.namespace, cand.name)
+			target.IO.Fprintln()
+			target.IO.Fprintf("%s", string(cand.patch))
+			target.IO.Fprintln()
+		}
+
+		step.Completef(result.StepSkipped, "Would patch %d deployment(s)", len(candidates))
+
+		return action.BuildResult(target)
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to patch readinessProbe on %d deployment(s)", len(candidates))
+
+		if !confirmation.Prompt(target.IO, "Proceed with patching?") {
+			step.Completef(result.StepSkipped, "User cancelled readinessProbe patching")
+
+			return action.BuildResult(target)
+		}
+	}
+
+	gvr := resources.Deployment.GVR()
+	patchedCount := 0
+
+	for _, cand := range candidates {
+		patchStep := step.Child(
+			fmt.Sprintf("patch-%s-%s", cand.namespace, cand.name),
+			fmt.Sprintf("Patch %s/%s", cand.namespace, cand.name),
+		)
+
+		_, err := target.Client.Dynamic().Resource(gvr).Namespace(cand.namespace).Patch(
+			ctx,
+			cand.name,
+			types.StrategicMergePatchType,
+			cand.patch,
+			metav1.PatchOptions{},
+		)
+		if err != nil {
+			patchStep.Completef(result.StepFailed, "Failed to patch %s/%s: %v", cand.namespace, cand.name, err)
+
+			continue
+		}
+
+		patchStep.Completef(result.StepCompleted, "Patched %s/%s", cand.namespace, cand.name)
+
+		patchedCount++
+	}
+
+	step.Completef(result.StepCompleted, "Patched %d/%d deployment(s)", patchedCount, len(candidates))
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) discoverGorchs(ctx context.Context, target action.Target) ([]*unstructured.Unstructured, error) {
+	gorchs, err := target.Client.List(ctx, resources.GuardrailsOrchestrator)
+	if err != nil {
+		return nil, fmt.Errorf("listing GuardrailsOrchestrators: %w", err)
+	}
+
+	if t.action.GorchName == "" {
+		return gorchs, nil
+	}
+
+	var filtered []*unstructured.Unstructured
+
+	for _, gorch := range gorchs {
+		if gorch.GetName() == t.action.GorchName {
+			filtered = append(filtered, gorch)
+		}
+	}
+
+	return filtered, nil
+}
+
+func checkProbe(deployment *unstructured.Unstructured, containerName string) probeStatus {
+	containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		return probeNeedsPatch
+	}
+
+	for _, c := range containers {
+		container, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _, _ := unstructured.NestedString(container, "name")
+		if name != containerName {
+			continue
+		}
+
+		path, _, _ := unstructured.NestedString(container, "readinessProbe", "httpGet", "path")
+		port, _, _ := unstructured.NestedFieldNoCopy(container, "readinessProbe", "httpGet", "port")
+
+		portInt := toInt64(port)
+
+		if path == expectedProbePath && portInt == expectedProbePort {
+			return probeOK
+		}
+
+		return probeNeedsPatch
+	}
+
+	return probeNeedsPatch
+}
+
+func toInt64(v any) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case int32:
+		return int64(n)
+	case int:
+		return int64(n)
+	case float64:
+		return int64(n)
+	default:
+		return 0
+	}
+}
+
+func buildReadinessProbePatch(containerName string) ([]byte, error) {
+	patch := map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []map[string]any{
+						{
+							"name": containerName,
+							"readinessProbe": map[string]any{
+								"httpGet": map[string]any{
+									"path":   expectedProbePath,
+									"port":   expectedProbePort,
+									"scheme": "HTTP",
+								},
+								"initialDelaySeconds": probeInitialDelaySeconds,
+								"timeoutSeconds":      probeTimeoutSeconds,
+								"periodSeconds":       probePeriodSeconds,
+								"successThreshold":    probeSuccessThreshold,
+								"failureThreshold":    probeFailureThreshold,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(patch, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	return data, nil
+}

--- a/pkg/migrate/actions/trustyai/guardrails/run_task_test.go
+++ b/pkg/migrate/actions/trustyai/guardrails/run_task_test.go
@@ -1,0 +1,448 @@
+//nolint:testpackage // Tests internal implementation
+package guardrails
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+func newFakeClient(scheme *runtime.Scheme, objects ...runtime.Object) client.Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.GuardrailsOrchestrator.GVR(): resources.GuardrailsOrchestrator.ListKind(),
+		resources.Deployment.GVR():             resources.Deployment.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newGORCH(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.GuardrailsOrchestrator.APIVersion(),
+			"kind":       resources.GuardrailsOrchestrator.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newDeployment(name, namespace string, hasProbe bool) *unstructured.Unstructured {
+	container := map[string]any{
+		"name":  name,
+		"image": "guardrails:latest",
+	}
+
+	if hasProbe {
+		container["readinessProbe"] = map[string]any{
+			"httpGet": map[string]any{
+				"path": "/health",
+				"port": int64(8034),
+			},
+		}
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Deployment.APIVersion(),
+			"kind":       resources.Deployment.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{container},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func TestPatchGuardrailsAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &PatchGuardrailsAction{}
+
+	g.Expect(a.ID()).To(Equal("trustyai.patch-guardrails"))
+	g.Expect(a.Name()).To(ContainSubstring("Patch"))
+	g.Expect(a.Description()).To(ContainSubstring("readinessProbe"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
+	g.Expect(a.Prepare()).To(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestPatchGuardrailsAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &PatchGuardrailsAction{}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	flag := fs.Lookup("gorch-name")
+	g.Expect(flag).ToNot(BeNil())
+	g.Expect(flag.DefValue).To(Equal(""))
+}
+
+func TestPatchGuardrailsAction_CanApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		target   string
+		expected bool
+	}{
+		{"2.25 to 3.0", "2.25.0", "3.0.0", true},
+		{"3.0 to 3.1", "3.0.0", "3.1.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			a := &PatchGuardrailsAction{}
+			cv := semver.MustParse(tt.current)
+			tv := semver.MustParse(tt.target)
+			g.Expect(a.CanApply(action.Target{CurrentVersion: &cv, TargetVersion: &tv})).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestPatchGuardrailsAction_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &PatchGuardrailsAction{}
+	g.Expect(a.CanApply(action.Target{})).To(BeFalse())
+}
+
+func TestRunTask_Validate_NoGORCHs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_ProbeOK(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	deploy := newDeployment("my-gorch", "ns1", true)
+
+	target := newTarget(newFakeClient(newScheme(), gorch, deploy))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_NeedsPatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	deploy := newDeployment("my-gorch", "ns1", false)
+
+	target := newTarget(newFakeClient(newScheme(), gorch, deploy))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_DeploymentNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	target := newTarget(newFakeClient(newScheme(), gorch))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DeploymentNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	target := newTarget(newFakeClient(newScheme(), gorch))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	deploy := newDeployment("my-gorch", "ns1", false)
+
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+	k8sClient := newFakeClient(newScheme(), gorch, deploy)
+	target := newTarget(k8sClient, func(t *action.Target) {
+		t.SkipConfirm = false
+		t.IO = io
+		t.Recorder = action.NewVerboseRootRecorder(io)
+	})
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoGORCHs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_PatchesMissingProbe(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	deploy := newDeployment("my-gorch", "ns1", false)
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch, deploy)
+	target := newTarget(k8sClient)
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.Deployment.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-gorch", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	containers, _, _ := unstructured.NestedSlice(updated.Object, "spec", "template", "spec", "containers")
+	g.Expect(containers).ToNot(BeEmpty())
+}
+
+func TestRunTask_Execute_SkipsExistingProbe(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	deploy := newDeployment("my-gorch", "ns1", true)
+
+	target := newTarget(newFakeClient(newScheme(), gorch, deploy))
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1")
+	deploy := newDeployment("my-gorch", "ns1", false)
+
+	target := newTarget(newFakeClient(newScheme(), gorch, deploy), withDryRun)
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_GorchNameFilter(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch1 := newGORCH("gorch-1", "ns1")
+	gorch2 := newGORCH("gorch-2", "ns1")
+	deploy1 := newDeployment("gorch-1", "ns1", false)
+	deploy2 := newDeployment("gorch-2", "ns1", false)
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch1, gorch2, deploy1, deploy2)
+	target := newTarget(k8sClient)
+
+	a := &PatchGuardrailsAction{GorchName: "gorch-1"}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_MultiNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch1 := newGORCH("gorch-1", "ns1")
+	gorch2 := newGORCH("gorch-2", "ns2")
+	deploy1 := newDeployment("gorch-1", "ns1", false)
+	deploy2 := newDeployment("gorch-2", "ns2", false)
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch1, gorch2, deploy1, deploy2)
+	target := newTarget(k8sClient)
+
+	a := &PatchGuardrailsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestCheckProbe(t *testing.T) {
+	tests := []struct {
+		name     string
+		hasProbe bool
+		expected probeStatus
+	}{
+		{"with probe", true, probeOK},
+		{"without probe", false, probeNeedsPatch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			deploy := newDeployment("test", "ns1", tt.hasProbe)
+			g.Expect(checkProbe(deploy, "test")).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestCheckProbe_NoContainers(t *testing.T) {
+	g := NewWithT(t)
+
+	deploy := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Deployment.APIVersion(),
+			"kind":       resources.Deployment.Kind,
+			"metadata":   map[string]any{"name": "test", "namespace": "ns1"},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{},
+				},
+			},
+		},
+	}
+
+	g.Expect(checkProbe(deploy, "test")).To(Equal(probeNeedsPatch))
+}
+
+func TestCheckProbe_WrongContainerName(t *testing.T) {
+	g := NewWithT(t)
+
+	deploy := newDeployment("other-container", "ns1", true)
+	g.Expect(checkProbe(deploy, "nonexistent")).To(Equal(probeNeedsPatch))
+}
+
+func TestToInt64(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(toInt64(int64(42))).To(Equal(int64(42)))
+	g.Expect(toInt64(float64(42))).To(Equal(int64(42)))
+	g.Expect(toInt64("not a number")).To(Equal(int64(0)))
+	g.Expect(toInt64(nil)).To(Equal(int64(0)))
+}
+
+func TestBuildReadinessProbePatch(t *testing.T) {
+	g := NewWithT(t)
+
+	patch, err := buildReadinessProbePatch("my-container")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(patch)).To(ContainSubstring("my-container"))
+	g.Expect(string(patch)).To(ContainSubstring("/health"))
+	g.Expect(string(patch)).To(ContainSubstring("8034"))
+}

--- a/pkg/migrate/actions/trustyai/metrics/http.go
+++ b/pkg/migrate/actions/trustyai/metrics/http.go
@@ -1,0 +1,207 @@
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/rest"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	defaultRouteLabel  = "trustyai-service-name=trustyai-service"
+	fallbackRouteLabel = "app=trustyai-service"
+	defaultRouteName   = "trustyai-service"
+	maxResponseSize    = 10 << 20 // 10 MiB
+)
+
+//nolint:gochecknoglobals // Static endpoint mapping; Go has no const maps.
+var metricEndpoints = map[string]string{
+	"spd":          "/metrics/group/fairness/spd/request",
+	"dir":          "/metrics/group/fairness/dir/request",
+	"meanshift":    "/metrics/drift/meanshift/request",
+	"kstest":       "/metrics/drift/kstest/request",
+	"approxkstest": "/metrics/drift/approxkstest/request",
+	"fouriermmd":   "/metrics/drift/fouriermmd/request",
+}
+
+type httpHelper struct {
+	client      *http.Client
+	bearerToken string
+}
+
+func newHTTPHelper(restConfig *rest.Config) (*httpHelper, error) {
+	token := ""
+
+	if restConfig != nil {
+		token = restConfig.BearerToken
+		if token == "" && restConfig.BearerTokenFile != "" {
+			tokenBytes, err := os.ReadFile(restConfig.BearerTokenFile)
+			if err != nil {
+				return nil, fmt.Errorf("reading bearer token file: %w", err)
+			}
+
+			token = strings.TrimSpace(string(tokenBytes))
+		}
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				//nolint:gosec // In-cluster routes use self-signed certs; matches original curl -sk behavior.
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	return &httpHelper{client: httpClient, bearerToken: token}, nil
+}
+
+func (h *httpHelper) get(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating GET request: %w", err)
+	}
+
+	if h.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+h.bearerToken)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing GET request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func (h *httpHelper) post(ctx context.Context, url string, payload []byte) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return 0, fmt.Errorf("creating POST request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if h.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+h.bearerToken)
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("executing POST request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return resp.StatusCode, nil
+}
+
+func discoverRouteInNamespace(ctx context.Context, k8sClient client.Client, namespace, routeLabel string) (string, error) {
+	host, err := findRouteByLabel(ctx, k8sClient, namespace, routeLabel)
+	if err != nil {
+		return "", err
+	}
+
+	if host != "" {
+		return host, nil
+	}
+
+	if routeLabel != fallbackRouteLabel {
+		host, err = findRouteByLabel(ctx, k8sClient, namespace, fallbackRouteLabel)
+		if err != nil {
+			return "", err
+		}
+
+		if host != "" {
+			return host, nil
+		}
+	}
+
+	host, err = findRouteByName(ctx, k8sClient, namespace, defaultRouteName)
+	if err != nil {
+		return "", err
+	}
+
+	return host, nil
+}
+
+func findRouteByLabel(ctx context.Context, k8sClient client.Client, namespace, label string) (string, error) {
+	routes, err := k8sClient.List(ctx, resources.Route,
+		client.WithNamespace(namespace),
+		client.WithLabelSelector(label),
+		client.WithLimit(1),
+	)
+	if err != nil {
+		return "", fmt.Errorf("listing routes with label %q: %w", label, err)
+	}
+
+	if len(routes) == 0 {
+		return "", nil
+	}
+
+	return extractRouteHost(routes[0])
+}
+
+func findRouteByName(ctx context.Context, k8sClient client.Client, namespace, name string) (string, error) {
+	route, err := k8sClient.GetResource(ctx, resources.Route, name, client.InNamespace(namespace))
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("getting route %q: %w", name, err)
+	}
+
+	if route == nil {
+		return "", nil
+	}
+
+	return extractRouteHost(route)
+}
+
+func extractRouteHost(route *unstructured.Unstructured) (string, error) {
+	host, found, err := unstructured.NestedString(route.Object, "spec", "host")
+	if err != nil || !found || host == "" {
+		return "", nil
+	}
+
+	return host, nil
+}
+
+type backupResponse struct {
+	Requests []json.RawMessage `json:"requests"`
+}
+
+type restoreEntry struct {
+	ID      string          `json:"id"`
+	Request restoreRequest  `json:"request"`
+	Raw     json.RawMessage `json:"-"`
+}
+
+type restoreRequest struct {
+	MetricName string `json:"metricName"`
+	ModelID    string `json:"modelId"`
+}

--- a/pkg/migrate/actions/trustyai/metrics/metrics.go
+++ b/pkg/migrate/actions/trustyai/metrics/metrics.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+)
+
+const (
+	actionID          = "trustyai.metrics"
+	actionName        = "Backup and restore TrustyAI scheduled metrics"
+	actionDescription = "Backup scheduled metrics via REST API before upgrade, restore after upgrade"
+)
+
+type MetricsAction struct {
+	BackupDir    string
+	BackupFile   string
+	MetricType   string
+	SkipExisting bool
+	RouteLabel   string
+}
+
+func (a *MetricsAction) ID() string          { return actionID }
+func (a *MetricsAction) Name() string        { return actionName }
+func (a *MetricsAction) Description() string { return actionDescription }
+
+func (a *MetricsAction) Group() action.ActionGroup {
+	return action.GroupBackup
+}
+
+func (a *MetricsAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *MetricsAction) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&a.BackupDir, "metrics-dir", "/tmp/rhoai-upgrade-backup/trustyai",
+		"Directory to write metrics backup files")
+	fs.StringVar(&a.BackupFile, "metrics-file", "",
+		"Backup file to restore from (used with migrate run)")
+	fs.StringVar(&a.MetricType, "metrics-type", "all",
+		"Metric type filter: all or fairness")
+	fs.BoolVar(&a.SkipExisting, "metrics-skip-existing", false,
+		"Skip metrics that already exist during restore")
+	fs.StringVar(&a.RouteLabel, "metrics-route-label", "trustyai-service-name=trustyai-service",
+		"Route label selector for TrustyAI service")
+}
+
+func (a *MetricsAction) CanApply(_ action.Target) bool {
+	return true
+}
+
+func (a *MetricsAction) Prepare() action.Task {
+	return &prepareTask{action: a}
+}
+
+func (a *MetricsAction) Run() action.Task {
+	return &runTask{action: a}
+}

--- a/pkg/migrate/actions/trustyai/metrics/metrics_test.go
+++ b/pkg/migrate/actions/trustyai/metrics/metrics_test.go
@@ -1,0 +1,1298 @@
+//nolint:testpackage // Tests internal implementation
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+func newFakeClient(scheme *runtime.Scheme, objects ...runtime.Object) client.Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.Route.GVR():           resources.Route.ListKind(),
+		resources.TrustyAIService.GVR(): resources.TrustyAIService.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func newRoute(name, namespace, host string, labels map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Route.APIVersion(),
+			"kind":       resources.Route.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"host": host,
+			},
+		},
+	}
+
+	if labels != nil {
+		obj.SetLabels(labels)
+	}
+
+	return obj
+}
+
+func newTrustyAIService(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.TrustyAIService.APIVersion(),
+			"kind":       resources.TrustyAIService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+type actionRecorder struct {
+	action.StepRecorder
+
+	action action.Action
+}
+
+func (r *actionRecorder) Action() action.Action { return r.action }
+
+func (r *actionRecorder) Build() *result.ActionResult {
+	if root, ok := r.StepRecorder.(action.RootRecorder); ok {
+		return root.Build()
+	}
+
+	return nil
+}
+
+func metricsJSON(t *testing.T, requests ...map[string]any) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(map[string]any{"requests": requests})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return data
+}
+
+func newMetricEntry(metricName, modelID string) map[string]any {
+	return map[string]any{
+		"id": metricName + "-" + modelID,
+		"request": map[string]any{
+			"metricName": metricName,
+			"modelId":    modelID,
+		},
+	}
+}
+
+func serverHost(server *httptest.Server) string {
+	return strings.TrimPrefix(server.URL, "https://")
+}
+
+// ---------------------------------------------------------------------------
+// MetricsAction metadata
+// ---------------------------------------------------------------------------
+
+func TestMetricsAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &MetricsAction{}
+
+	g.Expect(a.ID()).To(Equal("trustyai.metrics"))
+	g.Expect(a.Name()).To(Equal("Backup and restore TrustyAI scheduled metrics"))
+	g.Expect(a.Description()).To(ContainSubstring("metrics"))
+	g.Expect(a.Group()).To(Equal(action.GroupBackup))
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.CanApply(action.Target{})).To(BeTrue())
+	g.Expect(a.Prepare()).ToNot(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestMetricsAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &MetricsAction{}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	g.Expect(fs.Lookup("metrics-dir")).ToNot(BeNil())
+	g.Expect(fs.Lookup("metrics-file")).ToNot(BeNil())
+	g.Expect(fs.Lookup("metrics-type")).ToNot(BeNil())
+	g.Expect(fs.Lookup("metrics-skip-existing")).ToNot(BeNil())
+	g.Expect(fs.Lookup("metrics-route-label")).ToNot(BeNil())
+}
+
+// ---------------------------------------------------------------------------
+// extractRouteHost
+// ---------------------------------------------------------------------------
+
+func TestExtractRouteHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    *unstructured.Unstructured
+		expected string
+	}{
+		{
+			"valid host",
+			newRoute("r1", "ns1", "trustyai.example.com", nil),
+			"trustyai.example.com",
+		},
+		{
+			"empty host",
+			newRoute("r1", "ns1", "", nil),
+			"",
+		},
+		{
+			"no spec",
+			&unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "route.openshift.io/v1",
+				"kind":       "Route",
+				"metadata":   map[string]any{"name": "r1", "namespace": "ns1"},
+			}},
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			host, err := extractRouteHost(tt.route)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(host).To(Equal(tt.expected))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findRouteByLabel / findRouteByName
+// ---------------------------------------------------------------------------
+
+func TestFindRouteByLabel_Found(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "trustyai.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	k8sClient := newFakeClient(newScheme(), route)
+
+	host, err := findRouteByLabel(ctx, k8sClient, "ns1", "trustyai-service-name=trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal("trustyai.example.com"))
+}
+
+func TestFindRouteByLabel_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+
+	host, err := findRouteByLabel(ctx, k8sClient, "ns1", "nonexistent=label")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal(""))
+}
+
+func TestFindRouteByName_Found(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("trustyai-service", "ns1", "trustyai.example.com", nil)
+	k8sClient := newFakeClient(newScheme(), route)
+
+	host, err := findRouteByName(ctx, k8sClient, "ns1", "trustyai-service")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal("trustyai.example.com"))
+}
+
+func TestFindRouteByName_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+
+	host, err := findRouteByName(ctx, k8sClient, "ns1", "nonexistent")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal(""))
+}
+
+// ---------------------------------------------------------------------------
+// discoverRouteInNamespace
+// ---------------------------------------------------------------------------
+
+func TestDiscoverRouteInNamespace_ByPrimaryLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "primary.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	k8sClient := newFakeClient(newScheme(), route)
+
+	host, err := discoverRouteInNamespace(ctx, k8sClient, "ns1", defaultRouteLabel)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal("primary.example.com"))
+}
+
+func TestDiscoverRouteInNamespace_ByName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("trustyai-service", "ns1", "byname.example.com", nil)
+	k8sClient := newFakeClient(newScheme(), route)
+
+	host, err := discoverRouteInNamespace(ctx, k8sClient, "ns1", "nonexistent=label")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal("byname.example.com"))
+}
+
+func TestDiscoverRouteInNamespace_FallbackLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "fallback.example.com", map[string]string{
+		"app": "trustyai-service",
+	})
+
+	k8sClient := newFakeClient(newScheme(), route)
+
+	host, err := discoverRouteInNamespace(ctx, k8sClient, "ns1", "nonexistent=label")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal("fallback.example.com"))
+}
+
+func TestDiscoverRouteInNamespace_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+
+	host, err := discoverRouteInNamespace(ctx, k8sClient, "ns1", defaultRouteLabel)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(host).To(Equal(""))
+}
+
+// ---------------------------------------------------------------------------
+// discoverTrustyAINamespaces
+// ---------------------------------------------------------------------------
+
+func TestDiscoverTrustyAINamespaces_NoRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(BeEmpty())
+}
+
+func TestDiscoverTrustyAINamespaces_WithRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "tai.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(HaveLen(1))
+	g.Expect(ns["ns1"]).To(Equal("tai.example.com"))
+}
+
+func TestDiscoverTrustyAINamespaces_FallbackToTrustyAIService(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("trustyai", "ns1")
+	route := newRoute("trustyai-service", "ns1", "tai.example.com", nil)
+
+	target := newTarget(newFakeClient(newScheme(), svc, route))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(HaveLen(1))
+}
+
+func TestDiscoverTrustyAINamespaces_TrustyAIServiceNoRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	svc := newTrustyAIService("trustyai", "ns1")
+	target := newTarget(newFakeClient(newScheme(), svc))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(BeEmpty())
+}
+
+func TestDiscoverTrustyAINamespaces_MultipleRoutesInNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route1 := newRoute("route1", "ns1", "host1.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+	route2 := newRoute("route2", "ns1", "host2.example.com", nil)
+
+	target := newTarget(newFakeClient(newScheme(), route1, route2))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(HaveLen(1))
+	g.Expect(ns["ns1"]).To(Equal("host1.example.com"))
+}
+
+func TestDiscoverTrustyAINamespaces_CustomRouteLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "custom.example.com", map[string]string{
+		"custom-label": "custom-value",
+	})
+
+	metricsAction := &MetricsAction{RouteLabel: "custom-label=custom-value"}
+
+	target := newTarget(newFakeClient(newScheme(), route))
+	target.Recorder = &actionRecorder{
+		StepRecorder: target.Recorder,
+		action:       metricsAction,
+	}
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(HaveLen(1))
+	g.Expect(ns["ns1"]).To(Equal("custom.example.com"))
+}
+
+func TestDiscoverTrustyAINamespaces_TrustyAIFallbackWithRoute(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	unrelatedRoute := newRoute("other-route", "other-ns", "other.example.com", nil)
+	svc := newTrustyAIService("trustyai", "ns1")
+	serviceRoute := newRoute("trustyai-service", "ns1", "tai.example.com", nil)
+
+	target := newTarget(newFakeClient(newScheme(), unrelatedRoute, svc, serviceRoute))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(HaveKeyWithValue("ns1", "tai.example.com"))
+}
+
+func TestDiscoverTrustyAINamespaces_RouteNoHost(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "", nil)
+	target := newTarget(newFakeClient(newScheme(), route))
+
+	ns, err := discoverTrustyAINamespaces(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(BeEmpty())
+}
+
+// ---------------------------------------------------------------------------
+// newHTTPHelper
+// ---------------------------------------------------------------------------
+
+func TestNewHTTPHelper_NilConfig(t *testing.T) {
+	g := NewWithT(t)
+
+	h, err := newHTTPHelper(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(h.bearerToken).To(Equal(""))
+}
+
+func TestNewHTTPHelper_WithToken(t *testing.T) {
+	g := NewWithT(t)
+
+	cfg := &rest.Config{BearerToken: "my-token"}
+
+	h, err := newHTTPHelper(cfg)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(h.bearerToken).To(Equal("my-token"))
+}
+
+func TestNewHTTPHelper_WithTokenFile(t *testing.T) {
+	g := NewWithT(t)
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	_ = os.WriteFile(tokenFile, []byte("file-token\n"), 0o600)
+
+	cfg := &rest.Config{BearerTokenFile: tokenFile}
+
+	h, err := newHTTPHelper(cfg)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(h.bearerToken).To(Equal("file-token"))
+}
+
+func TestNewHTTPHelper_TokenFileMissing(t *testing.T) {
+	g := NewWithT(t)
+
+	cfg := &rest.Config{BearerTokenFile: "/nonexistent/token"}
+
+	_, err := newHTTPHelper(cfg)
+	g.Expect(err).To(HaveOccurred())
+}
+
+// ---------------------------------------------------------------------------
+// httpHelper.get / httpHelper.post
+// ---------------------------------------------------------------------------
+
+func TestHTTPHelper_Get(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Method).To(Equal(http.MethodGet))
+		g.Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-token"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"requests":[]}`))
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client(), bearerToken: "test-token"}
+	body, err := h.get(ctx, server.URL+"/metrics/all/requests")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(body)).To(ContainSubstring("requests"))
+}
+
+func TestHTTPHelper_Get_Error(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client(), bearerToken: ""}
+	_, err := h.get(ctx, server.URL+"/fail")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("HTTP 500"))
+}
+
+func TestHTTPHelper_Get_NoToken(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Header.Get("Authorization")).To(Equal(""))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client(), bearerToken: ""}
+	_, err := h.get(ctx, server.URL+"/test")
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestHTTPHelper_Post(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Method).To(Equal(http.MethodPost))
+		g.Expect(r.Header.Get("Content-Type")).To(Equal("application/json"))
+		g.Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-token"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client(), bearerToken: "test-token"}
+	status, err := h.post(ctx, server.URL+"/metrics/group/fairness/spd/request", []byte(`{"modelId":"m1"}`))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(status).To(Equal(http.StatusOK))
+}
+
+func TestHTTPHelper_Post_NoToken(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.Header.Get("Authorization")).To(Equal(""))
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client(), bearerToken: ""}
+	status, err := h.post(ctx, server.URL+"/test", []byte("{}"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(status).To(Equal(http.StatusCreated))
+}
+
+// ---------------------------------------------------------------------------
+// fetchExistingMetrics
+// ---------------------------------------------------------------------------
+
+func TestFetchExistingMetrics(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(metricsJSON(t,
+			newMetricEntry("SPD", "model-a"),
+			newMetricEntry("DIR", "model-b"),
+		))
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client()}
+	existing, err := fetchExistingMetrics(ctx, h, serverHost(server))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(existing).To(HaveKey("model-a:SPD"))
+	g.Expect(existing).To(HaveKey("model-b:DIR"))
+}
+
+func TestFetchExistingMetrics_Empty(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"requests":[]}`))
+	}))
+	defer server.Close()
+
+	h := &httpHelper{client: server.Client()}
+	existing, err := fetchExistingMetrics(ctx, h, serverHost(server))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(existing).To(BeEmpty())
+}
+
+// ---------------------------------------------------------------------------
+// prepareTask.Validate
+// ---------------------------------------------------------------------------
+
+func TestPrepareTask_Validate_NoRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Validate_WithRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "tai.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route))
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// prepareTask.Execute
+// ---------------------------------------------------------------------------
+
+func TestPrepareTask_Execute_NoRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(metricsJSON(t,
+			newMetricEntry("SPD", "model-a"),
+			newMetricEntry("DIR", "model-b"),
+		))
+	}))
+	defer server.Close()
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), withDryRun, func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_BackupToFile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(metricsJSON(t,
+			newMetricEntry("SPD", "model-a"),
+		))
+	}))
+	defer server.Close()
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	outputDir := t.TempDir()
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+		t.OutputDir = outputDir
+	})
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	metricsDir := filepath.Join(outputDir, "trustyai-metrics")
+	entries, _ := os.ReadDir(metricsDir)
+	g.Expect(entries).To(HaveLen(1))
+}
+
+func TestPrepareTask_Execute_FairnessFilter(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.URL.RawQuery).To(Equal("type=fairness"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(metricsJSON(t, newMetricEntry("SPD", "model-a")))
+	}))
+	defer server.Close()
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	outputDir := t.TempDir()
+	target := newTarget(newFakeClient(newScheme(), route), func(tgt *action.Target) {
+		tgt.RESTConfig = &rest.Config{BearerToken: "test"}
+		tgt.OutputDir = outputDir
+	})
+
+	a := &MetricsAction{MetricType: "fairness"}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_HTTPError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_NoRESTConfig(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	route := newRoute("tai-route", "ns1", "tai.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route))
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// runTask.Validate
+// ---------------------------------------------------------------------------
+
+func TestRunTask_Validate_NoBackupFile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_FileNotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{BackupFile: "/nonexistent/file.json"}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_NoRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_Ready(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	route := newRoute("tai-route", "ns1", "tai.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route))
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// runTask.Execute
+// ---------------------------------------------------------------------------
+
+func TestRunTask_Execute_NoBackupFile(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_EmptyBackup(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, []byte(`{"requests":[]}`), 0o600)
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_InvalidBackup(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, []byte(`{invalid json`), 0o600)
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoRoutes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), withDryRun, func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_RestoresMetrics(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	var postedEndpoints []string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			postedEndpoints = append(postedEndpoints, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t,
+		newMetricEntry("SPD", "model-a"),
+		newMetricEntry("DIR", "model-b"),
+	), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(postedEndpoints).To(ContainElement("/metrics/group/fairness/spd/request"))
+	g.Expect(postedEndpoints).To(ContainElement("/metrics/group/fairness/dir/request"))
+}
+
+func TestRunTask_Execute_SkipExisting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	var postCount int
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(metricsJSON(t, newMetricEntry("SPD", "model-a")))
+
+			return
+		}
+		if r.Method == http.MethodPost {
+			postCount++
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t,
+		newMetricEntry("SPD", "model-a"),
+		newMetricEntry("DIR", "model-b"),
+	), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{BackupFile: backupFile, SkipExisting: true}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(postCount).To(Equal(1))
+}
+
+func TestRunTask_Execute_UnknownMetricType(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	entry := map[string]any{
+		"id":      "unknown-1",
+		"request": map[string]any{"metricName": "UNKNOWN_METRIC", "modelId": "m1"},
+	}
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, entry), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_HTTPError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoRESTConfig(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	route := newRoute("tai-route", "ns1", "tai.example.com", map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route))
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t, newMetricEntry("SPD", "m1")), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+		t.SkipConfirm = false
+		t.IO = io
+		t.Recorder = action.NewVerboseRootRecorder(io)
+	})
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// parseBackupEntries
+// ---------------------------------------------------------------------------
+
+func TestRunTask_Execute_MissingRequestField(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	entry := map[string]any{
+		"id":      "no-request-1",
+		"request": map[string]any{"metricName": "SPD", "modelId": "m1"},
+	}
+
+	entryJSON, err := json.Marshal(entry)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var rawEntry map[string]json.RawMessage
+	_ = json.Unmarshal(entryJSON, &rawEntry)
+	delete(rawEntry, "request")
+
+	modifiedEntry, err := json.Marshal(rawEntry)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, []byte(`{"requests":[`+string(modifiedEntry)+`]}`), 0o600)
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), route), func(t *action.Target) {
+		t.RESTConfig = &rest.Config{BearerToken: "test"}
+	})
+
+	a := &MetricsAction{BackupFile: backupFile}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_InvalidResponse(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	route := newRoute("tai-route", "ns1", serverHost(server), map[string]string{
+		"trustyai-service-name": "trustyai-service",
+	})
+
+	outputDir := t.TempDir()
+	target := newTarget(newFakeClient(newScheme(), route), func(tgt *action.Target) {
+		tgt.RESTConfig = &rest.Config{BearerToken: "test"}
+		tgt.OutputDir = outputDir
+	})
+
+	a := &MetricsAction{}
+	result, err := a.Prepare().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestParseBackupEntries(t *testing.T) {
+	g := NewWithT(t)
+
+	backupFile := filepath.Join(t.TempDir(), "backup.json")
+	_ = os.WriteFile(backupFile, metricsJSON(t,
+		newMetricEntry("SPD", "model-a"),
+		newMetricEntry("DIR", "model-b"),
+	), 0o600)
+
+	task := &runTask{action: &MetricsAction{BackupFile: backupFile}}
+	entries, err := task.parseBackupEntries()
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(2))
+	g.Expect(entries[0].Request.MetricName).To(Equal("SPD"))
+	g.Expect(entries[1].Request.ModelID).To(Equal("model-b"))
+}
+
+func TestParseBackupEntries_InvalidJSON(t *testing.T) {
+	g := NewWithT(t)
+
+	backupFile := filepath.Join(t.TempDir(), "bad.json")
+	_ = os.WriteFile(backupFile, []byte("not json"), 0o600)
+
+	task := &runTask{action: &MetricsAction{BackupFile: backupFile}}
+	_, err := task.parseBackupEntries()
+
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestParseBackupEntries_FileNotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	task := &runTask{action: &MetricsAction{BackupFile: "/nonexistent"}}
+	_, err := task.parseBackupEntries()
+
+	g.Expect(err).To(HaveOccurred())
+}

--- a/pkg/migrate/actions/trustyai/metrics/prepare_task.go
+++ b/pkg/migrate/actions/trustyai/metrics/prepare_task.go
@@ -1,0 +1,211 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	backupTimestampFmt   = "20060102-150405"
+	backupFilePermission = 0o644
+	backupDirPermission  = 0o755
+	metricTypeFairness   = "fairness"
+)
+
+type prepareTask struct {
+	action *MetricsAction
+}
+
+func (t *prepareTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("check-trustyai-metrics", "Check TrustyAI metrics routes")
+
+	namespaces, err := discoverTrustyAINamespaces(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover TrustyAI routes: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(namespaces) == 0 {
+		step.Completef(result.StepSkipped, "No TrustyAI routes found")
+	} else {
+		step.Completef(result.StepCompleted, "Found TrustyAI routes in %d namespace(s)", len(namespaces))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("backup-trustyai-metrics", "Backup TrustyAI scheduled metrics")
+
+	namespaces, err := discoverTrustyAINamespaces(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover TrustyAI routes: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(namespaces) == 0 {
+		step.Completef(result.StepSkipped, "No TrustyAI routes found")
+
+		return action.BuildResult(target)
+	}
+
+	http, err := newHTTPHelper(target.RESTConfig)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to create HTTP client: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	outputDir := t.action.BackupDir
+	if target.OutputDir != "" {
+		outputDir = filepath.Join(target.OutputDir, "trustyai-metrics")
+	}
+
+	totalMetrics := 0
+
+	for ns, routeHost := range namespaces {
+		nsStep := step.Child(
+			"backup-"+ns,
+			"Backup metrics in "+ns,
+		)
+
+		count, err := t.backupNamespace(ctx, http, routeHost, ns, outputDir, target, nsStep)
+		if err != nil {
+			nsStep.Completef(result.StepFailed, "Failed to backup metrics in %s: %v", ns, err)
+
+			continue
+		}
+
+		totalMetrics += count
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would backup %d metric(s) across %d namespace(s)", totalMetrics, len(namespaces))
+	} else {
+		step.Completef(result.StepCompleted, "Backed up %d metric(s) across %d namespace(s) to %s", totalMetrics, len(namespaces), outputDir)
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *prepareTask) backupNamespace(
+	ctx context.Context,
+	http *httpHelper,
+	routeHost, namespace, outputDir string,
+	target action.Target,
+	step action.StepRecorder,
+) (int, error) {
+	apiURL := "https://" + routeHost + "/metrics/all/requests"
+	if t.action.MetricType == metricTypeFairness {
+		apiURL += "?type=fairness"
+	}
+
+	body, err := http.get(ctx, apiURL)
+	if err != nil {
+		return 0, fmt.Errorf("fetching metrics: %w", err)
+	}
+
+	var resp backupResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, fmt.Errorf("parsing metrics response: %w", err)
+	}
+
+	metricCount := len(resp.Requests)
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would backup %d metric(s) from %s", metricCount, namespace)
+
+		return metricCount, nil
+	}
+
+	if err := os.MkdirAll(outputDir, backupDirPermission); err != nil {
+		return 0, fmt.Errorf("creating backup directory: %w", err)
+	}
+
+	typeSuffix := ""
+	if t.action.MetricType == metricTypeFairness {
+		typeSuffix = "-fairness"
+	}
+
+	timestamp := time.Now().Format(backupTimestampFmt)
+	filename := fmt.Sprintf("trustyai-metrics-%s%s-%s.json", namespace, typeSuffix, timestamp)
+	backupPath := filepath.Join(outputDir, filename)
+
+	prettyJSON, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("formatting backup JSON: %w", err)
+	}
+
+	if err := os.WriteFile(backupPath, prettyJSON, backupFilePermission); err != nil {
+		return 0, fmt.Errorf("writing backup file: %w", err)
+	}
+
+	step.Completef(result.StepCompleted, "Backed up %d metric(s) to %s", metricCount, backupPath)
+
+	return metricCount, nil
+}
+
+func discoverTrustyAINamespaces(ctx context.Context, target action.Target) (map[string]string, error) {
+	routes, err := target.Client.List(ctx, resources.Route)
+	if err != nil {
+		return nil, fmt.Errorf("listing routes: %w", err)
+	}
+
+	discovered := make(map[string]string)
+	routeLabel := defaultRouteLabel
+
+	if a, ok := target.Recorder.(interface{ Action() action.Action }); ok {
+		if ma, ok := a.Action().(*MetricsAction); ok && ma.RouteLabel != "" {
+			routeLabel = ma.RouteLabel
+		}
+	}
+
+	for _, route := range routes {
+		ns := route.GetNamespace()
+		if _, exists := discovered[ns]; exists {
+			continue
+		}
+
+		host, err := discoverRouteInNamespace(ctx, target.Client, ns, routeLabel)
+		if err != nil {
+			continue
+		}
+
+		if host != "" {
+			discovered[ns] = host
+		}
+	}
+
+	if len(discovered) == 0 {
+		taiServices, err := target.Client.List(ctx, resources.TrustyAIService)
+		if err != nil {
+			return nil, fmt.Errorf("listing TrustyAIServices: %w", err)
+		}
+
+		for _, svc := range taiServices {
+			ns := svc.GetNamespace()
+			if _, exists := discovered[ns]; exists {
+				continue
+			}
+
+			host, err := discoverRouteInNamespace(ctx, target.Client, ns, routeLabel)
+			if err != nil || host == "" {
+				continue
+			}
+
+			discovered[ns] = host
+		}
+	}
+
+	return discovered, nil
+}

--- a/pkg/migrate/actions/trustyai/metrics/run_task.go
+++ b/pkg/migrate/actions/trustyai/metrics/run_task.go
@@ -1,0 +1,300 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+type runTask struct {
+	action *MetricsAction
+}
+
+func (t *runTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("check-metrics-restore", "Check metrics restore readiness")
+
+	if t.action.BackupFile == "" {
+		step.Completef(result.StepSkipped, "No --metrics-file specified; nothing to restore")
+
+		return action.BuildResult(target)
+	}
+
+	if _, err := os.Stat(t.action.BackupFile); err != nil {
+		step.Completef(result.StepFailed, "Backup file %s not found: %v", t.action.BackupFile, err)
+
+		return action.BuildResult(target)
+	}
+
+	namespaces, err := discoverTrustyAINamespaces(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover TrustyAI routes: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(namespaces) == 0 {
+		step.Completef(result.StepFailed, "No TrustyAI routes found for restore")
+	} else {
+		step.Completef(result.StepCompleted, "Ready to restore: backup file exists, %d route(s) available", len(namespaces))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("restore-trustyai-metrics", "Restore TrustyAI scheduled metrics")
+
+	if t.action.BackupFile == "" {
+		step.Completef(result.StepSkipped, "No --metrics-file specified; nothing to restore")
+
+		return action.BuildResult(target)
+	}
+
+	entries, err := t.parseBackupEntries()
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to load backup: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(entries) == 0 {
+		step.Completef(result.StepSkipped, "No metrics found in backup file")
+
+		return action.BuildResult(target)
+	}
+
+	step.Recordf("parse", "Found %d metric(s) in backup file", result.StepCompleted, len(entries))
+
+	namespaces, err := discoverTrustyAINamespaces(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover TrustyAI routes: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(namespaces) == 0 {
+		step.Completef(result.StepFailed, "No TrustyAI routes found for restore")
+
+		return action.BuildResult(target)
+	}
+
+	httpH, err := newHTTPHelper(target.RESTConfig)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to create HTTP client: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if !target.DryRun && !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to restore %d metric(s) to %d namespace(s)", len(entries), len(namespaces))
+
+		if !confirmation.Prompt(target.IO, "Proceed with metrics restore?") {
+			step.Completef(result.StepSkipped, "User cancelled metrics restore")
+
+			return action.BuildResult(target)
+		}
+	}
+
+	for ns, routeHost := range namespaces {
+		nsStep := step.Child("restore-"+ns, "Restore metrics to "+ns)
+		t.restoreToNamespace(ctx, httpH, routeHost, ns, entries, target, nsStep)
+	}
+
+	step.Completef(result.StepCompleted, "Metrics restore complete")
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) parseBackupEntries() ([]restoreEntry, error) {
+	data, err := os.ReadFile(t.action.BackupFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading backup file: %w", err)
+	}
+
+	var raw struct {
+		Requests []json.RawMessage `json:"requests"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing backup file: %w", err)
+	}
+
+	entries := make([]restoreEntry, 0, len(raw.Requests))
+
+	for _, rawReq := range raw.Requests {
+		var entry restoreEntry
+		if err := json.Unmarshal(rawReq, &entry); err != nil {
+			return nil, fmt.Errorf("parsing metric entry: %w", err)
+		}
+
+		entry.Raw = rawReq
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}
+
+func (t *runTask) restoreToNamespace(
+	ctx context.Context,
+	httpH *httpHelper,
+	routeHost, ns string,
+	entries []restoreEntry,
+	target action.Target,
+	nsStep action.StepRecorder,
+) {
+	var existingMetrics map[string]bool
+
+	if t.action.SkipExisting {
+		var err error
+
+		existingMetrics, err = fetchExistingMetrics(ctx, httpH, routeHost)
+		if err != nil {
+			target.IO.Errorf("WARNING: could not fetch existing metrics in %s: %v", ns, err)
+
+			existingMetrics = map[string]bool{}
+		}
+	}
+
+	restored, skipped, failed := 0, 0, 0
+
+	for _, entry := range entries {
+		status := t.restoreMetric(ctx, httpH, routeHost, entry, existingMetrics, target, nsStep)
+
+		switch status {
+		case restoreSuccess:
+			restored++
+		case restoreSkipped:
+			skipped++
+		case restoreFailed:
+			failed++
+		}
+	}
+
+	if target.DryRun {
+		nsStep.Completef(result.StepSkipped, "Would restore %d metric(s) to %s", len(entries), ns)
+	} else {
+		nsStep.Completef(result.StepCompleted, "Restored %d, skipped %d, failed %d in %s", restored, skipped, failed, ns)
+	}
+}
+
+type restoreStatus int
+
+const (
+	restoreSuccess restoreStatus = iota
+	restoreSkipped
+	restoreFailed
+)
+
+func (t *runTask) restoreMetric(
+	ctx context.Context,
+	httpH *httpHelper,
+	routeHost string,
+	entry restoreEntry,
+	existingMetrics map[string]bool,
+	target action.Target,
+	step action.StepRecorder,
+) restoreStatus {
+	metricName := entry.Request.MetricName
+	modelID := entry.Request.ModelID
+
+	if t.action.SkipExisting && existingMetrics != nil {
+		key := modelID + ":" + metricName
+		if existingMetrics[key] {
+			step.Recordf(fmt.Sprintf("skip-%s-%s", modelID, metricName),
+				"Skipped %s for model %s (already exists)", result.StepSkipped, metricName, modelID)
+
+			return restoreSkipped
+		}
+	}
+
+	endpointPath, ok := metricEndpoints[strings.ToLower(metricName)]
+	if !ok {
+		step.Recordf(fmt.Sprintf("unknown-%s-%s", modelID, metricName),
+			"Unknown metric type %s for model %s", result.StepFailed, metricName, modelID)
+
+		return restoreFailed
+	}
+
+	endpoint := "https://" + routeHost + endpointPath
+
+	if target.DryRun {
+		step.Recordf(fmt.Sprintf("dryrun-%s-%s", modelID, metricName),
+			"Would POST %s for model %s to %s", result.StepSkipped, metricName, modelID, endpointPath)
+
+		return restoreSkipped
+	}
+
+	var full map[string]json.RawMessage
+	if err := json.Unmarshal(entry.Raw, &full); err != nil {
+		step.Recordf(fmt.Sprintf("parse-err-%s-%s", modelID, metricName),
+			"Failed to parse entry for %s/%s: %v", result.StepFailed, metricName, modelID, err)
+
+		return restoreFailed
+	}
+
+	requestPayload, ok := full["request"]
+	if !ok {
+		step.Recordf(fmt.Sprintf("missing-req-%s-%s", modelID, metricName),
+			"Entry missing .request field for %s/%s", result.StepFailed, metricName, modelID)
+
+		return restoreFailed
+	}
+
+	statusCode, err := httpH.post(ctx, endpoint, requestPayload)
+	if err != nil {
+		step.Recordf(fmt.Sprintf("http-err-%s-%s", modelID, metricName),
+			"HTTP error for %s/%s: %v", result.StepFailed, metricName, modelID, err)
+
+		return restoreFailed
+	}
+
+	if statusCode != http.StatusOK {
+		step.Recordf(fmt.Sprintf("http-status-%s-%s", modelID, metricName),
+			"HTTP %d for %s/%s", result.StepFailed, statusCode, metricName, modelID)
+
+		return restoreFailed
+	}
+
+	step.Recordf(fmt.Sprintf("restored-%s-%s", modelID, metricName),
+		"Restored %s for model %s", result.StepCompleted, metricName, modelID)
+
+	return restoreSuccess
+}
+
+func fetchExistingMetrics(ctx context.Context, httpH *httpHelper, routeHost string) (map[string]bool, error) {
+	apiURL := "https://" + routeHost + "/metrics/all/requests"
+
+	body, err := httpH.get(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching existing metrics: %w", err)
+	}
+
+	var resp struct {
+		Requests []struct {
+			Request struct {
+				MetricName string `json:"metricName"`
+				ModelID    string `json:"modelId"`
+			} `json:"request"`
+		} `json:"requests"`
+	}
+
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing existing metrics: %w", err)
+	}
+
+	existing := make(map[string]bool, len(resp.Requests))
+	for _, r := range resp.Requests {
+		key := r.Request.ModelID + ":" + r.Request.MetricName
+		existing[key] = true
+	}
+
+	return existing, nil
+}

--- a/pkg/migrate/actions/trustyai/otelexporter/fields.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/fields.go
@@ -1,0 +1,224 @@
+package otelexporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+)
+
+const (
+	oldFieldProtocol        = "protocol"
+	oldFieldTracesProtocol  = "tracesProtocol"
+	oldFieldMetricsProtocol = "metricsProtocol"
+	oldFieldOtlpEndpoint    = "otlpEndpoint"
+	oldFieldTracesEndpoint  = "tracesEndpoint"
+	oldFieldMetricsEndpoint = "metricsEndpoint"
+	oldFieldOtlpExport      = "otlpExport"
+
+	newFieldOtlpProtocol        = "otlpProtocol"
+	newFieldOtlpTracesEndpoint  = "otlpTracesEndpoint"
+	newFieldOtlpMetricsEndpoint = "otlpMetricsEndpoint"
+	newFieldEnableTraces        = "enableTraces"
+	newFieldEnableMetrics       = "enableMetrics"
+)
+
+//nolint:gochecknoglobals // Static field name lists; Go has no const slices.
+var oldSchemaFields = []string{
+	oldFieldProtocol, oldFieldTracesProtocol, oldFieldMetricsProtocol,
+	oldFieldOtlpEndpoint, oldFieldTracesEndpoint, oldFieldMetricsEndpoint,
+	oldFieldOtlpExport,
+}
+
+//nolint:gochecknoglobals // Static field name lists; Go has no const slices.
+var newSchemaFields = []string{
+	newFieldOtlpProtocol, newFieldOtlpTracesEndpoint, newFieldOtlpMetricsEndpoint,
+	newFieldEnableTraces, newFieldEnableMetrics,
+}
+
+type migrationStatus string
+
+const (
+	statusSkipped        migrationStatus = "SKIPPED"
+	statusInvalid        migrationStatus = "INVALID"
+	statusNeedsMigration migrationStatus = "NEEDS_MIGRATION"
+)
+
+type migrationInfo struct {
+	gorchName string
+	namespace string
+	status    migrationStatus
+	message   string
+}
+
+type migrationCandidate struct {
+	name      string
+	namespace string
+	patchData []byte
+}
+
+func hasAnyOldFields(otel map[string]any) bool {
+	for _, field := range oldSchemaFields {
+		if _, ok := otel[field]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasOnlyNewFields(otel map[string]any) bool {
+	hasNew := false
+
+	for _, field := range newSchemaFields {
+		if _, ok := otel[field]; ok {
+			hasNew = true
+		}
+	}
+
+	if !hasNew {
+		return false
+	}
+
+	return !hasAnyOldFields(otel)
+}
+
+func mapOtelFields(otel map[string]any) (map[string]any, []string) {
+	result := make(map[string]any)
+	var warnings []string
+
+	protocol := resolveProtocol(otel, &warnings)
+	if protocol != "" {
+		result[newFieldOtlpProtocol] = protocol
+	}
+
+	endpoints := resolveEndpoints(otel)
+	if endpoints.traces != "" {
+		result[newFieldOtlpTracesEndpoint] = endpoints.traces
+	}
+
+	if endpoints.metrics != "" {
+		result[newFieldOtlpMetricsEndpoint] = endpoints.metrics
+	}
+
+	exports := resolveExportFlags(otel)
+	if exports.traces {
+		result[newFieldEnableTraces] = true
+	}
+
+	if exports.metrics {
+		result[newFieldEnableMetrics] = true
+	}
+
+	return result, warnings
+}
+
+func resolveProtocol(otel map[string]any, warnings *[]string) string {
+	if p, ok := getString(otel, oldFieldProtocol); ok {
+		return p
+	}
+
+	tracesP, hasTraces := getString(otel, oldFieldTracesProtocol)
+	metricsP, hasMetrics := getString(otel, oldFieldMetricsProtocol)
+
+	if hasTraces && hasMetrics && tracesP != metricsP {
+		*warnings = append(*warnings, "tracesProtocol and metricsProtocol differ; new schema supports a single protocol")
+	}
+
+	if hasTraces {
+		return tracesP
+	}
+
+	if hasMetrics {
+		return metricsP
+	}
+
+	return ""
+}
+
+type resolvedEndpoints struct {
+	traces  string
+	metrics string
+}
+
+func resolveEndpoints(otel map[string]any) resolvedEndpoints {
+	sharedEndpoint, _ := getString(otel, oldFieldOtlpEndpoint)
+
+	traces := sharedEndpoint
+	if ep, ok := getString(otel, oldFieldTracesEndpoint); ok {
+		traces = ep
+	}
+
+	metrics := sharedEndpoint
+	if ep, ok := getString(otel, oldFieldMetricsEndpoint); ok {
+		metrics = ep
+	}
+
+	return resolvedEndpoints{traces: traces, metrics: metrics}
+}
+
+type resolvedExportFlags struct {
+	traces  bool
+	metrics bool
+}
+
+func resolveExportFlags(otel map[string]any) resolvedExportFlags {
+	exportVal, ok := otel[oldFieldOtlpExport]
+	if !ok {
+		return resolvedExportFlags{}
+	}
+
+	tokens := strings.FieldsFunc(strings.ToLower(fmt.Sprintf("%v", exportVal)), func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '|'
+	})
+
+	var flags resolvedExportFlags
+
+	for _, tok := range tokens {
+		switch tok {
+		case "all":
+			flags.traces = true
+			flags.metrics = true
+		case "trace", "traces":
+			flags.traces = true
+		case "metric", "metrics":
+			flags.metrics = true
+		}
+	}
+
+	return flags
+}
+
+func getString(m map[string]any, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+
+	s, ok := v.(string)
+
+	return s, ok
+}
+
+func buildOtelMigrationPatch(newFields map[string]any) ([]byte, error) {
+	otelPatch := make(map[string]any, len(newFields)+len(oldSchemaFields))
+
+	for _, field := range oldSchemaFields {
+		otelPatch[field] = nil
+	}
+
+	maps.Copy(otelPatch, newFields)
+
+	patch := map[string]any{
+		"spec": map[string]any{
+			"otelExporter": otelPatch,
+		},
+	}
+
+	data, err := json.MarshalIndent(patch, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	return data, nil
+}

--- a/pkg/migrate/actions/trustyai/otelexporter/fields_test.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/fields_test.go
@@ -1,0 +1,151 @@
+//nolint:testpackage // Tests internal pure functions
+package otelexporter
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHasAnyOldFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		otel     map[string]any
+		expected bool
+	}{
+		{"has protocol", map[string]any{"protocol": "grpc"}, true},
+		{"has otlpEndpoint", map[string]any{"otlpEndpoint": "http://host"}, true},
+		{"has otlpExport", map[string]any{"otlpExport": "all"}, true},
+		{"new fields only", map[string]any{"otlpProtocol": "grpc"}, false},
+		{"empty", map[string]any{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hasAnyOldFields(tt.otel)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestHasOnlyNewFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		otel     map[string]any
+		expected bool
+	}{
+		{"new fields only", map[string]any{"otlpProtocol": "grpc", "enableTraces": true}, true},
+		{"mixed old and new", map[string]any{"otlpProtocol": "grpc", "protocol": "grpc"}, false},
+		{"old fields only", map[string]any{"protocol": "grpc"}, false},
+		{"empty", map[string]any{}, false},
+		{"unknown fields", map[string]any{"foo": "bar"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hasOnlyNewFields(tt.otel)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestMapOtelFields(t *testing.T) {
+	t.Run("maps shared protocol", func(t *testing.T) {
+		g := NewWithT(t)
+
+		otel := map[string]any{"protocol": "grpc"}
+		result, warnings := mapOtelFields(otel)
+
+		g.Expect(warnings).To(BeEmpty())
+		g.Expect(result).To(HaveKeyWithValue("otlpProtocol", "grpc"))
+	})
+
+	t.Run("maps per-signal endpoints", func(t *testing.T) {
+		g := NewWithT(t)
+
+		otel := map[string]any{
+			"tracesEndpoint":  "http://traces:4317",
+			"metricsEndpoint": "http://metrics:4317",
+		}
+		result, warnings := mapOtelFields(otel)
+
+		g.Expect(warnings).To(BeEmpty())
+		g.Expect(result).To(HaveKeyWithValue("otlpTracesEndpoint", "http://traces:4317"))
+		g.Expect(result).To(HaveKeyWithValue("otlpMetricsEndpoint", "http://metrics:4317"))
+	})
+
+	t.Run("maps shared endpoint to both", func(t *testing.T) {
+		g := NewWithT(t)
+
+		otel := map[string]any{"otlpEndpoint": "http://shared:4317"}
+		result, _ := mapOtelFields(otel)
+
+		g.Expect(result).To(HaveKeyWithValue("otlpTracesEndpoint", "http://shared:4317"))
+		g.Expect(result).To(HaveKeyWithValue("otlpMetricsEndpoint", "http://shared:4317"))
+	})
+
+	t.Run("maps export flags", func(t *testing.T) {
+		g := NewWithT(t)
+
+		otel := map[string]any{"otlpExport": "all"}
+		result, _ := mapOtelFields(otel)
+
+		g.Expect(result).To(HaveKeyWithValue("enableTraces", true))
+		g.Expect(result).To(HaveKeyWithValue("enableMetrics", true))
+	})
+
+	t.Run("warns on conflicting protocols", func(t *testing.T) {
+		g := NewWithT(t)
+
+		otel := map[string]any{
+			"tracesProtocol":  "grpc",
+			"metricsProtocol": "http",
+		}
+		_, warnings := mapOtelFields(otel)
+
+		g.Expect(warnings).To(HaveLen(1))
+		g.Expect(warnings[0]).To(ContainSubstring("differ"))
+	})
+}
+
+func TestResolveExportFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		otel          map[string]any
+		expectTraces  bool
+		expectMetrics bool
+	}{
+		{"all", map[string]any{"otlpExport": "all"}, true, true},
+		{"traces only", map[string]any{"otlpExport": "traces"}, true, false},
+		{"metrics only", map[string]any{"otlpExport": "metrics"}, false, true},
+		{"comma separated", map[string]any{"otlpExport": "traces,metrics"}, true, true},
+		{"space separated", map[string]any{"otlpExport": "traces metrics"}, true, true},
+		{"substring not matched", map[string]any{"otlpExport": "notrace"}, false, false},
+		{"no export field", map[string]any{}, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := resolveExportFlags(tt.otel)
+			g.Expect(result.traces).To(Equal(tt.expectTraces))
+			g.Expect(result.metrics).To(Equal(tt.expectMetrics))
+		})
+	}
+}
+
+func TestBuildOtelMigrationPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	newFields := map[string]any{
+		"otlpProtocol": "grpc",
+		"enableTraces": true,
+	}
+
+	patchBytes, err := buildOtelMigrationPatch(newFields)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(patchBytes)).To(ContainSubstring("otlpProtocol"))
+	g.Expect(string(patchBytes)).To(ContainSubstring("enableTraces"))
+	g.Expect(string(patchBytes)).To(ContainSubstring(`"protocol": null`))
+}

--- a/pkg/migrate/actions/trustyai/otelexporter/otelexporter.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/otelexporter.go
@@ -1,0 +1,41 @@
+package otelexporter
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+)
+
+const (
+	actionID          = "trustyai.migrate-gorch-otel-exporter"
+	actionName        = "Migrate GuardrailsOrchestrator otelExporter schema"
+	actionDescription = "Migrate otelExporter from RHOAI 2.25 schema to current schema"
+)
+
+type MigrateOtelExporterAction struct{}
+
+func (a *MigrateOtelExporterAction) ID() string          { return actionID }
+func (a *MigrateOtelExporterAction) Name() string        { return actionName }
+func (a *MigrateOtelExporterAction) Description() string { return actionDescription }
+
+func (a *MigrateOtelExporterAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *MigrateOtelExporterAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *MigrateOtelExporterAction) CanApply(target action.Target) bool {
+	if target.CurrentVersion == nil || target.TargetVersion == nil {
+		return false
+	}
+
+	return target.CurrentVersion.Major == 2 && target.TargetVersion.Major >= 3
+}
+
+func (a *MigrateOtelExporterAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *MigrateOtelExporterAction) Run() action.Task {
+	return &runTask{action: a}
+}

--- a/pkg/migrate/actions/trustyai/otelexporter/run_task.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/run_task.go
@@ -1,0 +1,240 @@
+package otelexporter
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+type runTask struct {
+	action *MigrateOtelExporterAction
+}
+
+func (t *runTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("check-otel-schema", "Check otelExporter schema")
+
+	gorchs, err := target.Client.List(ctx, resources.GuardrailsOrchestrator)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list GuardrailsOrchestrators: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(gorchs) == 0 {
+		step.Completef(result.StepSkipped, "No GuardrailsOrchestrator CRs found")
+
+		return action.BuildResult(target)
+	}
+
+	needsMigration := 0
+
+	for _, gorch := range gorchs {
+		info := classifyCR(gorch)
+		if info.status == statusNeedsMigration {
+			needsMigration++
+		}
+	}
+
+	if needsMigration == 0 {
+		step.Completef(result.StepCompleted, "All %d GuardrailsOrchestrator CR(s) have current otelExporter schema", len(gorchs))
+	} else {
+		step.Completef(result.StepCompleted, "Found %d/%d GuardrailsOrchestrator CR(s) needing otelExporter migration", needsMigration, len(gorchs))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	step := target.Recorder.Child("migrate-otel-schema", "Migrate otelExporter schema")
+
+	gorchs, err := target.Client.List(ctx, resources.GuardrailsOrchestrator)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list GuardrailsOrchestrators: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(gorchs) == 0 {
+		step.Completef(result.StepSkipped, "No GuardrailsOrchestrator CRs found")
+
+		return action.BuildResult(target)
+	}
+
+	step.Recordf("discover", "Found %d GuardrailsOrchestrator CR(s)", result.StepCompleted, len(gorchs))
+
+	var candidates []migrationCandidate
+
+	for _, gorch := range gorchs {
+		if cand, ok := evaluateCR(gorch, step, target); ok {
+			candidates = append(candidates, cand)
+		}
+	}
+
+	if len(candidates) == 0 {
+		step.Completef(result.StepCompleted, "No GuardrailsOrchestrator CRs need otelExporter migration")
+
+		return action.BuildResult(target)
+	}
+
+	if target.DryRun {
+		for _, cand := range candidates {
+			target.IO.Fprintln()
+			target.IO.Fprintf("DRY RUN: Would apply patch to %s/%s:", cand.namespace, cand.name)
+			target.IO.Fprintln()
+			target.IO.Fprintf("%s", string(cand.patchData))
+			target.IO.Fprintln()
+		}
+
+		step.Completef(result.StepSkipped, "Would migrate %d GuardrailsOrchestrator(s)", len(candidates))
+
+		return action.BuildResult(target)
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to migrate otelExporter on %d GuardrailsOrchestrator(s)", len(candidates))
+
+		if !confirmation.Prompt(target.IO, "Proceed with otelExporter migration?") {
+			step.Completef(result.StepSkipped, "User cancelled otelExporter migration")
+
+			return action.BuildResult(target)
+		}
+	}
+
+	gvr := resources.GuardrailsOrchestrator.GVR()
+	migratedCount := 0
+
+	for _, cand := range candidates {
+		patchStep := step.Child(
+			fmt.Sprintf("patch-%s-%s", cand.namespace, cand.name),
+			fmt.Sprintf("Patch %s/%s", cand.namespace, cand.name),
+		)
+
+		_, err := target.Client.Dynamic().Resource(gvr).Namespace(cand.namespace).Patch(
+			ctx,
+			cand.name,
+			types.MergePatchType,
+			cand.patchData,
+			metav1.PatchOptions{},
+		)
+		if err != nil {
+			patchStep.Completef(result.StepFailed, "Failed to patch %s/%s: %v", cand.namespace, cand.name, err)
+
+			continue
+		}
+
+		patchStep.Completef(result.StepCompleted, "Migrated %s/%s", cand.namespace, cand.name)
+
+		migratedCount++
+	}
+
+	step.Completef(result.StepCompleted, "Migrated %d/%d GuardrailsOrchestrator(s)", migratedCount, len(candidates))
+
+	return action.BuildResult(target)
+}
+
+func evaluateCR(gorch *unstructured.Unstructured, step action.StepRecorder, target action.Target) (migrationCandidate, bool) {
+	info := classifyCR(gorch)
+
+	crStep := step.Child(
+		fmt.Sprintf("check-%s-%s", info.namespace, info.gorchName),
+		fmt.Sprintf("Check %s/%s", info.namespace, info.gorchName),
+	)
+
+	if info.status == statusInvalid {
+		crStep.Completef(result.StepFailed, "%s: %s", info.gorchName, info.message)
+
+		return migrationCandidate{}, false
+	}
+
+	if info.status != statusNeedsMigration {
+		crStep.Completef(result.StepSkipped, "%s: %s", info.gorchName, info.message)
+
+		return migrationCandidate{}, false
+	}
+
+	otel, _, _ := unstructured.NestedMap(gorch.Object, "spec", "otelExporter")
+	newFields, warnings := mapOtelFields(otel)
+
+	for _, w := range warnings {
+		target.IO.Errorf("WARNING: %s/%s: %s", info.namespace, info.gorchName, w)
+	}
+
+	if len(newFields) == 0 {
+		crStep.Completef(result.StepSkipped, "%s: old-schema found but could not infer new fields", info.gorchName)
+
+		return migrationCandidate{}, false
+	}
+
+	patchData, err := buildOtelMigrationPatch(newFields)
+	if err != nil {
+		crStep.Completef(result.StepFailed, "Failed to build patch for %s: %v", info.gorchName, err)
+
+		return migrationCandidate{}, false
+	}
+
+	crStep.Completef(result.StepCompleted, "%s needs migration", info.gorchName)
+
+	return migrationCandidate{
+		name:      info.gorchName,
+		namespace: info.namespace,
+		patchData: patchData,
+	}, true
+}
+
+func classifyCR(gorch *unstructured.Unstructured) migrationInfo {
+	name := gorch.GetName()
+	namespace := gorch.GetNamespace()
+
+	otel, found, err := unstructured.NestedMap(gorch.Object, "spec", "otelExporter")
+	if err != nil {
+		return migrationInfo{
+			gorchName: name,
+			namespace: namespace,
+			status:    statusInvalid,
+			message:   fmt.Sprintf("invalid otelExporter: %v", err),
+		}
+	}
+
+	if !found || len(otel) == 0 {
+		return migrationInfo{
+			gorchName: name,
+			namespace: namespace,
+			status:    statusSkipped,
+			message:   "no otelExporter configured",
+		}
+	}
+
+	if hasOnlyNewFields(otel) {
+		return migrationInfo{
+			gorchName: name,
+			namespace: namespace,
+			status:    statusSkipped,
+			message:   "already on new otelExporter schema",
+		}
+	}
+
+	if !hasAnyOldFields(otel) {
+		return migrationInfo{
+			gorchName: name,
+			namespace: namespace,
+			status:    statusSkipped,
+			message:   "unknown otelExporter schema; leaving untouched",
+		}
+	}
+
+	return migrationInfo{
+		gorchName: name,
+		namespace: namespace,
+		status:    statusNeedsMigration,
+		message:   "needs migration",
+	}
+}

--- a/pkg/migrate/actions/trustyai/otelexporter/run_task_test.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/run_task_test.go
@@ -1,0 +1,395 @@
+//nolint:testpackage // Tests internal implementation
+package otelexporter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	if err := metav1.AddMetaToScheme(scheme); err != nil {
+		panic("AddMetaToScheme failed: " + err.Error())
+	}
+
+	return scheme
+}
+
+func newFakeClient(scheme *runtime.Scheme, objects ...runtime.Object) client.Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.GuardrailsOrchestrator.GVR(): resources.GuardrailsOrchestrator.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newGORCH(name, namespace string, otelExporter map[string]any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": resources.GuardrailsOrchestrator.APIVersion(),
+		"kind":       resources.GuardrailsOrchestrator.Kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+
+	if otelExporter != nil {
+		obj["spec"] = map[string]any{
+			"otelExporter": otelExporter,
+		}
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func TestMigrateOtelExporterAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &MigrateOtelExporterAction{}
+
+	g.Expect(a.ID()).To(Equal("trustyai.migrate-gorch-otel-exporter"))
+	g.Expect(a.Name()).To(ContainSubstring("otelExporter"))
+	g.Expect(a.Description()).To(ContainSubstring("otelExporter"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.Prepare()).To(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestMigrateOtelExporterAction_CanApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		target   string
+		expected bool
+	}{
+		{"2.25 to 3.0", "2.25.0", "3.0.0", true},
+		{"3.0 to 3.1", "3.0.0", "3.1.0", false},
+		{"1.0 to 2.0", "1.0.0", "2.0.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			a := &MigrateOtelExporterAction{}
+			cv := semver.MustParse(tt.current)
+			tv := semver.MustParse(tt.target)
+
+			g.Expect(a.CanApply(action.Target{CurrentVersion: &cv, TargetVersion: &tv})).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestMigrateOtelExporterAction_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &MigrateOtelExporterAction{}
+	g.Expect(a.CanApply(action.Target{})).To(BeFalse())
+}
+
+func TestRunTask_Validate_NoGORCHs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_WithOldSchema(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", map[string]any{
+		"protocol":     "grpc",
+		"otlpEndpoint": "http://otel:4317",
+	})
+
+	target := newTarget(newFakeClient(newScheme(), gorch))
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoGORCHs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTarget(newFakeClient(newScheme()))
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_MigratesOldSchema(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", map[string]any{
+		"protocol":     "grpc",
+		"otlpEndpoint": "http://otel:4317",
+		"otlpExport":   "all",
+	})
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch)
+	target := newTarget(k8sClient)
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.GuardrailsOrchestrator.GVR()).
+		Namespace("ns1").Get(ctx, "my-gorch", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	otel, _, _ := unstructured.NestedMap(updated.Object, "spec", "otelExporter")
+	g.Expect(otel).To(HaveKeyWithValue("otlpProtocol", "grpc"))
+	g.Expect(otel).To(HaveKeyWithValue("enableTraces", true))
+	g.Expect(otel).To(HaveKeyWithValue("enableMetrics", true))
+}
+
+func TestRunTask_Execute_SkipsNewSchema(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", map[string]any{
+		"otlpProtocol": "grpc",
+		"enableTraces": true,
+	})
+
+	target := newTarget(newFakeClient(newScheme(), gorch))
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_SkipsNoOtelExporter(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", nil)
+	target := newTarget(newFakeClient(newScheme(), gorch))
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", map[string]any{
+		"protocol":     "grpc",
+		"otlpEndpoint": "http://otel:4317",
+	})
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch)
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.GuardrailsOrchestrator.GVR()).
+		Namespace("ns1").Get(ctx, "my-gorch", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	otel, _, _ := unstructured.NestedMap(updated.Object, "spec", "otelExporter")
+	g.Expect(otel).To(HaveKey("protocol"))
+	g.Expect(otel).ToNot(HaveKey("otlpProtocol"))
+}
+
+func TestRunTask_Execute_MultiNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch1 := newGORCH("gorch-1", "ns1", map[string]any{
+		"protocol": "grpc",
+	})
+	gorch2 := newGORCH("gorch-2", "ns2", map[string]any{
+		"protocol": "http",
+	})
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch1, gorch2)
+	target := newTarget(k8sClient)
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	updated1, err := k8sClient.Dynamic().Resource(resources.GuardrailsOrchestrator.GVR()).
+		Namespace("ns1").Get(ctx, "gorch-1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	otel1, _, _ := unstructured.NestedMap(updated1.Object, "spec", "otelExporter")
+	g.Expect(otel1).To(HaveKeyWithValue("otlpProtocol", "grpc"))
+
+	updated2, err := k8sClient.Dynamic().Resource(resources.GuardrailsOrchestrator.GVR()).
+		Namespace("ns2").Get(ctx, "gorch-2", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	otel2, _, _ := unstructured.NestedMap(updated2.Object, "spec", "otelExporter")
+	g.Expect(otel2).To(HaveKeyWithValue("otlpProtocol", "http"))
+}
+
+func TestRunTask_Execute_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", map[string]any{
+		"protocol": "grpc",
+	})
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch)
+
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+	target := newTarget(k8sClient, func(t *action.Target) {
+		t.SkipConfirm = false
+		t.IO = io
+		t.Recorder = action.NewVerboseRootRecorder(io)
+	})
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_WithWarnings(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	gorch := newGORCH("my-gorch", "ns1", map[string]any{
+		"tracesProtocol":  "grpc",
+		"metricsProtocol": "http/protobuf",
+		"otlpEndpoint":    "http://otel:4317",
+	})
+
+	scheme := newScheme()
+	k8sClient := newFakeClient(scheme, gorch)
+	target := newTarget(k8sClient)
+
+	a := &MigrateOtelExporterAction{}
+	result, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	errBuf, ok := target.IO.ErrOut().(*bytes.Buffer)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(errBuf.String()).To(ContainSubstring("tracesProtocol and metricsProtocol differ"))
+}
+
+func TestClassifyCR(t *testing.T) {
+	tests := []struct {
+		name     string
+		otel     map[string]any
+		expected migrationStatus
+	}{
+		{"no otel", nil, statusSkipped},
+		{"new schema", map[string]any{"otlpProtocol": "grpc"}, statusSkipped},
+		{"old schema", map[string]any{"protocol": "grpc"}, statusNeedsMigration},
+		{"unknown fields", map[string]any{"foo": "bar"}, statusSkipped},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			gorch := newGORCH("test", "ns1", tt.otel)
+			info := classifyCR(gorch)
+			g.Expect(info.status).To(Equal(tt.expected))
+		})
+	}
+
+	t.Run("invalid otelExporter type", func(t *testing.T) {
+		g := NewWithT(t)
+		gorch := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "test", "namespace": "ns1"},
+			"spec":     map[string]any{"otelExporter": "not-a-map"},
+		}}
+		info := classifyCR(gorch)
+		g.Expect(info.status).To(Equal(statusInvalid))
+		g.Expect(info.message).To(ContainSubstring("invalid otelExporter"))
+	})
+}

--- a/pkg/migrate/command_options.go
+++ b/pkg/migrate/command_options.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/rest"
 
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
@@ -38,6 +39,7 @@ type SharedOptions struct {
 	Verbose      bool
 	Timeout      time.Duration
 	Client       client.Client
+	RESTConfig   *rest.Config
 
 	// Throttling settings for Kubernetes API client
 	QPS   float32
@@ -61,6 +63,8 @@ func (o *SharedOptions) Complete() error {
 	if err != nil {
 		return fmt.Errorf("failed to create REST config: %w", err)
 	}
+
+	o.RESTConfig = restConfig
 
 	// Create client with configured throttling
 	c, err := client.NewClientWithConfig(restConfig)

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -190,6 +190,7 @@ func (c *PrepareCommand) runPrepareMode(
 
 		target := action.Target{
 			Client:         c.Client,
+			RESTConfig:     c.RESTConfig,
 			CurrentVersion: currentVersion,
 			TargetVersion:  targetVersion,
 			DryRun:         c.DryRun,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -245,6 +245,7 @@ func (c *RunCommand) runMigrationMode(
 
 		target := action.Target{
 			Client:         c.Client,
+			RESTConfig:     c.RESTConfig,
 			CurrentVersion: currentVersion,
 			TargetVersion:  targetVersion,
 			DryRun:         c.DryRun,

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -5,6 +5,11 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/data"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/deadlock"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/guardrails"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/metrics"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/otelexporter"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 )
 
@@ -21,6 +26,11 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
+	registry.MustRegister(&deadlock.BreakGPUDeadlockAction{})
+	registry.MustRegister(&guardrails.PatchGuardrailsAction{})
+	registry.MustRegister(&otelexporter.MigrateOtelExporterAction{})
+	registry.MustRegister(&metrics.MetricsAction{})
+	registry.MustRegister(&data.DataAction{})
 
 	return registry
 }

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -435,4 +435,20 @@ var (
 		Kind:     "PackageManifest",
 		Resource: "packagemanifests",
 	}
+
+	// Route is the OpenShift Route resource for external service access.
+	Route = ResourceType{
+		Group:    "route.openshift.io",
+		Version:  "v1",
+		Kind:     "Route",
+		Resource: "routes",
+	}
+
+	// TrustyAIService is the TrustyAI operator's TrustyAIService resource.
+	TrustyAIService = ResourceType{
+		Group:    "trustyai.opendatahub.io",
+		Version:  "v1alpha1",
+		Kind:     "TrustyAIService",
+		Resource: "trustyaiservices",
+	}
 )

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -1,0 +1,81 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// ExecOptions configures a single pod exec invocation.
+type ExecOptions struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+	Command       []string
+	Stdin         io.Reader
+	Stdout        io.Writer
+	Stderr        io.Writer
+}
+
+// Executor runs commands inside Kubernetes pods.
+type Executor interface {
+	Exec(ctx context.Context, opts ExecOptions) error
+}
+
+// spdyExecutor implements Executor using SPDY-based remote command execution.
+type spdyExecutor struct {
+	config *rest.Config
+	client corev1client.CoreV1Interface
+}
+
+// NewSPDYExecutor creates an Executor that uses SPDY to stream commands to pods.
+func NewSPDYExecutor(config *rest.Config, client corev1client.CoreV1Interface) Executor {
+	return &spdyExecutor{
+		config: config,
+		client: client,
+	}
+}
+
+func (e *spdyExecutor) Exec(ctx context.Context, opts ExecOptions) error {
+	if e.client == nil {
+		return errors.New("exec: client is nil")
+	}
+	if e.config == nil {
+		return errors.New("exec: REST config is nil")
+	}
+
+	req := e.client.RESTClient().Post().
+		Resource("pods").
+		Name(opts.PodName).
+		Namespace(opts.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: opts.ContainerName,
+			Command:   opts.Command,
+			Stdin:     opts.Stdin != nil,
+			Stdout:    opts.Stdout != nil,
+			Stderr:    opts.Stderr != nil,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(e.config, "POST", req.URL())
+	if err != nil {
+		return fmt.Errorf("creating SPDY executor: %w", err)
+	}
+
+	if err := executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  opts.Stdin,
+		Stdout: opts.Stdout,
+		Stderr: opts.Stderr,
+	}); err != nil {
+		return fmt.Errorf("executing command in pod %s/%s: %w", opts.Namespace, opts.PodName, err)
+	}
+
+	return nil
+}

--- a/pkg/util/exec/mock.go
+++ b/pkg/util/exec/mock.go
@@ -1,0 +1,16 @@
+package exec
+
+import "context"
+
+// MockExecutor is a test double for Executor.
+type MockExecutor struct {
+	ExecFn func(ctx context.Context, opts ExecOptions) error
+}
+
+func (m *MockExecutor) Exec(ctx context.Context, opts ExecOptions) error {
+	if m.ExecFn != nil {
+		return m.ExecFn(ctx, opts)
+	}
+
+	return nil
+}

--- a/pkg/util/exec/tar.go
+++ b/pkg/util/exec/tar.go
@@ -1,0 +1,198 @@
+package exec
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	tarDirPermission  = 0o755
+	tarFilePermission = 0o644
+)
+
+// CopyOptions configures a file copy between a local path and a pod.
+type CopyOptions struct {
+	Namespace     string
+	PodName       string
+	ContainerName string
+	PodPath       string
+	LocalPath     string
+}
+
+// CopyFromPod copies files from a pod directory to a local directory using tar.
+func CopyFromPod(ctx context.Context, executor Executor, opts CopyOptions) error {
+	reader, writer := io.Pipe()
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer func() { _ = writer.Close() }()
+
+		errCh <- executor.Exec(ctx, ExecOptions{
+			Namespace:     opts.Namespace,
+			PodName:       opts.PodName,
+			ContainerName: opts.ContainerName,
+			Command:       []string{"tar", "cf", "-", "-C", opts.PodPath, "--exclude=lost+found", "."},
+			Stdout:        writer,
+			Stderr:        io.Discard,
+		})
+	}()
+
+	extractErr := extractTar(reader, opts.LocalPath)
+	// Close the read end so the producer goroutine unblocks if it is still writing.
+	_ = reader.CloseWithError(extractErr)
+
+	execErr := <-errCh
+
+	if extractErr != nil {
+		return fmt.Errorf("extracting tar from pod: %w", extractErr)
+	}
+
+	if execErr != nil {
+		return fmt.Errorf("tar exec in pod: %w", execErr)
+	}
+
+	return nil
+}
+
+// CopyToPod copies files from a local directory to a pod directory using tar.
+func CopyToPod(ctx context.Context, executor Executor, opts CopyOptions) error {
+	reader, writer := io.Pipe()
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer func() { _ = writer.Close() }()
+		errCh <- createTar(writer, opts.LocalPath)
+	}()
+
+	execErr := executor.Exec(ctx, ExecOptions{
+		Namespace:     opts.Namespace,
+		PodName:       opts.PodName,
+		ContainerName: opts.ContainerName,
+		Command:       []string{"tar", "xf", "-", "-C", opts.PodPath},
+		Stdin:         reader,
+		Stderr:        io.Discard,
+	})
+	// Close the read end so the producer goroutine unblocks if it is still writing.
+	_ = reader.CloseWithError(execErr)
+
+	tarErr := <-errCh
+
+	if execErr != nil {
+		return fmt.Errorf("tar exec in pod: %w", execErr)
+	}
+
+	if tarErr != nil {
+		return fmt.Errorf("creating tar archive: %w", tarErr)
+	}
+
+	return nil
+}
+
+func extractTar(r io.Reader, destDir string) error {
+	tr := tar.NewReader(r)
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("reading tar header: %w", err)
+		}
+
+		target := filepath.Join(destDir, filepath.Clean(header.Name))
+
+		if !strings.HasPrefix(target, filepath.Clean(destDir)+string(os.PathSeparator)) && target != filepath.Clean(destDir) {
+			return fmt.Errorf("tar entry %q escapes destination directory", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, tarDirPermission); err != nil {
+				return fmt.Errorf("creating directory %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), tarDirPermission); err != nil {
+				return fmt.Errorf("creating parent directory: %w", err)
+			}
+
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, tarFilePermission) //nolint:gosec // Path validated above against directory traversal.
+			if err != nil {
+				return fmt.Errorf("creating file %s: %w", target, err)
+			}
+
+			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec // Trusted source, bounded by pod filesystem.
+				_ = f.Close()
+
+				return fmt.Errorf("writing file %s: %w", target, err)
+			}
+
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("closing file %s: %w", target, err)
+			}
+		}
+	}
+}
+
+func createTar(w io.Writer, srcDir string) error {
+	tw := tar.NewWriter(w)
+	defer func() { _ = tw.Close() }()
+
+	if err := filepath.Walk(srcDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return fmt.Errorf("computing relative path: %w", err)
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		if info.IsDir() && info.Name() == "lost+found" {
+			return filepath.SkipDir
+		}
+
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("creating tar header: %w", err)
+		}
+
+		header.Name = relPath
+
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("writing tar header: %w", err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		f, err := os.Open(path) //nolint:gosec // Path comes from trusted local Walk, not user input.
+		if err != nil {
+			return fmt.Errorf("opening file %s: %w", path, err)
+		}
+		defer func() { _ = f.Close() }()
+
+		if _, err := io.Copy(tw, f); err != nil {
+			return fmt.Errorf("writing file %s to tar: %w", path, err)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("walking source directory: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
feat: adding trustyai break-gpu-deadlock command

feat: adding patch-guardrails command

feat: adding trustyai migrate-gorch-otel-exporter command

feat: adding trustyai metrics export and import subcommands

feat: add trustyai data export and import subcommands

fix: otel migration fix to nullify the old fields, data backup/restore fix to ignore lost+found directory

chore: go.sum update

chore: update io.ReadAll to io.LimitReader

Signed-off-by: Max Whittingham <mwhittingham@redhat.com>

## Description

Converting TrustyAI migration shell scripts to Go actions

## Testing
Validated TrustyAI Go commands on RHOAI 2.25, on a 4.21.5 cluster.

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TrustyAI: data backup/restore (PVC & DB), metrics backup/restore, GPU predictor deadlock remediation, Guardrails readiness-probe patching, OpenTelemetry exporter migration; discovery of TrustyAI services and OpenShift Routes; pod exec and tar-based pod↔local copy.
  * CLI/runtime: migration commands now carry Kubernetes REST config to enable in-cluster exec/HTTP operations.

* **Tests**
  * Extensive unit/integration tests covering new TrustyAI flows, discovery, exec/copy, metrics HTTP helpers, and migrations.

* **Chores**
  * Small config and packaging updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->