### PR TITLE
feat: convert dashboard helper script

### DIFF
--- a/pkg/migrate/action/recorder_impl.go
+++ b/pkg/migrate/action/recorder_impl.go
@@ -139,14 +139,43 @@ func (r *stepRecorderImpl) Build() *result.ActionResult {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	steps := r.buildSteps()
 	actionResult := &result.ActionResult{
 		Status: result.ActionStatus{
-			Steps:     r.buildSteps(),
-			Completed: true,
+			Steps:     steps,
+			Completed: !hasFailedSteps(steps) && !hasNonTerminalSteps(steps),
 		},
 	}
 
 	return actionResult
+}
+
+// hasFailedSteps recursively checks if any step in the tree has failed.
+func hasFailedSteps(steps []result.ActionStep) bool {
+	for i := range steps {
+		if steps[i].Status == result.StepFailed {
+			return true
+		}
+		if len(steps[i].Children) > 0 && hasFailedSteps(steps[i].Children) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasNonTerminalSteps recursively checks if any step in the tree is pending or running.
+func hasNonTerminalSteps(steps []result.ActionStep) bool {
+	for i := range steps {
+		if steps[i].Status == result.StepPending || steps[i].Status == result.StepRunning {
+			return true
+		}
+		if len(steps[i].Children) > 0 && hasNonTerminalSteps(steps[i].Children) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // buildSteps recursively builds the step tree.

--- a/pkg/migrate/action/recorder_test.go
+++ b/pkg/migrate/action/recorder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 func TestRecorder_Child(t *testing.T) {
@@ -22,11 +23,13 @@ func TestRecorder_Child(t *testing.T) {
 
 	actionResult := recorder.Build()
 	g.Expect(actionResult).ToNot(BeNil())
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
-	g.Expect(actionResult.Status.Steps[0].Name).To(Equal("step1"))
-	g.Expect(actionResult.Status.Steps[0].Description).To(Equal("First Step"))
-	g.Expect(actionResult.Status.Steps[0].Status).To(Equal(result.StepCompleted))
-	g.Expect(actionResult.Status.Steps[0].Message).To(Equal("Step 1 completed"))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult.Status.Steps[0]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":        Equal("step1"),
+		"Description": Equal("First Step"),
+		"Status":      Equal(result.StepCompleted),
+		"Message":     Equal("Step 1 completed"),
+	}))
 }
 
 func TestRecorder_NestedChildren(t *testing.T) {
@@ -43,15 +46,20 @@ func TestRecorder_NestedChildren(t *testing.T) {
 	parent.Complete(result.StepFailed, "Parent failed due to child")
 
 	actionResult := recorder.Build()
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
 
 	parentStep := actionResult.Status.Steps[0]
-	g.Expect(parentStep.Name).To(Equal("parent"))
-	g.Expect(parentStep.Children).To(HaveLen(2))
-	g.Expect(parentStep.Children[0].Name).To(Equal("child1"))
-	g.Expect(parentStep.Children[0].Status).To(Equal(result.StepCompleted))
-	g.Expect(parentStep.Children[1].Name).To(Equal("child2"))
-	g.Expect(parentStep.Children[1].Status).To(Equal(result.StepFailed))
+	g.Expect(parentStep).To(HaveField("Name", Equal("parent")))
+	g.Expect(parentStep).To(HaveField("Children", HaveLen(2)))
+	g.Expect(parentStep.Children[0]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":   Equal("child1"),
+		"Status": Equal(result.StepCompleted),
+	}))
+	g.Expect(parentStep.Children[1]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":   Equal("child2"),
+		"Status": Equal(result.StepFailed),
+	}))
 }
 
 func TestRecorder_AddDetail(t *testing.T) {
@@ -65,11 +73,11 @@ func TestRecorder_AddDetail(t *testing.T) {
 	step.Complete(result.StepCompleted, "Done")
 
 	actionResult := recorder.Build()
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
-	g.Expect(actionResult.Status.Steps[0].Details).To(HaveKey("key1"))
-	g.Expect(actionResult.Status.Steps[0].Details["key1"]).To(Equal("value1"))
-	g.Expect(actionResult.Status.Steps[0].Details).To(HaveKey("key2"))
-	g.Expect(actionResult.Status.Steps[0].Details["key2"]).To(Equal(42))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult.Status.Steps[0]).To(HaveField("Details", And(
+		HaveKeyWithValue("key1", "value1"),
+		HaveKeyWithValue("key2", 42),
+	)))
 }
 
 func TestRecorder_Record(t *testing.T) {
@@ -79,8 +87,55 @@ func TestRecorder_Record(t *testing.T) {
 	recorder.Record("quick-step", "Quick step message", result.StepCompleted)
 
 	actionResult := recorder.Build()
-	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
-	g.Expect(actionResult.Status.Steps[0].Name).To(Equal("quick-step"))
-	g.Expect(actionResult.Status.Steps[0].Message).To(Equal("Quick step message"))
-	g.Expect(actionResult.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+	g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+	g.Expect(actionResult.Status.Steps[0]).To(MatchFields(IgnoreExtras, Fields{
+		"Name":    Equal("quick-step"),
+		"Message": Equal("Quick step message"),
+		"Status":  Equal(result.StepCompleted),
+	}))
+}
+
+func TestRecorder_NonTerminalSteps(t *testing.T) {
+	t.Run("running child prevents completion", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recorder := action.NewRootRecorder()
+
+		parent := recorder.Child("parent", "Parent Step")
+		// Leave child in running state (default state when created)
+		parent.Child("child1", "Child 1")
+		parent.Complete(result.StepCompleted, "Parent completed but child running")
+
+		actionResult := recorder.Build()
+		g.Expect(actionResult).To(HaveField("Status.Steps", HaveLen(1)))
+		g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
+	})
+
+	t.Run("pending step prevents completion", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recorder := action.NewRootRecorder()
+		pendingChild := recorder.Child("pending", "Pending Step")
+		pendingChild.Complete(result.StepPending, "Explicitly pending")
+
+		actionResult := recorder.Build()
+		g.Expect(actionResult).To(HaveField("Status.Completed", BeFalse()))
+	})
+
+	t.Run("all terminal steps allows completion", func(t *testing.T) {
+		g := NewWithT(t)
+
+		recorder := action.NewRootRecorder()
+
+		parent := recorder.Child("parent", "Parent Step")
+		child1 := parent.Child("child1", "Child 1")
+		child2 := parent.Child("child2", "Child 2")
+
+		child1.Complete(result.StepCompleted, "Child 1 done")
+		child2.Complete(result.StepSkipped, "Child 2 skipped")
+		parent.Complete(result.StepCompleted, "Parent completed")
+
+		actionResult := recorder.Build()
+		g.Expect(actionResult).To(HaveField("Status.Completed", BeTrue()))
+	})
 }

--- a/pkg/migrate/actions/dashboard/redirect/redirect.go
+++ b/pkg/migrate/actions/dashboard/redirect/redirect.go
@@ -1,0 +1,476 @@
+package redirect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	actionID          = "dashboard.generate-redirect"
+	actionName        = "Generate Dashboard Redirect"
+	actionDescription = "Generate nginx-redirect resources to maintain backward compatibility after upgrade removes old dashboard route"
+
+	rhodsDashboardLabel = "rhods-dashboard"
+	odhDashboardLabel   = "odh-dashboard"
+
+	maxDomainParts = 2
+
+	msgErrNotRootRecorder      = "recorder is not a RootRecorder"
+	msgStepDetectPlatform      = "Detect platform type"
+	msgPlatformDetectFailed    = "Unable to detect platform type"
+	msgPlatformDetected        = "Detected platform %s in namespace %s"
+	msgStepDiscoverURL         = "Discover redirect URL"
+	msgURLDiscoverFailed       = "Unable to discover redirect URL"
+	msgURLDiscovered           = "Discovered redirect URL: %s"
+	msgURLOverride             = "Using override redirect URL: %s"
+	msgStepApplyResources      = "Apply nginx-redirect resources"
+	msgApplyDesc               = "Apply %s"
+	msgWouldApply              = "Would apply %s"
+	msgTemplateRenderFailed    = "Failed to render template %q: %v"
+	msgUnmarshalFailed         = "Failed to unmarshal YAML: %v"
+	msgApplyResourcesFailed    = "Failed to apply resources"
+	msgApplyFailed             = "Failed to apply resource: %v"
+	msgApplied                 = "Applied %s"
+	msgDryRunSkipped           = "Dry run: resources skipped"
+	msgApplyResourcesCompleted = "Successfully applied dashboard redirect resources"
+)
+
+type DashboardRedirectAction struct {
+	RouteHost   string
+	RedirectURL string
+}
+
+var _ action.ActionConfigurer = (*DashboardRedirectAction)(nil)
+
+func (a *DashboardRedirectAction) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&a.RouteHost, "redirect-route-host", "",
+		"Override the hostname for the dashboard redirect route (for legacy custom URLs)")
+	fs.StringVar(&a.RedirectURL, "redirect-url", "",
+		"Override the auto-discovered redirect destination URL")
+}
+
+func (a *DashboardRedirectAction) ID() string                { return actionID }
+func (a *DashboardRedirectAction) Name() string              { return actionName }
+func (a *DashboardRedirectAction) Description() string       { return actionDescription }
+func (a *DashboardRedirectAction) Group() action.ActionGroup { return action.GroupMigration }
+func (a *DashboardRedirectAction) Phase() action.ActionPhase { return action.PhasePostUpgrade }
+
+func (a *DashboardRedirectAction) CanApply(_ action.Target) bool {
+	return true
+}
+
+func (a *DashboardRedirectAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *DashboardRedirectAction) Run() action.Task {
+	return &runTask{action: a}
+}
+
+type runTask struct {
+	action *DashboardRedirectAction
+}
+
+type preflightResult struct {
+	info        platformInfo
+	redirectURL string
+}
+
+// preflight performs the common read-only checks shared by Validate and Execute:
+// platform detection and redirect URL discovery. It records step results onto
+// target.Recorder and returns early (with a built ActionResult) on failure.
+// On success it returns a non-nil *preflightResult; the caller is responsible
+// for calling rootRecorder.Build() after any additional work.
+func (t *runTask) preflight(ctx context.Context, target action.Target) (*preflightResult, action.RootRecorder, error) {
+	rootRecorder, ok := target.Recorder.(action.RootRecorder)
+	if !ok {
+		return nil, nil, errors.New(msgErrNotRootRecorder)
+	}
+
+	info := detectPlatform(ctx, target)
+	if info.PlatformType == "" {
+		target.Recorder.Child("detect-platform", msgStepDetectPlatform).Complete(result.StepFailed, msgPlatformDetectFailed)
+
+		return nil, rootRecorder, nil
+	}
+	target.Recorder.Child("detect-platform", msgStepDetectPlatform).Complete(result.StepCompleted, msgPlatformDetected, info.PlatformType, info.Namespace)
+
+	redirectURL := t.resolveRedirectURL(ctx, target, info.Namespace)
+	if redirectURL == "" {
+		target.Recorder.Child("discover-url", msgStepDiscoverURL).Complete(result.StepFailed, msgURLDiscoverFailed)
+
+		return nil, rootRecorder, nil
+	}
+
+	urlMsg := msgURLDiscovered
+	if t.action.RedirectURL != "" {
+		urlMsg = msgURLOverride
+	}
+	target.Recorder.Child("discover-url", msgStepDiscoverURL).Complete(result.StepCompleted, urlMsg, redirectURL)
+
+	return &preflightResult{info: info, redirectURL: redirectURL}, rootRecorder, nil
+}
+
+func (t *runTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	_, rootRecorder, err := t.preflight(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	return rootRecorder.Build(), nil
+}
+
+func (t *runTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	pf, rootRecorder, err := t.preflight(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	if pf != nil {
+		applyResources(ctx, target, pf.info.Namespace, pf.info.RouteName, pf.redirectURL, t.action.RouteHost)
+	}
+
+	return rootRecorder.Build(), nil
+}
+
+func (t *runTask) resolveRedirectURL(ctx context.Context, target action.Target, namespace string) string {
+	if t.action.RedirectURL != "" {
+		urlStr := strings.TrimRight(t.action.RedirectURL, "/")
+		if !strings.HasPrefix(urlStr, "http://") && !strings.HasPrefix(urlStr, "https://") {
+			urlStr = "https://" + urlStr
+		}
+
+		return urlStr
+	}
+
+	return discoverRedirectURL(ctx, target, namespace)
+}
+
+type platformInfo struct {
+	PlatformType string
+	Namespace    string
+	RouteName    string
+}
+
+func detectPlatform(ctx context.Context, target action.Target) platformInfo {
+	info := detectPlatformFromConfig(ctx, target)
+	if info.PlatformType != "" {
+		return info
+	}
+
+	return detectPlatformFromSubscription(ctx, target)
+}
+
+func detectPlatformFromConfig(ctx context.Context, target action.Target) platformInfo {
+	configs, err := target.Client.Dynamic().Resource(resources.OdhDashboardConfig.GVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil || len(configs.Items) == 0 {
+		return platformInfo{}
+	}
+
+	for _, item := range configs.Items {
+		anns := item.GetAnnotations()
+		ns := item.GetNamespace()
+		labels := item.GetLabels()
+
+		if strings.Contains(anns["platform.opendatahub.io/type"], "OpenShift AI") || labels["app"] == rhodsDashboardLabel {
+			if ns == "" {
+				ns = "redhat-ods-applications"
+			}
+
+			return platformInfo{PlatformType: "rhoai", Namespace: ns, RouteName: rhodsDashboardLabel}
+		} else if labels["app"] == odhDashboardLabel {
+			if ns == "" {
+				ns = "opendatahub"
+			}
+
+			return platformInfo{PlatformType: "odh", Namespace: ns, RouteName: odhDashboardLabel}
+		}
+	}
+
+	return platformInfo{}
+}
+
+func detectPlatformFromSubscription(ctx context.Context, target action.Target) platformInfo {
+	subs, err := target.Client.Dynamic().Resource(resources.Subscription.GVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return platformInfo{}
+	}
+
+	for _, sub := range subs.Items {
+		name, _ := jq.Query[string](&sub, ".spec.name")
+		if name == "rhods-operator" {
+			return platformInfo{PlatformType: "rhoai", Namespace: "redhat-ods-applications", RouteName: rhodsDashboardLabel}
+		}
+		if name == "opendatahub-operator" {
+			return platformInfo{PlatformType: "odh", Namespace: "opendatahub", RouteName: odhDashboardLabel}
+		}
+	}
+
+	return platformInfo{}
+}
+
+func discoverRedirectURL(ctx context.Context, target action.Target, namespace string) string {
+	links, err := target.Client.Dynamic().Resource(resources.ConsoleLink.GVR()).List(ctx, metav1.ListOptions{})
+	if err == nil {
+		for _, link := range links.Items {
+			text, _ := jq.Query[string](&link, ".spec.text")
+			if strings.Contains(text, "OpenShift AI") || strings.Contains(text, "Open Data Hub") {
+				href, _ := jq.Query[string](&link, ".spec.href")
+				if href != "" {
+					return strings.TrimRight(href, "/")
+				}
+			}
+		}
+	}
+
+	routes, err := target.Client.Dynamic().Resource(resources.Route.GVR()).Namespace(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=data-science-gateway",
+	})
+	if err == nil {
+		for _, route := range routes.Items {
+			host, _ := jq.Query[string](&route, ".spec.host")
+			if host != "" {
+				return "https://" + host
+			}
+		}
+	}
+
+	return ""
+}
+
+type redirectTemplateData struct {
+	Namespace   string
+	RedirectURL string
+	RouteName   string
+	RouteHost   string
+	LegacyHost  string
+}
+
+func renderTemplate(name, tmpl string, data redirectTemplateData) (string, error) {
+	t, err := template.New(name).Parse(tmpl)
+	if err != nil {
+		return "", fmt.Errorf("parsing template %q: %w", name, err)
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing template %q: %w", name, err)
+	}
+
+	return buf.String(), nil
+}
+
+func applyResources(ctx context.Context, target action.Target, namespace, routeName, redirectURL, routeHost string) {
+	step := target.Recorder.Child("apply-redirect-resources", msgStepApplyResources)
+
+	data := redirectTemplateData{
+		Namespace:   namespace,
+		RedirectURL: redirectURL,
+		RouteName:   routeName,
+		RouteHost:   routeHost,
+	}
+
+	configMapTmpl := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-redirect-config
+  namespace: {{ .Namespace }}
+  labels:
+    app: nginx-redirect
+data:
+  redirect.conf: |
+    location / {
+        return 301 {{ .RedirectURL }}$request_uri;
+    }
+`
+
+	deploymentTmpl := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-redirect
+  namespace: {{ .Namespace }}
+  labels:
+    app: nginx-redirect
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-redirect
+  template:
+    metadata:
+      labels:
+        app: nginx-redirect
+    spec:
+      containers:
+      - name: nginx
+        image: registry.redhat.io/ubi9/nginx-126:latest
+        command:
+        - /usr/libexec/s2i/run
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /opt/app-root/etc/nginx.default.d/redirect.conf
+          subPath: redirect.conf
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-redirect-config
+`
+
+	serviceTmpl := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-redirect
+  namespace: {{ .Namespace }}
+  labels:
+    app: nginx-redirect
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: nginx-redirect
+  type: ClusterIP
+`
+
+	routeTmpl := `
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .RouteName }}
+  namespace: {{ .Namespace }}
+  annotations:
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: nginx-redirect
+spec:
+{{- if .RouteHost }}
+  host: {{ .RouteHost }}
+{{- end }}
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: nginx-redirect
+    weight: 100
+  wildcardPolicy: None
+`
+
+	type resourceSpec struct {
+		desc string
+		tmpl string
+		res  resources.ResourceType
+	}
+
+	toApply := []resourceSpec{
+		{"ConfigMap", configMapTmpl, resources.ConfigMap},
+		{"Deployment", deploymentTmpl, resources.Deployment},
+		{"Service", serviceTmpl, resources.Service},
+		{"Route", routeTmpl, resources.Route},
+	}
+
+	if strings.Contains(redirectURL, "rh-ai") {
+		parsed, err := url.Parse(redirectURL)
+		if err == nil && parsed.Hostname() != "" {
+			parts := strings.SplitN(parsed.Hostname(), ".", maxDomainParts)
+			if len(parts) > 1 {
+				data.LegacyHost = "data-science-gateway." + parts[1]
+
+				legacyRouteTmpl := `
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: data-science-gateway-legacy
+  namespace: {{ .Namespace }}
+  annotations:
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: nginx-redirect
+spec:
+  host: {{ .LegacyHost }}
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: nginx-redirect
+    weight: 100
+  wildcardPolicy: None
+`
+				toApply = append(toApply, resourceSpec{"Legacy Route", legacyRouteTmpl, resources.Route})
+			}
+		}
+	}
+
+	for _, r := range toApply {
+		child := step.Child("apply-"+strings.ToLower(strings.ReplaceAll(r.desc, " ", "-")), fmt.Sprintf(msgApplyDesc, r.desc))
+
+		if target.DryRun {
+			child.Complete(result.StepSkipped, msgWouldApply, r.desc)
+
+			continue
+		}
+
+		rendered, err := renderTemplate(r.desc, r.tmpl, data)
+		if err != nil {
+			child.Complete(result.StepFailed, msgTemplateRenderFailed, r.desc, err)
+			step.Complete(result.StepFailed, msgApplyResourcesFailed)
+
+			return
+		}
+
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(rendered), &obj.Object); err != nil {
+			child.Complete(result.StepFailed, msgUnmarshalFailed, err)
+			step.Complete(result.StepFailed, msgApplyResourcesFailed)
+
+			return
+		}
+
+		_, err = target.Client.Dynamic().Resource(r.res.GVR()).Namespace(namespace).Apply(ctx, obj.GetName(), &obj, metav1.ApplyOptions{FieldManager: "odh-cli", Force: true})
+		if err != nil {
+			child.Complete(result.StepFailed, msgApplyFailed, err)
+			step.Complete(result.StepFailed, msgApplyResourcesFailed)
+
+			return
+		}
+
+		child.Complete(result.StepCompleted, msgApplied, r.desc)
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgDryRunSkipped)
+	} else {
+		step.Complete(result.StepCompleted, msgApplyResourcesCompleted)
+	}
+}

--- a/pkg/migrate/actions/dashboard/redirect/redirect_test.go
+++ b/pkg/migrate/actions/dashboard/redirect/redirect_test.go
@@ -1,0 +1,444 @@
+package redirect_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/dashboard/redirect"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func createFakeClient(scheme *runtime.Scheme, objects ...runtime.Object) (*dynamicfake.FakeDynamicClient, client.Client) {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.OdhDashboardConfig.GVR(): "OdhDashboardConfigList",
+		resources.Subscription.GVR():       "SubscriptionList",
+		resources.ConsoleLink.GVR():        "ConsoleLinkList",
+		resources.Route.GVR():              "RouteList",
+		resources.ConfigMap.GVR():          "ConfigMapList",
+		resources.Deployment.GVR():         "DeploymentList",
+		resources.Service.GVR():            "ServiceList",
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	// Mock Patch (Apply) to return success and record the object creation
+	dynamicClient.PrependReactor("patch", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(clienttesting.PatchAction)
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name":      patchAction.GetName(),
+					"namespace": patchAction.GetNamespace(),
+				},
+			},
+		}
+
+		return true, obj, nil
+	})
+
+	return dynamicClient, client.NewForTesting(client.TestClientConfig{Dynamic: dynamicClient})
+}
+
+func expectAppliedResources(g *WithT, dynamicClient *dynamicfake.FakeDynamicClient, expectedNames ...string) {
+	var appliedNames []string
+	for _, a := range dynamicClient.Actions() {
+		if a.GetVerb() == "patch" {
+			appliedNames = append(appliedNames, a.(clienttesting.PatchAction).GetName())
+		}
+	}
+	for _, name := range expectedNames {
+		g.Expect(appliedNames).To(ContainElement(name))
+	}
+}
+
+func TestDashboardRedirectAction_Execute(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	consoleLink := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "console.openshift.io/v1",
+			"kind":       "ConsoleLink",
+			"metadata": map[string]any{
+				"name": "test-link",
+			},
+			"spec": map[string]any{
+				"text": "OpenShift AI",
+				"href": "https://rh-ai.apps.cluster.com/",
+			},
+		},
+	}
+
+	rhoaiDashboardConfig := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "opendatahub.io/v1alpha",
+			"kind":       "OdhDashboardConfig",
+			"metadata": map[string]any{
+				"name":      "test-config",
+				"namespace": "redhat-ods-applications",
+				"labels": map[string]any{
+					"app": "rhods-dashboard",
+				},
+				"annotations": map[string]any{
+					"platform.opendatahub.io/type": "OpenShift AI",
+				},
+			},
+		},
+	}
+
+	odhDashboardConfig := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "opendatahub.io/v1alpha",
+			"kind":       "OdhDashboardConfig",
+			"metadata": map[string]any{
+				"name":      "test-config",
+				"namespace": "opendatahub",
+				"labels": map[string]any{
+					"app": "odh-dashboard",
+				},
+			},
+		},
+	}
+
+	rhoaiSubscription := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "Subscription",
+			"metadata": map[string]any{
+				"name":      "rhods-operator",
+				"namespace": "redhat-ods-applications",
+			},
+			"spec": map[string]any{
+				"name": "rhods-operator",
+			},
+		},
+	}
+
+	dataScienceGatewayRoute := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "route.openshift.io/v1",
+			"kind":       "Route",
+			"metadata": map[string]any{
+				"name":      "data-science-gateway",
+				"namespace": "redhat-ods-applications",
+			},
+			"spec": map[string]any{
+				"host": "dsg.apps.cluster.com",
+			},
+		},
+	}
+
+	t.Run("Happy path (RHOAI via ConsoleLink)", func(t *testing.T) {
+		g := NewWithT(t)
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig, consoleLink)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		// Verify Apply name fix - resources should be created with correct names
+		expectAppliedResources(g, dynamicClient, "nginx-redirect-config", "rhods-dashboard", "data-science-gateway-legacy")
+	})
+
+	t.Run("Happy path (ODH via labels)", func(t *testing.T) {
+		g := NewWithT(t)
+		dynamicClient, testClient := createFakeClient(scheme, odhDashboardConfig, consoleLink)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		expectAppliedResources(g, dynamicClient, "odh-dashboard")
+	})
+
+	t.Run("Happy path (Subscription fallback)", func(t *testing.T) {
+		g := NewWithT(t)
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiSubscription, consoleLink)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		expectAppliedResources(g, dynamicClient, "nginx-redirect-config")
+	})
+
+	t.Run("Route-based URL discovery fallback", func(t *testing.T) {
+		g := NewWithT(t)
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig, dataScienceGatewayRoute)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		expectAppliedResources(g, dynamicClient, "nginx-redirect-config")
+		// Ideally we would also verify the patch payload contains the right URL, but
+		// checking that the resources applied is sufficient for this test suite.
+	})
+
+	t.Run("Dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig, consoleLink)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   true, // Dry run enabled
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		// Verify resources were NOT created (no patch actions)
+		for _, a := range dynamicClient.Actions() {
+			g.Expect(a.GetVerb()).NotTo(Equal("patch"))
+		}
+	})
+
+	t.Run("Platform detection failure", func(t *testing.T) {
+		g := NewWithT(t)
+		_, testClient := createFakeClient(scheme, consoleLink)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeFalse(), "Expected Completed to be false when platform detection fails")
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("URL discovery failure", func(t *testing.T) {
+		g := NewWithT(t)
+		_, testClient := createFakeClient(scheme, rhoaiDashboardConfig)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeFalse(), "Expected Completed to be false when URL discovery fails")
+		g.Expect(res.Status.Steps[1].Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("Redirect URL override bypasses auto-discovery", func(t *testing.T) {
+		g := NewWithT(t)
+		// No ConsoleLink or Route objects - auto-discovery would fail
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{
+			RedirectURL: "https://custom-dashboard.apps.cluster.com",
+		}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		expectAppliedResources(g, dynamicClient, "nginx-redirect-config", "rhods-dashboard")
+	})
+
+	t.Run("Route host override injects host into primary route", func(t *testing.T) {
+		g := NewWithT(t)
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig, consoleLink)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{
+			RouteHost: "custom-dashboard.apps.cluster.com",
+		}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		// Verify the primary route was applied (the host is injected into the YAML)
+		expectAppliedResources(g, dynamicClient, "rhods-dashboard")
+
+		// Verify the patch payload contains the custom host
+		for _, act := range dynamicClient.Actions() {
+			if act.GetVerb() == "patch" {
+				patchAction := act.(clienttesting.PatchAction)
+				if patchAction.GetName() == "rhods-dashboard" {
+					g.Expect(string(patchAction.GetPatch())).To(ContainSubstring("custom-dashboard.apps.cluster.com"))
+				}
+			}
+		}
+	})
+
+	t.Run("Missing scheme in redirect URL override adds https://", func(t *testing.T) {
+		g := NewWithT(t)
+		// No ConsoleLink or Route objects - auto-discovery would fail
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{
+			RedirectURL: "custom-dashboard.apps.cluster.com",
+		}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		expectAppliedResources(g, dynamicClient, "nginx-redirect-config", "rhods-dashboard")
+
+		for _, act := range dynamicClient.Actions() {
+			if act.GetVerb() == "patch" {
+				patchAction := act.(clienttesting.PatchAction)
+				if patchAction.GetName() == "nginx-redirect-config" {
+					g.Expect(string(patchAction.GetPatch())).To(ContainSubstring("https://custom-dashboard.apps.cluster.com"))
+				}
+			}
+		}
+	})
+
+	t.Run("Both overrides together", func(t *testing.T) {
+		g := NewWithT(t)
+		// No ConsoleLink or Route objects - auto-discovery would fail
+		dynamicClient, testClient := createFakeClient(scheme, rhoaiDashboardConfig)
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:   testClient,
+			DryRun:   false,
+			Recorder: recorder,
+			IO:       ioStreams,
+		}
+
+		a := &redirect.DashboardRedirectAction{
+			RedirectURL: "https://custom-dashboard.apps.cluster.com",
+			RouteHost:   "old-dashboard.apps.cluster.com",
+		}
+		res, err := a.Run().Execute(context.Background(), target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+
+		expectAppliedResources(g, dynamicClient, "nginx-redirect-config", "rhods-dashboard")
+
+		// Verify the route has custom host and the redirect URL is used
+		for _, act := range dynamicClient.Actions() {
+			if act.GetVerb() == "patch" {
+				patchAction := act.(clienttesting.PatchAction)
+				if patchAction.GetName() == "rhods-dashboard" {
+					g.Expect(string(patchAction.GetPatch())).To(ContainSubstring("old-dashboard.apps.cluster.com"))
+				}
+				if patchAction.GetName() == "nginx-redirect-config" {
+					g.Expect(string(patchAction.GetPatch())).To(ContainSubstring("custom-dashboard.apps.cluster.com"))
+				}
+			}
+		}
+	})
+}

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/dashboard/redirect"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
@@ -58,6 +59,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
+	registry.MustRegister(&redirect.DashboardRedirectAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/dashboard/redirect"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
@@ -53,6 +54,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
+	registry.MustRegister(&redirect.DashboardRedirectAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/dashboard/redirect"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
@@ -49,6 +50,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
+	registry.MustRegister(&redirect.DashboardRedirectAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -124,6 +124,27 @@ var (
 		Resource: "datasciencepipelinesapplications",
 	}
 
+	OdhDashboardConfig = ResourceType{
+		Group:    "opendatahub.io",
+		Version:  "v1alpha",
+		Kind:     "OdhDashboardConfig",
+		Resource: "odhdashboardconfigs",
+	}
+
+	ConsoleLink = ResourceType{
+		Group:    "console.openshift.io",
+		Version:  "v1",
+		Kind:     "ConsoleLink",
+		Resource: "consolelinks",
+	}
+
+	Route = ResourceType{
+		Group:    "route.openshift.io",
+		Version:  "v1",
+		Kind:     "Route",
+		Resource: "routes",
+	}
+
 	// StatefulSet is the Kubernetes StatefulSet resource.
 	StatefulSet = ResourceType{
 		Group:    "apps",


### PR DESCRIPTION
This is the 3rd PR in a stack, after #83 and #84, in an attempt to make review easier (I'm not sure if it does or not, let me know). Until those are merged, the changes from them will be reflected in the "Files changed" tab here. It can either be reviewed and merged as-is, or in step after the other two.

## Description

<!-- What does this PR do? -->
https://issues.redhat.com/browse/RHOAIENG-61437

The purpose of this new functionality is to replace the dashboard URL redirect script from [rhoai-upgrade-helpers](https://github.com/red-hat-data-services/rhoai-upgrade-helpers/tree/a9aa2e6c8b03f54ed4a1699c25d66e58cbf90652/dashboard).

- Added new GVR definitions for OdhDashboardConfig, ConsoleLink, and Route.
- Implemented `dashboard.generate-redirect` action to dynamically
  generate legacy dashboard redirect configurations.
- Registered action into the CLI migration framework.
- Handled dry-run flags and robust cluster environment discovery.
- Added comprehensive unit tests mocking dynamic client behavior.

- Replace bare Pod with a Deployment (replicas: 1) so the nginx
redirect workload is rescheduled automatically if the node goes down
or the pod is evicted.

- Restrict Route query in discoverRedirectURL to the detected platform
namespace rather than querying cluster-wide, preventing false
positives from user routes.

- Automatically prepend 'https://' to custom redirect URLs missing a
scheme to ensure valid NGINX redirects and legacy route compatibility.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected migration completion reporting: actions are now marked complete only when no steps failed and no steps remain pending/running.

* **New Features**
  * Added a dashboard redirect migration that installs a redirect service for legacy dashboard routes, with configurable redirect URL and hostname; now available in list/prepare/run commands.

* **Tests**
  * Expanded unit tests for step-status logic and comprehensive tests for the redirect action, including discovery, overrides, dry-run, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->