### PR TITLE
feat: add workbenches.upgrade-2x-to-3x migration action (RHOAIENG-61433)

### DIFF
--- a/pkg/migrate/actions/workbenches/upgrade/prepare_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/prepare_task.go
@@ -1,0 +1,70 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+)
+
+type prepareTask struct {
+	action *WorkbenchUpgradeAction
+}
+
+func (t *prepareTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child(
+		"validate-notebooks",
+		"Check for Notebook resources",
+	)
+
+	notebooks, err := t.action.listNotebooks(ctx, target)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+	} else if len(notebooks) == 0 {
+		step.Complete(result.StepCompleted, "No Notebook instances found")
+	} else {
+		step.Complete(result.StepCompleted, "Found %d Notebook(s) across the cluster", len(notebooks))
+	}
+
+	return buildResult(target.Recorder)
+}
+
+func (t *prepareTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child(
+		"prepare-backup",
+		"Prepare workbench backup",
+	)
+
+	notebooks, err := t.action.listNotebooks(ctx, target)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return buildResult(target.Recorder)
+	}
+
+	if len(notebooks) == 0 {
+		step.Complete(result.StepCompleted, "No Notebook instances found, nothing to back up")
+
+		return buildResult(target.Recorder)
+	}
+
+	if err := t.action.backupNotebooks(ctx, target, notebooks, step); err != nil {
+		r, buildErr := buildResult(target.Recorder)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		return r, fmt.Errorf("prepare backup failed: %w", err)
+	}
+
+	step.Complete(result.StepCompleted, "Backup phase complete")
+
+	return buildResult(target.Recorder)
+}

--- a/pkg/migrate/actions/workbenches/upgrade/run_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/run_task.go
@@ -1,0 +1,237 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+)
+
+type runTask struct {
+	action *WorkbenchUpgradeAction
+}
+
+func (t *runTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child(
+		"validate-prerequisites",
+		"Validate migration prerequisites",
+	)
+
+	notebooks, err := t.action.listNotebooks(ctx, target)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return buildResult(target.Recorder)
+	}
+
+	if len(notebooks) == 0 {
+		step.Complete(result.StepCompleted, "No Notebook instances found, nothing to migrate")
+
+		return buildResult(target.Recorder)
+	}
+
+	stopped := t.action.handleNonStoppedNotebooks(target, notebooks, step)
+
+	mismatchCount := 0
+	checkErrCount := 0
+
+	for _, nb := range stopped {
+		hasMismatch, checkErr := hasContainerNameMismatch(nb)
+		if checkErr != nil {
+			step.Record("check-error",
+				fmt.Sprintf("Failed to inspect Notebook %s/%s: %v", nb.GetNamespace(), nb.GetName(), checkErr),
+				result.StepFailed)
+			checkErrCount++
+
+			continue
+		}
+
+		if hasMismatch {
+			mismatchCount++
+		}
+	}
+
+	if checkErrCount > 0 {
+		step.Complete(result.StepFailed,
+			"Failed to inspect %d Notebook(s); resolve validation errors first", checkErrCount)
+	} else if mismatchCount > 0 {
+		step.Complete(result.StepCompleted,
+			"Found %d Notebook(s) with container name mismatches requiring update", mismatchCount)
+	} else {
+		step.Complete(result.StepCompleted,
+			"All %d stopped Notebook(s) have correct container names", len(stopped))
+	}
+
+	return buildResult(target.Recorder)
+}
+
+func (t *runTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	listStep := target.Recorder.Child(
+		"list-notebooks",
+		"List Notebook resources",
+	)
+
+	notebooks, err := t.action.listNotebooks(ctx, target)
+	if err != nil {
+		listStep.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return buildResult(target.Recorder)
+	}
+
+	if len(notebooks) == 0 {
+		listStep.Complete(result.StepCompleted, "No Notebook instances found, nothing to migrate")
+
+		return buildResult(target.Recorder)
+	}
+
+	listStep.Complete(result.StepCompleted, "Found %d Notebook(s)", len(notebooks))
+
+	stopped := t.action.handleNonStoppedNotebooks(target, notebooks, target.Recorder)
+
+	if len(stopped) == 0 {
+		target.Recorder.Record("no-eligible-notebooks",
+			"No eligible Notebook(s) to migrate (all non-stopped)", result.StepSkipped)
+
+		return buildResult(target.Recorder)
+	}
+
+	t.fixContainerNames(ctx, target, stopped)
+
+	return buildResult(target.Recorder)
+}
+
+func (t *runTask) fixContainerNames(
+	ctx context.Context,
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+) {
+	step := target.Recorder.Child(
+		"fix-container-names",
+		"Fix container name mismatches",
+	)
+
+	var toFix []*unstructured.Unstructured
+
+	checkErrCount := 0
+
+	for _, nb := range notebooks {
+		hasMismatch, err := hasContainerNameMismatch(nb)
+		if err != nil {
+			step.Record("check-error",
+				fmt.Sprintf("Error checking %s/%s: %v", nb.GetNamespace(), nb.GetName(), err),
+				result.StepFailed)
+			checkErrCount++
+
+			continue
+		}
+
+		if hasMismatch {
+			toFix = append(toFix, nb)
+		}
+	}
+
+	if len(toFix) == 0 && checkErrCount > 0 {
+		step.Complete(result.StepFailed,
+			"Failed to inspect %d Notebook(s), no fixable mismatches found", checkErrCount)
+
+		return
+	}
+
+	if len(toFix) == 0 {
+		step.Complete(result.StepCompleted,
+			"All %d Notebook(s) have correct container names, no changes needed", len(notebooks))
+
+		return
+	}
+
+	if target.DryRun {
+		for _, nb := range toFix {
+			containers, _ := extractWorkloadContainers(nb)
+			if len(containers) > 0 {
+				step.Record("would-fix",
+					fmt.Sprintf("Would rename container %q to %q in %s/%s",
+						containers[0].Name, nb.GetName(), nb.GetNamespace(), nb.GetName()),
+					result.StepSkipped)
+			}
+		}
+
+		if checkErrCount > 0 {
+			step.Complete(result.StepFailed,
+				"Would fix %d Notebook(s), but failed to inspect %d",
+				len(toFix), checkErrCount)
+		} else {
+			step.Complete(result.StepSkipped,
+				"Would fix container names in %d Notebook(s)", len(toFix))
+		}
+
+		return
+	}
+
+	if !t.action.promptBeforeModification(target, len(toFix)) {
+		step.Complete(result.StepSkipped, "User cancelled modification")
+
+		return
+	}
+
+	successCount, failCount := t.applyContainerFixes(ctx, target, toFix, step)
+
+	if failCount > 0 || checkErrCount > 0 {
+		step.Complete(result.StepFailed,
+			"Fixed %d/%d Notebook(s), %d update failure(s), %d inspection failure(s)",
+			successCount, len(toFix), failCount, checkErrCount)
+	} else {
+		step.Complete(result.StepCompleted,
+			"Fixed container names in %d/%d Notebook(s)", successCount, len(toFix))
+	}
+}
+
+//nolint:revive // confusing-results: unnamed (int, int) conflicts with nonamedreturns linter.
+func (t *runTask) applyContainerFixes(
+	ctx context.Context,
+	target action.Target,
+	toFix []*unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) (int, int) {
+	successCount := 0
+	failCount := 0
+
+	for _, nb := range toFix {
+		nbStep := parentStep.Child(
+			fmt.Sprintf("fix-%s-%s", nb.GetNamespace(), nb.GetName()),
+			fmt.Sprintf("Fix container name in %s/%s", nb.GetNamespace(), nb.GetName()),
+		)
+
+		patched := nb.DeepCopy()
+
+		oldName, err := fixContainerName(patched)
+		if err != nil {
+			nbStep.Complete(result.StepFailed, "Failed to fix container name: %v", err)
+			failCount++
+
+			continue
+		}
+
+		if err := t.action.updateNotebook(ctx, target, patched); err != nil {
+			nbStep.Complete(result.StepFailed,
+				"Failed to update Notebook %s/%s: %v", nb.GetNamespace(), nb.GetName(), err)
+			failCount++
+
+			continue
+		}
+
+		nbStep.Complete(result.StepCompleted,
+			"Renamed container %q to %q", oldName, nb.GetName())
+		successCount++
+	}
+
+	return successCount, failCount
+}

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade.go
@@ -1,0 +1,379 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	actionID          = "workbenches.upgrade-2x-to-3x"
+	actionName        = "Upgrade workbenches from 2.x to 3.x"
+	actionDescription = "Updates workbench notebook container names for 3.x compatibility"
+
+	annotationKubeflowResourceStopped = "kubeflow-resource-stopped"
+	annotationAcceleratorName         = "opendatahub.io/accelerator-name"
+	annotationLastSizeSelection       = "notebooks.opendatahub.io/last-size-selection"
+
+	oauthProxyContainerName = "oauth-proxy"
+	oauthProxyImageSubstr   = "ose-oauth-proxy-rhel9"
+)
+
+// WorkbenchUpgradeAction implements the workbenches.upgrade-2x-to-3x migration action.
+// It fixes container name mismatches in Dashboard-managed notebooks so that accelerator
+// injection and size selection work correctly after upgrading to RHOAI 3.x.
+type WorkbenchUpgradeAction struct {
+	ForceNonStopped bool
+}
+
+func (a *WorkbenchUpgradeAction) ID() string          { return actionID }
+func (a *WorkbenchUpgradeAction) Name() string        { return actionName }
+func (a *WorkbenchUpgradeAction) Description() string { return actionDescription }
+
+func (a *WorkbenchUpgradeAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *WorkbenchUpgradeAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func buildResult(recorder action.StepRecorder) (*result.ActionResult, error) {
+	rootRecorder, ok := recorder.(action.RootRecorder)
+	if !ok {
+		return nil, errors.New("recorder is not a RootRecorder")
+	}
+
+	return rootRecorder.Build(), nil
+}
+
+func (a *WorkbenchUpgradeAction) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&a.ForceNonStopped, "force-non-stopped", false,
+		"Include non-stopped workbenches in migration (unsafe: may cause data loss)")
+}
+
+func (a *WorkbenchUpgradeAction) CanApply(target action.Target) bool {
+	if target.CurrentVersion == nil || target.TargetVersion == nil {
+		return false
+	}
+
+	return target.CurrentVersion.Major == 2 &&
+		target.CurrentVersion.Minor >= 16 &&
+		target.TargetVersion.Major >= 3
+}
+
+func (a *WorkbenchUpgradeAction) Prepare() action.Task {
+	return &prepareTask{action: a}
+}
+
+func (a *WorkbenchUpgradeAction) Run() action.Task {
+	return &runTask{action: a}
+}
+
+// listNotebooks lists all Notebook CRs across all namespaces.
+func (a *WorkbenchUpgradeAction) listNotebooks(
+	ctx context.Context,
+	target action.Target,
+) ([]*unstructured.Unstructured, error) {
+	nbs, err := target.Client.List(ctx, resources.Notebook)
+	if err != nil {
+		return nil, fmt.Errorf("listing notebooks: %w", err)
+	}
+
+	return nbs, nil
+}
+
+// isStopped returns true if the notebook has the kubeflow-resource-stopped annotation.
+func isStopped(nb *unstructured.Unstructured) bool {
+	annotations := nb.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, stopped := annotations[annotationKubeflowResourceStopped]
+
+	return stopped
+}
+
+// hasDashboardAnnotation returns true if the notebook has Dashboard-managed annotations.
+func hasDashboardAnnotation(nb *unstructured.Unstructured) bool {
+	annotations := nb.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	return annotations[annotationAcceleratorName] != "" ||
+		annotations[annotationLastSizeSelection] != ""
+}
+
+// notebookContainer holds the parsed name and image of a container.
+type notebookContainer struct {
+	Name  string
+	Image string
+}
+
+// isInfrastructureContainer returns true if the container is a known sidecar.
+func isInfrastructureContainer(name string, image string) bool {
+	return name == oauthProxyContainerName && strings.Contains(image, oauthProxyImageSubstr)
+}
+
+// extractWorkloadContainers extracts non-infrastructure containers from a notebook.
+func extractWorkloadContainers(nb *unstructured.Unstructured) ([]notebookContainer, error) {
+	rawContainers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return nil, fmt.Errorf("querying containers: %w", err)
+	}
+
+	var containers []notebookContainer
+
+	for _, raw := range rawContainers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := containerMap["name"].(string)
+		image, _ := containerMap["image"].(string)
+
+		if isInfrastructureContainer(name, image) {
+			continue
+		}
+
+		containers = append(containers, notebookContainer{
+			Name:  name,
+			Image: image,
+		})
+	}
+
+	return containers, nil
+}
+
+// hasContainerNameMismatch returns true if the primary workload container name
+// does not match the notebook CR name.
+func hasContainerNameMismatch(nb *unstructured.Unstructured) (bool, error) {
+	if !hasDashboardAnnotation(nb) {
+		return false, nil
+	}
+
+	containers, err := extractWorkloadContainers(nb)
+	if err != nil {
+		return false, err
+	}
+
+	if len(containers) != 1 {
+		return false, nil
+	}
+
+	return containers[0].Name != nb.GetName(), nil
+}
+
+// fixContainerName renames the primary workload container to match the notebook CR name.
+// Preserves all other container properties (env vars, volume mounts, resources, etc.).
+func fixContainerName(nb *unstructured.Unstructured) (string, error) {
+	workloads, err := extractWorkloadContainers(nb)
+	if err != nil {
+		return "", err
+	}
+
+	if len(workloads) != 1 {
+		return "", fmt.Errorf("expected exactly 1 workload container, found %d", len(workloads))
+	}
+
+	rawContainers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return "", fmt.Errorf("querying containers: %w", err)
+	}
+
+	crName := nb.GetName()
+	var oldName string
+
+	for _, raw := range rawContainers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := containerMap["name"].(string)
+		image, _ := containerMap["image"].(string)
+
+		if isInfrastructureContainer(name, image) {
+			continue
+		}
+
+		oldName = name
+		containerMap["name"] = crName
+
+		break
+	}
+
+	containersJSON, err := json.Marshal(rawContainers)
+	if err != nil {
+		return "", fmt.Errorf("marshaling containers: %w", err)
+	}
+
+	if err := jq.Transform(nb, ".spec.template.spec.containers = %s", containersJSON); err != nil {
+		return "", fmt.Errorf("setting containers: %w", err)
+	}
+
+	return oldName, nil
+}
+
+// backupNotebooks writes notebook resources to the output directory, grouped by namespace.
+// Returns an error if any backup write fails — callers must not proceed with mutations.
+func (a *WorkbenchUpgradeAction) backupNotebooks(
+	_ context.Context,
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) error {
+	step := parentStep.Child(
+		"backup-notebooks",
+		"Backup Notebook resources",
+	)
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, "Would backup %d Notebook(s) to %s", len(notebooks), target.OutputDir)
+
+		return nil
+	}
+
+	byNamespace := make(map[string][]*unstructured.Unstructured)
+	for _, nb := range notebooks {
+		ns := nb.GetNamespace()
+		byNamespace[ns] = append(byNamespace[ns], nb)
+	}
+
+	totalBacked := 0
+
+	for ns, nbs := range byNamespace {
+		outputDir := filepath.Join(target.OutputDir, ns)
+
+		if err := backup.WriteResourcesToDir(outputDir, resources.Notebook.GVR(), nbs); err != nil {
+			step.Complete(result.StepFailed, "Failed to write Notebooks in namespace %s: %v", ns, err)
+
+			return fmt.Errorf("backup failed for namespace %s: %w", ns, err)
+		}
+
+		totalBacked += len(nbs)
+	}
+
+	step.Complete(result.StepCompleted, "Backed up %d Notebook(s) across %d namespace(s) to %s", totalBacked, len(byNamespace), target.OutputDir)
+
+	return nil
+}
+
+// handleNonStoppedNotebooks checks for non-stopped notebooks and returns only the stopped ones.
+// When --force-non-stopped is set, includes all notebooks regardless of stopped state.
+func (a *WorkbenchUpgradeAction) handleNonStoppedNotebooks(
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) []*unstructured.Unstructured {
+	step := parentStep.Child(
+		"check-non-stopped",
+		"Check for non-stopped workbenches",
+	)
+
+	var stopped, nonStopped []*unstructured.Unstructured
+
+	for _, nb := range notebooks {
+		if isStopped(nb) {
+			stopped = append(stopped, nb)
+		} else {
+			nonStopped = append(nonStopped, nb)
+		}
+	}
+
+	if len(nonStopped) == 0 {
+		step.Complete(result.StepCompleted, "All %d Notebook(s) are stopped", len(notebooks))
+
+		return stopped
+	}
+
+	var names []string
+	for _, nb := range nonStopped {
+		names = append(names, fmt.Sprintf("%s/%s", nb.GetNamespace(), nb.GetName()))
+	}
+
+	step.AddDetail("non_stopped_notebooks", names)
+
+	if a.ForceNonStopped {
+		step.Complete(result.StepCompleted,
+			"Including %d non-stopped Notebook(s) (--force-non-stopped): %s",
+			len(nonStopped), strings.Join(names, ", "))
+
+		return notebooks
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped,
+			"Found %d non-stopped Notebook(s) (would skip in dry-run): %s",
+			len(nonStopped), strings.Join(names, ", "))
+
+		return stopped
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("Found %d non-stopped Notebook(s):", len(nonStopped))
+
+		for _, name := range names {
+			target.IO.Errorf("  - %s", name)
+		}
+
+		target.IO.Errorf("Non-stopped notebooks will be skipped. Stop them before upgrading.")
+		target.IO.Errorf("Use --force-non-stopped to include them (unsafe).")
+	}
+
+	step.Complete(result.StepCompleted,
+		"Skipping %d non-stopped Notebook(s), proceeding with %d stopped Notebook(s)",
+		len(nonStopped), len(stopped))
+
+	return stopped
+}
+
+// updateNotebook applies changes to a notebook on the cluster.
+func (a *WorkbenchUpgradeAction) updateNotebook(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+) error {
+	_, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace(nb.GetNamespace()).
+		Update(ctx, nb, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating notebook %s/%s: %w", nb.GetNamespace(), nb.GetName(), err)
+	}
+
+	return nil
+}
+
+// promptBeforeModification asks the user for confirmation before modifying notebooks.
+func (a *WorkbenchUpgradeAction) promptBeforeModification(
+	target action.Target,
+	count int,
+) bool {
+	if target.SkipConfirm {
+		return true
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("About to modify %d Notebook(s) to fix container name mismatches", count)
+
+	return confirmation.Prompt(target.IO, "Proceed with workbench modifications?")
+}

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -1,0 +1,1888 @@
+//nolint:testpackage // Tests internal implementation (unexported helpers)
+package upgrade
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+// --- Test Fixtures ---
+
+type notebookOpts struct {
+	Labels      map[string]any
+	Annotations map[string]any
+	Containers  []any
+	Status      map[string]any
+}
+
+func newNotebook(name, namespace string, opts notebookOpts) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(opts.Labels) > 0 {
+		metadata["labels"] = opts.Labels
+	}
+
+	if len(opts.Annotations) > 0 {
+		metadata["annotations"] = opts.Annotations
+	}
+
+	obj := map[string]any{
+		"apiVersion": resources.Notebook.APIVersion(),
+		"kind":       resources.Notebook.Kind,
+		"metadata":   metadata,
+	}
+
+	if opts.Containers != nil {
+		obj["spec"] = map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": opts.Containers,
+				},
+			},
+		}
+	}
+
+	if opts.Status != nil {
+		obj["status"] = opts.Status
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func container(name, image string) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"image": image,
+	}
+}
+
+func containerWithEnv(name, image string, envVars []map[string]any) map[string]any {
+	env := make([]any, len(envVars))
+	for i, e := range envVars {
+		env[i] = e
+	}
+
+	return map[string]any{
+		"name":  name,
+		"image": image,
+		"env":   env,
+	}
+}
+
+func containerWithVolumeMounts(name, image string, mounts []map[string]any) map[string]any {
+	vms := make([]any, len(mounts))
+	for i, m := range mounts {
+		vms[i] = m
+	}
+
+	return map[string]any{
+		"name":         name,
+		"image":        image,
+		"volumeMounts": vms,
+	}
+}
+
+func stoppedAnnotations() map[string]any {
+	return map[string]any{
+		"kubeflow-resource-stopped": "2026-01-15T00:00:00Z",
+	}
+}
+
+func dashboardAnnotations() map[string]any {
+	return map[string]any{
+		"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+	}
+}
+
+func stoppedDashboardAnnotations() map[string]any {
+	return map[string]any{
+		"kubeflow-resource-stopped":                    "2026-01-15T00:00:00Z",
+		"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+		"opendatahub.io/accelerator-name":              "migrated-gpu",
+	}
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+func newFakeClient(scheme *runtime.Scheme, objects ...runtime.Object) client.Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.Notebook.GVR(): resources.Notebook.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newFailingListClient() client.Client {
+	scheme := newScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.Notebook.GVR(): resources.Notebook.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "notebooks", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated API server error")
+	})
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newFailingUpdateClient(scheme *runtime.Scheme, objects ...runtime.Object) client.Client {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.Notebook.GVR(): resources.Notebook.ListKind(),
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+	dynamicClient.PrependReactor("update", "notebooks", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated update error")
+	})
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func withOutputDir(dir string) func(*action.Target) {
+	return func(t *action.Target) {
+		t.OutputDir = dir
+	}
+}
+
+// --- Action Metadata Tests ---
+
+func TestWorkbenchUpgradeAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+
+	g.Expect(a.ID()).To(Equal("workbenches.upgrade-2x-to-3x"))
+	g.Expect(a.Name()).To(Equal("Upgrade workbenches from 2.x to 3.x"))
+	g.Expect(a.Description()).To(ContainSubstring("container names"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+}
+
+func TestWorkbenchUpgradeAction_CanApply(t *testing.T) {
+	v3 := semver.MustParse("3.0.0")
+	v33 := semver.MustParse("3.3.0")
+	v35 := semver.MustParse("3.5.0")
+
+	tests := []struct {
+		name          string
+		current       string
+		targetVersion *semver.Version
+		expected      bool
+	}{
+		{"applies for 2.25 -> 3.0", "2.25.0", &v3, true},
+		{"applies for 2.16 -> 3.0", "2.16.0", &v3, true},
+		{"applies for 2.25 -> 3.3", "2.25.0", &v33, true},
+		{"applies for 2.25 -> 3.5", "2.25.0", &v35, true},
+		{"does not apply for 2.15 (too old)", "2.15.0", &v3, false},
+		{"does not apply for 2.0 (too old)", "2.0.0", &v3, false},
+		{"does not apply for 3.0 current", "3.0.0", &v3, false},
+		{"does not apply for 1.0 current", "1.0.0", &v3, false},
+		{"does not apply for nil target version", "2.25.0", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			a := &WorkbenchUpgradeAction{}
+			ver := semver.MustParse(tt.current)
+			target := action.Target{
+				CurrentVersion: &ver,
+				TargetVersion:  tt.targetVersion,
+			}
+
+			g.Expect(a.CanApply(target)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWorkbenchUpgradeAction_CanApply_NilCurrentVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	target := action.Target{CurrentVersion: nil, TargetVersion: nil}
+	g.Expect(a.CanApply(target)).To(BeFalse())
+}
+
+func TestWorkbenchUpgradeAction_PrepareNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	g.Expect(a.Prepare()).ToNot(BeNil())
+}
+
+func TestWorkbenchUpgradeAction_RunNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+// --- Helper Function Tests ---
+
+func TestIsStopped(t *testing.T) {
+	tests := []struct {
+		name     string
+		nb       *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			"stopped notebook",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Annotations: map[string]any{
+					"kubeflow-resource-stopped": "2026-01-15T00:00:00Z",
+				},
+			}),
+			true,
+		},
+		{
+			"running notebook (no annotation)",
+			newNotebook("nb1", "ns1", notebookOpts{}),
+			false,
+		},
+		{
+			"running notebook (nil annotations)",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Annotations: nil,
+			}),
+			false,
+		},
+		{
+			"notebook with controller lock (still counts as stopped)",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Annotations: map[string]any{
+					"kubeflow-resource-stopped": "odh-notebook-controller-lock",
+				},
+			}),
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isStopped(tt.nb)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestHasDashboardAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		nb       *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			"has accelerator annotation",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Annotations: map[string]any{
+					"opendatahub.io/accelerator-name": "gpu",
+				},
+			}),
+			true,
+		},
+		{
+			"has size selection annotation",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Annotations: map[string]any{
+					"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+				},
+			}),
+			true,
+		},
+		{
+			"no dashboard annotations",
+			newNotebook("nb1", "ns1", notebookOpts{}),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hasDashboardAnnotation(tt.nb)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestIsInfrastructureContainer(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctrName  string
+		image    string
+		expected bool
+	}{
+		{"oauth-proxy sidecar", "oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest", true},
+		{"oauth-proxy but custom image", "oauth-proxy", "custom-image:latest", false},
+		{"workload named oauth-proxy", "oauth-proxy", "jupyter:latest", false},
+		{"normal container", "my-notebook", "jupyter:latest", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isInfrastructureContainer(tt.ctrName, tt.image)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestExtractWorkloadContainers(t *testing.T) {
+	tests := []struct {
+		name          string
+		nb            *unstructured.Unstructured
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			"single workload container",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Containers: []any{
+					container("nb1", "jupyter:latest"),
+				},
+			}),
+			1, []string{"nb1"},
+		},
+		{
+			"workload with oauth-proxy sidecar",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Containers: []any{
+					container("nb1", "jupyter:latest"),
+					container("oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest"),
+				},
+			}),
+			1, []string{"nb1"},
+		},
+		{
+			"multiple workload containers",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Containers: []any{
+					container("main", "jupyter:latest"),
+					container("sidecar", "helper:latest"),
+				},
+			}),
+			2, []string{"main", "sidecar"},
+		},
+		{
+			"no containers",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Containers: []any{},
+			}),
+			0, nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			containers, err := extractWorkloadContainers(tt.nb)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(containers).To(HaveLen(tt.expectedCount))
+
+			for i, name := range tt.expectedNames {
+				g.Expect(containers[i].Name).To(Equal(name))
+			}
+		})
+	}
+}
+
+func TestHasContainerNameMismatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		nb       *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			"mismatch with dashboard annotation",
+			newNotebook("my-notebook", "ns1", notebookOpts{
+				Annotations: dashboardAnnotations(),
+				Containers:  []any{container("old-name", "jupyter:latest")},
+			}),
+			true,
+		},
+		{
+			"no mismatch",
+			newNotebook("my-notebook", "ns1", notebookOpts{
+				Annotations: dashboardAnnotations(),
+				Containers:  []any{container("my-notebook", "jupyter:latest")},
+			}),
+			false,
+		},
+		{
+			"mismatch but no dashboard annotation (not checked)",
+			newNotebook("my-notebook", "ns1", notebookOpts{
+				Containers: []any{container("old-name", "jupyter:latest")},
+			}),
+			false,
+		},
+		{
+			"no containers",
+			newNotebook("my-notebook", "ns1", notebookOpts{
+				Annotations: dashboardAnnotations(),
+				Containers:  []any{},
+			}),
+			false,
+		},
+		{
+			"multiple workload containers skipped",
+			newNotebook("my-notebook", "ns1", notebookOpts{
+				Annotations: dashboardAnnotations(),
+				Containers: []any{
+					container("wrong-name", "jupyter:latest"),
+					container("sidecar", "helper:latest"),
+				},
+			}),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hasMismatch, err := hasContainerNameMismatch(tt.nb)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(hasMismatch).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestFixContainerName(t *testing.T) {
+	t.Run("renames primary container to match CR name", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nb := newNotebook("my-notebook", "ns1", notebookOpts{
+			Annotations: dashboardAnnotations(),
+			Containers: []any{
+				container("old-name", "jupyter:latest"),
+			},
+		})
+
+		oldName, err := fixContainerName(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(oldName).To(Equal("old-name"))
+
+		containers, err := extractWorkloadContainers(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(containers).To(HaveLen(1))
+		g.Expect(containers[0].Name).To(Equal("my-notebook"))
+		g.Expect(containers[0].Image).To(Equal("jupyter:latest"))
+	})
+
+	t.Run("skips infrastructure containers", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nb := newNotebook("my-notebook", "ns1", notebookOpts{
+			Annotations: dashboardAnnotations(),
+			Containers: []any{
+				container("oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest"),
+				container("old-name", "jupyter:latest"),
+			},
+		})
+
+		oldName, err := fixContainerName(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(oldName).To(Equal("old-name"))
+
+		containers, err := extractWorkloadContainers(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(containers).To(HaveLen(1))
+		g.Expect(containers[0].Name).To(Equal("my-notebook"))
+	})
+
+	t.Run("preserves environment variables", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nb := newNotebook("my-notebook", "ns1", notebookOpts{
+			Annotations: dashboardAnnotations(),
+			Containers: []any{
+				containerWithEnv("old-name", "jupyter:latest", []map[string]any{
+					{"name": "MY_VAR", "value": "my-value"},
+					{"name": "SECRET_REF", "valueFrom": map[string]any{
+						"secretKeyRef": map[string]any{"name": "secret", "key": "key"},
+					}},
+				}),
+			},
+		})
+
+		_, err := fixContainerName(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		containers, err := extractWorkloadContainers(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(containers[0].Name).To(Equal("my-notebook"))
+	})
+
+	t.Run("preserves volume mounts", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nb := newNotebook("my-notebook", "ns1", notebookOpts{
+			Annotations: dashboardAnnotations(),
+			Containers: []any{
+				containerWithVolumeMounts("old-name", "jupyter:latest", []map[string]any{
+					{"name": "data-vol", "mountPath": "/data"},
+					{"name": "config-vol", "mountPath": "/config"},
+				}),
+			},
+		})
+
+		_, err := fixContainerName(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		containers, err := extractWorkloadContainers(nb)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(containers[0].Name).To(Equal("my-notebook"))
+	})
+
+	t.Run("rejects multiple workload containers", func(t *testing.T) {
+		g := NewWithT(t)
+
+		nb := newNotebook("my-notebook", "ns1", notebookOpts{
+			Annotations: dashboardAnnotations(),
+			Containers: []any{
+				container("wrong-name", "jupyter:latest"),
+				container("sidecar", "helper:latest"),
+			},
+		})
+
+		_, err := fixContainerName(nb)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("expected exactly 1 workload container, found 2"))
+	})
+}
+
+// --- Prepare Task Tests ---
+
+func TestPrepareTask_Validate_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Validate_WithNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_WithBackup(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+
+	outputDir := t.TempDir()
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient, withOutputDir(outputDir))
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_BackupFailure_ReturnsError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	g.Expect(os.WriteFile(blocker, []byte("x"), 0o600)).To(Succeed())
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient, withOutputDir(filepath.Join(blocker, "sub")))
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Execute(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("prepare backup failed"))
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- Run Task Tests ---
+
+func TestRunTask_Validate_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_WithMismatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(newScheme())
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_AllCorrectNames(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("my-notebook", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_FixContainerNameMismatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	containers, _ := extractWorkloadContainersFromUnstructured(updated)
+	g.Expect(containers).To(HaveLen(1))
+	g.Expect(containers[0]["name"]).To(Equal("my-notebook"))
+	g.Expect(containers[0]["image"]).To(Equal("jupyter:latest"))
+}
+
+func TestRunTask_Execute_DryRun_NoChanges(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	original, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	containers, _ := extractWorkloadContainersFromUnstructured(original)
+	g.Expect(containers).To(HaveLen(1))
+	g.Expect(containers[0]["name"]).To(Equal("old-name"))
+}
+
+func TestRunTask_Execute_SkipsNonStoppedNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	stoppedNb := newNotebook("stopped-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	runningNb := newNotebook("running-nb", "ns1", notebookOpts{
+		Annotations: dashboardAnnotations(),
+		Containers:  []any{container("wrong-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), stoppedNb, runningNb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	stoppedUpdated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "stopped-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	stoppedContainers, _ := extractWorkloadContainersFromUnstructured(stoppedUpdated)
+	g.Expect(stoppedContainers[0]["name"]).To(Equal("stopped-nb"))
+
+	runningOriginal, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "running-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	runningContainers, _ := extractWorkloadContainersFromUnstructured(runningOriginal)
+	g.Expect(runningContainers[0]["name"]).To(Equal("wrong-name"))
+}
+
+func TestRunTask_Execute_MultipleNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb1 := newNotebook("nb1", "ns-alpha", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("wrong-alpha", "jupyter:latest")},
+	})
+
+	nb2 := newNotebook("nb2", "ns-beta", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("wrong-beta", "rstudio:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb1, nb2)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	updated1, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns-alpha").Get(context.Background(), "nb1", metav1.GetOptions{})
+	containers1, _ := extractWorkloadContainersFromUnstructured(updated1)
+	g.Expect(containers1[0]["name"]).To(Equal("nb1"))
+
+	updated2, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns-beta").Get(context.Background(), "nb2", metav1.GetOptions{})
+	containers2, _ := extractWorkloadContainersFromUnstructured(updated2)
+	g.Expect(containers2[0]["name"]).To(Equal("nb2"))
+}
+
+func TestRunTask_Execute_MultipleWorkloadContainers_Skipped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers: []any{
+			container("oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest"),
+			container("wrong-name", "jupyter:latest"),
+			container("helper", "sidecar:latest"),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	allContainers, _ := extractWorkloadContainersFromUnstructured(updated)
+
+	g.Expect(allContainers).To(HaveLen(3))
+	g.Expect(allContainers[0]["name"]).To(Equal("oauth-proxy"))
+	g.Expect(allContainers[1]["name"]).To(Equal("wrong-name"))
+	g.Expect(allContainers[2]["name"]).To(Equal("helper"))
+}
+
+func TestRunTask_Execute_PreservesEnvVars(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers: []any{
+			containerWithEnv("wrong-name", "jupyter:latest", []map[string]any{
+				{"name": "VAR1", "value": "val1"},
+				{"name": "VAR2", "value": "val2"},
+			}),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	_, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	allContainers, _ := extractWorkloadContainersFromUnstructured(updated)
+
+	g.Expect(allContainers[0]["name"]).To(Equal("my-notebook"))
+	envVars, ok := allContainers[0]["env"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(envVars).To(HaveLen(2))
+}
+
+func TestRunTask_Execute_PreservesVolumeMounts(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers: []any{
+			containerWithVolumeMounts("wrong-name", "jupyter:latest", []map[string]any{
+				{"name": "pvc-data", "mountPath": "/opt/data"},
+				{"name": "config", "mountPath": "/etc/config"},
+			}),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	_, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	allContainers, _ := extractWorkloadContainersFromUnstructured(updated)
+
+	g.Expect(allContainers[0]["name"]).To(Equal("my-notebook"))
+	mounts, ok := allContainers[0]["volumeMounts"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(mounts).To(HaveLen(2))
+}
+
+func TestRunTask_Execute_NoDashboardAnnotation_NoChange(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: map[string]any{
+			"kubeflow-resource-stopped": "2026-01-15T00:00:00Z",
+		},
+		Containers: []any{container("different-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(original)
+	g.Expect(containers[0]["name"]).To(Equal("different-name"))
+}
+
+func TestRunTask_Execute_AllNonStopped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("running-nb", "ns1", notebookOpts{
+		Annotations: dashboardAnnotations(),
+		Containers:  []any{container("wrong-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "running-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(original)
+	g.Expect(containers[0]["name"]).To(Equal("wrong-name"))
+}
+
+func TestRunTask_Execute_CustomImages(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("custom-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("wrong-name", "my-registry.example.com/custom-jupyter:v1")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "custom-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(updated)
+	g.Expect(containers[0]["name"]).To(Equal("custom-nb"))
+	g.Expect(containers[0]["image"]).To(Equal("my-registry.example.com/custom-jupyter:v1"))
+}
+
+func TestRunTask_Execute_MountedPVCs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("pvc-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers: []any{
+			containerWithVolumeMounts("wrong-name", "jupyter:latest", []map[string]any{
+				{"name": "data-pvc", "mountPath": "/opt/app-root/src"},
+			}),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	_, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "pvc-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(updated)
+	g.Expect(containers[0]["name"]).To(Equal("pvc-nb"))
+
+	mounts, ok := containers[0]["volumeMounts"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(mounts).To(HaveLen(1))
+
+	mount, ok := mounts[0].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(mount["mountPath"]).To(Equal("/opt/app-root/src"))
+}
+
+// --- HandleNonStoppedNotebooks Tests ---
+
+func TestHandleNonStoppedNotebooks_AllStopped(t *testing.T) {
+	g := NewWithT(t)
+
+	nbs := []*unstructured.Unstructured{
+		newNotebook("nb1", "ns1", notebookOpts{
+			Annotations: map[string]any{"kubeflow-resource-stopped": "ts1"},
+		}),
+		newNotebook("nb2", "ns1", notebookOpts{
+			Annotations: map[string]any{"kubeflow-resource-stopped": "ts2"},
+		}),
+	}
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	a := &WorkbenchUpgradeAction{}
+	target := action.Target{
+		DryRun:      false,
+		SkipConfirm: true,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	stopped := a.handleNonStoppedNotebooks(target, nbs, recorder)
+	g.Expect(stopped).To(HaveLen(2))
+}
+
+func TestHandleNonStoppedNotebooks_MixedState(t *testing.T) {
+	g := NewWithT(t)
+
+	nbs := []*unstructured.Unstructured{
+		newNotebook("stopped-nb", "ns1", notebookOpts{
+			Annotations: map[string]any{"kubeflow-resource-stopped": "ts1"},
+		}),
+		newNotebook("running-nb", "ns1", notebookOpts{}),
+		newNotebook("also-stopped", "ns2", notebookOpts{
+			Annotations: map[string]any{"kubeflow-resource-stopped": "ts2"},
+		}),
+	}
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	a := &WorkbenchUpgradeAction{}
+	target := action.Target{
+		DryRun:      false,
+		SkipConfirm: true,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	stopped := a.handleNonStoppedNotebooks(target, nbs, recorder)
+	g.Expect(stopped).To(HaveLen(2))
+}
+
+func TestHandleNonStoppedNotebooks_DryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	nbs := []*unstructured.Unstructured{
+		newNotebook("running-nb", "ns1", notebookOpts{}),
+	}
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	a := &WorkbenchUpgradeAction{}
+	target := action.Target{
+		DryRun:      true,
+		SkipConfirm: true,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	stopped := a.handleNonStoppedNotebooks(target, nbs, recorder)
+	g.Expect(stopped).To(BeEmpty())
+}
+
+// --- Step Recording Tests ---
+
+func TestRunTask_StepRecording(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult.Status.Steps).ToNot(BeEmpty())
+
+	hasFixStep := false
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "fix-container-names" {
+			hasFixStep = true
+		}
+	}
+
+	g.Expect(hasFixStep).To(BeTrue())
+}
+
+// --- Non-SkipConfirm Path Tests ---
+
+func TestHandleNonStoppedNotebooks_NonSkipConfirm_ShowsWarning(t *testing.T) {
+	g := NewWithT(t)
+
+	nbs := []*unstructured.Unstructured{
+		newNotebook("stopped-nb", "ns1", notebookOpts{
+			Annotations: map[string]any{"kubeflow-resource-stopped": "ts1"},
+		}),
+		newNotebook("running-nb", "ns2", notebookOpts{}),
+	}
+
+	errBuf := &bytes.Buffer{}
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, errBuf)
+	recorder := action.NewVerboseRootRecorder(io)
+
+	a := &WorkbenchUpgradeAction{}
+	target := action.Target{
+		DryRun:      false,
+		SkipConfirm: false,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	stopped := a.handleNonStoppedNotebooks(target, nbs, recorder)
+	g.Expect(stopped).To(HaveLen(1))
+	g.Expect(errBuf.String()).To(ContainSubstring("non-stopped"))
+}
+
+func TestRunTask_Execute_DryRun_WithNonStopped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("running-nb", "ns1", notebookOpts{
+		Annotations: dashboardAnnotations(),
+		Containers:  []any{container("wrong-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DryRun_WithMismatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(original)
+	g.Expect(containers[0]["name"]).To(Equal("old-name"))
+}
+
+func TestRunTask_Validate_AllCorrectNames(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("my-nb", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_WithNonStopped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("running-nb", "ns1", notebookOpts{
+		Annotations: dashboardAnnotations(),
+		Containers:  []any{container("wrong-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_NonSkipConfirm_UserConfirms(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+
+	inBuf := bytes.NewBufferString("y\n")
+	target := newTarget(k8sClient)
+	target.SkipConfirm = false
+	target.IO = iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+	target.Recorder = action.NewVerboseRootRecorder(target.IO)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(updated)
+	g.Expect(containers[0]["name"]).To(Equal("my-nb"))
+}
+
+func TestRunTask_Execute_NonSkipConfirm_UserCancels(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+
+	inBuf := bytes.NewBufferString("n\n")
+	target := newTarget(k8sClient)
+	target.SkipConfirm = false
+	target.IO = iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+	target.Recorder = action.NewVerboseRootRecorder(target.IO)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(original)
+	g.Expect(containers[0]["name"]).To(Equal("old-name"))
+}
+
+func TestPrepareTask_Execute_MultipleNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb1 := newNotebook("nb1", "ns-a", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+	nb2 := newNotebook("nb2", "ns-b", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb2", "rstudio:latest")},
+	})
+
+	outputDir := t.TempDir()
+	k8sClient := newFakeClient(newScheme(), nb1, nb2)
+	target := newTarget(k8sClient, withOutputDir(outputDir))
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPromptBeforeModification_SkipConfirm(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	target := action.Target{
+		SkipConfirm: true,
+		IO:          io,
+	}
+
+	g.Expect(a.promptBeforeModification(target, 5)).To(BeTrue())
+}
+
+func TestPromptBeforeModification_UserConfirms(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	inBuf := bytes.NewBufferString("y\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+	target := action.Target{
+		SkipConfirm: false,
+		IO:          io,
+	}
+
+	g.Expect(a.promptBeforeModification(target, 3)).To(BeTrue())
+}
+
+func TestPromptBeforeModification_UserDeclines(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	inBuf := bytes.NewBufferString("n\n")
+	io := iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+	target := action.Target{
+		SkipConfirm: false,
+		IO:          io,
+	}
+
+	g.Expect(a.promptBeforeModification(target, 3)).To(BeFalse())
+}
+
+func TestExtractWorkloadContainers_NoSpec(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Notebook.APIVersion(),
+			"kind":       resources.Notebook.Kind,
+			"metadata": map[string]any{
+				"name":      "bare-nb",
+				"namespace": "ns1",
+			},
+		},
+	}
+
+	_, err := extractWorkloadContainers(nb)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestHasContainerNameMismatch_NoSpec(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Notebook.APIVersion(),
+			"kind":       resources.Notebook.Kind,
+			"metadata": map[string]any{
+				"name":      "bare-nb",
+				"namespace": "ns1",
+				"annotations": map[string]any{
+					"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+				},
+			},
+		},
+	}
+
+	_, err := hasContainerNameMismatch(nb)
+	g.Expect(err).To(HaveOccurred())
+}
+
+// --- Error Path Tests ---
+
+func TestPrepareTask_Validate_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFailingListClient()
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestPrepareTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFailingListClient()
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	prepTask := a.Prepare()
+
+	result, err := prepTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFailingListClient()
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFailingListClient()
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_UpdateError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFailingUpdateClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
+	containers, _ := extractWorkloadContainersFromUnstructured(updated)
+	g.Expect(containers[0]["name"]).To(Equal("old-name"))
+}
+
+func TestFixContainerNames_WithNoSpecNotebook(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nbNoSpec := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Notebook.APIVersion(),
+			"kind":       resources.Notebook.Kind,
+			"metadata": map[string]any{
+				"name":      "broken-nb",
+				"namespace": "ns1",
+				"annotations": map[string]any{
+					"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+				},
+			},
+		},
+	}
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	target := action.Target{
+		DryRun:      false,
+		SkipConfirm: true,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	task := &runTask{action: &WorkbenchUpgradeAction{}}
+	task.fixContainerNames(ctx, target, []*unstructured.Unstructured{nbNoSpec})
+
+	result := recorder.Build()
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestFixContainerName_NoSpec(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Notebook.APIVersion(),
+			"kind":       resources.Notebook.Kind,
+			"metadata": map[string]any{
+				"name":      "bare-nb",
+				"namespace": "ns1",
+			},
+		},
+	}
+
+	_, err := fixContainerName(nb)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestBackupNotebooks_InvalidOutputDir(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	_ = os.WriteFile(blocker, []byte("x"), 0o600)
+	invalidDir := filepath.Join(blocker, "sub")
+
+	target := action.Target{
+		DryRun:      false,
+		SkipConfirm: true,
+		OutputDir:   invalidDir,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	a := &WorkbenchUpgradeAction{}
+	err := a.backupNotebooks(ctx, target, []*unstructured.Unstructured{nb}, recorder)
+	g.Expect(err).To(HaveOccurred())
+
+	actionResult := recorder.Build()
+	g.Expect(actionResult).ToNot(BeNil())
+}
+
+func TestBackupNotebooks_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Annotations: stoppedAnnotations(),
+		Containers:  []any{container("nb1", "jupyter:latest")},
+	})
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	target := action.Target{
+		DryRun:      true,
+		SkipConfirm: true,
+		OutputDir:   "/tmp/backup",
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	a := &WorkbenchUpgradeAction{}
+	err := a.backupNotebooks(ctx, target, []*unstructured.Unstructured{nb}, recorder)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	actionResult := recorder.Build()
+	g.Expect(actionResult).ToNot(BeNil())
+}
+
+func TestRunTask_Validate_MixedNonStoppedWithMismatch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	stoppedMismatch := newNotebook("stopped-nb", "ns1", notebookOpts{
+		Annotations: stoppedDashboardAnnotations(),
+		Containers:  []any{container("old-name", "jupyter:latest")},
+	})
+
+	runningNb := newNotebook("running-nb", "ns1", notebookOpts{
+		Annotations: dashboardAnnotations(),
+		Containers:  []any{container("wrong-name", "jupyter:latest")},
+	})
+
+	k8sClient := newFakeClient(newScheme(), stoppedMismatch, runningNb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestExtractWorkloadContainers_NonMapEntry(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("nb1", "ns1", notebookOpts{
+		Containers: []any{
+			"not-a-map",
+			container("real", "jupyter:latest"),
+		},
+	})
+
+	containers, err := extractWorkloadContainers(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(containers).To(HaveLen(1))
+	g.Expect(containers[0].Name).To(Equal("real"))
+}
+
+func TestHandleNonStoppedNotebooks_ForceNonStopped(t *testing.T) {
+	g := NewWithT(t)
+
+	nbs := []*unstructured.Unstructured{
+		newNotebook("stopped-nb", "ns1", notebookOpts{
+			Annotations: map[string]any{"kubeflow-resource-stopped": "ts1"},
+		}),
+		newNotebook("running-nb", "ns1", notebookOpts{}),
+	}
+
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+	recorder := action.NewVerboseRootRecorder(io)
+
+	a := &WorkbenchUpgradeAction{ForceNonStopped: true}
+	target := action.Target{
+		DryRun:      false,
+		SkipConfirm: true,
+		IO:          io,
+		Recorder:    recorder,
+	}
+
+	result := a.handleNonStoppedNotebooks(target, nbs, recorder)
+	g.Expect(result).To(HaveLen(2))
+}
+
+func TestWorkbenchUpgradeAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &WorkbenchUpgradeAction{}
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	flag := fs.Lookup("force-non-stopped")
+	g.Expect(flag).ToNot(BeNil())
+	g.Expect(flag.DefValue).To(Equal("false"))
+}
+
+// --- Test Helpers ---
+
+func extractWorkloadContainersFromUnstructured(nb *unstructured.Unstructured) ([]map[string]any, error) {
+	spec, ok := nb.Object["spec"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	template, ok := spec["template"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	podSpec, ok := template["spec"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+
+	rawContainers, ok := podSpec["containers"].([]any)
+	if !ok {
+		return nil, nil
+	}
+
+	var result []map[string]any
+
+	for _, raw := range rawContainers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		result = append(result, containerMap)
+	}
+
+	return result, nil
+}

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -56,6 +57,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
+	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -51,6 +52,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
+	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -47,6 +48,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
+	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,


### PR DESCRIPTION
## Description

Converts the workbench container-name-fix portion of
`workbench-2.x-to-3.x-upgrade.sh` to a Go migration action
(`workbenches.upgrade-2x-to-3x`) for the odh-cli migrate framework.

Dashboard-managed notebooks in RHOAI 2.x can end up with a primary
container name that doesn't match the Notebook CR name. This breaks
accelerator injection and size selection in 3.x. The action detects
and fixes these mismatches.

### Features
- Dry-run support across prepare and run phases
- Non-stopped notebook detection with `--force-non-stopped` override
- Pre-migration backup of notebook specs grouped by namespace
- Backup failure halts mutation (no half-broken state)
- DeepCopy before mutation to prevent in-memory corruption on update failure
- Partial failure tracking and reporting

### New files (4)
```
pkg/migrate/actions/workbenches/upgrade/
  upgrade.go       — Action struct, helpers (backup, classify, fix)
  prepare_task.go  — Backup notebook specs before migration
  run_task.go      — List → filter → backup → fix container names
  upgrade_test.go  — 68 test functions, 91.1% coverage
```

### Modified files (3)
- `pkg/migrate/command_list.go` — Register action
- `pkg/migrate/command_prepare.go` — Register action
- `pkg/migrate/command_run.go` — Register action

Ref: RHOAIENG-61433

## Testing

- [x] Unit tests pass — 68 tests in 1 file, 91.1% coverage
- [x] `go build`, `go vet`, `gofmt`, `go test -race` all pass
- [x] Tested against live RHOAI 2.25.6 cluster (7 notebooks, dry-run)

Test coverage includes:
- Container name mismatch detection and fix
- Multi-container notebooks with infrastructure sidecars
- Custom images, volume mounts, env vars preserved through rename
- Non-stopped notebook handling (skip, force, dry-run)
- Backup writes grouped by namespace + backup failure halts mutation
- Failing list/update client error paths
- Dry-run across all mutation paths
- ActionConfigurer flag registration

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Workbench upgrade action to migrate notebooks 2.x→3.x: detects and fixes container-name mismatches, preserves container image/env/volume mounts, supports backups, dry-run, and optional inclusion of non-stopped notebooks with interactive confirmation.
  * Action is registered and available in migrate prepare, run, and list commands.

* **Tests**
  * Extensive tests covering validation, execution, backup/error cases, dry-run, prompting, multi-namespace, and update behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->