### PR TITLE
[RHOAIENG-61438] Ported v1 Training Workload Validation Script to Go Action

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,8 +97,12 @@ linters:
           disabled: true  # Standard wg.Add/Done pattern is fine
         - name: empty-block
           disabled: true  # Empty blocks with comments are intentional
+        - name: confusing-results
+          disabled: true  # Conflicts with nonamedreturns linter
         - name: enforce-switch-style
           disabled: true # default would make it more verbose
+        - name: flag-parameter
+          disabled: true  # Bool parameters for CLI flags (e.g. showNamespace) are idiomatic
 
 formatters:
   enable:

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -57,6 +57,9 @@ const cmdExample = `
 
   # Run multiple migrations sequentially
   kubectl odh migrate run --migration kueue.rhbok.migrate --migration other.migration --target-version 3.0.0 --yes
+
+  # Check for running training workloads before upgrade
+  kubectl odh migrate run -m training.verify-workloads --target-version 3.0.0
 `
 
 // AddCommand adds the migrate command to the root command.

--- a/pkg/deps/fetch.go
+++ b/pkg/deps/fetch.go
@@ -54,7 +54,7 @@ type ManifestResult struct {
 
 // GetManifest returns the parsed manifest and version, using embedded data by default.
 // If refresh is true, fetches the latest manifest from GitHub.
-func GetManifest(ctx context.Context, refresh bool) (*ManifestResult, error) { //nolint:revive // flag-parameter: refresh is intentional API design
+func GetManifest(ctx context.Context, refresh bool) (*ManifestResult, error) {
 	if refresh {
 		return fetchAndParseManifest(ctx, gitopsBaseURL)
 	}

--- a/pkg/events/filter.go
+++ b/pkg/events/filter.go
@@ -270,7 +270,6 @@ func newLabelCache() *labelCache {
 	return &labelCache{cache: make(map[string]bool)}
 }
 
-//nolint:revive // map lookup pattern returns (value, found)
 func (lc *labelCache) lookup(key string) (bool, bool) {
 	lc.mu.RLock()
 	defer lc.mu.RUnlock()

--- a/pkg/events/output.go
+++ b/pkg/events/output.go
@@ -103,8 +103,6 @@ func (c *Command) renderOutput(events []clusterhealth.EventInfo) error {
 
 // outputTable renders events as a formatted table.
 // When showNamespace is true, adds a NAMESPACE column (like kubectl -A).
-//
-//nolint:revive // flag-parameter: showNamespace mirrors kubectl -A behavior
 func outputTable(w io.Writer, events []clusterhealth.EventInfo, showNamespace bool) error {
 	if len(events) == 0 {
 		if _, err := fmt.Fprintln(w, msgNoEventsFound); err != nil {

--- a/pkg/lint/checks/workloads/notebook/impacted.go
+++ b/pkg/lint/checks/workloads/notebook/impacted.go
@@ -1406,7 +1406,7 @@ func isCompliantBuildRef(buildRef string) bool {
 // mustParseVersionParts parses a "X.Y" version string into its major and minor
 // integer components. Panics if the format is invalid.
 //
-//nolint:revive // confusing-results: unnamed (int, int) conflicts with nonamedreturns linter.
+
 func mustParseVersionParts(v string) (int, int) {
 	majorStr, minorStr, ok := strings.Cut(v, ".")
 	if !ok {

--- a/pkg/migrate/actions/training/constants.go
+++ b/pkg/migrate/actions/training/constants.go
@@ -1,0 +1,15 @@
+package training
+
+const (
+	verifyWorkloadsID          = "training.verify-workloads"
+	verifyWorkloadsName        = "Verify training workloads"
+	verifyWorkloadsDescription = "Pre-upgrade check for Kubeflow v1 training workloads requiring migration to Trainer v2 TrainJob"
+)
+
+//nolint:gochecknoglobals // Immutable mapping from v1 training job kinds to v2 TrainJob runtimes
+var v1KindToV2Runtime = map[string]string{
+	"PyTorchJob": "torch",
+	"TFJob":      "tensorflow",
+	"MPIJob":     "mpi",
+	"XGBoostJob": "xgboost",
+}

--- a/pkg/migrate/actions/training/verify_workloads.go
+++ b/pkg/migrate/actions/training/verify_workloads.go
@@ -1,0 +1,229 @@
+package training
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// VerifyWorkloadsAction enumerates Kubeflow v1 training workloads as a pre-upgrade check,
+// categorizing them by migration readiness for Trainer v2 TrainJob.
+type VerifyWorkloadsAction struct{}
+
+func (a *VerifyWorkloadsAction) ID() string          { return verifyWorkloadsID }
+func (a *VerifyWorkloadsAction) Name() string        { return verifyWorkloadsName }
+func (a *VerifyWorkloadsAction) Description() string { return verifyWorkloadsDescription }
+
+func (a *VerifyWorkloadsAction) Group() action.ActionGroup { return action.GroupValidation }
+func (a *VerifyWorkloadsAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
+
+func (a *VerifyWorkloadsAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion != nil && target.TargetVersion != nil &&
+		target.CurrentVersion.Major == 2 && target.TargetVersion.Major == 3
+}
+
+func (a *VerifyWorkloadsAction) Prepare() action.Task { return nil }
+func (a *VerifyWorkloadsAction) Run() action.Task     { return &verifyWorkloadsTask{} }
+
+type verifyWorkloadsTask struct{}
+
+func (t *verifyWorkloadsTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	return t.Execute(ctx, target)
+}
+
+func (t *verifyWorkloadsTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	trainjobReady, err := t.checkTrainJobCRD(ctx, target, recorder)
+	if err != nil {
+		return recorder.Build(), err
+	}
+
+	allEntries, err := t.enumerateV1Workloads(ctx, target, recorder)
+	if err != nil {
+		return recorder.Build(), err
+	}
+
+	t.assessMigrationReadiness(allEntries, recorder)
+	t.buildSummary(allEntries, trainjobReady, recorder)
+
+	return recorder.Build(), nil
+}
+
+func (t *verifyWorkloadsTask) checkTrainJobCRD(
+	ctx context.Context,
+	target action.Target,
+	recorder action.RootRecorder,
+) (bool, error) {
+	step := recorder.Child("trainjob-crd", "Check TrainJob v2 CRD readiness")
+
+	_, err := target.Client.List(ctx, resources.TrainJob)
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			step.AddDetail("trainjobCRDInstalled", false)
+			step.Completef(result.StepCompleted, "TrainJob CRD not installed — v2 API not yet available on this cluster")
+
+			return false, nil
+		}
+
+		step.AddDetail("trainjobCRDInstalled", false)
+		step.Completef(result.StepFailed, "Failed to check TrainJob CRD: %v", err)
+
+		return false, fmt.Errorf("checking TrainJob CRD: %w", err)
+	}
+
+	step.AddDetail("trainjobCRDInstalled", true)
+	step.Completef(result.StepCompleted, "TrainJob CRD installed — v2 API available")
+
+	return true, nil
+}
+
+func (t *verifyWorkloadsTask) enumerateV1Workloads(
+	ctx context.Context,
+	target action.Target,
+	recorder action.RootRecorder,
+) ([]WorkloadEntry, error) {
+	entries, failures, err := EnumerateWorkloads(ctx, target.Client)
+
+	failuresByKind := make(map[string]ListFailure, len(failures))
+	for _, f := range failures {
+		failuresByKind[f.Kind] = f
+	}
+
+	entriesByKind := make(map[string][]WorkloadEntry)
+	for _, e := range entries {
+		entriesByKind[e.Kind] = append(entriesByKind[e.Kind], e)
+	}
+
+	for _, rt := range TrainingJobTypes {
+		step := recorder.Child(rt.Resource, fmt.Sprintf("List %s workloads", rt.Kind))
+
+		if f, ok := failuresByKind[rt.Kind]; ok {
+			step.Completef(result.StepFailed, "Failed to list: %v", f.Err)
+
+			continue
+		}
+
+		kindEntries := entriesByKind[rt.Kind]
+		if len(kindEntries) == 0 {
+			step.Completef(result.StepCompleted, "No %s found", rt.Kind)
+
+			continue
+		}
+
+		for _, entry := range kindEntries {
+			step.Recordf(
+				entry.Name,
+				"%s/%s — %s (age: %s)",
+				result.StepCompleted,
+				entry.Namespace, entry.Name, entry.Status, entry.Age,
+			)
+		}
+
+		step.Completef(result.StepCompleted, "Found %d %s(s)", len(kindEntries), rt.Kind)
+	}
+
+	if err != nil {
+		return entries, fmt.Errorf("enumerating v1 workloads: %w", err)
+	}
+
+	return entries, nil
+}
+
+func (t *verifyWorkloadsTask) assessMigrationReadiness(
+	entries []WorkloadEntry,
+	recorder action.RootRecorder,
+) {
+	step := recorder.Child("migration-readiness", "Assess migration readiness")
+
+	var blockers []WorkloadEntry
+
+	for _, e := range entries {
+		if isActiveStatus(e.Status) {
+			blockers = append(blockers, e)
+		}
+	}
+
+	step.AddDetail("blockers", len(blockers))
+	step.AddDetail("completable", len(entries)-len(blockers))
+
+	if len(entries) == 0 {
+		step.Completef(result.StepCompleted, "No v1 training workloads found — nothing to migrate")
+
+		return
+	}
+
+	if len(blockers) == 0 {
+		step.Completef(result.StepCompleted, "All %d v1 training job(s) are completed — safe to proceed with migration", len(entries))
+
+		return
+	}
+
+	for _, b := range blockers {
+		step.Recordf(
+			b.Name,
+			"%s/%s is %s — must complete or stop before migration",
+			result.StepFailed,
+			b.Namespace, b.Name, b.Status,
+		)
+	}
+
+	step.Completef(result.StepFailed,
+		"[BLOCKER] %d active v1 job(s) must complete or be stopped before migration", len(blockers))
+}
+
+func (t *verifyWorkloadsTask) buildSummary(
+	entries []WorkloadEntry,
+	trainjobReady bool,
+	recorder action.RootRecorder,
+) {
+	step := recorder.Child("summary", "Migration summary")
+
+	report := BuildReport(entries)
+
+	step.AddDetail("total", report.Summary.Total)
+	step.AddDetail("byKind", report.Summary.ByKind)
+	step.AddDetail("byStatus", report.Summary.ByStatus)
+	step.AddDetail("trainjobCRDInstalled", trainjobReady)
+
+	migrationMap := buildMigrationMap(report.Summary.ByKind)
+	step.AddDetail("migrationMap", migrationMap)
+
+	var blockerCount int
+
+	for _, e := range entries {
+		if isActiveStatus(e.Status) {
+			blockerCount++
+		}
+	}
+
+	step.AddDetail("blockers", blockerCount)
+	step.AddDetail("completable", report.Summary.Total-blockerCount)
+
+	step.Completef(result.StepCompleted,
+		"Found %d v1 training workload(s): %d blocking migration, %d completable",
+		report.Summary.Total, blockerCount, report.Summary.Total-blockerCount)
+}
+
+func isActiveStatus(status string) bool {
+	lower := strings.ToLower(status)
+
+	return lower == "running" || lower == "created"
+}
+
+func buildMigrationMap(byKind map[string]int) map[string]string {
+	migrationMap := make(map[string]string)
+
+	for kind := range byKind {
+		if runtime, ok := v1KindToV2Runtime[kind]; ok {
+			migrationMap[kind] = fmt.Sprintf("TrainJob with runtime %q", runtime)
+		}
+	}
+
+	return migrationMap
+}

--- a/pkg/migrate/actions/training/verify_workloads_test.go
+++ b/pkg/migrate/actions/training/verify_workloads_test.go
@@ -1,0 +1,508 @@
+package training_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	trainingaction "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/training"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+const testTimestamp = "2025-01-01T00:00:00Z"
+
+//nolint:gochecknoglobals // Test fixture
+var listKinds = map[schema.GroupVersionResource]string{
+	resources.PyTorchJob.GVR(): resources.PyTorchJob.ListKind(),
+	resources.TFJob.GVR():      resources.TFJob.ListKind(),
+	resources.MPIJob.GVR():     resources.MPIJob.ListKind(),
+	resources.XGBoostJob.GVR(): resources.XGBoostJob.ListKind(),
+	resources.TrainJob.GVR():   resources.TrainJob.ListKind(),
+}
+
+func newTrainingJob(rt resources.ResourceType, name, namespace string, conditions []any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": rt.APIVersion(),
+		"kind":       rt.Kind,
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": testTimestamp,
+		},
+	}
+
+	if conditions != nil {
+		obj["status"] = map[string]any{
+			"conditions": conditions,
+		}
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func succeededConditions() []any {
+	return []any{
+		map[string]any{"type": "Created", "status": "True"},
+		map[string]any{"type": "Running", "status": "False"},
+		map[string]any{"type": "Succeeded", "status": "True"},
+	}
+}
+
+func runningConditions() []any {
+	return []any{
+		map[string]any{"type": "Created", "status": "True"},
+		map[string]any{"type": "Running", "status": "True"},
+	}
+}
+
+func failedConditions() []any {
+	return []any{
+		map[string]any{"type": "Created", "status": "True"},
+		map[string]any{"type": "Running", "status": "False"},
+		map[string]any{"type": "Failed", "status": "True"},
+	}
+}
+
+func createdConditions() []any {
+	return []any{
+		map[string]any{"type": "Created", "status": "True"},
+	}
+}
+
+func newTestTarget(objects ...runtime.Object) action.Target {
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	v := semver.MustParse("2.25.0")
+	tv := semver.MustParse("3.0.0")
+
+	return action.Target{
+		Client:         testClient,
+		CurrentVersion: &v,
+		TargetVersion:  &tv,
+		DryRun:         false,
+		SkipConfirm:    true,
+		Recorder:       action.NewRootRecorder(),
+		IO:             iostreams.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}),
+	}
+}
+
+func TestVerifyWorkloadsAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	g.Expect(a.ID()).To(Equal("training.verify-workloads"))
+	g.Expect(a.Group()).To(Equal(action.GroupValidation))
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.Prepare()).To(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestVerifyWorkloadsAction_CanApply(t *testing.T) {
+	t.Run("applies when current version is 2.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &trainingaction.VerifyWorkloadsAction{}
+		v := semver.MustParse("2.25.0")
+		tv := semver.MustParse("3.0.0")
+
+		g.Expect(a.CanApply(action.Target{
+			CurrentVersion: &v,
+			TargetVersion:  &tv,
+		})).To(BeTrue())
+	})
+
+	t.Run("does not apply when current version is 3.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &trainingaction.VerifyWorkloadsAction{}
+		v := semver.MustParse("3.0.0")
+		tv := semver.MustParse("3.1.0")
+
+		g.Expect(a.CanApply(action.Target{
+			CurrentVersion: &v,
+			TargetVersion:  &tv,
+		})).To(BeFalse())
+	})
+
+	t.Run("does not apply when current version is nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &trainingaction.VerifyWorkloadsAction{}
+		tv := semver.MustParse("3.0.0")
+
+		g.Expect(a.CanApply(action.Target{
+			TargetVersion: &tv,
+		})).To(BeFalse())
+	})
+
+	t.Run("does not apply when target version is nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &trainingaction.VerifyWorkloadsAction{}
+		v := semver.MustParse("2.25.0")
+
+		g.Expect(a.CanApply(action.Target{
+			CurrentVersion: &v,
+		})).To(BeFalse())
+	})
+
+	t.Run("does not apply for 2.x to 2.x upgrade", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &trainingaction.VerifyWorkloadsAction{}
+		v := semver.MustParse("2.16.0")
+		tv := semver.MustParse("2.25.0")
+
+		g.Expect(a.CanApply(action.Target{
+			CurrentVersion: &v,
+			TargetVersion:  &tv,
+		})).To(BeFalse())
+	})
+}
+
+func TestVerifyWorkloadsAction_RunCategorizesBlockers(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	running := newTrainingJob(resources.PyTorchJob, "running-job", "ns-a", runningConditions())
+	created := newTrainingJob(resources.TFJob, "created-job", "ns-b", createdConditions())
+
+	target := newTestTarget(running, created)
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	readiness := findStep(actionResult.Status.Steps, "migration-readiness")
+	g.Expect(readiness).ToNot(BeNil())
+	g.Expect(readiness.Status).To(Equal(result.StepFailed))
+	g.Expect(readiness.Message).To(ContainSubstring("[BLOCKER]"))
+	g.Expect(readiness.Message).To(ContainSubstring("2 active"))
+	g.Expect(readiness.Details["blockers"]).To(Equal(2))
+	g.Expect(readiness.Details["completable"]).To(Equal(0))
+}
+
+func TestVerifyWorkloadsAction_RunNoBlockers(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	succeeded := newTrainingJob(resources.PyTorchJob, "done-job", "ns-a", succeededConditions())
+	failed := newTrainingJob(resources.TFJob, "failed-job", "ns-a", failedConditions())
+
+	target := newTestTarget(succeeded, failed)
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+
+	readiness := findStep(actionResult.Status.Steps, "migration-readiness")
+	g.Expect(readiness).ToNot(BeNil())
+	g.Expect(readiness.Status).To(Equal(result.StepCompleted))
+	g.Expect(readiness.Message).To(ContainSubstring("safe to proceed"))
+	g.Expect(readiness.Details["blockers"]).To(Equal(0))
+	g.Expect(readiness.Details["completable"]).To(Equal(2))
+}
+
+func TestVerifyWorkloadsAction_RunMixed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	running := newTrainingJob(resources.PyTorchJob, "active-1", "ns-a", runningConditions())
+	succeeded1 := newTrainingJob(resources.PyTorchJob, "done-1", "ns-a", succeededConditions())
+	succeeded2 := newTrainingJob(resources.TFJob, "done-2", "ns-a", succeededConditions())
+	failed := newTrainingJob(resources.MPIJob, "failed-1", "ns-b", failedConditions())
+
+	target := newTestTarget(running, succeeded1, succeeded2, failed)
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	readiness := findStep(actionResult.Status.Steps, "migration-readiness")
+	g.Expect(readiness).ToNot(BeNil())
+	g.Expect(readiness.Status).To(Equal(result.StepFailed))
+	g.Expect(readiness.Details["blockers"]).To(Equal(1))
+	g.Expect(readiness.Details["completable"]).To(Equal(3))
+
+	summary := findStep(actionResult.Status.Steps, "summary")
+	g.Expect(summary).ToNot(BeNil())
+	g.Expect(summary.Details["total"]).To(Equal(4))
+	g.Expect(summary.Details["blockers"]).To(Equal(1))
+	g.Expect(summary.Details["completable"]).To(Equal(3))
+}
+
+func TestVerifyWorkloadsAction_RunTrainJobCRDInstalled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTestTarget()
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	crdStep := findStep(actionResult.Status.Steps, "trainjob-crd")
+	g.Expect(crdStep).ToNot(BeNil())
+	g.Expect(crdStep.Status).To(Equal(result.StepCompleted))
+	g.Expect(crdStep.Details["trainjobCRDInstalled"]).To(BeTrue())
+	g.Expect(crdStep.Message).To(ContainSubstring("v2 API available"))
+
+	summary := findStep(actionResult.Status.Steps, "summary")
+	g.Expect(summary).ToNot(BeNil())
+	g.Expect(summary.Details["trainjobCRDInstalled"]).To(BeTrue())
+}
+
+func TestVerifyWorkloadsAction_RunTrainJobCRDNotInstalled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "trainjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: resources.TrainJob.Group, Resource: resources.TrainJob.Resource},
+			"",
+		)
+	})
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	v := semver.MustParse("2.25.0")
+	tv := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client:         testClient,
+		CurrentVersion: &v,
+		TargetVersion:  &tv,
+		Recorder:       action.NewRootRecorder(),
+		IO:             iostreams.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}),
+	}
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	crdStep := findStep(actionResult.Status.Steps, "trainjob-crd")
+	g.Expect(crdStep).ToNot(BeNil())
+	g.Expect(crdStep.Status).To(Equal(result.StepCompleted))
+	g.Expect(crdStep.Details["trainjobCRDInstalled"]).To(BeFalse())
+	g.Expect(crdStep.Message).To(ContainSubstring("not installed"))
+}
+
+func TestVerifyWorkloadsAction_RunTrainJobCRDCheckError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "trainjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	v := semver.MustParse("2.25.0")
+	tv := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client:         testClient,
+		CurrentVersion: &v,
+		TargetVersion:  &tv,
+		Recorder:       action.NewRootRecorder(),
+		IO:             iostreams.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}),
+	}
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("checking TrainJob CRD"))
+
+	crdStep := findStep(actionResult.Status.Steps, "trainjob-crd")
+	g.Expect(crdStep).ToNot(BeNil())
+	g.Expect(crdStep.Status).To(Equal(result.StepFailed))
+	g.Expect(crdStep.Details["trainjobCRDInstalled"]).To(BeFalse())
+}
+
+func TestVerifyWorkloadsAction_RunMigrationMap(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pytorch := newTrainingJob(resources.PyTorchJob, "pt-1", "ns-a", succeededConditions())
+	tfjob := newTrainingJob(resources.TFJob, "tf-1", "ns-a", succeededConditions())
+
+	target := newTestTarget(pytorch, tfjob)
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	summary := findStep(actionResult.Status.Steps, "summary")
+	g.Expect(summary).ToNot(BeNil())
+
+	migrationMap, ok := summary.Details["migrationMap"].(map[string]string)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(migrationMap).To(HaveLen(2))
+	g.Expect(migrationMap["PyTorchJob"]).To(ContainSubstring("torch"))
+	g.Expect(migrationMap["TFJob"]).To(ContainSubstring("tensorflow"))
+	g.Expect(migrationMap).ToNot(HaveKey("MPIJob"))
+	g.Expect(migrationMap).ToNot(HaveKey("XGBoostJob"))
+}
+
+func TestVerifyWorkloadsAction_RunNoWorkloads(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := newTestTarget()
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	readiness := findStep(actionResult.Status.Steps, "migration-readiness")
+	g.Expect(readiness).ToNot(BeNil())
+	g.Expect(readiness.Status).To(Equal(result.StepCompleted))
+	g.Expect(readiness.Message).To(ContainSubstring("nothing to migrate"))
+
+	summary := findStep(actionResult.Status.Steps, "summary")
+	g.Expect(summary).ToNot(BeNil())
+	g.Expect(summary.Details["total"]).To(Equal(0))
+}
+
+func TestVerifyWorkloadsAction_RunAllListsFail(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "*", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+	dynamicClient.PrependReactor("list", "trainjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	v := semver.MustParse("2.25.0")
+	tv := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client:         testClient,
+		CurrentVersion: &v,
+		TargetVersion:  &tv,
+		Recorder:       action.NewRootRecorder(),
+		IO:             iostreams.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}),
+	}
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	_, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to list any training workload types"))
+}
+
+func TestVerifyWorkloadsAction_RunPartialFailure(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	tfjob := newTrainingJob(resources.TFJob, "tf-1", "ns-a", succeededConditions())
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, tfjob)
+	dynamicClient.PrependReactor("list", "pytorchjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	v := semver.MustParse("2.25.0")
+	tv := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client:         testClient,
+		CurrentVersion: &v,
+		TargetVersion:  &tv,
+		Recorder:       action.NewRootRecorder(),
+		IO:             iostreams.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}),
+	}
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Execute(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+	pytorchStep := findStep(actionResult.Status.Steps, "pytorchjobs")
+	g.Expect(pytorchStep).ToNot(BeNil())
+	g.Expect(pytorchStep.Status).To(Equal(result.StepFailed))
+
+	summary := findStep(actionResult.Status.Steps, "summary")
+	g.Expect(summary).ToNot(BeNil())
+	g.Expect(summary.Details["total"]).To(Equal(1))
+}
+
+func TestVerifyWorkloadsAction_ValidateSameAsExecute(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pytorch := newTrainingJob(resources.PyTorchJob, "pt-1", "ns-a", succeededConditions())
+	target := newTestTarget(pytorch)
+
+	a := &trainingaction.VerifyWorkloadsAction{}
+	actionResult, err := a.Run().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+}
+
+func findStep(steps []result.ActionStep, name string) *result.ActionStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/training/workloads.go
+++ b/pkg/migrate/actions/training/workloads.go
@@ -1,0 +1,184 @@
+package training
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	statusUnknown = "Unknown"
+	hoursPerDay   = 24
+)
+
+//nolint:gochecknoglobals // Immutable list of supported training job types
+var TrainingJobTypes = []resources.ResourceType{
+	resources.PyTorchJob,
+	resources.TFJob,
+	resources.MPIJob,
+	resources.XGBoostJob,
+}
+
+type WorkloadEntry struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Age       string `json:"age"`
+}
+
+type ListFailure struct {
+	Kind string
+	Err  error
+}
+
+type WorkloadReport struct {
+	Kind    string          `json:"kind"`
+	Items   []WorkloadEntry `json:"items"`
+	Summary ReportSummary   `json:"summary"`
+}
+
+type ReportSummary struct {
+	Total    int            `json:"total"`
+	ByKind   map[string]int `json:"byKind"`
+	ByStatus map[string]int `json:"byStatus"`
+}
+
+// EnumerateWorkloads lists all v1 training workloads across all namespaces.
+// It returns entries for successfully listed types and failures for types that
+// could not be listed. An error is returned only if every type fails.
+func EnumerateWorkloads(ctx context.Context, k8sClient client.Client) ([]WorkloadEntry, []ListFailure, error) {
+	var entries []WorkloadEntry
+
+	var failures []ListFailure
+
+	for _, rt := range TrainingJobTypes {
+		items, err := k8sClient.List(ctx, rt)
+		if err != nil {
+			if client.IsResourceTypeNotFound(err) {
+				continue
+			}
+
+			if ctx.Err() != nil {
+				return entries, failures, fmt.Errorf("listing %s: %w", rt.Kind, ctx.Err())
+			}
+
+			failures = append(failures, ListFailure{Kind: rt.Kind, Err: fmt.Errorf("listing %s: %w", rt.Kind, err)})
+
+			continue
+		}
+
+		for _, item := range items {
+			entries = append(entries, ExtractWorkloadEntry(item, rt.Kind))
+		}
+	}
+
+	if len(failures) == len(TrainingJobTypes) {
+		return nil, failures, errors.New("failed to list any training workload types")
+	}
+
+	if len(entries) == 0 && len(failures) > 0 {
+		return nil, failures, errors.New("failed to list any training workload types")
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Namespace != entries[j].Namespace {
+			return entries[i].Namespace < entries[j].Namespace
+		}
+
+		if entries[i].Kind != entries[j].Kind {
+			return entries[i].Kind < entries[j].Kind
+		}
+
+		return entries[i].Name < entries[j].Name
+	})
+
+	return entries, failures, nil
+}
+
+func ExtractWorkloadEntry(obj *unstructured.Unstructured, kind string) WorkloadEntry {
+	return WorkloadEntry{
+		Namespace: obj.GetNamespace(),
+		Kind:      kind,
+		Name:      obj.GetName(),
+		Status:    ExtractJobStatus(obj),
+		Age:       formatAge(obj.GetCreationTimestamp().Time),
+	}
+}
+
+func ExtractJobStatus(obj *unstructured.Unstructured) string {
+	statusObj, ok := obj.Object["status"].(map[string]any)
+	if !ok {
+		return statusUnknown
+	}
+
+	conditions, ok := statusObj["conditions"].([]any)
+	if !ok || len(conditions) == 0 {
+		return statusUnknown
+	}
+
+	for i := len(conditions) - 1; i >= 0; i-- {
+		cond, ok := conditions[i].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		condStatus, _ := cond["status"].(string)
+		if condStatus != "True" {
+			continue
+		}
+
+		condType, _ := cond["type"].(string)
+		if condType != "" {
+			return condType
+		}
+	}
+
+	return statusUnknown
+}
+
+func BuildReport(entries []WorkloadEntry) WorkloadReport {
+	byKind := make(map[string]int)
+	byStatus := make(map[string]int)
+
+	for _, e := range entries {
+		byKind[e.Kind]++
+		byStatus[e.Status]++
+	}
+
+	return WorkloadReport{
+		Kind:  "TrainingWorkloadReport",
+		Items: entries,
+		Summary: ReportSummary{
+			Total:    len(entries),
+			ByKind:   byKind,
+			ByStatus: byStatus,
+		},
+	}
+}
+
+func formatAge(t time.Time) string {
+	if t.IsZero() {
+		return "<unknown>"
+	}
+
+	d := time.Since(t)
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/hoursPerDay))
+	}
+}

--- a/pkg/migrate/actions/training/workloads_test.go
+++ b/pkg/migrate/actions/training/workloads_test.go
@@ -1,0 +1,265 @@
+package training_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	training "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/training"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func newDynamicClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+// --- ExtractJobStatus tests ---
+
+func TestExtractJobStatus_Succeeded(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "test-ns", succeededConditions())
+	g.Expect(training.ExtractJobStatus(obj)).To(Equal("Succeeded"))
+}
+
+func TestExtractJobStatus_Running(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "test-ns", runningConditions())
+	g.Expect(training.ExtractJobStatus(obj)).To(Equal("Running"))
+}
+
+func TestExtractJobStatus_Failed(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "test-ns", failedConditions())
+	g.Expect(training.ExtractJobStatus(obj)).To(Equal("Failed"))
+}
+
+func TestExtractJobStatus_NoConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "test-ns", nil)
+	g.Expect(training.ExtractJobStatus(obj)).To(Equal("Unknown"))
+}
+
+func TestExtractJobStatus_EmptyConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "test-ns", []any{})
+	g.Expect(training.ExtractJobStatus(obj)).To(Equal("Unknown"))
+}
+
+func TestExtractJobStatus_AllConditionsFalse(t *testing.T) {
+	g := NewWithT(t)
+
+	conditions := []any{
+		map[string]any{"type": "Created", "status": "False"},
+		map[string]any{"type": "Running", "status": "False"},
+	}
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "test-ns", conditions)
+	g.Expect(training.ExtractJobStatus(obj)).To(Equal("Unknown"))
+}
+
+// --- EnumerateWorkloads tests ---
+
+func TestEnumerateWorkloads_MultipleJobTypes(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	pytorch := newTrainingJob(resources.PyTorchJob, "pytorch-1", "test-ns", succeededConditions())
+	tfjob := newTrainingJob(resources.TFJob, "tf-1", "test-ns", runningConditions())
+	mpijob := newTrainingJob(resources.MPIJob, "mpi-1", "test-ns", failedConditions())
+	xgboost := newTrainingJob(resources.XGBoostJob, "xgb-1", "test-ns", succeededConditions())
+
+	entries, failures, err := training.EnumerateWorkloads(ctx, newDynamicClient(pytorch, tfjob, mpijob, xgboost))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(failures).To(BeEmpty())
+	g.Expect(entries).To(HaveLen(4))
+}
+
+func TestEnumerateWorkloads_Empty(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	entries, failures, err := training.EnumerateWorkloads(ctx, newDynamicClient())
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(failures).To(BeEmpty())
+	g.Expect(entries).To(BeEmpty())
+}
+
+func TestEnumerateWorkloads_SortsResults(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	jobB := newTrainingJob(resources.PyTorchJob, "b-job", "test-ns", succeededConditions())
+	jobA := newTrainingJob(resources.PyTorchJob, "a-job", "test-ns", succeededConditions())
+	jobC := newTrainingJob(resources.TFJob, "c-job", "test-ns", runningConditions())
+
+	entries, _, err := training.EnumerateWorkloads(ctx, newDynamicClient(jobB, jobA, jobC))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(entries).To(HaveLen(3))
+
+	g.Expect(entries[0].Kind).To(Equal("PyTorchJob"))
+	g.Expect(entries[0].Name).To(Equal("a-job"))
+	g.Expect(entries[1].Kind).To(Equal("PyTorchJob"))
+	g.Expect(entries[1].Name).To(Equal("b-job"))
+	g.Expect(entries[2].Kind).To(Equal("TFJob"))
+	g.Expect(entries[2].Name).To(Equal("c-job"))
+}
+
+func TestEnumerateWorkloads_AllListsFail(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "*", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	k8sClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	_, _, err := training.EnumerateWorkloads(ctx, k8sClient)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to list any training workload types"))
+}
+
+func TestEnumerateWorkloads_PartialFailure(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	tfjob := newTrainingJob(resources.TFJob, "tf-1", "test-ns", succeededConditions())
+	mpijob := newTrainingJob(resources.MPIJob, "mpi-1", "test-ns", runningConditions())
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, tfjob, mpijob)
+	dynamicClient.PrependReactor("list", "pytorchjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	k8sClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	entries, failures, err := training.EnumerateWorkloads(ctx, k8sClient)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(failures).To(HaveLen(1))
+	g.Expect(failures[0].Kind).To(Equal("PyTorchJob"))
+	g.Expect(entries).To(HaveLen(2))
+}
+
+func TestEnumerateWorkloads_NoEntriesWithFailures(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "pytorchjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: resources.PyTorchJob.Group, Resource: resources.PyTorchJob.Resource}, "")
+	})
+	dynamicClient.PrependReactor("list", "tfjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: resources.TFJob.Group, Resource: resources.TFJob.Resource}, "")
+	})
+	dynamicClient.PrependReactor("list", "mpijobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	k8sClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	_, failures, err := training.EnumerateWorkloads(ctx, k8sClient)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to list any training workload types"))
+	g.Expect(failures).To(HaveLen(1))
+	g.Expect(failures[0].Kind).To(Equal("MPIJob"))
+}
+
+func TestEnumerateWorkloads_ContextCanceled(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	dynamicClient.PrependReactor("list", "pytorchjobs", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		cancel()
+
+		return true, nil, context.Canceled
+	})
+
+	k8sClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	_, _, err := training.EnumerateWorkloads(ctx, k8sClient)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("context canceled"))
+}
+
+// --- BuildReport tests ---
+
+func TestBuildReport(t *testing.T) {
+	g := NewWithT(t)
+
+	entries := []training.WorkloadEntry{
+		{Kind: "PyTorchJob", Status: "Succeeded"},
+		{Kind: "PyTorchJob", Status: "Running"},
+		{Kind: "PyTorchJob", Status: "Failed"},
+		{Kind: "TFJob", Status: "Succeeded"},
+		{Kind: "TFJob", Status: "Succeeded"},
+		{Kind: "MPIJob", Status: "Running"},
+	}
+
+	report := training.BuildReport(entries)
+	g.Expect(report.Kind).To(Equal("TrainingWorkloadReport"))
+	g.Expect(report.Summary.Total).To(Equal(6))
+	g.Expect(report.Summary.ByKind["PyTorchJob"]).To(Equal(3))
+	g.Expect(report.Summary.ByKind["TFJob"]).To(Equal(2))
+	g.Expect(report.Summary.ByKind["MPIJob"]).To(Equal(1))
+	g.Expect(report.Summary.ByStatus["Succeeded"]).To(Equal(3))
+	g.Expect(report.Summary.ByStatus["Running"]).To(Equal(2))
+	g.Expect(report.Summary.ByStatus["Failed"]).To(Equal(1))
+}
+
+func TestBuildReport_Empty(t *testing.T) {
+	g := NewWithT(t)
+
+	report := training.BuildReport(nil)
+	g.Expect(report.Kind).To(Equal("TrainingWorkloadReport"))
+	g.Expect(report.Summary.Total).To(Equal(0))
+}
+
+// --- ExtractWorkloadEntry tests ---
+
+func TestExtractWorkloadEntry(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := newTrainingJob(resources.PyTorchJob, "my-job", "my-ns", succeededConditions())
+	entry := training.ExtractWorkloadEntry(obj, "PyTorchJob")
+
+	g.Expect(entry.Namespace).To(Equal("my-ns"))
+	g.Expect(entry.Kind).To(Equal("PyTorchJob"))
+	g.Expect(entry.Name).To(Equal("my-job"))
+	g.Expect(entry.Status).To(Equal("Succeeded"))
+	g.Expect(entry.Age).ToNot(BeEmpty())
+}

--- a/pkg/migrate/actions/workbenches/upgrade/run_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/run_task.go
@@ -194,7 +194,6 @@ func (t *runTask) fixContainerNames(
 	}
 }
 
-//nolint:revive // confusing-results: unnamed (int, int) conflicts with nonamedreturns linter.
 func (t *runTask) applyContainerFixes(
 	ctx context.Context,
 	target action.Target,

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -5,6 +5,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/training"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/data"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/deadlock"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/guardrails"
@@ -31,6 +32,7 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&otelexporter.MigrateOtelExporterAction{})
 	registry.MustRegister(&metrics.MetricsAction{})
 	registry.MustRegister(&data.DataAction{})
+	registry.MustRegister(&training.VerifyWorkloadsAction{})
 
 	return registry
 }

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -330,6 +330,38 @@ var (
 		Resource: "pytorchjobs",
 	}
 
+	// TFJob is the Kubeflow Training TFJob resource.
+	TFJob = ResourceType{
+		Group:    "kubeflow.org",
+		Version:  "v1",
+		Kind:     "TFJob",
+		Resource: "tfjobs",
+	}
+
+	// MPIJob is the Kubeflow Training MPIJob resource.
+	MPIJob = ResourceType{
+		Group:    "kubeflow.org",
+		Version:  "v1",
+		Kind:     "MPIJob",
+		Resource: "mpijobs",
+	}
+
+	// XGBoostJob is the Kubeflow Training XGBoostJob resource.
+	XGBoostJob = ResourceType{
+		Group:    "kubeflow.org",
+		Version:  "v1",
+		Kind:     "XGBoostJob",
+		Resource: "xgboostjobs",
+	}
+
+	// TrainJob is the Kubeflow Trainer v2 TrainJob resource.
+	TrainJob = ResourceType{
+		Group:    "kubeflow.org",
+		Version:  "v2alpha1",
+		Kind:     "TrainJob",
+		Resource: "trainjobs",
+	}
+
 	// GuardrailsOrchestrator is the TrustyAI GuardrailsOrchestrator resource.
 	GuardrailsOrchestrator = ResourceType{
 		Group:    "trustyai.opendatahub.io",


### PR DESCRIPTION
## Description

Add a pre-migration list and validation of existing v1 Trainer jobs that may be impacted by a migration to 3.x. Highlights the ability to migrate to v2 TrainJobs as part of the summary.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-upgrade verification that scans cluster training workloads, builds a readiness summary report, and flags active blockers.
  * Expanded detection of additional Kubeflow training workload types (TensorFlow, MPI, XGBoost) and registered the check in the default migration actions.

* **Documentation**
  * Updated migrate command examples to show running the training workload verification before upgrading.

* **Tests**
  * Added comprehensive unit tests for workload enumeration, status extraction, reporting, and the verification check.

* **Chores**
  * Minor linter/comment cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->