### PR TITLE
RHOAIENG-54659: add shell completion command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,42 @@ build: gen-schemas
 	CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		go build $(GO_BUILD_TAGS) -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) cmd/main.go
 
+# Install completion (defaults to bash)
+.PHONY: install-completion
+install-completion: install-completion-bash
+
+# Install bash completion for the current user
+.PHONY: install-completion-bash
+install-completion-bash: build
+	@echo "Installing bash completion..."
+	@mkdir -p ~/.local/share/bash-completion/completions
+	@"$(BINARY_NAME)" completion bash > ~/.local/share/bash-completion/completions/kubectl-odh
+	@echo "Done! Start a new terminal for completions to take effect."
+
+# Install zsh completion for the current user
+.PHONY: install-completion-zsh
+install-completion-zsh: build
+	@echo "Installing zsh completion..."
+	@mkdir -p ~/.zsh/completions
+	@"$(BINARY_NAME)" completion zsh > ~/.zsh/completions/_kubectl-odh
+	@if ! grep -q 'fpath=(~/.zsh/completions' ~/.zshrc 2>/dev/null; then \
+		echo 'fpath=(~/.zsh/completions $$fpath)' >> ~/.zshrc; \
+		echo "Added fpath to ~/.zshrc"; \
+	fi
+	@if ! grep -q 'autoload -Uz compinit' ~/.zshrc 2>/dev/null; then \
+		echo 'autoload -Uz compinit && compinit' >> ~/.zshrc; \
+		echo "Added compinit to ~/.zshrc"; \
+	fi
+	@echo "Done! Run 'source ~/.zshrc' or start a new terminal."
+
+# Install fish completion for the current user
+.PHONY: install-completion-fish
+install-completion-fish: build
+	@echo "Installing fish completion..."
+	@mkdir -p ~/.config/fish/completions
+	@"$(BINARY_NAME)" completion fish > ~/.config/fish/completions/kubectl-odh.fish
+	@echo "Done! Start a new terminal or run 'source ~/.config/fish/completions/kubectl-odh.fish'"
+
 # Run the doctor command
 .PHONY: run
 run: gen-schemas
@@ -149,18 +185,22 @@ publish: build-image
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  build       - Build the kubectl-odh binary"
-	@echo "  build-image - Build container image without pushing (creates local manifest)"
-	@echo "  publish     - Build and push container image using Podman manifest"
-	@echo "  run         - Run the doctor command"
-	@echo "  tidy        - Tidy up Go module dependencies"
-	@echo "  clean       - Remove build artifacts and test cache"
-	@echo "  fmt         - Format Go code"
-	@echo "  lint        - Run golangci-lint"
-	@echo "  lint/fix    - Run golangci-lint with auto-fix"
-	@echo "  vulncheck   - Run vulnerability scanner"
-	@echo "  check       - Run all checks (lint)"
-	@echo "  test        - Run tests"
-	@echo "  fetch-deps  - Fetch dependency manifest from odh-gitops"
-	@echo "  gen-schemas - Generate JSON schemas from Go types"
-	@echo "  help        - Show this help message"
+	@echo "  build                   - Build the kubectl-odh binary"
+	@echo "  install-completion      - Install shell completion (defaults to bash)"
+	@echo "  install-completion-bash - Install bash completion for current user"
+	@echo "  install-completion-zsh  - Install zsh completion for current user"
+	@echo "  install-completion-fish - Install fish completion for current user"
+	@echo "  build-image             - Build container image without pushing (creates local manifest)"
+	@echo "  publish                 - Build and push container image using Podman manifest"
+	@echo "  run                     - Run the doctor command"
+	@echo "  tidy                    - Tidy up Go module dependencies"
+	@echo "  clean                   - Remove build artifacts and test cache"
+	@echo "  fmt                     - Format Go code"
+	@echo "  lint                    - Run golangci-lint"
+	@echo "  lint/fix                - Run golangci-lint with auto-fix"
+	@echo "  vulncheck               - Run vulnerability scanner"
+	@echo "  check                   - Run all checks (lint)"
+	@echo "  test                    - Run tests"
+	@echo "  fetch-deps              - Fetch dependency manifest from odh-gitops"
+	@echo "  gen-schemas             - Generate JSON schemas from Go types"
+	@echo "  help                    - Show this help message"

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -1,0 +1,139 @@
+package completion
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	cmdName  = "completion"
+	cmdShort = "Generate shell completion scripts"
+)
+
+const cmdLong = `Generate shell completion scripts for kubectl-odh.
+
+To load completions:
+
+Bash:
+  $ source <(kubectl-odh completion bash)
+  # Or for kubectl plugin:
+  $ source <(kubectl odh completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ kubectl-odh completion bash > /etc/bash_completion.d/kubectl-odh
+  # macOS:
+  $ kubectl-odh completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl-odh
+
+Zsh:
+  $ source <(kubectl-odh completion zsh)
+
+  # To load completions for each session, execute once:
+  $ kubectl-odh completion zsh > "${fpath[1]}/_kubectl-odh"
+
+Fish:
+  $ kubectl-odh completion fish | source
+
+  # To load completions for each session, execute once:
+  $ kubectl-odh completion fish > ~/.config/fish/completions/kubectl-odh.fish
+`
+
+const bashLong = `Generate bash completion script.
+
+Installation:
+  # Linux (persistent)
+  kubectl-odh completion bash > /etc/bash_completion.d/kubectl-odh
+
+  # macOS with Homebrew
+  kubectl-odh completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl-odh
+
+  # Current session only
+  source <(kubectl-odh completion bash)
+
+Note: Requires bash-completion v2 (bash 4.1+).
+Run 'type _init_completion' to verify bash-completion is installed.
+`
+
+const zshLong = `Generate zsh completion script.
+
+Installation:
+  # To load completions for each session, execute once:
+  kubectl-odh completion zsh > "${fpath[1]}/_kubectl-odh"
+
+  # Current session only
+  source <(kubectl-odh completion zsh)
+
+Note: You may need to start a new shell for completions to take effect.
+If completions are not working, try adding this to your ~/.zshrc:
+  autoload -Uz compinit && compinit
+`
+
+const fishLong = `Generate fish completion script.
+
+Installation:
+  # To load completions for each session, execute once:
+  kubectl-odh completion fish > ~/.config/fish/completions/kubectl-odh.fish
+
+  # Current session only
+  kubectl-odh completion fish | source
+`
+
+// AddCommand adds the completion command and its shell-specific subcommands.
+func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
+	cmd := &cobra.Command{
+		Use:           cmdName,
+		Short:         cmdShort,
+		Long:          cmdLong,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cmd.AddCommand(newBashCmd(root))
+	cmd.AddCommand(newZshCmd(root))
+	cmd.AddCommand(newFishCmd(root))
+
+	root.AddCommand(cmd)
+}
+
+func newBashCmd(root *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:                   "bash",
+		Short:                 "Generate bash completion script",
+		Long:                  bashLong,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return root.GenBashCompletionV2(cmd.OutOrStdout(), true)
+		},
+	}
+}
+
+func newZshCmd(root *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:                   "zsh",
+		Short:                 "Generate zsh completion script",
+		Long:                  zshLong,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return root.GenZshCompletion(cmd.OutOrStdout())
+		},
+	}
+}
+
+func newFishCmd(root *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:                   "fish",
+		Short:                 "Generate fish completion script",
+		Long:                  fishLong,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return root.GenFishCompletion(cmd.OutOrStdout(), true)
+		},
+	}
+}

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -1,0 +1,128 @@
+package completion_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/opendatahub-io/odh-cli/cmd/completion"
+	"github.com/opendatahub-io/odh-cli/cmd/get"
+	"github.com/opendatahub-io/odh-cli/cmd/logs"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCompletionCommandExists(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "test"}
+	completion.AddCommand(root, nil)
+
+	cmd, _, err := root.Find([]string{"completion"})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cmd.Use).To(Equal("completion"))
+}
+
+func TestCompletionSubcommandsExist(t *testing.T) {
+	root := &cobra.Command{Use: "test"}
+	completion.AddCommand(root, nil)
+
+	shells := []string{"bash", "zsh", "fish"}
+	for _, shell := range shells {
+		t.Run(shell, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cmd, _, err := root.Find([]string{"completion", shell})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(cmd.Use).To(Equal(shell))
+		})
+	}
+}
+
+func TestCompletionOutputsScript(t *testing.T) {
+	tests := []struct {
+		shell    string
+		contains string
+	}{
+		{"bash", "bash completion"},
+		{"zsh", "#compdef"},
+		{"fish", "fish completion"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			g := NewWithT(t)
+
+			root := &cobra.Command{Use: "test"}
+			completion.AddCommand(root, nil)
+
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetArgs([]string{"completion", tt.shell})
+
+			err := root.Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(buf.String()).ToNot(BeEmpty())
+			g.Expect(buf.String()).To(ContainSubstring(tt.contains))
+		})
+	}
+}
+
+func TestCompletionReturnsSubcommands(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	completion.AddCommand(root, nil)
+	get.AddCommand(root, nil)
+	logs.AddCommand(root, nil)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"__complete", ""})
+
+	err := root.Execute()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+	g.Expect(output).To(ContainSubstring("completion"))
+	g.Expect(output).To(ContainSubstring("get"))
+	g.Expect(output).To(ContainSubstring("logs"))
+}
+
+func TestGetCommandCompletion(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	get.AddCommand(root, nil)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"__complete", "get", ""})
+
+	err := root.Execute()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+	g.Expect(output).To(ContainSubstring("notebooks"))
+	g.Expect(output).To(ContainSubstring("inferenceservices"))
+}
+
+func TestLogsCommandCompletion(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	logs.AddCommand(root, nil)
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"__complete", "logs", ""})
+
+	err := root.Execute()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+	g.Expect(output).To(ContainSubstring("operator"))
+	g.Expect(output).To(ContainSubstring("dashboard"))
+	g.Expect(output).To(ContainSubstring("kserve"))
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/opendatahub-io/odh-cli/cmd/completion"
 	"github.com/opendatahub-io/odh-cli/cmd/components"
 	"github.com/opendatahub-io/odh-cli/cmd/deps"
 	"github.com/opendatahub-io/odh-cli/cmd/get"
@@ -39,6 +40,7 @@ func main() {
 	components.AddCommand(cmd, flags)
 	status.AddCommand(cmd, flags)
 	logs.AddCommand(cmd, flags)
+	completion.AddCommand(cmd, flags)
 
 	if err := cmd.Execute(); err != nil {
 		exitCode := int(clierrors.ExitCodeFromError(err))


### PR DESCRIPTION
## Description

Add shell completion command for bash, zsh, and fish using Cobra's built-in generation.

```bash
kubectl-odh completion bash|zsh|fish

# Makefile targets
make install-completion       # defaults to bash
make install-completion-bash
make install-completion-zsh
make install-completion-fish
```

Jira: [RHOAIENG-54659](https://issues.redhat.com/browse/RHOAIENG-54659)

## Testing

- [x] Linter passes (`make lint`)
- [x] Manual testing: `source <(./bin/kubectl-odh completion bash)` then `kubectl-odh <TAB>`

## Review checklist

- [x] Code follows project conventions
- [x] Help text includes installation instructions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add shell completion support for bash, zsh, and fish via new install targets and CLI completion commands.
  * Install per-user completion scripts and configure shell startup lines when needed.

* **Documentation**
  * Help output updated to include the new completion commands and clearer, reflowed command descriptions.

* **Tests**
  * New tests validating completion commands and generated completion scripts for bash, zsh, and fish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->