### PR TITLE
fix(migrate): propagate step failures to action result status

### DIFF
--- a/pkg/migrate/action/recorder_impl.go
+++ b/pkg/migrate/action/recorder_impl.go
@@ -137,14 +137,43 @@ func (r *stepRecorderImpl) Build() *result.ActionResult {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	steps := r.buildSteps()
 	actionResult := &result.ActionResult{
 		Status: result.ActionStatus{
-			Steps:     r.buildSteps(),
-			Completed: true,
+			Steps:     steps,
+			Completed: !hasFailedSteps(steps) && !hasNonTerminalSteps(steps),
 		},
 	}
 
 	return actionResult
+}
+
+// hasFailedSteps recursively checks if any step in the tree has failed.
+func hasFailedSteps(steps []result.ActionStep) bool {
+	for i := range steps {
+		if steps[i].Status == result.StepFailed {
+			return true
+		}
+		if len(steps[i].Children) > 0 && hasFailedSteps(steps[i].Children) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasNonTerminalSteps recursively checks if any step in the tree is pending or running.
+func hasNonTerminalSteps(steps []result.ActionStep) bool {
+	for i := range steps {
+		if steps[i].Status == result.StepPending || steps[i].Status == result.StepRunning {
+			return true
+		}
+		if len(steps[i].Children) > 0 && hasNonTerminalSteps(steps[i].Children) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // buildSteps recursively builds the step tree.

--- a/pkg/migrate/action/recorder_impl.go
+++ b/pkg/migrate/action/recorder_impl.go
@@ -140,26 +140,15 @@ func (r *stepRecorderImpl) Build() *result.ActionResult {
 	steps := r.buildSteps()
 	actionResult := &result.ActionResult{
 		Status: result.ActionStatus{
-			Steps:     steps,
-			Completed: !hasFailedSteps(steps) && !hasNonTerminalSteps(steps),
+			Steps: steps,
 		},
 	}
 
+	// Use the canonical failure check from result.ActionResult instead of
+	// duplicating the traversal here.
+	actionResult.Status.Completed = !actionResult.HasFailedSteps() && !hasNonTerminalSteps(steps)
+
 	return actionResult
-}
-
-// hasFailedSteps recursively checks if any step in the tree has failed.
-func hasFailedSteps(steps []result.ActionStep) bool {
-	for i := range steps {
-		if steps[i].Status == result.StepFailed {
-			return true
-		}
-		if len(steps[i].Children) > 0 && hasFailedSteps(steps[i].Children) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // hasNonTerminalSteps recursively checks if any step in the tree is pending or running.

--- a/pkg/migrate/action/recorder_test.go
+++ b/pkg/migrate/action/recorder_test.go
@@ -104,7 +104,7 @@ func TestRecorder_NonTerminalSteps(t *testing.T) {
 		parent := recorder.Child("parent", "Parent Step")
 		// Leave child in running state (default state when created)
 		parent.Child("child1", "Child 1")
-		parent.Complete(result.StepCompleted, "Parent completed but child running")
+		parent.Completef(result.StepCompleted, "Parent completed but child running")
 
 		actionResult := recorder.Build()
 		g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
@@ -116,7 +116,7 @@ func TestRecorder_NonTerminalSteps(t *testing.T) {
 
 		recorder := action.NewRootRecorder()
 		pendingChild := recorder.Child("pending", "Pending Step")
-		pendingChild.Complete(result.StepPending, "Explicitly pending")
+		pendingChild.Completef(result.StepPending, "Explicitly pending")
 
 		actionResult := recorder.Build()
 		g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
@@ -131,9 +131,9 @@ func TestRecorder_NonTerminalSteps(t *testing.T) {
 		child1 := parent.Child("child1", "Child 1")
 		child2 := parent.Child("child2", "Child 2")
 
-		child1.Complete(result.StepCompleted, "Child 1 done")
-		child2.Complete(result.StepSkipped, "Child 2 skipped")
-		parent.Complete(result.StepCompleted, "Parent completed")
+		child1.Completef(result.StepCompleted, "Child 1 done")
+		child2.Completef(result.StepSkipped, "Child 2 skipped")
+		parent.Completef(result.StepCompleted, "Parent completed")
 
 		actionResult := recorder.Build()
 		g.Expect(actionResult).To(HaveField("Status.Completed", BeTrue()))

--- a/pkg/migrate/action/recorder_test.go
+++ b/pkg/migrate/action/recorder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 func TestRecorder_Child(t *testing.T) {
@@ -22,11 +23,13 @@ func TestRecorder_Child(t *testing.T) {
 
 	actionResult := recorder.Build()
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
-	g.Expect(actionResult.Status.Steps[0].Name).To(Equal("step1"))
-	g.Expect(actionResult.Status.Steps[0].Description).To(Equal("First Step"))
-	g.Expect(actionResult.Status.Steps[0].Status).To(Equal(result.StepCompleted))
-	g.Expect(actionResult.Status.Steps[0].Message).To(Equal("Step 1 completed"))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult.Status.Steps[0]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":        Equal("step1"),
+		"Description": Equal("First Step"),
+		"Status":      Equal(result.StepCompleted),
+		"Message":     Equal("Step 1 completed"),
+	}))
 }
 
 func TestRecorder_NestedChildren(t *testing.T) {
@@ -43,15 +46,20 @@ func TestRecorder_NestedChildren(t *testing.T) {
 	parent.Completef(result.StepFailed, "Parent failed due to child")
 
 	actionResult := recorder.Build()
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
 
 	parentStep := actionResult.Status.Steps[0]
-	g.Expect(parentStep.Name).To(Equal("parent"))
-	g.Expect(parentStep.Children).To(HaveLen(2))
-	g.Expect(parentStep.Children[0].Name).To(Equal("child1"))
-	g.Expect(parentStep.Children[0].Status).To(Equal(result.StepCompleted))
-	g.Expect(parentStep.Children[1].Name).To(Equal("child2"))
-	g.Expect(parentStep.Children[1].Status).To(Equal(result.StepFailed))
+	g.Expect(parentStep).To(HaveField("Name", Equal("parent")))
+	g.Expect(parentStep).To(HaveField("Children", HaveLen(2)))
+	g.Expect(parentStep.Children[0]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":   Equal("child1"),
+		"Status": Equal(result.StepCompleted),
+	}))
+	g.Expect(parentStep.Children[1]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":   Equal("child2"),
+		"Status": Equal(result.StepFailed),
+	}))
 }
 
 func TestRecorder_AddDetail(t *testing.T) {
@@ -65,11 +73,11 @@ func TestRecorder_AddDetail(t *testing.T) {
 	step.Completef(result.StepCompleted, "Done")
 
 	actionResult := recorder.Build()
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
-	g.Expect(actionResult.Status.Steps[0].Details).To(HaveKey("key1"))
-	g.Expect(actionResult.Status.Steps[0].Details["key1"]).To(Equal("value1"))
-	g.Expect(actionResult.Status.Steps[0].Details).To(HaveKey("key2"))
-	g.Expect(actionResult.Status.Steps[0].Details["key2"]).To(Equal(42))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult.Status.Steps[0]).To(HaveField("Details", And(
+		HaveKeyWithValue("key1", "value1"),
+		HaveKeyWithValue("key2", 42),
+	)))
 }
 
 func TestRecorder_Record(t *testing.T) {
@@ -79,8 +87,55 @@ func TestRecorder_Record(t *testing.T) {
 	recorder.Recordf("quick-step", "Quick step message", result.StepCompleted)
 
 	actionResult := recorder.Build()
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
-	g.Expect(actionResult.Status.Steps[0].Name).To(Equal("quick-step"))
-	g.Expect(actionResult.Status.Steps[0].Message).To(Equal("Quick step message"))
-	g.Expect(actionResult.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult.Status.Steps[0]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":    Equal("quick-step"),
+		"Message": Equal("Quick step message"),
+		"Status":  Equal(result.StepCompleted),
+	}))
+}
+
+func TestRecorder_NonTerminalSteps(t *testing.T) {
+	t.Run("running child prevents completion", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recorder := action.NewRootRecorder()
+
+		parent := recorder.Child("parent", "Parent Step")
+		// Leave child in running state (default state when created)
+		parent.Child("child1", "Child 1")
+		parent.Complete(result.StepCompleted, "Parent completed but child running")
+
+		actionResult := recorder.Build()
+		g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+		g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
+	})
+
+	t.Run("pending step prevents completion", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recorder := action.NewRootRecorder()
+		pendingChild := recorder.Child("pending", "Pending Step")
+		pendingChild.Complete(result.StepPending, "Explicitly pending")
+
+		actionResult := recorder.Build()
+		g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
+	})
+
+	t.Run("all terminal steps allows completion", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recorder := action.NewRootRecorder()
+
+		parent := recorder.Child("parent", "Parent Step")
+		child1 := parent.Child("child1", "Child 1")
+		child2 := parent.Child("child2", "Child 2")
+
+		child1.Complete(result.StepCompleted, "Child 1 done")
+		child2.Complete(result.StepSkipped, "Child 2 skipped")
+		parent.Complete(result.StepCompleted, "Parent completed")
+
+		actionResult := recorder.Build()
+		g.Expect(actionResult).To(HaveField("Status.Completed", BeTrue()))
+	})
 }

--- a/pkg/migrate/actions/llamastack/backup/backup_test.go
+++ b/pkg/migrate/actions/llamastack/backup/backup_test.go
@@ -441,7 +441,7 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-				"Completed": BeTrue(),
+				"Completed": BeFalse(),
 			}),
 		})))
 	})
@@ -476,7 +476,7 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 		res, err := prepareTask.Execute(ctx, target)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(res.Status.Completed).To(BeFalse())
 		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
 			"Expected to find a failed step for "+stepNameBackupLLSD)
 	})
@@ -511,7 +511,7 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 		res, err := prepareTask.Execute(ctx, target)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(res.Status.Completed).To(BeFalse())
 		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
 			"Expected to find a failed step for "+stepNameBackupLLSD)
 	})
@@ -546,7 +546,7 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 		res, err := prepareTask.Execute(ctx, target)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(res.Status.Completed).To(BeFalse())
 		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
 			"Expected to find a failed step for "+stepNameBackupLLSD)
 	})
@@ -583,7 +583,7 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 		res, err := prepareTask.Execute(ctx, target)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(res.Status.Completed).To(BeFalse())
 		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
 			"Expected backup to fail when oc/kubectl are not in PATH")
 	})

--- a/pkg/migrate/actions/modelserving/add_owner_references.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references.go
@@ -98,6 +98,7 @@ func (a *AddOwnerReferencesAction) addOwnerReferences(
 		)
 
 		a.patchAuthResourceOwnerRefs(ctx, target, isvc, isvcStep)
+		isvcStep.Complete(result.StepCompleted, "Processed owner references for %s/%s", isvc.GetNamespace(), isvc.GetName())
 		patchedCount++
 	}
 
@@ -193,7 +194,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 
 	_, err = target.Client.Dynamic().Resource(resourceType.GVR()).
 		Namespace(namespace).
-		Patch(ctx, resourceName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+		Patch(ctx, resourceName, types.MergePatchType, patchData, metav1.PatchOptions{})
 
 	if err != nil {
 		step.Recordf(

--- a/pkg/migrate/actions/modelserving/add_owner_references.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references.go
@@ -20,13 +20,15 @@ const (
 	addOwnerRefsActionName        = "Add owner references to auth resources"
 	addOwnerRefsActionDescription = "Patches ServiceAccounts, Roles, and RoleBindings associated with RawDeployment InferenceServices with ownerReferences pointing to the ISVC"
 
-	msgOwnerRefNoISVCs     = "No InferenceServices found with deploymentMode=RawDeployment"
-	msgOwnerRefFoundISVCs  = "Found %d InferenceServices with deploymentMode=RawDeployment"
-	msgOwnerRefPatched     = "Patched %s %s/%s with ownerReference to %s"
-	msgOwnerRefPatchDryRun = "Would patch %s %s/%s with ownerReference to %s"
-	msgOwnerRefPatchFailed = "Failed to patch %s %s/%s: %v"
-	msgOwnerRefNotFound    = "%s %s/%s not found (skipped)"
-	msgOwnerRefComplete    = "Processed owner references for %d InferenceService(s)"
+	msgOwnerRefNoISVCs        = "No InferenceServices found with deploymentMode=RawDeployment"
+	msgOwnerRefFoundISVCs     = "Found %d InferenceServices with deploymentMode=RawDeployment"
+	msgOwnerRefPatched        = "Patched %s %s/%s with ownerReference to %s"
+	msgOwnerRefPatchDryRun    = "Would patch %s %s/%s with ownerReference to %s"
+	msgOwnerRefPatchFailed    = "Failed to patch %s %s/%s: %v"
+	msgOwnerRefNotFound       = "%s %s/%s not found (skipped)"
+	msgOwnerRefComplete       = "Processed owner references for %d InferenceService(s)"
+	msgOwnerRefPartialFailure = "Processed owner references for %d/%d InferenceService(s); %d failed"
+	msgOwnerRefISVCProcessed  = "Processed owner references for %s/%s"
 )
 
 // AddOwnerReferencesAction patches auth resources (SA, Role, RoleBinding) with
@@ -89,7 +91,8 @@ func (a *AddOwnerReferencesAction) addOwnerReferences(
 
 	step.Recordf("list-isvcs", msgOwnerRefFoundISVCs, result.StepCompleted, len(isvcs))
 
-	patchedCount := 0
+	processedCount := 0
+	failedCount := 0
 
 	for _, isvc := range isvcs {
 		isvcStep := step.Child(
@@ -97,20 +100,37 @@ func (a *AddOwnerReferencesAction) addOwnerReferences(
 			fmt.Sprintf("Add owner references for %s/%s", isvc.GetNamespace(), isvc.GetName()),
 		)
 
-		a.patchAuthResourceOwnerRefs(ctx, target, isvc, isvcStep)
-		isvcStep.Completef(result.StepCompleted, "Processed owner references for %s/%s", isvc.GetNamespace(), isvc.GetName())
-		patchedCount++
+		// patchAuthResourceOwnerRefs already sets a failing condition on isvcStep
+		// when a patch or marshal error occurs; only mark the step completed here
+		// when every underlying patch succeeded, so failures are never overwritten.
+		if !a.patchAuthResourceOwnerRefs(ctx, target, isvc, isvcStep) {
+			failedCount++
+
+			continue
+		}
+
+		isvcStep.Completef(result.StepCompleted, msgOwnerRefISVCProcessed, isvc.GetNamespace(), isvc.GetName())
+		processedCount++
 	}
 
-	step.Completef(result.StepCompleted, msgOwnerRefComplete, patchedCount)
+	switch {
+	case failedCount > 0:
+		step.Completef(result.StepFailed, msgOwnerRefPartialFailure, processedCount, len(isvcs), failedCount)
+	default:
+		step.Completef(result.StepCompleted, msgOwnerRefComplete, processedCount)
+	}
 }
 
+// patchAuthResourceOwnerRefs patches the ServiceAccount, Role, and RoleBinding
+// associated with isvc. It returns false if the patch payload could not be
+// built or if any of the three resource patches failed, so callers must not
+// mark the parent step completed on top of a failing condition.
 func (a *AddOwnerReferencesAction) patchAuthResourceOwnerRefs(
 	ctx context.Context,
 	target action.Target,
 	isvc *unstructured.Unstructured,
 	step action.StepRecorder,
-) {
+) bool {
 	name := isvc.GetName()
 	ns := isvc.GetNamespace()
 	uid := isvc.GetUID()
@@ -131,19 +151,28 @@ func (a *AddOwnerReferencesAction) patchAuthResourceOwnerRefs(
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to marshal owner reference patch: %v", err)
 
-		return
+		return false
 	}
 
 	// Patch ServiceAccount
-	a.patchResourceOwnerRef(ctx, target, resources.ServiceAccount, ns, name+authSASuffix, name, ownerRefPatch, step)
+	success := a.patchResourceOwnerRef(ctx, target, resources.ServiceAccount, ns, name+authSASuffix, name, ownerRefPatch, step)
 
 	// Patch Role
-	a.patchResourceOwnerRef(ctx, target, resources.Role, ns, name+authRoleSuffix, name, ownerRefPatch, step)
+	if !a.patchResourceOwnerRef(ctx, target, resources.Role, ns, name+authRoleSuffix, name, ownerRefPatch, step) {
+		success = false
+	}
 
 	// Patch RoleBinding
-	a.patchResourceOwnerRef(ctx, target, resources.RoleBinding, ns, name+authRoleBindingSuffix, name, ownerRefPatch, step)
+	if !a.patchResourceOwnerRef(ctx, target, resources.RoleBinding, ns, name+authRoleBindingSuffix, name, ownerRefPatch, step) {
+		success = false
+	}
+
+	return success
 }
 
+// patchResourceOwnerRef patches a single auth resource with an ownerReference.
+// It returns true for success, skip (resource not found), and dry-run cases,
+// and false only when the resource lookup or patch call actually fails.
 func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 	ctx context.Context,
 	target action.Target,
@@ -153,7 +182,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 	isvcName string,
 	patchData []byte,
 	step action.StepRecorder,
-) {
+) bool {
 	// Check if resource exists first
 	_, err := target.Client.Dynamic().Resource(resourceType.GVR()).
 		Namespace(namespace).
@@ -168,7 +197,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 				resourceType.Kind, namespace, resourceName,
 			)
 
-			return
+			return true
 		}
 
 		step.Recordf(
@@ -178,7 +207,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 			resourceType.Kind, namespace, resourceName, err,
 		)
 
-		return
+		return false
 	}
 
 	if target.DryRun {
@@ -189,7 +218,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 			resourceType.Kind, namespace, resourceName, isvcName,
 		)
 
-		return
+		return true
 	}
 
 	_, err = target.Client.Dynamic().Resource(resourceType.GVR()).
@@ -204,7 +233,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 			resourceType.Kind, namespace, resourceName, err,
 		)
 
-		return
+		return false
 	}
 
 	step.Recordf(
@@ -213,6 +242,8 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 		result.StepCompleted,
 		resourceType.Kind, namespace, resourceName, isvcName,
 	)
+
+	return true
 }
 
 // --- Run Task ---

--- a/pkg/migrate/actions/modelserving/add_owner_references.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references.go
@@ -98,7 +98,7 @@ func (a *AddOwnerReferencesAction) addOwnerReferences(
 		)
 
 		a.patchAuthResourceOwnerRefs(ctx, target, isvc, isvcStep)
-		isvcStep.Complete(result.StepCompleted, "Processed owner references for %s/%s", isvc.GetNamespace(), isvc.GetName())
+		isvcStep.Completef(result.StepCompleted, "Processed owner references for %s/%s", isvc.GetNamespace(), isvc.GetName())
 		patchedCount++
 	}
 

--- a/pkg/migrate/actions/training/verify_workloads_test.go
+++ b/pkg/migrate/actions/training/verify_workloads_test.go
@@ -193,7 +193,7 @@ func TestVerifyWorkloadsAction_RunCategorizesBlockers(t *testing.T) {
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	readiness := findStep(actionResult.Status.Steps, "migration-readiness")
 	g.Expect(readiness).ToNot(BeNil())
@@ -471,7 +471,7 @@ func TestVerifyWorkloadsAction_RunPartialFailure(t *testing.T) {
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	pytorchStep := findStep(actionResult.Status.Steps, "pytorchjobs")
 	g.Expect(pytorchStep).ToNot(BeNil())

--- a/pkg/migrate/actions/trustyai/data/prepare_task_test.go
+++ b/pkg/migrate/actions/trustyai/data/prepare_task_test.go
@@ -145,7 +145,7 @@ func TestRunTask_Validate_FileNotFound(t *testing.T) {
 	result, err := a.Run().Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Validate_NotDirectory(t *testing.T) {
@@ -161,7 +161,7 @@ func TestRunTask_Validate_NotDirectory(t *testing.T) {
 	result, err := a.Run().Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Validate_Ready(t *testing.T) {
@@ -207,7 +207,7 @@ func TestRunTask_Execute_CannotDetectType(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_NoServicesForRestore(t *testing.T) {
@@ -223,7 +223,7 @@ func TestRunTask_Execute_NoServicesForRestore(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_DryRun_PVC(t *testing.T) {
@@ -290,7 +290,7 @@ func TestRunTask_Execute_DryRun_Database(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_UnsupportedBackupType(t *testing.T) {
@@ -310,7 +310,7 @@ func TestRunTask_Execute_UnsupportedBackupType(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/migrate/actions/trustyai/data/prepare_task_test.go
+++ b/pkg/migrate/actions/trustyai/data/prepare_task_test.go
@@ -289,8 +289,13 @@ func TestRunTask_Execute_DryRun_Database(t *testing.T) {
 	a := &DataAction{BackupFile: backupDir}
 	result, err := a.Run().Execute(ctx, target)
 
+	// target.RESTConfig is unset (no SPDY executor available), but a dry-run
+	// must still succeed without requiring a live executor or remote client
+	// command detection.
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeFalse())
+	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Steps).To(HaveLen(1))
+	g.Expect(result.Status.Steps[0].Message).To(ContainSubstring("Would restore"))
 }
 
 func TestRunTask_Execute_UnsupportedBackupType(t *testing.T) {

--- a/pkg/migrate/actions/trustyai/data/run_task.go
+++ b/pkg/migrate/actions/trustyai/data/run_task.go
@@ -219,6 +219,16 @@ func (t *runTask) restoreDatabase(
 		return
 	}
 
+	// Check dry-run before requiring a live SPDY executor or detecting the
+	// remote client command: a dry-run only needs to report what would
+	// happen and must not depend on RESTConfig/exec being available.
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would restore %d-line dump to database %s via %s",
+			dumpLines, creds.database, mariadbPod.Name)
+
+		return
+	}
+
 	if executor == nil {
 		step.Completef(result.StepFailed, "No SPDY executor available (RESTConfig not set)")
 
@@ -228,13 +238,6 @@ func (t *runTask) restoreDatabase(
 	clientCmd, err := detectClientCommand(ctx, executor, svc.namespace, mariadbPod)
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to detect client command: %v", err)
-
-		return
-	}
-
-	if target.DryRun {
-		step.Completef(result.StepSkipped, "Would restore %d-line dump to database %s via %s",
-			dumpLines, creds.database, mariadbPod.Name)
 
 		return
 	}

--- a/pkg/migrate/actions/trustyai/guardrails/run_task_test.go
+++ b/pkg/migrate/actions/trustyai/guardrails/run_task_test.go
@@ -301,7 +301,7 @@ func TestRunTask_Execute_PatchesMissingProbe(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 
 	updated, err := k8sClient.Dynamic().Resource(resources.Deployment.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-gorch", metav1.GetOptions{})
@@ -360,7 +360,7 @@ func TestRunTask_Execute_GorchNameFilter(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_MultiNamespace(t *testing.T) {
@@ -380,7 +380,7 @@ func TestRunTask_Execute_MultiNamespace(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestCheckProbe(t *testing.T) {

--- a/pkg/migrate/actions/trustyai/metrics/metrics_test.go
+++ b/pkg/migrate/actions/trustyai/metrics/metrics_test.go
@@ -802,7 +802,7 @@ func TestPrepareTask_Execute_HTTPError(t *testing.T) {
 	result, err := a.Prepare().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestPrepareTask_Execute_NoRESTConfig(t *testing.T) {
@@ -819,7 +819,7 @@ func TestPrepareTask_Execute_NoRESTConfig(t *testing.T) {
 	result, err := a.Prepare().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 // ---------------------------------------------------------------------------
@@ -849,7 +849,7 @@ func TestRunTask_Validate_FileNotFound(t *testing.T) {
 	result, err := a.Run().Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Validate_NoRoutes(t *testing.T) {
@@ -865,7 +865,7 @@ func TestRunTask_Validate_NoRoutes(t *testing.T) {
 	result, err := a.Run().Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Validate_Ready(t *testing.T) {
@@ -934,7 +934,7 @@ func TestRunTask_Execute_InvalidBackup(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_NoRoutes(t *testing.T) {
@@ -950,7 +950,7 @@ func TestRunTask_Execute_NoRoutes(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_DryRun(t *testing.T) {
@@ -1093,7 +1093,7 @@ func TestRunTask_Execute_UnknownMetricType(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_HTTPError(t *testing.T) {
@@ -1127,7 +1127,7 @@ func TestRunTask_Execute_HTTPError(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_NoRESTConfig(t *testing.T) {
@@ -1147,7 +1147,7 @@ func TestRunTask_Execute_NoRESTConfig(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_UserCancels(t *testing.T) {
@@ -1228,7 +1228,7 @@ func TestRunTask_Execute_MissingRequestField(t *testing.T) {
 	result, err := a.Run().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestPrepareTask_Execute_InvalidResponse(t *testing.T) {
@@ -1255,7 +1255,7 @@ func TestPrepareTask_Execute_InvalidResponse(t *testing.T) {
 	result, err := a.Prepare().Execute(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestParseBackupEntries(t *testing.T) {

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
@@ -778,7 +778,7 @@ func TestRunTask_Execute_PreCheckFails_SkipConfirm(t *testing.T) {
 	actionResult, err := task.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
 
 	// SkipConfirm=true with failed pre-check means cleanup is refused (resources NOT deleted)

--- a/pkg/migrate/actions/workbenches/kueue/kueue_test.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue_test.go
@@ -707,7 +707,7 @@ func TestRunTask_Execute_PatchError(t *testing.T) {
 	result, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_PatchError_ContinuesWithRemaining(t *testing.T) {
@@ -757,7 +757,7 @@ func TestRunTask_Execute_PatchError_ContinuesWithRemaining(t *testing.T) {
 	result, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 
 	nbOk, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "nb-ok", metav1.GetOptions{})

--- a/pkg/migrate/actions/workbenches/upgrade/run_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/run_task.go
@@ -224,7 +224,7 @@ func (t *runTask) verifyAuthModel(
 			step.Recordf(
 				fmt.Sprintf("auth-model-%s-%s", nb.GetNamespace(), nb.GetName()),
 				"%s/%s needs auth model patch: %s",
-				result.StepFailed,
+				result.StepSkipped,
 				nb.GetNamespace(), nb.GetName(), strings.Join(failures, "; "),
 			)
 
@@ -233,7 +233,10 @@ func (t *runTask) verifyAuthModel(
 	}
 
 	if needsPatchCount > 0 {
-		step.Completef(result.StepFailed,
+		// Auth model migration is intentionally informational here: it is completed
+		// separately via workbenches.patch-auth-model, so it must not fail this action
+		// or block the overall migration run/prepare loop.
+		step.Completef(result.StepSkipped,
 			"%d stopped Notebook(s) still have legacy OAuth-proxy sidecar — run workbenches.patch-auth-model to complete migration",
 			needsPatchCount)
 	} else {

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -787,7 +787,9 @@ func TestRunTask_Validate_WithMismatch(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeFalse())
+	// Only the (informational) auth-model check flags this notebook; the mismatch
+	// detection itself succeeds, so the action still completes.
+	g.Expect(result.Status.Completed).To(BeTrue())
 }
 
 func TestRunTask_Execute_NoNotebooks(t *testing.T) {
@@ -824,7 +826,8 @@ func TestRunTask_Execute_AllCorrectNames(t *testing.T) {
 	result, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeFalse())
+	// Auth-model check is informational only; no fixable mismatch here either.
+	g.Expect(result.Status.Completed).To(BeTrue())
 }
 
 func TestRunTask_Execute_FixContainerNameMismatch(t *testing.T) {
@@ -845,7 +848,9 @@ func TestRunTask_Execute_FixContainerNameMismatch(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	// Container name fix succeeds; the informational auth-model check is the
+	// only outstanding item and does not block completion.
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -875,7 +880,9 @@ func TestRunTask_Execute_DryRun_NoChanges(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	// Dry-run "would fix" is a Skipped step, and the auth-model check is
+	// informational, so nothing here should block completion.
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	original, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -909,7 +916,7 @@ func TestRunTask_Execute_SkipsNonStoppedNotebooks(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	stoppedUpdated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "stopped-nb", metav1.GetOptions{})
@@ -947,7 +954,7 @@ func TestRunTask_Execute_MultipleNamespaces(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	updated1, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns-alpha").Get(context.Background(), "nb1", metav1.GetOptions{})
@@ -982,7 +989,7 @@ func TestRunTask_Execute_MultipleWorkloadContainers_Skipped(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -1080,7 +1087,7 @@ func TestRunTask_Execute_NoDashboardAnnotation_NoChange(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -1132,7 +1139,7 @@ func TestRunTask_Execute_CustomImages(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "custom-nb", metav1.GetOptions{})
@@ -1356,7 +1363,7 @@ func TestRunTask_Execute_DryRun_WithMismatch(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
@@ -1382,7 +1389,7 @@ func TestRunTask_Validate_AllCorrectNames(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeFalse())
+	g.Expect(result.Status.Completed).To(BeTrue())
 }
 
 func TestRunTask_Validate_WithNonStopped(t *testing.T) {
@@ -1434,7 +1441,7 @@ func TestRunTask_Execute_NonSkipConfirm_UserConfirms(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
@@ -1465,7 +1472,7 @@ func TestRunTask_Execute_NonSkipConfirm_UserCancels(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
 
 	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
@@ -1807,7 +1814,7 @@ func TestRunTask_Validate_MixedNonStoppedWithMismatch(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeFalse())
+	g.Expect(result.Status.Completed).To(BeTrue())
 }
 
 func TestExtractWorkloadContainers_NonMapEntry(t *testing.T) {
@@ -1904,15 +1911,18 @@ func TestRunTask_Validate_DetectsLegacyAuthModel(t *testing.T) {
 	actionResult, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
-	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+	// The auth-model check is informational only: it flags notebooks needing
+	// workbenches.patch-auth-model, but must not fail this action or block
+	// the migrate run/prepare loop.
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeFalse())
 
 	hasAuthModelStep := false
 
 	for _, step := range actionResult.Status.Steps {
 		if step.Name == "verify-auth-model" {
 			hasAuthModelStep = true
-			g.Expect(step.Status).To(Equal(result.StepFailed))
+			g.Expect(step.Status).To(Equal(result.StepSkipped))
 			g.Expect(step.Message).To(ContainSubstring("patch-auth-model"))
 		}
 	}
@@ -1941,15 +1951,16 @@ func TestRunTask_Execute_DetectsLegacyAuthModel(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
-	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+	// The auth-model check is informational only and must not fail this action.
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeFalse())
 
 	hasAuthModelStep := false
 
 	for _, step := range actionResult.Status.Steps {
 		if step.Name == "verify-auth-model" {
 			hasAuthModelStep = true
-			g.Expect(step.Status).To(Equal(result.StepFailed))
+			g.Expect(step.Status).To(Equal(result.StepSkipped))
 			g.Expect(step.Message).To(ContainSubstring("patch-auth-model"))
 		}
 	}
@@ -2009,8 +2020,10 @@ func TestRunTask_Execute_FixesNamesAndDetectsAuthModel(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeFalse())
-	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+	// Container name fix succeeds; the informational auth-model check must not
+	// fail this action.
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeFalse())
 
 	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -2023,7 +2036,7 @@ func TestRunTask_Execute_FixesNamesAndDetectsAuthModel(t *testing.T) {
 
 	for _, step := range actionResult.Status.Steps {
 		if step.Name == "verify-auth-model" {
-			g.Expect(step.Status).To(Equal(result.StepFailed))
+			g.Expect(step.Status).To(Equal(result.StepSkipped))
 			g.Expect(step.Message).To(ContainSubstring("patch-auth-model"))
 		}
 	}

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -1594,7 +1594,7 @@ func TestPrepareTask_Validate_ListError(t *testing.T) {
 	result, err := prepTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestPrepareTask_Execute_ListError(t *testing.T) {
@@ -1610,7 +1610,7 @@ func TestPrepareTask_Execute_ListError(t *testing.T) {
 	result, err := prepTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Validate_ListError(t *testing.T) {
@@ -1626,7 +1626,7 @@ func TestRunTask_Validate_ListError(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_ListError(t *testing.T) {
@@ -1642,7 +1642,7 @@ func TestRunTask_Execute_ListError(t *testing.T) {
 	result, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_UpdateError(t *testing.T) {
@@ -1663,7 +1663,7 @@ func TestRunTask_Execute_UpdateError(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -787,7 +787,7 @@ func TestRunTask_Validate_WithMismatch(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_NoNotebooks(t *testing.T) {
@@ -824,7 +824,7 @@ func TestRunTask_Execute_AllCorrectNames(t *testing.T) {
 	result, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Execute_FixContainerNameMismatch(t *testing.T) {
@@ -845,7 +845,7 @@ func TestRunTask_Execute_FixContainerNameMismatch(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -875,7 +875,7 @@ func TestRunTask_Execute_DryRun_NoChanges(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	original, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -909,7 +909,7 @@ func TestRunTask_Execute_SkipsNonStoppedNotebooks(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	stoppedUpdated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "stopped-nb", metav1.GetOptions{})
@@ -947,7 +947,7 @@ func TestRunTask_Execute_MultipleNamespaces(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	updated1, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns-alpha").Get(context.Background(), "nb1", metav1.GetOptions{})
@@ -982,7 +982,7 @@ func TestRunTask_Execute_MultipleWorkloadContainers_Skipped(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -1080,7 +1080,7 @@ func TestRunTask_Execute_NoDashboardAnnotation_NoChange(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
@@ -1132,7 +1132,7 @@ func TestRunTask_Execute_CustomImages(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "custom-nb", metav1.GetOptions{})
@@ -1356,7 +1356,7 @@ func TestRunTask_Execute_DryRun_WithMismatch(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
@@ -1382,7 +1382,7 @@ func TestRunTask_Validate_AllCorrectNames(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestRunTask_Validate_WithNonStopped(t *testing.T) {
@@ -1434,7 +1434,7 @@ func TestRunTask_Execute_NonSkipConfirm_UserConfirms(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	updated, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
@@ -1465,7 +1465,7 @@ func TestRunTask_Execute_NonSkipConfirm_UserCancels(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 
 	original, _ := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "my-nb", metav1.GetOptions{})
@@ -1807,7 +1807,7 @@ func TestRunTask_Validate_MixedNonStoppedWithMismatch(t *testing.T) {
 	result, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(result.Status.Completed).To(BeFalse())
 }
 
 func TestExtractWorkloadContainers_NonMapEntry(t *testing.T) {
@@ -1904,7 +1904,7 @@ func TestRunTask_Validate_DetectsLegacyAuthModel(t *testing.T) {
 	actionResult, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
 
 	hasAuthModelStep := false
@@ -1941,7 +1941,7 @@ func TestRunTask_Execute_DetectsLegacyAuthModel(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
 
 	hasAuthModelStep := false
@@ -2009,7 +2009,7 @@ func TestRunTask_Execute_FixesNamesAndDetectsAuthModel(t *testing.T) {
 	actionResult, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.Status.Completed).To(BeFalse())
 	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
 
 	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).


### PR DESCRIPTION
This is the 2nd PR in a stack, after #83 and before #85, in an attempt to make review easier (I'm not sure if it does or not, let me know). Until #83 is merged, the changes from it will be reflected in the "Files changed" tab here. It can either be reviewed and merged as-is, or after #83.

## Description

<!-- What does this PR do? -->
https://redhat.atlassian.net/browse/RHOAIENG-61437

Fixes an issue where `Build()` on a step recorder unconditionally set `Completed: true` on the `ActionResult`, even if one or more steps had failed. Now, `Build()` recursively checks all steps and sets `Completed: false` if any step has a `Failed` or non-terminal status.
This prevents failed migrations from silently reporting success upstream.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration action status is now correctly tracked based on the complete state of all steps. Actions no longer appear complete when steps are still running or have failed.
  * Owner-reference updates now report partial failures accurately for individual services.
  * Dry-run database restores no longer require a live command executor.
* **Workflow Updates**
  * Legacy authentication model detection is reported as informational rather than as a failed migration step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->