### PR TITLE
feat(migrate): ActionConfigurer flag interface

### DIFF
--- a/pkg/migrate/action/action.go
+++ b/pkg/migrate/action/action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -40,6 +41,13 @@ type Action interface {
 
 	// Run returns the Task for the migration execution phase.
 	Run() Task
+}
+
+// ActionConfigurer is an optional interface that Actions can implement to register
+// their own CLI flags. Commands call AddFlags during flag setup for any registered
+// action that implements this interface.
+type ActionConfigurer interface {
+	AddFlags(fs *pflag.FlagSet)
 }
 
 // Target holds all context needed for executing migration actions.

--- a/pkg/migrate/action/flags.go
+++ b/pkg/migrate/action/flags.go
@@ -1,0 +1,48 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// RegisterActionFlags registers flags from all ActionConfigurer implementations in the registry
+// into the provided FlagSet. It detects naming collisions and panics with an actionable error
+// message if an action attempts to register a flag that already exists.
+func RegisterActionFlags(registry *ActionRegistry, fs *pflag.FlagSet) {
+	const maxParts = 2
+
+	for _, a := range registry.ListAll() {
+		configurer, ok := a.(ActionConfigurer)
+		if !ok {
+			continue
+		}
+
+		// Create an isolated FlagSet to collect the action's flags first
+		actionFS := pflag.NewFlagSet(a.ID(), pflag.ContinueOnError)
+		configurer.AddFlags(actionFS)
+
+		// Merge them into the main FlagSet, checking for collisions
+		actionFS.VisitAll(func(f *pflag.Flag) {
+			if existing := fs.Lookup(f.Name); existing != nil {
+				// Determine a suggested prefix (e.g., "dashboard" from "dashboard.generate-redirect")
+				parts := strings.SplitN(a.ID(), ".", maxParts)
+				shortPrefix := parts[0]
+
+				panic(fmt.Sprintf(
+					"flag --%s registered by action %q conflicts with an existing flag; "+
+						"use a unique flag name, e.g., --%s-%s",
+					f.Name, a.ID(), shortPrefix, f.Name,
+				))
+			}
+
+			// Shallow copy the flag allows us to add it safely to the main set
+			// Since AddFlag takes a pointer, we must not pass the loop variable directly
+			// if we were mutating it, but since we aren't, pflag handles it correctly.
+			// However, pflag's AddFlag specifically says "Adds a flag to the FlagSet".
+			// We can just add it directly.
+			fs.AddFlag(f)
+		})
+	}
+}

--- a/pkg/migrate/action/flags_test.go
+++ b/pkg/migrate/action/flags_test.go
@@ -1,0 +1,128 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+
+	. "github.com/onsi/gomega"
+)
+
+// mockAction implements Action and ActionConfigurer.
+type mockAction struct {
+	id    string
+	flags map[string]string // Flag name -> default value
+}
+
+func (m *mockAction) ID() string                { return m.id }
+func (m *mockAction) Name() string              { return "Mock " + m.id }
+func (m *mockAction) Description() string       { return "Mock description" }
+func (m *mockAction) Group() action.ActionGroup { return action.GroupMigration }
+
+func (m *mockAction) CanApply(target action.Target) bool { return true }
+func (m *mockAction) Prepare() action.Task               { return nil }
+func (m *mockAction) Run() action.Task                   { return nil }
+
+func (m *mockAction) AddFlags(fs *pflag.FlagSet) {
+	for name, val := range m.flags {
+		fs.String(name, val, "mock flag")
+	}
+}
+
+var _ action.ActionConfigurer = (*mockAction)(nil)
+
+func TestRegisterActionFlags(t *testing.T) {
+	t.Run("merges distinct flags successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+
+		err := registry.Register(&mockAction{
+			id:    "action.one",
+			flags: map[string]string{"flag-one": "val1"},
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		err = registry.Register(&mockAction{
+			id:    "action.two",
+			flags: map[string]string{"flag-two": "val2"},
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+		action.RegisterActionFlags(registry, fs)
+
+		g.Expect(fs.Lookup("flag-one")).NotTo(BeNil())
+		g.Expect(fs.Lookup("flag-two")).NotTo(BeNil())
+	})
+
+	t.Run("panics on collision with another action", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+
+		err := registry.Register(&mockAction{
+			id:    "action.one",
+			flags: map[string]string{"shared-flag": "val1"},
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		err = registry.Register(&mockAction{
+			id:    "action.two",
+			flags: map[string]string{"shared-flag": "val2"},
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+		g.Expect(func() {
+			action.RegisterActionFlags(registry, fs)
+		}).To(PanicWith(MatchRegexp(`flag --shared-flag registered by action "action.(one|two)" conflicts with an existing flag; use a unique flag name, e.g., --action-shared-flag`)))
+	})
+
+	t.Run("panics on collision with command flag", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+
+		err := registry.Register(&mockAction{
+			id:    "dashboard.redirect",
+			flags: map[string]string{"dry-run": "false"},
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.Bool("dry-run", false, "command flag")
+
+		g.Expect(func() {
+			action.RegisterActionFlags(registry, fs)
+		}).To(PanicWith(MatchRegexp(`flag --dry-run registered by action "dashboard.redirect" conflicts with an existing flag; use a unique flag name, e.g., --dashboard-dry-run`)))
+	})
+
+	t.Run("ignores actions without ActionConfigurer", func(t *testing.T) {
+		g := NewWithT(t)
+		registry := action.NewActionRegistry()
+
+		// action that doesn't implement ActionConfigurer
+		err := registry.Register(&mockActionWithoutFlags{id: "no.flags"})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+		g.Expect(func() {
+			action.RegisterActionFlags(registry, fs)
+		}).NotTo(Panic())
+	})
+}
+
+type mockActionWithoutFlags struct {
+	id string
+}
+
+func (m *mockActionWithoutFlags) ID() string                         { return m.id }
+func (m *mockActionWithoutFlags) Name() string                       { return "Mock " + m.id }
+func (m *mockActionWithoutFlags) Description() string                { return "Mock description" }
+func (m *mockActionWithoutFlags) Group() action.ActionGroup          { return action.GroupMigration }
+func (m *mockActionWithoutFlags) CanApply(target action.Target) bool { return true }
+func (m *mockActionWithoutFlags) Prepare() action.Task               { return nil }
+func (m *mockActionWithoutFlags) Run() action.Task                   { return nil }

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -61,6 +61,13 @@ func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
 	fs.IntVar(&c.Burst, "burst", c.Burst, "Kubernetes API burst capacity")
+
+	// Let actions register their own flags
+	for _, a := range c.registry.ListAll() {
+		if configurer, ok := a.(action.ActionConfigurer); ok {
+			configurer.AddFlags(fs)
+		}
+	}
 }
 
 func (c *PrepareCommand) Complete() error {

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -63,11 +63,7 @@ func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.Burst, "burst", c.Burst, "Kubernetes API burst capacity")
 
 	// Let actions register their own flags
-	for _, a := range c.registry.ListAll() {
-		if configurer, ok := a.(action.ActionConfigurer); ok {
-			configurer.AddFlags(fs)
-		}
-	}
+	action.RegisterActionFlags(c.registry, fs)
 }
 
 func (c *PrepareCommand) Complete() error {

--- a/pkg/migrate/command_prepare_test.go
+++ b/pkg/migrate/command_prepare_test.go
@@ -3,6 +3,8 @@ package migrate_test
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
+
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
@@ -116,5 +118,19 @@ func TestPrepareCommand_Complete(t *testing.T) {
 		err := cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.Verbose).To(BeTrue())
+	})
+}
+
+func TestPrepareCommand_ActionFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("should register action-specific flags", func(t *testing.T) {
+		cmd := migrate.NewPrepareCommand(genericiooptions.IOStreams{})
+		cmd.ActionRegistry().MustRegister(&MockActionWithFlags{})
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		g.Expect(fs.Lookup("mock-flag-1")).NotTo(BeNil())
+		g.Expect(fs.Lookup("mock-flag-2")).NotTo(BeNil())
 	})
 }

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -57,6 +57,13 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
 	fs.IntVar(&c.Burst, "burst", c.Burst, "Kubernetes API burst capacity")
+
+	// Let actions register their own flags
+	for _, a := range c.registry.ListAll() {
+		if configurer, ok := a.(action.ActionConfigurer); ok {
+			configurer.AddFlags(fs)
+		}
+	}
 }
 
 func (c *RunCommand) Complete() error {

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -59,11 +59,7 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.Burst, "burst", c.Burst, "Kubernetes API burst capacity")
 
 	// Let actions register their own flags
-	for _, a := range c.registry.ListAll() {
-		if configurer, ok := a.(action.ActionConfigurer); ok {
-			configurer.AddFlags(fs)
-		}
-	}
+	action.RegisterActionFlags(c.registry, fs)
 }
 
 func (c *RunCommand) Complete() error {

--- a/pkg/migrate/command_run_test.go
+++ b/pkg/migrate/command_run_test.go
@@ -3,6 +3,8 @@ package migrate_test
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
+
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
@@ -97,5 +99,19 @@ func TestRunCommand_Complete(t *testing.T) {
 		err := cmd.Complete()
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(cmd.Verbose).To(BeTrue()) // Always enabled for migrate run
+	})
+}
+
+func TestRunCommand_ActionFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("should register action-specific flags", func(t *testing.T) {
+		cmd := migrate.NewRunCommand(genericiooptions.IOStreams{})
+		cmd.ActionRegistry().MustRegister(&MockActionWithFlags{})
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		g.Expect(fs.Lookup("mock-flag-1")).NotTo(BeNil())
+		g.Expect(fs.Lookup("mock-flag-2")).NotTo(BeNil())
 	})
 }

--- a/pkg/migrate/export_test.go
+++ b/pkg/migrate/export_test.go
@@ -1,0 +1,11 @@
+package migrate
+
+import "github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+
+func (c *PrepareCommand) ActionRegistry() *action.ActionRegistry {
+	return c.registry
+}
+
+func (c *RunCommand) ActionRegistry() *action.ActionRegistry {
+	return c.registry
+}

--- a/pkg/migrate/mock_action_test.go
+++ b/pkg/migrate/mock_action_test.go
@@ -1,0 +1,27 @@
+package migrate_test
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+)
+
+type MockActionWithFlags struct {
+	action.Action
+}
+
+func (m *MockActionWithFlags) ID() string                { return "mock.action.flags" }
+func (m *MockActionWithFlags) Name() string              { return "Mock Action with Flags" }
+func (m *MockActionWithFlags) Description() string       { return "Mock" }
+func (m *MockActionWithFlags) Group() action.ActionGroup { return action.GroupMigration }
+
+func (m *MockActionWithFlags) CanApply(target action.Target) bool { return true }
+func (m *MockActionWithFlags) Prepare() action.Task               { return nil }
+func (m *MockActionWithFlags) Run() action.Task                   { return nil }
+
+func (m *MockActionWithFlags) AddFlags(fs *pflag.FlagSet) {
+	fs.String("mock-flag-1", "", "")
+	fs.String("mock-flag-2", "", "")
+}
+
+var _ action.ActionConfigurer = (*MockActionWithFlags)(nil)


### PR DESCRIPTION
This is the 1st PR in a stack, before #84 and #85, in an attempt to make review easier (I'm not sure if it does or not, let me know). It can either be reviewed and merged as-is, or by merging one or other of the other two.

## Description

<!-- What does this PR do? -->
https://issues.redhat.com/browse/RHOAIENG-61437

The purpose of this one is to allow the dashboard URL redirect action proposed in #85 to accept `--redirect-url` and `--redirect-route-host` flags akin to the flags that were available on the [old upgrade helper script](https://github.com/red-hat-data-services/rhoai-upgrade-helpers/tree/a9aa2e6c8b03f54ed4a1699c25d66e58cbf90652/dashboard).

- Add optional ActionConfigurer interface allowing actions to declare their own CLI flags via AddFlags(*pflag.FlagSet)
- Wire flag registration in RunCommand and PrepareCommand
- Add tests for override behaviour and command flag registration

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration actions can now define and register their own CLI flags, enabling action-specific configuration options for prepare and run commands.

* **Tests**
  * Added tests to verify action-specific flags are properly registered and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->