### PR TITLE
RHOAIENG-54672 - feat(lint): add --from-stdin for JSON/YAML batch input

### DIFF
--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -43,6 +44,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/stdin"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -82,6 +84,9 @@ type Command struct {
 	// registry is the check registry for this command instance.
 	// Explicitly populated to avoid global state and enable test isolation.
 	registry *check.CheckRegistry
+
+	// flags stores the FlagSet for checking explicitly set flags
+	flags *pflag.FlagSet
 }
 
 // NewCommand creates a new Command with defaults.
@@ -161,6 +166,7 @@ func NewCommand(
 
 // AddFlags registers command-specific flags with the provided FlagSet.
 func (c *Command) AddFlags(fs *pflag.FlagSet) {
+	c.flags = fs // Store for checking explicitly set flags in applyStdinInput
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescTargetVersion)
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescOutput)
 	fs.StringVar((*string)(&c.SeverityLevel), "severity", string(SeverityLevelInfo), flagDescSeverity)
@@ -171,6 +177,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
 	fs.StringVar(&c.ISVCDeploymentMode, "isvc-deployment-mode", "all", flagDescISVCDeploymentMode)
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, flagDescQPS)
@@ -180,11 +187,88 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	c.OutputOptions.AddFlags(fs)
 }
 
+// parseStdinConfig reads and applies configuration from stdin.
+func (c *Command) parseStdinConfig() error {
+	// Only check for TTY if input is an *os.File (skip for bytes.Buffer in tests)
+	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
+		c.IO.Errorf(warnStdinIsTerminal)
+	}
+
+	var input StdinInput
+	if err := stdin.Parse(c.IO.In(), &input); err != nil {
+		return fmt.Errorf("parsing stdin: %w", err)
+	}
+
+	// Merge stdin values into command options (stdin overrides defaults)
+	if err := c.applyStdinInput(&input); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// applyStdinInput merges stdin configuration into command options.
+// Explicit CLI flags take precedence over stdin values.
+// Returns an error if stdin contains invalid values.
+func (c *Command) applyStdinInput(input *StdinInput) error {
+	if len(input.Checks) > 0 && !c.flagChanged("checks") {
+		c.CheckSelectors = input.Checks
+	}
+
+	if input.Severity != "" && !c.flagChanged("severity") {
+		level := SeverityLevel(input.Severity)
+		if err := level.Validate(); err != nil {
+			return fmt.Errorf("stdin input: %w", err)
+		}
+		c.SeverityLevel = level
+	}
+
+	if input.TargetVersion != "" && !c.flagChanged("target-version") {
+		c.TargetVersion = input.TargetVersion
+	}
+
+	if input.Verbose && !c.flagChanged("verbose") {
+		c.Verbose = true
+	}
+
+	if input.Quiet && !c.flagChanged("quiet") {
+		c.Quiet = true
+	}
+
+	if input.Output != "" && !c.flagChanged("output") {
+		format := OutputFormat(input.Output)
+		if err := format.Validate(); err != nil {
+			return fmt.Errorf("stdin input: %w", err)
+		}
+		c.OutputFormat = format
+	}
+
+	return nil
+}
+
+// flagChanged returns true if the flag was explicitly set on the command line.
+func (c *Command) flagChanged(name string) bool {
+	if c.flags == nil {
+		return false
+	}
+	f := c.flags.Lookup(name)
+
+	return f != nil && f.Changed
+}
+
 // Complete populates Options and performs pre-validation setup.
 func (c *Command) Complete() error {
 	// Skip client creation when only outputting schema
 	if c.OutputSchema {
 		return nil
+	}
+
+	// Parse stdin configuration if --from-stdin is specified
+	if c.FromStdin {
+		if err := c.parseStdinConfig(); err != nil {
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation, err)
+		}
 	}
 
 	// Validate mutual exclusivity of verbose and quiet

--- a/pkg/lint/command_options.go
+++ b/pkg/lint/command_options.go
@@ -19,6 +19,29 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 )
 
+// StdinInput defines the JSON/YAML schema for stdin input to the lint command.
+// Use with --from-stdin to pass configuration via stdin. Precedence: defaults < stdin values.
+// Fields set in stdin override command defaults; omitted fields keep their defaults.
+type StdinInput struct {
+	// Checks specifies check selector patterns (replaces --checks flag)
+	Checks []string `json:"checks,omitempty" yaml:"checks,omitempty"`
+
+	// Severity sets the minimum severity level (replaces --severity flag)
+	Severity string `json:"severity,omitempty" yaml:"severity,omitempty"`
+
+	// TargetVersion sets the target version for upgrade checks (replaces --target-version flag)
+	TargetVersion string `json:"targetVersion,omitempty" yaml:"targetVersion,omitempty"`
+
+	// Verbose enables verbose output (replaces --verbose flag)
+	Verbose bool `json:"verbose,omitempty" yaml:"verbose,omitempty"`
+
+	// Quiet suppresses non-essential output (replaces --quiet flag)
+	Quiet bool `json:"quiet,omitempty" yaml:"quiet,omitempty"`
+
+	// Output sets the output format (replaces --output flag)
+	Output string `json:"output,omitempty" yaml:"output,omitempty"`
+}
+
 // OutputFormat represents the output format for lint commands.
 type OutputFormat string
 
@@ -91,6 +114,9 @@ type SharedOptions struct {
 
 	// NoColor disables color output (default: false)
 	NoColor bool
+
+	// FromStdin reads configuration from stdin (JSON/YAML) instead of flags
+	FromStdin bool
 
 	// Timeout is the maximum duration for command execution
 	Timeout time.Duration

--- a/pkg/lint/command_test.go
+++ b/pkg/lint/command_test.go
@@ -15,6 +15,24 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// Test fixtures for stdin input parsing.
+const (
+	fixtureStdinJSON = `{"checks": ["components.*"], "severity": "warning", "targetVersion": "3.0.0", "verbose": true}`
+
+	fixtureStdinYAML = `
+checks:
+  - "platform.*"
+  - "workloads.*"
+severity: critical
+output: json
+`
+	fixtureStdinInvalid         = `{"checks": invalid}`
+	fixtureStdinUnknownFields   = `{"cheks": ["components.*"]}`
+	fixtureStdinMinimal         = `{"targetVersion": "3.0.0"}`
+	fixtureStdinInvalidSeverity = `{"severity": "invalid"}`
+	fixtureStdinInvalidOutput   = `{"output": "invalid"}`
+)
+
 // testConfigFlags creates ConfigFlags for testing.
 func testConfigFlags() *genericclioptions.ConfigFlags {
 	return genericclioptions.NewConfigFlags(true)
@@ -254,5 +272,219 @@ func TestCommand_FunctionalOptions(t *testing.T) {
 		g.Expect(command).ToNot(BeNil())
 		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
 		g.Expect(command.IO).ToNot(BeNil())
+	})
+}
+
+func TestCommand_FromStdinFlag(t *testing.T) {
+	t.Run("AddFlags should register --from-stdin flag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+
+		// Verify --from-stdin flag is registered
+		flag := fs.Lookup("from-stdin")
+		g.Expect(flag).ToNot(BeNil())
+		g.Expect(flag.DefValue).To(Equal("false"))
+	})
+}
+
+func TestCommand_StdinInput(t *testing.T) {
+	t.Run("Complete should parse stdin JSON and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify stdin values were applied
+		g.Expect(command.CheckSelectors).To(Equal([]string{"components.*"}))
+		g.Expect(command.SeverityLevel).To(Equal(lint.SeverityLevel("warning")))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.Verbose).To(BeTrue())
+	})
+
+	t.Run("Complete should parse stdin YAML and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinYAML)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.CheckSelectors).To(Equal([]string{"platform.*", "workloads.*"}))
+		g.Expect(command.SeverityLevel).To(Equal(lint.SeverityLevel("critical")))
+		g.Expect(command.OutputFormat).To(Equal(lint.OutputFormat("json")))
+	})
+
+	t.Run("Complete should fail on invalid stdin JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInvalid)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should reject unknown fields in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinUnknownFields)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should keep defaults when stdin fields are omitted", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinMinimal)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// TargetVersion should be set from stdin
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+
+		// Defaults should be preserved
+		g.Expect(command.CheckSelectors).To(Equal([]string{"*"}))
+		g.Expect(command.SeverityLevel).To(Equal(lint.SeverityLevelInfo))
+		g.Expect(command.Verbose).To(BeFalse())
+	})
+
+	t.Run("Explicit CLI flags should take precedence over stdin values", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Stdin sets severity=warning, but CLI flag sets severity=critical
+		stdin := bytes.NewBufferString(fixtureStdinJSON) // has severity: "warning"
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+
+		// Register flags and simulate --severity critical being explicitly set
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+		err := fs.Parse([]string{"--severity", "critical", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag should win over stdin
+		g.Expect(command.SeverityLevel).To(Equal(lint.SeverityLevel("critical")))
+
+		// Stdin values should apply for non-explicitly-set flags
+		g.Expect(command.CheckSelectors).To(Equal([]string{"components.*"}))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.Verbose).To(BeTrue())
+	})
+
+	t.Run("Complete should reject invalid severity in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInvalidSeverity)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("stdin input"))
+		g.Expect(err.Error()).To(ContainSubstring("invalid"))
+	})
+
+	t.Run("Complete should reject invalid output format in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInvalidOutput)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := lint.NewCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("stdin input"))
+		g.Expect(err.Error()).To(ContainSubstring("invalid"))
 	})
 }

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -13,6 +13,12 @@ const (
 	flagDescBurst              = "Kubernetes API burst capacity"
 	flagDescISVCDeploymentMode = "filter InferenceService display by deployment mode (all|serverless|modelmesh)"
 	flagDescNoColor            = "disable colored output (also respects NO_COLOR env var)"
+	flagDescFromStdin          = "read configuration from stdin (JSON/YAML); stdin values override flag defaults"
+)
+
+// Warning messages for the lint command.
+const (
+	warnStdinIsTerminal = "Warning: --from-stdin specified but stdin is a terminal"
 )
 
 const flagDescChecks = `check selector patterns (glob patterns or categories):

--- a/pkg/util/stdin/stdin.go
+++ b/pkg/util/stdin/stdin.go
@@ -1,0 +1,54 @@
+package stdin
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+const maxInputBytes = 1 << 20 // 1 MiB
+
+// Parse reads JSON or YAML from the reader and unmarshals it into the target struct.
+// It uses strict unmarshaling to reject unknown fields, helping catch typos in input.
+// Input is limited to 1 MiB to prevent memory exhaustion.
+func Parse(r io.Reader, target any) error {
+	limited := io.LimitReader(r, maxInputBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	if len(data) > maxInputBytes {
+		return fmt.Errorf("input too large: max %d bytes", maxInputBytes)
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return errors.New("empty input: expected JSON or YAML")
+	}
+
+	// UnmarshalStrict rejects unknown fields (catches typos)
+	// sigs.k8s.io/yaml handles both JSON and YAML
+	if err := yaml.UnmarshalStrict(data, target); err != nil {
+		return fmt.Errorf("parsing input: %w", err)
+	}
+
+	return nil
+}
+
+// IsPiped returns true if the file is not a terminal (i.e., has piped data).
+// Use this to warn users who specify --from-stdin but forget to pipe input.
+func IsPiped(f *os.File) bool {
+	stat, err := f.Stat()
+	if err != nil {
+		// Stat failure is rare; return false to assume terminal and show warning.
+		// This is safe: the warning is non-blocking and helps catch user mistakes.
+		return false
+	}
+
+	// If it's a character device, it's a terminal (not piped)
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}

--- a/pkg/util/stdin/stdin_test.go
+++ b/pkg/util/stdin/stdin_test.go
@@ -1,0 +1,205 @@
+package stdin_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/stdin"
+
+	. "github.com/onsi/gomega"
+)
+
+// Test fixtures for stdin parsing.
+const (
+	fixtureJSONSimple     = `{"name": "test", "enabled": true}`
+	fixtureJSONWithArrays = `{"name": "test", "items": ["a", "b", "c"]}`
+	fixtureJSONMinimal    = `{"name": "minimal"}`
+	fixtureJSONUnknown    = `{"name": "test", "unknownField": "value"}`
+	fixtureJSONMalformed  = `{"name": "test"`
+	fixtureYAMLMalformed  = "name: [unclosed bracket\n"
+
+	fixtureYAMLSimple = `
+name: test
+enabled: true
+count: 42
+`
+	fixtureYAMLWithArrays = `
+name: test
+items:
+  - alpha
+  - beta
+  - gamma
+`
+)
+
+type testInput struct {
+	Name    string   `json:"name"`
+	Items   []string `json:"items,omitempty"`
+	Enabled bool     `json:"enabled,omitempty"`
+	Count   int      `json:"count,omitempty"`
+}
+
+func TestParse_JSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantErr  bool
+	}{
+		{
+			name:     "simple JSON",
+			input:    fixtureJSONSimple,
+			wantName: "test",
+			wantErr:  false,
+		},
+		{
+			name:     "JSON with arrays",
+			input:    fixtureJSONWithArrays,
+			wantName: "test",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			reader := strings.NewReader(tt.input)
+
+			var result testInput
+			err := stdin.Parse(reader, &result)
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result.Name).To(Equal(tt.wantName))
+			}
+		})
+	}
+}
+
+func TestParse_YAML(t *testing.T) {
+	t.Run("simple YAML", func(t *testing.T) {
+		g := NewWithT(t)
+		reader := strings.NewReader(fixtureYAMLSimple)
+
+		var result testInput
+		err := stdin.Parse(reader, &result)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Name).To(Equal("test"))
+		g.Expect(result.Enabled).To(BeTrue())
+		g.Expect(result.Count).To(Equal(42))
+	})
+
+	t.Run("YAML with arrays", func(t *testing.T) {
+		g := NewWithT(t)
+		reader := strings.NewReader(fixtureYAMLWithArrays)
+
+		var result testInput
+		err := stdin.Parse(reader, &result)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.Name).To(Equal("test"))
+		g.Expect(result.Items).To(Equal([]string{"alpha", "beta", "gamma"}))
+	})
+}
+
+func TestParse_InvalidInput(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		errContains string
+	}{
+		{
+			name:        "empty input",
+			input:       "",
+			errContains: "empty input",
+		},
+		{
+			name:        "unknown fields rejected",
+			input:       fixtureJSONUnknown,
+			errContains: "parsing input",
+		},
+		{
+			name:        "malformed JSON",
+			input:       fixtureJSONMalformed,
+			errContains: "parsing input",
+		},
+		{
+			name:        "malformed YAML",
+			input:       fixtureYAMLMalformed,
+			errContains: "parsing input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			reader := strings.NewReader(tt.input)
+
+			var result testInput
+			err := stdin.Parse(reader, &result)
+
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring(tt.errContains))
+		})
+	}
+}
+
+func TestParse_PartialInput(t *testing.T) {
+	g := NewWithT(t)
+
+	reader := strings.NewReader(fixtureJSONMinimal)
+
+	var result testInput
+	err := stdin.Parse(reader, &result)
+
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Name).To(Equal("minimal"))
+	g.Expect(result.Items).To(BeNil())
+	g.Expect(result.Enabled).To(BeFalse())
+	g.Expect(result.Count).To(Equal(0))
+}
+
+func TestParse_InputTooLarge(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create input larger than 1 MiB limit
+	largeInput := strings.Repeat("x", 1<<20+1)
+	reader := strings.NewReader(largeInput)
+
+	var result testInput
+	err := stdin.Parse(reader, &result)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("input too large"))
+}
+
+func TestIsPiped(t *testing.T) {
+	t.Run("pipe returns true", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Create a pipe - the read end is not a TTY
+		r, w, err := os.Pipe()
+		g.Expect(err).NotTo(HaveOccurred())
+		t.Cleanup(func() {
+			_ = r.Close()
+			_ = w.Close()
+		})
+
+		g.Expect(stdin.IsPiped(r)).To(BeTrue())
+	})
+
+	t.Run("regular file returns true", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Create a temp file in t.TempDir() - auto-cleaned up
+		f, err := os.CreateTemp(t.TempDir(), "stdin-test-*")
+		g.Expect(err).NotTo(HaveOccurred())
+		t.Cleanup(func() { _ = f.Close() })
+
+		g.Expect(stdin.IsPiped(f)).To(BeTrue())
+	})
+}


### PR DESCRIPTION
## Description

[RHOAIENG-54672](https://redhat.atlassian.net/browse/RHOAIENG-54672)

Adds `--from-stdin` flag to the lint command for JSON/YAML batch input, enabling scripted/automated workflows.

**Changes:**
- New `pkg/util/stdin` utility package (~44 lines) for reusable stdin parsing
- Lint command integration via `--from-stdin` flag
- Strict unmarshaling rejects unknown fields (catches typos)
- Stdin values override flag defaults; omitted fields keep defaults

**Usage:**
```bash
# JSON
echo '{"checks": ["components.*"], "severity": "warning"}' | kubectl odh lint --from-stdin

# YAML
kubectl odh lint --from-stdin < lint-config.yaml
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed

## Follow-up

PRs will be created to add `--from-stdin` support to:
- `status` command
- `migrate` command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --from-stdin flag to configure the lint command via JSON/YAML from stdin.
  * Stdin-provided options (checks, severity, target version, verbosity, output format) override defaults but not explicit CLI flags.
  * Warns if --from-stdin is used while stdin appears to be a terminal; rejects empty or overly large stdin inputs.

* **Tests**
  * Expanded tests covering JSON/YAML parsing, validation errors, precedence behavior, and piped/stdin detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->