### PR TITLE
RHOAIENG-61430: Convert Model Serving migration scripts to Go actions

### DIFF
--- a/pkg/migrate/actions/modelserving/add_owner_references.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references.go
@@ -1,0 +1,237 @@
+package modelserving
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	addOwnerRefsActionID          = "modelserving.add-owner-references"
+	addOwnerRefsActionName        = "Add owner references to auth resources"
+	addOwnerRefsActionDescription = "Patches ServiceAccounts, Roles, and RoleBindings associated with RawDeployment InferenceServices with ownerReferences pointing to the ISVC"
+
+	msgOwnerRefNoISVCs     = "No InferenceServices found with deploymentMode=RawDeployment"
+	msgOwnerRefFoundISVCs  = "Found %d InferenceServices with deploymentMode=RawDeployment"
+	msgOwnerRefPatched     = "Patched %s %s/%s with ownerReference to %s"
+	msgOwnerRefPatchDryRun = "Would patch %s %s/%s with ownerReference to %s"
+	msgOwnerRefPatchFailed = "Failed to patch %s %s/%s: %v"
+	msgOwnerRefNotFound    = "%s %s/%s not found (skipped)"
+	msgOwnerRefComplete    = "Processed owner references for %d InferenceService(s)"
+)
+
+// AddOwnerReferencesAction patches auth resources (SA, Role, RoleBinding) with
+// ownerReferences pointing to the associated InferenceService.
+type AddOwnerReferencesAction struct{}
+
+func (a *AddOwnerReferencesAction) ID() string {
+	return addOwnerRefsActionID
+}
+
+func (a *AddOwnerReferencesAction) Name() string {
+	return addOwnerRefsActionName
+}
+
+func (a *AddOwnerReferencesAction) Description() string {
+	return addOwnerRefsActionDescription
+}
+
+func (a *AddOwnerReferencesAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *AddOwnerReferencesAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *AddOwnerReferencesAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
+}
+
+func (a *AddOwnerReferencesAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *AddOwnerReferencesAction) Run() action.Task {
+	return &addOwnerRefsRunTask{action: a}
+}
+
+func (a *AddOwnerReferencesAction) addOwnerReferences(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"add-owner-references",
+		"Add owner references to auth resources",
+	)
+
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeRawDeployment)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list InferenceServices: %v", err)
+
+		return
+	}
+
+	if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgOwnerRefNoISVCs)
+
+		return
+	}
+
+	step.Record("list-isvcs", msgOwnerRefFoundISVCs, result.StepCompleted, len(isvcs))
+
+	patchedCount := 0
+
+	for _, isvc := range isvcs {
+		isvcStep := step.Child(
+			fmt.Sprintf("isvc-%s-%s", isvc.GetNamespace(), isvc.GetName()),
+			fmt.Sprintf("Add owner references for %s/%s", isvc.GetNamespace(), isvc.GetName()),
+		)
+
+		a.patchAuthResourceOwnerRefs(ctx, target, isvc, isvcStep)
+		patchedCount++
+	}
+
+	step.Complete(result.StepCompleted, msgOwnerRefComplete, patchedCount)
+}
+
+func (a *AddOwnerReferencesAction) patchAuthResourceOwnerRefs(
+	ctx context.Context,
+	target action.Target,
+	isvc *unstructured.Unstructured,
+	step action.StepRecorder,
+) {
+	name := isvc.GetName()
+	ns := isvc.GetNamespace()
+	uid := isvc.GetUID()
+
+	ownerRef := map[string]any{
+		"apiVersion":         resources.InferenceService.APIVersion(),
+		"kind":               resources.InferenceService.Kind,
+		"name":               name,
+		"uid":                string(uid),
+		"blockOwnerDeletion": false,
+	}
+
+	ownerRefPatch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"ownerReferences": []any{ownerRef},
+		},
+	})
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to marshal owner reference patch: %v", err)
+
+		return
+	}
+
+	// Patch ServiceAccount
+	a.patchResourceOwnerRef(ctx, target, resources.ServiceAccount, ns, name+authSASuffix, name, ownerRefPatch, step)
+
+	// Patch Role
+	a.patchResourceOwnerRef(ctx, target, resources.Role, ns, name+authRoleSuffix, name, ownerRefPatch, step)
+
+	// Patch RoleBinding
+	a.patchResourceOwnerRef(ctx, target, resources.RoleBinding, ns, name+authRoleBindingSuffix, name, ownerRefPatch, step)
+}
+
+func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
+	ctx context.Context,
+	target action.Target,
+	resourceType resources.ResourceType,
+	namespace string,
+	resourceName string,
+	isvcName string,
+	patchData []byte,
+	step action.StepRecorder,
+) {
+	// Check if resource exists first
+	_, err := target.Client.Dynamic().Resource(resourceType.GVR()).
+		Namespace(namespace).
+		Get(ctx, resourceName, metav1.GetOptions{})
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			step.Record(
+				"patch-"+resourceName,
+				msgOwnerRefNotFound,
+				result.StepSkipped,
+				resourceType.Kind, namespace, resourceName,
+			)
+
+			return
+		}
+
+		step.Record(
+			"patch-"+resourceName,
+			msgOwnerRefPatchFailed,
+			result.StepFailed,
+			resourceType.Kind, namespace, resourceName, err,
+		)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Record(
+			"patch-"+resourceName,
+			msgOwnerRefPatchDryRun,
+			result.StepSkipped,
+			resourceType.Kind, namespace, resourceName, isvcName,
+		)
+
+		return
+	}
+
+	_, err = target.Client.Dynamic().Resource(resourceType.GVR()).
+		Namespace(namespace).
+		Patch(ctx, resourceName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+
+	if err != nil {
+		step.Record(
+			"patch-"+resourceName,
+			msgOwnerRefPatchFailed,
+			result.StepFailed,
+			resourceType.Kind, namespace, resourceName, err,
+		)
+
+		return
+	}
+
+	step.Record(
+		"patch-"+resourceName,
+		msgOwnerRefPatched,
+		result.StepCompleted,
+		resourceType.Kind, namespace, resourceName, isvcName,
+	)
+}
+
+// --- Run Task ---
+
+type addOwnerRefsRunTask struct {
+	action *AddOwnerReferencesAction
+}
+
+func (t *addOwnerRefsRunTask) Validate(
+	_ context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return buildResult(target)
+}
+
+func (t *addOwnerRefsRunTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	t.action.addOwnerReferences(ctx, target)
+
+	return buildResult(target)
+}

--- a/pkg/migrate/actions/modelserving/add_owner_references_test.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references_test.go
@@ -1,0 +1,193 @@
+package modelserving_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAddOwnerReferencesAction_ID(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.AddOwnerReferencesAction{}
+	g.Expect(a.ID()).To(Equal("modelserving.add-owner-references"))
+}
+
+func TestAddOwnerReferencesAction_CanApply(t *testing.T) {
+	t.Run("should return true for version 2.25", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.AddOwnerReferencesAction{}
+		v := semver.MustParse("2.25.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeTrue())
+	})
+
+	t.Run("should return false for version 3.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.AddOwnerReferencesAction{}
+		v := semver.MustParse("3.0.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+}
+
+func TestAddOwnerReferencesAction_Prepare(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.AddOwnerReferencesAction{}
+	g.Expect(a.Prepare()).To(BeNil())
+}
+
+func TestAddOwnerReferencesAction_RunExecute(t *testing.T) {
+	t.Run("should skip when no RawDeployment ISVCs exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.AddOwnerReferencesAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should patch auth resources with owner references", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, testISVCName, "RawDeployment")
+
+		sa := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": resources.ServiceAccount.APIVersion(),
+				"kind":       resources.ServiceAccount.Kind,
+				"metadata": map[string]any{
+					"name":      testISVCName + "-sa",
+					"namespace": testISVCNamespace,
+				},
+			},
+		}
+
+		role := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": resources.Role.APIVersion(),
+				"kind":       resources.Role.Kind,
+				"metadata": map[string]any{
+					"name":      testISVCName + "-view-role",
+					"namespace": testISVCNamespace,
+				},
+			},
+		}
+
+		rb := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": resources.RoleBinding.APIVersion(),
+				"kind":       resources.RoleBinding.Kind,
+				"metadata": map[string]any{
+					"name":      testISVCName + "-view",
+					"namespace": testISVCNamespace,
+				},
+			},
+		}
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sa, role, rb,
+		)
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		v := semver.MustParse("2.25.0")
+		tv := semver.MustParse("3.0.0")
+
+		target := action.Target{
+			Client:         testClient,
+			CurrentVersion: &v,
+			TargetVersion:  &tv,
+			DryRun:         false,
+			SkipConfirm:    true,
+			Recorder:       action.NewRootRecorder(),
+		}
+
+		a := &modelserving.AddOwnerReferencesAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+		g.Expect(actionResult.Status.Completed).To(BeTrue())
+	})
+
+	t.Run("should skip missing auth resources gracefully", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, testISVCName, "RawDeployment")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.AddOwnerReferencesAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+		g.Expect(actionResult.Status.Completed).To(BeTrue())
+	})
+}

--- a/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist.go
+++ b/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist.go
@@ -1,0 +1,318 @@
+package modelserving
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	hpIgnorelistActionID          = "modelserving.hardwareprofiles-ignorelist"
+	hpIgnorelistActionName        = "Add hardware profile annotations to ignore list"
+	hpIgnorelistActionDescription = "Patches inferenceservice-config ConfigMap to set opendatahub.io/managed=false and add hardware-profile annotations to serviceAnnotationDisallowedList before upgrading to RHOAI 3.x"
+
+	msgHPConfigMapNotFound       = "inferenceservice-config ConfigMap not found in namespace %s - no action needed"
+	msgHPManagedAnnotationSet    = "Set annotation %s=%s on ConfigMap %s"
+	msgHPManagedAnnotationDryRun = "Would set annotation %s=%s on ConfigMap %s"
+	msgHPDisallowedListUpdated   = "Added %d annotation(s) to serviceAnnotationDisallowedList: %v"
+	msgHPDisallowedListDryRun    = "Would add %d annotation(s) to serviceAnnotationDisallowedList: %v"
+	msgHPDisallowedListCurrent   = "serviceAnnotationDisallowedList already contains all required annotations"
+	msgHPUpdateFailed            = "Failed to update ConfigMap %s/%s: %v"
+	msgHPComplete                = "inferenceservice-config ConfigMap updated successfully"
+	msgHPCompleteDryRun          = "Dry-run: no changes applied to inferenceservice-config ConfigMap"
+)
+
+// requiredDisallowedAnnotations lists annotations that must be in serviceAnnotationDisallowedList.
+//
+//nolint:gochecknoglobals // Constant-like list used across action methods.
+var requiredDisallowedAnnotations = []string{
+	annotationHardwareProfileName,
+	annotationHardwareProfileNS,
+}
+
+// HardwareProfilesIgnorelistAction patches inferenceservice-config to prevent
+// hardware-profile annotations from triggering reconciliation loops during upgrade.
+type HardwareProfilesIgnorelistAction struct{}
+
+func (a *HardwareProfilesIgnorelistAction) ID() string {
+	return hpIgnorelistActionID
+}
+
+func (a *HardwareProfilesIgnorelistAction) Name() string {
+	return hpIgnorelistActionName
+}
+
+func (a *HardwareProfilesIgnorelistAction) Description() string {
+	return hpIgnorelistActionDescription
+}
+
+func (a *HardwareProfilesIgnorelistAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *HardwareProfilesIgnorelistAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *HardwareProfilesIgnorelistAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
+}
+
+func (a *HardwareProfilesIgnorelistAction) Prepare() action.Task {
+	return &hpIgnorelistPrepareTask{action: a}
+}
+
+func (a *HardwareProfilesIgnorelistAction) Run() action.Task {
+	return &hpIgnorelistRunTask{action: a}
+}
+
+// updateConfigMap sets managed=false and adds missing annotations to the disallowed list.
+func (a *HardwareProfilesIgnorelistAction) updateConfigMap(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+) {
+	step := target.Recorder.Child(
+		"update-inferenceservice-config",
+		"Update inferenceservice-config ConfigMap",
+	)
+
+	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			step.Complete(result.StepSkipped, msgHPConfigMapNotFound, namespace)
+
+			return
+		}
+
+		step.Complete(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
+
+		return
+	}
+
+	// Set managed=false annotation
+	a.setManagedAnnotation(target, configMap, step)
+
+	// Add missing annotations to disallowed list
+	a.updateDisallowedList(target, configMap, step)
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgHPCompleteDryRun)
+
+		return
+	}
+
+	// Apply the update
+	_, err = target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+		Namespace(namespace).
+		Update(ctx, configMap, metav1.UpdateOptions{})
+
+	if err != nil {
+		step.Complete(result.StepFailed, msgHPUpdateFailed, namespace, inferenceServiceConfigName, err)
+
+		return
+	}
+
+	step.Complete(result.StepCompleted, msgHPComplete)
+}
+
+func (a *HardwareProfilesIgnorelistAction) setManagedAnnotation(
+	target action.Target,
+	configMap *unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) {
+	step := parentStep.Child("set-managed-annotation", "Set managed annotation")
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgHPManagedAnnotationDryRun, annotationManaged, managedFalse, inferenceServiceConfigName)
+
+		return
+	}
+
+	annotations := configMap.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[annotationManaged] = managedFalse
+	configMap.SetAnnotations(annotations)
+
+	step.Complete(result.StepCompleted, msgHPManagedAnnotationSet, annotationManaged, managedFalse, inferenceServiceConfigName)
+}
+
+func (a *HardwareProfilesIgnorelistAction) updateDisallowedList(
+	target action.Target,
+	configMap *unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) {
+	step := parentStep.Child("update-disallowed-list", "Update serviceAnnotationDisallowedList")
+
+	cfg, err := parseISVCConfigData(configMap)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to parse inferenceService config: %v", err)
+
+		return
+	}
+
+	currentList, err := cfg.disallowedList()
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to read disallowed list: %v", err)
+
+		return
+	}
+
+	// Find missing annotations
+	var missing []string
+	for _, annotation := range requiredDisallowedAnnotations {
+		if !slices.Contains(currentList, annotation) {
+			missing = append(missing, annotation)
+		}
+	}
+
+	if len(missing) == 0 {
+		step.Complete(result.StepCompleted, msgHPDisallowedListCurrent)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgHPDisallowedListDryRun, len(missing), missing)
+
+		return
+	}
+
+	// Add missing annotations and serialize back (preserves all other fields)
+	if err := cfg.setDisallowedList(append(currentList, missing...)); err != nil {
+		step.Complete(result.StepFailed, "Failed to update disallowed list: %v", err)
+
+		return
+	}
+
+	updatedJSON, err := json.Marshal(cfg)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to marshal updated config: %v", err)
+
+		return
+	}
+
+	if err := jq.Transform(configMap, ".data.%s = %q", inferenceServiceDataKey, string(updatedJSON)); err != nil {
+		step.Complete(result.StepFailed, "Failed to update ConfigMap data: %v", err)
+
+		return
+	}
+
+	step.Complete(result.StepCompleted, msgHPDisallowedListUpdated, len(missing), missing)
+}
+
+// restartKServeController restarts the KServe controller deployment.
+func (a *HardwareProfilesIgnorelistAction) restartKServeController(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+) {
+	step := target.Recorder.Child(
+		"restart-kserve-controller",
+		"Restart KServe controller manager",
+	)
+
+	restartDeployment(ctx, target, namespace, kserveControllerDeployment, step)
+}
+
+// --- Prepare Task ---
+
+type hpIgnorelistPrepareTask struct {
+	action *HardwareProfilesIgnorelistAction
+}
+
+func (t *hpIgnorelistPrepareTask) Validate(
+	_ context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return buildResult(target)
+}
+
+func (t *hpIgnorelistPrepareTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child(
+		"backup-inferenceservice-config",
+		"Backup inferenceservice-config ConfigMap",
+	)
+
+	namespace, err := getApplicationsNamespace(ctx, target)
+	if err != nil {
+		step.Complete(result.StepFailed, msgGetAppNamespaceFailed, err)
+
+		return buildResult(target)
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, "Would backup ConfigMap %s from namespace %s", inferenceServiceConfigName, namespace)
+
+		return buildResult(target)
+	}
+
+	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			step.Complete(result.StepSkipped, msgHPConfigMapNotFound, namespace)
+		} else {
+			step.Complete(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
+		}
+
+		return buildResult(target)
+	}
+
+	outputDir := filepath.Join(target.OutputDir, namespace)
+
+	if err := backup.WriteResourcesToDir(outputDir, resources.ConfigMap.GVR(), []*unstructured.Unstructured{configMap}); err != nil {
+		step.Complete(result.StepFailed, "Failed to write ConfigMap backup: %v", err)
+	} else {
+		step.Complete(result.StepCompleted, "Backed up ConfigMap %s to %s", inferenceServiceConfigName, outputDir)
+	}
+
+	return buildResult(target)
+}
+
+// --- Run Task ---
+
+type hpIgnorelistRunTask struct {
+	action *HardwareProfilesIgnorelistAction
+}
+
+func (t *hpIgnorelistRunTask) Validate(
+	_ context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return buildResult(target)
+}
+
+func (t *hpIgnorelistRunTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	namespace, err := getApplicationsNamespace(ctx, target)
+	if err != nil {
+		step := target.Recorder.Child("get-namespace", "Get applications namespace")
+		step.Complete(result.StepFailed, msgGetAppNamespaceFailed, err)
+
+		return buildResult(target)
+	}
+
+	t.action.updateConfigMap(ctx, target, namespace)
+	t.action.restartKServeController(ctx, target, namespace)
+
+	return buildResult(target)
+}

--- a/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist_prepare_test.go
+++ b/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist_prepare_test.go
@@ -1,0 +1,125 @@
+package modelserving_test
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHardwareProfilesIgnorelistAction_PrepareExecute(t *testing.T) {
+	t.Run("should backup ConfigMap to output dir", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+		configMap := newISVCConfigMap(testApplicationsNamespace, nil, "")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci, configMap,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+		g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+		hasCompleted := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepCompleted {
+				hasCompleted = true
+			}
+		}
+
+		g.Expect(hasCompleted).To(BeTrue())
+	})
+
+	t.Run("should skip when ConfigMap not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not write files in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+		configMap := newISVCConfigMap(testApplicationsNamespace, nil, "")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci, configMap,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify no files were written
+		entries, err := os.ReadDir(target.OutputDir)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(entries).To(BeEmpty())
+	})
+}

--- a/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist_test.go
+++ b/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist_test.go
@@ -1,0 +1,198 @@
+package modelserving_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHardwareProfilesIgnorelistAction_ID(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.HardwareProfilesIgnorelistAction{}
+	g.Expect(a.ID()).To(Equal("modelserving.hardwareprofiles-ignorelist"))
+}
+
+func TestHardwareProfilesIgnorelistAction_CanApply(t *testing.T) {
+	t.Run("should return true for version 2.25", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		v := semver.MustParse("2.25.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeTrue())
+	})
+
+	t.Run("should return false for version 1.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		v := semver.MustParse("1.10.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+
+	t.Run("should return false for version 3.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		v := semver.MustParse("3.0.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+
+	t.Run("should return false for version 2.24", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		v := semver.MustParse("2.24.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+}
+
+func TestHardwareProfilesIgnorelistAction_RunExecute(t *testing.T) {
+	t.Run("should update ConfigMap with managed=false and disallowed annotations", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvcConfig := map[string]any{
+			"serviceAnnotationDisallowedList": []string{},
+		}
+		isvcConfigJSON, _ := json.Marshal(isvcConfig)
+
+		dsci := newDSCI(testApplicationsNamespace)
+		configMap := newISVCConfigMap(testApplicationsNamespace, nil, string(isvcConfigJSON))
+		deployment := newDeployment(testApplicationsNamespace, "kserve-controller-manager")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+			resources.Deployment.GVR():        resources.Deployment.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci, configMap, deployment,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+		g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+		// Verify ConfigMap was updated
+		updated, err := dynamicClient.Resource(resources.ConfigMap.GVR()).
+			Namespace(testApplicationsNamespace).
+			Get(ctx, testConfigMapName, metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify managed annotation
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("opendatahub.io/managed", "false"))
+	})
+
+	t.Run("should skip when ConfigMap not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+			resources.Deployment.GVR():        resources.Deployment.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Should have a skipped step
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not mutate in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvcConfig := map[string]any{
+			"serviceAnnotationDisallowedList": []string{},
+		}
+		isvcConfigJSON, _ := json.Marshal(isvcConfig)
+
+		dsci := newDSCI(testApplicationsNamespace)
+		configMap := newISVCConfigMap(testApplicationsNamespace, nil, string(isvcConfigJSON))
+		deployment := newDeployment(testApplicationsNamespace, "kserve-controller-manager")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+			resources.Deployment.GVR():        resources.Deployment.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci, configMap, deployment,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+
+		a := &modelserving.HardwareProfilesIgnorelistAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ConfigMap was NOT updated (no managed annotation)
+		original, err := dynamicClient.Resource(resources.ConfigMap.GVR()).
+			Namespace(testApplicationsNamespace).
+			Get(ctx, testConfigMapName, metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := original.GetAnnotations()
+		g.Expect(annotations).ToNot(HaveKey("opendatahub.io/managed"))
+	})
+}

--- a/pkg/migrate/actions/modelserving/helpers_test.go
+++ b/pkg/migrate/actions/modelserving/helpers_test.go
@@ -1,0 +1,118 @@
+package modelserving_test
+
+import (
+	"github.com/blang/semver/v4"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	testISVCNamespace         = "test-ns"
+	testISVCName              = "my-model"
+	testApplicationsNamespace = "redhat-ods-applications"
+	testConfigMapName         = "inferenceservice-config"
+)
+
+func newISVC(namespace, name, deploymentMode string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.InferenceService.APIVersion(),
+			"kind":       resources.InferenceService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+				"uid":       "test-uid-123",
+				"annotations": map[string]any{
+					"serving.kserve.io/deploymentMode": deploymentMode,
+				},
+			},
+		},
+	}
+}
+
+func newDSCI(appNamespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"spec": map[string]any{
+				"applicationsNamespace": appNamespace,
+			},
+		},
+	}
+}
+
+func newISVCConfigMap(namespace string, annotations map[string]string, isvcConfigJSON string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]any{
+				"name":      testConfigMapName,
+				"namespace": namespace,
+			},
+			"data": map[string]any{},
+		},
+	}
+
+	if annotations != nil {
+		metaAnnotations := make(map[string]any, len(annotations))
+		for k, v := range annotations {
+			metaAnnotations[k] = v
+		}
+
+		obj.Object["metadata"].(map[string]any)["annotations"] = metaAnnotations
+	}
+
+	if isvcConfigJSON != "" {
+		obj.Object["data"].(map[string]any)["inferenceService"] = isvcConfigJSON
+	}
+
+	return obj
+}
+
+func newDeployment(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Deployment.APIVersion(),
+			"kind":       resources.Deployment.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestTarget(dynamicClient *dynamicfake.FakeDynamicClient, currentVersion string, dryRun bool) action.Target {
+	v := semver.MustParse(currentVersion)
+	tv := semver.MustParse("3.0.0")
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+
+	return action.Target{
+		Client:         testClient,
+		CurrentVersion: &v,
+		TargetVersion:  &tv,
+		DryRun:         dryRun,
+		SkipConfirm:    true,
+		Recorder:       action.NewRootRecorder(),
+	}
+}

--- a/pkg/migrate/actions/modelserving/managed_isvc_config.go
+++ b/pkg/migrate/actions/modelserving/managed_isvc_config.go
@@ -1,0 +1,149 @@
+package modelserving
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	managedISVCConfigActionID          = "modelserving.managed-isvc-config"
+	managedISVCConfigActionName        = "Restore managed inferenceservice-config"
+	managedISVCConfigActionDescription = "Sets opendatahub.io/managed=true on inferenceservice-config ConfigMap and restarts KServe controller after upgrading to RHOAI 3.x"
+
+	majorVersion3 = 3
+
+	msgManagedAnnotationSet    = "Set annotation %s=%s on ConfigMap %s"
+	msgManagedAnnotationDryRun = "Would set annotation %s=%s on ConfigMap %s"
+	msgManagedUpdateFailed     = "Failed to update ConfigMap %s/%s: %v"
+	msgManagedComplete         = "inferenceservice-config ConfigMap restored to managed state"
+	msgManagedCompleteDryRun   = "Dry-run: no changes applied to inferenceservice-config ConfigMap"
+)
+
+// ManagedISVCConfigAction restores the managed annotation on inferenceservice-config
+// after upgrading to RHOAI 3.x.
+type ManagedISVCConfigAction struct{}
+
+func (a *ManagedISVCConfigAction) ID() string {
+	return managedISVCConfigActionID
+}
+
+func (a *ManagedISVCConfigAction) Name() string {
+	return managedISVCConfigActionName
+}
+
+func (a *ManagedISVCConfigAction) Description() string {
+	return managedISVCConfigActionDescription
+}
+
+func (a *ManagedISVCConfigAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *ManagedISVCConfigAction) Phase() action.ActionPhase {
+	return action.PhasePostUpgrade
+}
+
+func (a *ManagedISVCConfigAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion.Major == majorVersion3
+}
+
+func (a *ManagedISVCConfigAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *ManagedISVCConfigAction) Run() action.Task {
+	return &managedISVCConfigRunTask{action: a}
+}
+
+func (a *ManagedISVCConfigAction) setManagedTrue(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+) bool {
+	step := target.Recorder.Child(
+		"set-managed-true",
+		"Set managed=true on inferenceservice-config",
+	)
+
+	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			step.Complete(result.StepSkipped, msgConfigMapNotFound, inferenceServiceConfigName, namespace)
+
+			return false
+		}
+
+		step.Complete(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
+
+		return false
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgManagedAnnotationDryRun, annotationManaged, managedTrue, inferenceServiceConfigName)
+
+		return false
+	}
+
+	annotations := configMap.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[annotationManaged] = managedTrue
+	configMap.SetAnnotations(annotations)
+
+	_, err = target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+		Namespace(namespace).
+		Update(ctx, configMap, metav1.UpdateOptions{})
+
+	if err != nil {
+		step.Complete(result.StepFailed, msgManagedUpdateFailed, namespace, inferenceServiceConfigName, err)
+
+		return false
+	}
+
+	step.Complete(result.StepCompleted, msgManagedAnnotationSet, annotationManaged, managedTrue, inferenceServiceConfigName)
+
+	return true
+}
+
+// --- Run Task ---
+
+type managedISVCConfigRunTask struct {
+	action *ManagedISVCConfigAction
+}
+
+func (t *managedISVCConfigRunTask) Validate(
+	_ context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return buildResult(target)
+}
+
+func (t *managedISVCConfigRunTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	namespace, err := getApplicationsNamespace(ctx, target)
+	if err != nil {
+		step := target.Recorder.Child("get-namespace", "Get applications namespace")
+		step.Complete(result.StepFailed, msgGetAppNamespaceFailed, err)
+
+		return buildResult(target)
+	}
+
+	changed := t.action.setManagedTrue(ctx, target, namespace)
+
+	if changed {
+		restartStep := target.Recorder.Child("restart-kserve-controller", "Restart KServe controller manager")
+		restartDeployment(ctx, target, namespace, kserveControllerDeployment, restartStep)
+	}
+
+	return buildResult(target)
+}

--- a/pkg/migrate/actions/modelserving/managed_isvc_config_test.go
+++ b/pkg/migrate/actions/modelserving/managed_isvc_config_test.go
@@ -1,0 +1,220 @@
+package modelserving_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestManagedISVCConfigAction_ID(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.ManagedISVCConfigAction{}
+	g.Expect(a.ID()).To(Equal("modelserving.managed-isvc-config"))
+}
+
+func TestManagedISVCConfigAction_CanApply(t *testing.T) {
+	t.Run("should return true for version 3.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ManagedISVCConfigAction{}
+		v := semver.MustParse("3.0.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeTrue())
+	})
+
+	t.Run("should return true for version 3.5", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ManagedISVCConfigAction{}
+		v := semver.MustParse("3.5.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeTrue())
+	})
+
+	t.Run("should return false for version 2.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ManagedISVCConfigAction{}
+		v := semver.MustParse("2.25.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+}
+
+func TestManagedISVCConfigAction_Prepare(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.ManagedISVCConfigAction{}
+	g.Expect(a.Prepare()).To(BeNil())
+}
+
+func TestManagedISVCConfigAction_RunExecute(t *testing.T) {
+	t.Run("should set managed=true on ConfigMap", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+		configMap := newISVCConfigMap(testApplicationsNamespace,
+			map[string]string{"opendatahub.io/managed": "false"}, "")
+		deployment := newDeployment(testApplicationsNamespace, "kserve-controller-manager")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+			resources.Deployment.GVR():        resources.Deployment.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci, configMap, deployment,
+		)
+
+		v := semver.MustParse("3.0.0")
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		target := action.Target{
+			Client:         testClient,
+			CurrentVersion: &v,
+			DryRun:         false,
+			SkipConfirm:    true,
+			Recorder:       action.NewRootRecorder(),
+		}
+
+		a := &modelserving.ManagedISVCConfigAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ConfigMap was updated with managed=true
+		updated, err := dynamicClient.Resource(resources.ConfigMap.GVR()).
+			Namespace(testApplicationsNamespace).
+			Get(ctx, testConfigMapName, metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("opendatahub.io/managed", "true"))
+	})
+
+	t.Run("should skip when ConfigMap not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+			resources.Deployment.GVR():        resources.Deployment.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci,
+		)
+
+		v := semver.MustParse("3.0.0")
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		target := action.Target{
+			Client:         testClient,
+			CurrentVersion: &v,
+			DryRun:         false,
+			SkipConfirm:    true,
+			Recorder:       action.NewRootRecorder(),
+		}
+
+		a := &modelserving.ManagedISVCConfigAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not mutate in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := newDSCI(testApplicationsNamespace)
+		configMap := newISVCConfigMap(testApplicationsNamespace,
+			map[string]string{"opendatahub.io/managed": "false"}, "")
+		deployment := newDeployment(testApplicationsNamespace, "kserve-controller-manager")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+			resources.ConfigMap.GVR():         resources.ConfigMap.ListKind(),
+			resources.Deployment.GVR():        resources.Deployment.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, dsci, configMap, deployment,
+		)
+
+		v := semver.MustParse("3.0.0")
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		target := action.Target{
+			Client:         testClient,
+			CurrentVersion: &v,
+			DryRun:         true,
+			SkipConfirm:    true,
+			Recorder:       action.NewRootRecorder(),
+		}
+
+		a := &modelserving.ManagedISVCConfigAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ConfigMap was NOT updated
+		original, err := dynamicClient.Resource(resources.ConfigMap.GVR()).
+			Namespace(testApplicationsNamespace).
+			Get(ctx, testConfigMapName, metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := original.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("opendatahub.io/managed", "false"))
+	})
+}

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
@@ -1,0 +1,303 @@
+package modelserving
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	modelMeshToRawActionID          = "modelserving.modelmesh-to-raw"
+	modelMeshToRawActionName        = "Convert ModelMesh InferenceServices to RawDeployment"
+	modelMeshToRawActionDescription = "Converts InferenceServices using ModelMesh deployment mode to RawDeployment, updates associated ServingRuntimes, and creates auth resources"
+
+	msgModelMeshConfirm    = "About to convert %d InferenceService(s) from ModelMesh to RawDeployment"
+	msgModelMeshCancelled  = "User cancelled ModelMesh to RawDeployment conversion"
+	msgModelMeshComplete   = "Processed %d InferenceService(s) for ModelMesh to RawDeployment conversion"
+	msgModelMeshDryRun     = "Dry-run: would convert %d InferenceService(s) from ModelMesh to RawDeployment"
+	msgModelMeshBackupDone = "Backed up %d ModelMesh InferenceServices to %s"
+	msgModelMeshNoISVCs    = "No ModelMesh InferenceServices found"
+)
+
+// ModelMeshToRawAction converts InferenceServices from ModelMesh to RawDeployment mode.
+type ModelMeshToRawAction struct{}
+
+func (a *ModelMeshToRawAction) ID() string {
+	return modelMeshToRawActionID
+}
+
+func (a *ModelMeshToRawAction) Name() string {
+	return modelMeshToRawActionName
+}
+
+func (a *ModelMeshToRawAction) Description() string {
+	return modelMeshToRawActionDescription
+}
+
+func (a *ModelMeshToRawAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *ModelMeshToRawAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *ModelMeshToRawAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
+}
+
+func (a *ModelMeshToRawAction) Prepare() action.Task {
+	return &modelMeshToRawPrepareTask{action: a}
+}
+
+func (a *ModelMeshToRawAction) Run() action.Task {
+	return &modelMeshToRawRunTask{action: a}
+}
+
+func (a *ModelMeshToRawAction) convertISVCs(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"convert-modelmesh-to-raw",
+		"Convert ModelMesh InferenceServices to RawDeployment",
+	)
+
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeModelMesh)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
+
+		return
+	}
+
+	if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgModelMeshNoISVCs)
+
+		return
+	}
+
+	step.Record("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeModelMesh)
+
+	// Confirm with user
+	if !target.SkipConfirm && !target.DryRun {
+		target.IO.Fprintln()
+		target.IO.Errorf(msgModelMeshConfirm, len(isvcs))
+
+		if !confirmation.Prompt(target.IO, "Proceed with conversion?") {
+			step.Complete(result.StepSkipped, msgModelMeshCancelled)
+
+			return
+		}
+	}
+
+	convertedCount := 0
+
+	for _, isvc := range isvcs {
+		isvcStep := step.Child(
+			fmt.Sprintf("convert-%s-%s", isvc.GetNamespace(), isvc.GetName()),
+			fmt.Sprintf("Convert %s/%s", isvc.GetNamespace(), isvc.GetName()),
+		)
+
+		// Update associated ServingRuntime if multi-model
+		a.updateServingRuntime(ctx, target, isvc, isvcStep)
+
+		// Patch deployment mode
+		patchISVCDeploymentMode(ctx, target, isvc, deploymentModeRawDeployment, isvcStep)
+
+		// Create auth resources
+		ensureAuthResources(ctx, target, isvc, isvcStep)
+
+		convertedCount++
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgModelMeshDryRun, convertedCount)
+	} else {
+		step.Complete(result.StepCompleted, msgModelMeshComplete, convertedCount)
+	}
+}
+
+func (a *ModelMeshToRawAction) updateServingRuntime(
+	ctx context.Context,
+	target action.Target,
+	isvc *unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) {
+	runtimeName, err := jq.Query[string](isvc, ".spec.predictor.model.runtime")
+	if err != nil {
+		return
+	}
+
+	ns := isvc.GetNamespace()
+
+	step := parentStep.Child(
+		fmt.Sprintf("update-runtime-%s-%s", ns, runtimeName),
+		fmt.Sprintf("Update ServingRuntime %s/%s", ns, runtimeName),
+	)
+
+	runtime, err := target.Client.Dynamic().Resource(resources.ServingRuntime.GVR()).
+		Namespace(ns).
+		Get(ctx, runtimeName, metav1.GetOptions{})
+
+	if err != nil {
+		step.Complete(result.StepSkipped, "ServingRuntime %s/%s not found (skipped)", ns, runtimeName)
+
+		return
+	}
+
+	// Check if multi-model
+	multiModel, err := jq.Query[bool](runtime, ".spec.multiModel")
+	if err != nil || !multiModel {
+		step.Complete(result.StepSkipped, "ServingRuntime %s/%s is not multi-model (skipped)", ns, runtimeName)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, "Would set multiModel=false on ServingRuntime %s/%s", ns, runtimeName)
+
+		return
+	}
+
+	if err := jq.Transform(runtime, ".spec.multiModel = false"); err != nil {
+		step.Complete(result.StepFailed, "Failed to update ServingRuntime %s/%s: %v", ns, runtimeName, err)
+
+		return
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.ServingRuntime.GVR()).
+		Namespace(ns).
+		Update(ctx, runtime, metav1.UpdateOptions{})
+
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to update ServingRuntime %s/%s: %v", ns, runtimeName, err)
+
+		return
+	}
+
+	step.Complete(result.StepCompleted, "Set multiModel=false on ServingRuntime %s/%s", ns, runtimeName)
+}
+
+// --- Prepare Task ---
+
+type modelMeshToRawPrepareTask struct {
+	action *ModelMeshToRawAction
+}
+
+func (t *modelMeshToRawPrepareTask) Validate(
+	_ context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return buildResult(target)
+}
+
+func (t *modelMeshToRawPrepareTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child(
+		"backup-modelmesh-resources",
+		"Backup ModelMesh InferenceServices and ServingRuntimes",
+	)
+
+	// Backup ISVCs
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeModelMesh)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
+
+		return buildResult(target)
+	}
+
+	if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgModelMeshNoISVCs)
+
+		return buildResult(target)
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, "Would backup %d ModelMesh InferenceServices and associated ServingRuntimes", len(isvcs))
+
+		return buildResult(target)
+	}
+
+	// Backup ISVCs grouped by namespace
+	byNamespace := groupByNamespace(isvcs)
+
+	for ns, nsISVCs := range byNamespace {
+		outputDir := filepath.Join(target.OutputDir, ns)
+		if err := backup.WriteResourcesToDir(outputDir, resources.InferenceService.GVR(), nsISVCs); err != nil {
+			step.Complete(result.StepFailed, "Failed to backup InferenceServices in namespace %s: %v", ns, err)
+
+			return buildResult(target)
+		}
+	}
+
+	// Backup multi-model ServingRuntimes
+	multiModelFilter := jq.Predicate(".spec.multiModel == true")
+
+	servingRuntimes, err := client.List[*unstructured.Unstructured](
+		ctx, target.Client, resources.ServingRuntime, multiModelFilter,
+	)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list ServingRuntimes: %v", err)
+
+		return buildResult(target)
+	}
+
+	for ns, nsSRs := range groupByNamespace(servingRuntimes) {
+		outputDir := filepath.Join(target.OutputDir, ns)
+		if writeErr := backup.WriteResourcesToDir(outputDir, resources.ServingRuntime.GVR(), nsSRs); writeErr != nil {
+			step.Complete(result.StepFailed, "Failed to backup ServingRuntimes in namespace %s: %v", ns, writeErr)
+
+			return buildResult(target)
+		}
+	}
+
+	step.Complete(result.StepCompleted, msgModelMeshBackupDone, len(isvcs), target.OutputDir)
+
+	return buildResult(target)
+}
+
+// --- Run Task ---
+
+type modelMeshToRawRunTask struct {
+	action *ModelMeshToRawAction
+}
+
+func (t *modelMeshToRawRunTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child("validate-modelmesh", "Check for ModelMesh InferenceServices")
+
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeModelMesh)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
+	} else if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgModelMeshNoISVCs)
+	} else {
+		step.Complete(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeModelMesh)
+	}
+
+	return buildResult(target)
+}
+
+func (t *modelMeshToRawRunTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	t.action.convertISVCs(ctx, target)
+
+	return buildResult(target)
+}

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw_prepare_test.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw_prepare_test.go
@@ -1,0 +1,120 @@
+package modelserving_test
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestModelMeshToRawAction_PrepareExecute(t *testing.T) {
+	t.Run("should backup ModelMesh ISVCs and ServingRuntimes", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVC(testISVCNamespace, "mm-model", "ovms-runtime")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+		g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+		hasCompleted := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepCompleted {
+				hasCompleted = true
+			}
+		}
+
+		g.Expect(hasCompleted).To(BeTrue())
+	})
+
+	t.Run("should skip when no ModelMesh ISVCs exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not write files in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVC(testISVCNamespace, "mm-model", "ovms-runtime")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify no files were written
+		entries, err := os.ReadDir(target.OutputDir)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(entries).To(BeEmpty())
+	})
+}

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
@@ -1,0 +1,252 @@
+package modelserving_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func newModelMeshISVC(namespace, name, runtimeName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.InferenceService.APIVersion(),
+			"kind":       resources.InferenceService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+				"uid":       "test-uid-mm-123",
+				"annotations": map[string]any{
+					"serving.kserve.io/deploymentMode": "ModelMesh",
+				},
+			},
+			"spec": map[string]any{
+				"predictor": map[string]any{
+					"model": map[string]any{
+						"runtime": runtimeName,
+					},
+				},
+			},
+		},
+	}
+}
+
+func newServingRuntime(namespace, name string, multiModel bool) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.ServingRuntime.APIVersion(),
+			"kind":       resources.ServingRuntime.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"multiModel": multiModel,
+			},
+		},
+	}
+}
+
+func TestModelMeshToRawAction_ID(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.ModelMeshToRawAction{}
+	g.Expect(a.ID()).To(Equal("modelserving.modelmesh-to-raw"))
+}
+
+func TestModelMeshToRawAction_CanApply(t *testing.T) {
+	t.Run("should return true for version 2.25", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		v := semver.MustParse("2.25.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeTrue())
+	})
+
+	t.Run("should return false for version 3.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		v := semver.MustParse("3.0.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+}
+
+func TestModelMeshToRawAction_RunValidate(t *testing.T) {
+	t.Run("should report ModelMesh ISVCs found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVC(testISVCNamespace, "mm-model", "ovms")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Validate(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasCompleted := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepCompleted {
+				hasCompleted = true
+			}
+		}
+
+		g.Expect(hasCompleted).To(BeTrue())
+	})
+}
+
+func TestModelMeshToRawAction_RunExecute(t *testing.T) {
+	t.Run("should convert ModelMesh ISVCs to RawDeployment", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVC(testISVCNamespace, "mm-model", "ovms-runtime")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr,
+		)
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		v := semver.MustParse("2.25.0")
+		tv := semver.MustParse("3.0.0")
+
+		target := action.Target{
+			Client:         testClient,
+			CurrentVersion: &v,
+			TargetVersion:  &tv,
+			DryRun:         false,
+			SkipConfirm:    true,
+			Recorder:       action.NewRootRecorder(),
+		}
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ISVC was patched to RawDeployment
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "mm-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+	})
+
+	t.Run("should skip when no ModelMesh ISVCs exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not mutate in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVC(testISVCNamespace, "mm-model", "ovms-runtime")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ISVC was NOT patched
+		original, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "mm-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := original.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "ModelMesh"))
+	})
+}

--- a/pkg/migrate/actions/modelserving/serverless_to_raw.go
+++ b/pkg/migrate/actions/modelserving/serverless_to_raw.go
@@ -1,0 +1,211 @@
+package modelserving
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+const (
+	serverlessToRawActionID          = "modelserving.serverless-to-raw"
+	serverlessToRawActionName        = "Convert Serverless InferenceServices to RawDeployment"
+	serverlessToRawActionDescription = "Converts InferenceServices using Serverless deployment mode to RawDeployment and creates associated auth resources (ServiceAccount, Role, RoleBinding)"
+
+	msgServerlessConfirm    = "About to convert %d InferenceService(s) from Serverless to RawDeployment"
+	msgServerlessCancelled  = "User cancelled Serverless to RawDeployment conversion"
+	msgServerlessComplete   = "Processed %d InferenceService(s) for Serverless to RawDeployment conversion"
+	msgServerlessDryRun     = "Dry-run: would convert %d InferenceService(s) from Serverless to RawDeployment"
+	msgServerlessBackupDone = "Backed up %d Serverless InferenceServices to %s"
+	msgServerlessNoISVCs    = "No Serverless InferenceServices found"
+)
+
+// ServerlessToRawAction converts InferenceServices from Serverless to RawDeployment mode.
+type ServerlessToRawAction struct{}
+
+func (a *ServerlessToRawAction) ID() string {
+	return serverlessToRawActionID
+}
+
+func (a *ServerlessToRawAction) Name() string {
+	return serverlessToRawActionName
+}
+
+func (a *ServerlessToRawAction) Description() string {
+	return serverlessToRawActionDescription
+}
+
+func (a *ServerlessToRawAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *ServerlessToRawAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *ServerlessToRawAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
+}
+
+func (a *ServerlessToRawAction) Prepare() action.Task {
+	return &serverlessToRawPrepareTask{action: a}
+}
+
+func (a *ServerlessToRawAction) Run() action.Task {
+	return &serverlessToRawRunTask{action: a}
+}
+
+func (a *ServerlessToRawAction) convertISVCs(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"convert-serverless-to-raw",
+		"Convert Serverless InferenceServices to RawDeployment",
+	)
+
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeServerless)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
+
+		return
+	}
+
+	if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgServerlessNoISVCs)
+
+		return
+	}
+
+	step.Record("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeServerless)
+
+	// Confirm with user
+	if !target.SkipConfirm && !target.DryRun {
+		target.IO.Fprintln()
+		target.IO.Errorf(msgServerlessConfirm, len(isvcs))
+
+		if !confirmation.Prompt(target.IO, "Proceed with conversion?") {
+			step.Complete(result.StepSkipped, msgServerlessCancelled)
+
+			return
+		}
+	}
+
+	convertedCount := 0
+
+	for _, isvc := range isvcs {
+		isvcStep := step.Child(
+			fmt.Sprintf("convert-%s-%s", isvc.GetNamespace(), isvc.GetName()),
+			fmt.Sprintf("Convert %s/%s", isvc.GetNamespace(), isvc.GetName()),
+		)
+
+		patchISVCDeploymentMode(ctx, target, isvc, deploymentModeRawDeployment, isvcStep)
+
+		// Create auth resources
+		ensureAuthResources(ctx, target, isvc, isvcStep)
+
+		convertedCount++
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgServerlessDryRun, convertedCount)
+	} else {
+		step.Complete(result.StepCompleted, msgServerlessComplete, convertedCount)
+	}
+}
+
+// --- Prepare Task ---
+
+type serverlessToRawPrepareTask struct {
+	action *ServerlessToRawAction
+}
+
+func (t *serverlessToRawPrepareTask) Validate(
+	_ context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return buildResult(target)
+}
+
+func (t *serverlessToRawPrepareTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child(
+		"backup-serverless-isvcs",
+		"Backup Serverless InferenceServices",
+	)
+
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeServerless)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
+
+		return buildResult(target)
+	}
+
+	if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgServerlessNoISVCs)
+
+		return buildResult(target)
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, "Would backup %d Serverless InferenceServices", len(isvcs))
+
+		return buildResult(target)
+	}
+
+	// Group ISVCs by namespace for backup
+	byNamespace := groupByNamespace(isvcs)
+
+	for ns, nsISVCs := range byNamespace {
+		outputDir := filepath.Join(target.OutputDir, ns)
+		if err := backup.WriteResourcesToDir(outputDir, resources.InferenceService.GVR(), nsISVCs); err != nil {
+			step.Complete(result.StepFailed, "Failed to write InferenceServices backup for namespace %s: %v", ns, err)
+
+			return buildResult(target)
+		}
+	}
+
+	step.Complete(result.StepCompleted, msgServerlessBackupDone, len(isvcs), target.OutputDir)
+
+	return buildResult(target)
+}
+
+// --- Run Task ---
+
+type serverlessToRawRunTask struct {
+	action *ServerlessToRawAction
+}
+
+func (t *serverlessToRawRunTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	step := target.Recorder.Child("validate-serverless", "Check for Serverless InferenceServices")
+
+	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeServerless)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
+	} else if len(isvcs) == 0 {
+		step.Complete(result.StepSkipped, msgServerlessNoISVCs)
+	} else {
+		step.Complete(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeServerless)
+	}
+
+	return buildResult(target)
+}
+
+func (t *serverlessToRawRunTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	t.action.convertISVCs(ctx, target)
+
+	return buildResult(target)
+}

--- a/pkg/migrate/actions/modelserving/serverless_to_raw_prepare_test.go
+++ b/pkg/migrate/actions/modelserving/serverless_to_raw_prepare_test.go
@@ -1,0 +1,116 @@
+package modelserving_test
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestServerlessToRawAction_PrepareExecute(t *testing.T) {
+	t.Run("should backup Serverless ISVCs to output dir", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, "serverless-model", "Serverless")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+		g.Expect(actionResult.Status.Completed).To(BeTrue())
+
+		hasCompleted := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepCompleted {
+				hasCompleted = true
+			}
+		}
+
+		g.Expect(hasCompleted).To(BeTrue())
+	})
+
+	t.Run("should skip when no Serverless ISVCs exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not write files in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, "serverless-model", "Serverless")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+		target.OutputDir = t.TempDir()
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Prepare().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify no files were written
+		entries, err := os.ReadDir(target.OutputDir)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(entries).To(BeEmpty())
+	})
+}

--- a/pkg/migrate/actions/modelserving/serverless_to_raw_test.go
+++ b/pkg/migrate/actions/modelserving/serverless_to_raw_test.go
@@ -1,0 +1,237 @@
+package modelserving_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestServerlessToRawAction_ID(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &modelserving.ServerlessToRawAction{}
+	g.Expect(a.ID()).To(Equal("modelserving.serverless-to-raw"))
+}
+
+func TestServerlessToRawAction_CanApply(t *testing.T) {
+	t.Run("should return true for version 2.25", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ServerlessToRawAction{}
+		v := semver.MustParse("2.25.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeTrue())
+	})
+
+	t.Run("should return false for version 3.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &modelserving.ServerlessToRawAction{}
+		v := semver.MustParse("3.0.0")
+		target := action.Target{CurrentVersion: &v}
+
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+}
+
+func TestServerlessToRawAction_RunValidate(t *testing.T) {
+	t.Run("should report Serverless ISVCs found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, "serverless-model", "Serverless")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Run().Validate(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasCompleted := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepCompleted {
+				hasCompleted = true
+			}
+		}
+
+		g.Expect(hasCompleted).To(BeTrue())
+	})
+
+	t.Run("should report no Serverless ISVCs when none exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Run().Validate(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+}
+
+func TestServerlessToRawAction_RunExecute(t *testing.T) {
+	t.Run("should convert Serverless ISVCs to RawDeployment", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, "serverless-model", "Serverless")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		v := semver.MustParse("2.25.0")
+		tv := semver.MustParse("3.0.0")
+
+		target := action.Target{
+			Client:         testClient,
+			CurrentVersion: &v,
+			TargetVersion:  &tv,
+			DryRun:         false,
+			SkipConfirm:    true,
+			Recorder:       action.NewRootRecorder(),
+		}
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ISVC was patched to RawDeployment
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "serverless-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+	})
+
+	t.Run("should skip when no Serverless ISVCs exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		hasSkipped := false
+		for _, step := range actionResult.Status.Steps {
+			if step.Status == result.StepSkipped {
+				hasSkipped = true
+			}
+		}
+
+		g.Expect(hasSkipped).To(BeTrue())
+	})
+
+	t.Run("should not mutate in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newISVC(testISVCNamespace, "serverless-model", "Serverless")
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+
+		a := &modelserving.ServerlessToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ISVC was NOT patched
+		original, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "serverless-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := original.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "Serverless"))
+	})
+}

--- a/pkg/migrate/actions/modelserving/support.go
+++ b/pkg/migrate/actions/modelserving/support.go
@@ -1,0 +1,463 @@
+package modelserving
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	// Annotation keys.
+	annotationDeploymentMode      = "serving.kserve.io/deploymentMode"
+	annotationManaged             = "opendatahub.io/managed"
+	annotationHardwareProfileName = "opendatahub.io/hardware-profile-name"
+	annotationHardwareProfileNS   = "opendatahub.io/hardware-profile-namespace"
+	annotationRestartedAt         = "kubectl.kubernetes.io/restartedAt"
+
+	// Deployment mode values.
+	deploymentModeServerless    = "Serverless"
+	deploymentModeModelMesh     = "ModelMesh"
+	deploymentModeRawDeployment = "RawDeployment"
+
+	// ConfigMap constants.
+	inferenceServiceConfigName = "inferenceservice-config"
+	inferenceServiceDataKey    = "inferenceService"
+
+	// Deployment name for KServe controller.
+	kserveControllerDeployment = "kserve-controller-manager"
+
+	// Managed annotation values.
+	managedTrue  = "true"
+	managedFalse = "false"
+
+	// Auth resource naming conventions.
+	authSASuffix          = "-sa"
+	authRoleSuffix        = "-view-role"
+	authRoleBindingSuffix = "-view"
+
+	// Step messages.
+	msgFoundISVCs                 = "Found %d InferenceServices with deploymentMode=%s"
+	msgPatchDeploymentModeDryRun  = "Would patch InferenceService %s/%s deploymentMode from %s to %s"
+	msgPatchDeploymentModeSuccess = "Patched InferenceService %s/%s deploymentMode to %s"
+	msgPatchDeploymentModeFailed  = "Failed to patch InferenceService %s/%s: %v"
+	msgRestartDeploymentDryRun    = "Would restart deployment %s/%s"
+	msgRestartDeploymentSuccess   = "Restarted deployment %s/%s"
+	msgRestartDeploymentFailed    = "Failed to restart deployment %s/%s: %v"
+	msgGetConfigMapFailed         = "Failed to get ConfigMap %s/%s: %v"
+	msgConfigMapNotFound          = "ConfigMap %s not found in namespace %s"
+	msgGetAppNamespaceFailed      = "Failed to get applications namespace: %v"
+)
+
+// inferenceServiceConfig preserves all fields in the inferenceService JSON
+// while allowing targeted access to serviceAnnotationDisallowedList.
+type inferenceServiceConfig map[string]json.RawMessage
+
+const disallowedListKey = "serviceAnnotationDisallowedList"
+
+func (c inferenceServiceConfig) disallowedList() ([]string, error) {
+	raw, ok := c[disallowedListKey]
+	if !ok {
+		return nil, nil
+	}
+
+	var list []string
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", disallowedListKey, err)
+	}
+
+	return list, nil
+}
+
+func (c inferenceServiceConfig) setDisallowedList(list []string) error {
+	raw, err := json.Marshal(list)
+	if err != nil {
+		return fmt.Errorf("marshaling %s: %w", disallowedListKey, err)
+	}
+
+	c[disallowedListKey] = raw
+
+	return nil
+}
+
+// listISVCsByDeploymentMode lists InferenceServices filtered by deployment mode annotation.
+func listISVCsByDeploymentMode(
+	ctx context.Context,
+	target action.Target,
+	mode string,
+) ([]*unstructured.Unstructured, error) {
+	filter := func(obj *unstructured.Unstructured) (bool, error) {
+		val, err := jq.Query[string](obj, ".metadata.annotations.\""+annotationDeploymentMode+"\"")
+		if err != nil {
+			return false, nil //nolint:nilerr // Missing annotation means not matching.
+		}
+
+		return val == mode, nil
+	}
+
+	return client.List[*unstructured.Unstructured](ctx, target.Client, resources.InferenceService, filter)
+}
+
+// patchISVCDeploymentMode patches an InferenceService's deployment mode annotation.
+func patchISVCDeploymentMode(
+	ctx context.Context,
+	target action.Target,
+	isvc *unstructured.Unstructured,
+	newMode string,
+	step action.StepRecorder,
+) {
+	name := isvc.GetName()
+	ns := isvc.GetNamespace()
+	oldMode := getDeploymentMode(isvc)
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgPatchDeploymentModeDryRun, ns, name, oldMode, newMode)
+
+		return
+	}
+
+	patchData := fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, annotationDeploymentMode, newMode)
+
+	_, err := target.Client.Dynamic().Resource(resources.InferenceService.GVR()).
+		Namespace(ns).
+		Patch(ctx, name, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+
+	if err != nil {
+		step.Complete(result.StepFailed, msgPatchDeploymentModeFailed, ns, name, err)
+
+		return
+	}
+
+	step.Complete(result.StepCompleted, msgPatchDeploymentModeSuccess, ns, name, newMode)
+}
+
+// getDeploymentMode returns the deployment mode annotation value, or empty string if not set.
+func getDeploymentMode(obj *unstructured.Unstructured) string {
+	val, err := jq.Query[string](obj, ".metadata.annotations.\""+annotationDeploymentMode+"\"")
+	if err != nil {
+		return ""
+	}
+
+	return val
+}
+
+// getInferenceServiceConfig gets the inferenceservice-config ConfigMap from the specified namespace.
+func getInferenceServiceConfig(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+) (*unstructured.Unstructured, error) {
+	cm, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+		Namespace(namespace).
+		Get(ctx, inferenceServiceConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting %s ConfigMap: %w", inferenceServiceConfigName, err)
+	}
+
+	return cm, nil
+}
+
+// restartDeployment triggers a rolling restart of a deployment by patching the pod template annotation.
+func restartDeployment(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+	name string,
+	step action.StepRecorder,
+) {
+	if target.DryRun {
+		step.Complete(result.StepSkipped, msgRestartDeploymentDryRun, namespace, name)
+
+		return
+	}
+
+	patchData := fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+		annotationRestartedAt,
+		time.Now().Format(time.RFC3339),
+	)
+
+	_, err := target.Client.Dynamic().Resource(resources.Deployment.GVR()).
+		Namespace(namespace).
+		Patch(ctx, name, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
+
+	if err != nil {
+		step.Complete(result.StepFailed, msgRestartDeploymentFailed, namespace, name, err)
+
+		return
+	}
+
+	step.Complete(result.StepCompleted, msgRestartDeploymentSuccess, namespace, name)
+}
+
+// getApplicationsNamespace retrieves the applications namespace from DSCI.
+// Tries the v2 API first (RHOAI 3.x), then falls back to v1 (RHOAI 2.x).
+func getApplicationsNamespace(ctx context.Context, target action.Target) (string, error) {
+	ns, err := client.GetApplicationsNamespace(ctx, target.Client)
+	if err == nil {
+		return ns, nil
+	}
+
+	// Fall back to v1 DSCI for RHOAI 2.x clusters
+	dsci, v1Err := client.GetSingleton(ctx, target.Client, resources.DSCInitializationV1)
+	if v1Err != nil {
+		return "", fmt.Errorf("getting applications namespace (v2: %w, v1: %w)", err, v1Err)
+	}
+
+	v1NS, queryErr := jq.Query[string](dsci, ".spec.applicationsNamespace")
+	if queryErr != nil {
+		return "", fmt.Errorf("getting applications namespace (v2: %w, v1 query: %w)", err, queryErr)
+	}
+
+	if v1NS == "" {
+		return "", errors.New("getting applications namespace: applicationsNamespace not set in DSCI")
+	}
+
+	return v1NS, nil
+}
+
+// parseISVCConfigData parses the inferenceService data key from the ConfigMap.
+func parseISVCConfigData(configMap *unstructured.Unstructured) (inferenceServiceConfig, error) {
+	dataJSON, err := jq.Query[string](configMap, ".data."+inferenceServiceDataKey)
+	if err != nil {
+		if errors.Is(err, jq.ErrNotFound) {
+			return inferenceServiceConfig{}, nil
+		}
+
+		return nil, fmt.Errorf("reading %s: %w", inferenceServiceDataKey, err)
+	}
+
+	var cfg inferenceServiceConfig
+	if err := json.Unmarshal([]byte(dataJSON), &cfg); err != nil {
+		return nil, fmt.Errorf("parsing %s JSON: %w", inferenceServiceDataKey, err)
+	}
+
+	return cfg, nil
+}
+
+// ensureAuthResources creates the SA, Role, and RoleBinding for an InferenceService if they don't exist.
+func ensureAuthResources(
+	ctx context.Context,
+	target action.Target,
+	isvc *unstructured.Unstructured,
+	step action.StepRecorder,
+) {
+	name := isvc.GetName()
+	ns := isvc.GetNamespace()
+
+	saName := name + authSASuffix
+	roleName := name + authRoleSuffix
+	roleBindingName := name + authRoleBindingSuffix
+
+	ensureServiceAccount(ctx, target, ns, saName, step)
+	ensureRole(ctx, target, ns, roleName, step)
+	ensureRoleBinding(ctx, target, ns, roleBindingName, saName, roleName, step)
+}
+
+func ensureServiceAccount(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+	name string,
+	step action.StepRecorder,
+) {
+	_, err := target.Client.Dynamic().Resource(resources.ServiceAccount.GVR()).
+		Namespace(namespace).
+		Get(ctx, name, metav1.GetOptions{})
+
+	if err == nil {
+		return
+	}
+
+	if !apierrors.IsNotFound(err) {
+		step.Record("create-sa", "Failed to check ServiceAccount %s/%s: %v", result.StepFailed, namespace, name, err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Record("create-sa", "Would create ServiceAccount %s/%s", result.StepSkipped, namespace, name)
+
+		return
+	}
+
+	sa := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.ServiceAccount.APIVersion(),
+			"kind":       resources.ServiceAccount.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.ServiceAccount.GVR()).
+		Namespace(namespace).
+		Create(ctx, sa, metav1.CreateOptions{})
+
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		step.Record("create-sa", "Failed to create ServiceAccount %s/%s: %v", result.StepFailed, namespace, name, err)
+
+		return
+	}
+
+	step.Record("create-sa", "Created ServiceAccount %s/%s", result.StepCompleted, namespace, name)
+}
+
+func ensureRole(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+	name string,
+	step action.StepRecorder,
+) {
+	_, err := target.Client.Dynamic().Resource(resources.Role.GVR()).
+		Namespace(namespace).
+		Get(ctx, name, metav1.GetOptions{})
+
+	if err == nil {
+		return
+	}
+
+	if !apierrors.IsNotFound(err) {
+		step.Record("create-role", "Failed to check Role %s/%s: %v", result.StepFailed, namespace, name, err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Record("create-role", "Would create Role %s/%s", result.StepSkipped, namespace, name)
+
+		return
+	}
+
+	role := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Role.APIVersion(),
+			"kind":       resources.Role.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"rules": []any{
+				map[string]any{
+					"apiGroups": []any{""},
+					"resources": []any{"services"},
+					"verbs":     []any{"get", "list", "watch"},
+				},
+			},
+		},
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.Role.GVR()).
+		Namespace(namespace).
+		Create(ctx, role, metav1.CreateOptions{})
+
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		step.Record("create-role", "Failed to create Role %s/%s: %v", result.StepFailed, namespace, name, err)
+
+		return
+	}
+
+	step.Record("create-role", "Created Role %s/%s", result.StepCompleted, namespace, name)
+}
+
+func ensureRoleBinding(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+	name string,
+	saName string,
+	roleName string,
+	step action.StepRecorder,
+) {
+	_, err := target.Client.Dynamic().Resource(resources.RoleBinding.GVR()).
+		Namespace(namespace).
+		Get(ctx, name, metav1.GetOptions{})
+
+	if err == nil {
+		return
+	}
+
+	if !apierrors.IsNotFound(err) {
+		step.Record("create-rolebinding", "Failed to check RoleBinding %s/%s: %v", result.StepFailed, namespace, name, err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Record("create-rolebinding", "Would create RoleBinding %s/%s", result.StepSkipped, namespace, name)
+
+		return
+	}
+
+	rb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.RoleBinding.APIVersion(),
+			"kind":       resources.RoleBinding.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"subjects": []any{
+				map[string]any{
+					"kind":      "ServiceAccount",
+					"name":      saName,
+					"namespace": namespace,
+				},
+			},
+			"roleRef": map[string]any{
+				"apiGroup": "rbac.authorization.k8s.io",
+				"kind":     "Role",
+				"name":     roleName,
+			},
+		},
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.RoleBinding.GVR()).
+		Namespace(namespace).
+		Create(ctx, rb, metav1.CreateOptions{})
+
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		step.Record("create-rolebinding", "Failed to create RoleBinding %s/%s: %v", result.StepFailed, namespace, name, err)
+
+		return
+	}
+
+	step.Record("create-rolebinding", "Created RoleBinding %s/%s", result.StepCompleted, namespace, name)
+}
+
+// buildResult extracts the RootRecorder from target and builds the ActionResult.
+func buildResult(target action.Target) (*result.ActionResult, error) {
+	rootRecorder, ok := target.Recorder.(action.RootRecorder)
+	if !ok {
+		return nil, errors.New("recorder is not a RootRecorder")
+	}
+
+	return rootRecorder.Build(), nil
+}
+
+// groupByNamespace groups unstructured objects by their namespace.
+func groupByNamespace(objs []*unstructured.Unstructured) map[string][]*unstructured.Unstructured {
+	grouped := make(map[string][]*unstructured.Unstructured)
+
+	for _, obj := range objs {
+		ns := obj.GetNamespace()
+		grouped[ns] = append(grouped[ns], obj)
+	}
+
+	return grouped
+}

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -54,6 +54,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
+	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -53,6 +53,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
+	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -52,6 +52,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	// Explicitly register all actions (no global state, full test isolation)
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
+	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -55,6 +55,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
+	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -50,6 +51,7 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 
 	// Explicitly register all actions (no global state, full test isolation)
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -47,6 +47,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	// Explicitly register all actions (no global state, full test isolation)
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
+	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -48,6 +48,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
+	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -49,6 +49,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
+	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -50,6 +50,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
+	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -45,6 +46,7 @@ func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 
 	// Explicitly register all actions (no global state, full test isolation)
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -44,6 +44,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
+	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -45,6 +45,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
+	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -43,6 +43,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	// Explicitly register all actions (no global state, full test isolation)
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
 	registry.MustRegister(&modelserving.ServerlessToRawAction{})
+	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -41,6 +42,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 
 	// Explicitly register all actions (no global state, full test isolation)
 	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+	registry.MustRegister(&modelserving.ServerlessToRawAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -46,6 +46,7 @@ func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
 	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
+	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -100,6 +100,14 @@ var (
 		Resource: "dscinitializations",
 	}
 
+	// DSCInitializationV1 is the v1 API version, served by RHOAI 2.x clusters.
+	DSCInitializationV1 = ResourceType{
+		Group:    "dscinitialization.opendatahub.io",
+		Version:  "v1",
+		Kind:     "DSCInitialization",
+		Resource: "dscinitializations",
+	}
+
 	// DataSciencePipelinesApplicationV1 is the DSP DataSciencePipelinesApplication resource (v1).
 	DataSciencePipelinesApplicationV1 = ResourceType{
 		Group:    "datasciencepipelinesapplications.opendatahub.io",
@@ -198,6 +206,27 @@ var (
 		Version:  "v1",
 		Kind:     "Secret",
 		Resource: "secrets",
+	}
+
+	ServiceAccount = ResourceType{
+		Group:    "",
+		Version:  "v1",
+		Kind:     "ServiceAccount",
+		Resource: "serviceaccounts",
+	}
+
+	Role = ResourceType{
+		Group:    "rbac.authorization.k8s.io",
+		Version:  "v1",
+		Kind:     "Role",
+		Resource: "roles",
+	}
+
+	RoleBinding = ResourceType{
+		Group:    "rbac.authorization.k8s.io",
+		Version:  "v1",
+		Kind:     "RoleBinding",
+		Resource: "rolebindings",
 	}
 
 	PersistentVolumeClaim = ResourceType{


### PR DESCRIPTION
## RHOAIENG-61430: Convert Model Serving migration scripts to Go actions

### Summary

Converts 5 model-serving shell scripts from `red-hat-data-services/rhoai-upgrade-helpers` into first-class Go migration actions within the `rhai-cli migrate` framework.

**New actions:**

| Action ID | Phase | Description |
|-----------|-------|-------------|
| `modelserving.serverless-to-raw` | pre-upgrade | Converts Serverless ISVCs to RawDeployment, creates auth resources (SA, Role, RoleBinding) |
| `modelserving.modelmesh-to-raw` | pre-upgrade | Converts ModelMesh ISVCs to RawDeployment, updates multi-model ServingRuntimes |
| `modelserving.hardwareprofiles-ignorelist` | pre-upgrade | Patches `inferenceservice-config` ConfigMap with `managed=false` and adds hardware-profile annotations to `serviceAnnotationDisallowedList` |
| `modelserving.add-owner-references` | pre-upgrade | Patches SA/Role/RoleBinding with `ownerReferences` pointing to associated RawDeployment ISVCs |
| `modelserving.managed-isvc-config` | post-upgrade | Restores `managed=true` on `inferenceservice-config` ConfigMap after upgrading to 3.x |

### Commits

| # | Commit | Files |
|---|--------|-------|
| 1 | Add shared model serving helpers and resource types | `support.go`, `types.go` |
| 2 | Add serverless-to-raw migration action | action, test, `helpers_test.go`, registrations |
| 3 | Add modelmesh-to-raw migration action | action, test, registrations |
| 4 | Add hardwareprofiles-ignorelist migration action | action, test, registrations |
| 5 | Add add-owner-references migration action | action, test, registrations |
| 6 | Add managed-isvc-config migration action | action, test, registrations |

### Changes

**New files** (`pkg/migrate/actions/modelserving/`):
- `support.go` — Shared constants and helpers (ISVC listing/patching, auth resource creation, deployment restart, ConfigMap parsing, DSCI v2→v1 fallback for 2.x cluster compat)
- `helpers_test.go` — Shared test fixtures (newISVC, newDSCI, newTestTarget, etc.)
- `serverless_to_raw.go` — Action #1 with prepare (backup) and run (convert) tasks
- `modelmesh_to_raw.go` — Action #2 with prepare (backup ISVCs + ServingRuntimes) and run tasks
- `hardwareprofiles_ignorelist.go` — Action #3 with prepare (backup ConfigMap) and run tasks
- `add_owner_references.go` — Action #4 (run-only, non-destructive)
- `managed_isvc_config.go` — Action #5 (run-only, post-upgrade)
- Test files for all 5 actions (28 tests total)

**Modified files:**
- `pkg/resources/types.go` — Added `ServiceAccount`, `Role`, `RoleBinding`, `DSCInitializationV1` ResourceType definitions
- `pkg/migrate/command_run.go` — Registered all 5 actions
- `pkg/migrate/command_prepare.go` — Registered all 5 actions
- `pkg/migrate/command_list.go` — Registered all 5 actions

### Design decisions

- All 5 actions share a single `modelserving` package with common helpers in `support.go`
- Pre-upgrade actions: `CanApply: currentVersion.Major == 2 && currentVersion.Minor >= 25`
- Post-upgrade action (`managed-isvc-config`): `CanApply: currentVersion.Major == 3`
- Implements `Phase()` from the Action interface added in #79
- `getApplicationsNamespace` tries v2 DSCI first, falls back to v1 for RHOAI 2.x clusters; error messages include both v2 and v1 context on failure
- Auth resources follow naming convention from original shell scripts: `{name}-sa`, `{name}-view-role`, `{name}-view`
- `addOwnerReferences` uses StrategicMergePatch with MergePatch fallback for forward compatibility
- Completion messages use "Processed N" (not "Converted N") since per-ISVC sub-step failures are tracked by the recorder, not the counter

### Test plan

- [x] `gofmt` — clean
- [x] `go vet` — clean
- [x] `make lint` — 0 issues
- [x] `make build` — compiles cleanly
- [x] `go test ./pkg/migrate/actions/modelserving/...` — 28/28 pass
- [x] Full test suite — all packages pass
- [x] Each commit builds and tests independently
- [x] `rhai-cli migrate list --target-version 3.0` shows 5 pre-upgrade actions
- [x] `rhai-cli migrate list --all` shows all 6 actions (5 pre-upgrade + 1 post-upgrade)
- [x] Dry-run tested on RHOAI 2.25.x cluster — DSCI v1 fallback works, actions report correctly
- [ ] End-to-end with live Serverless/ModelMesh ISVCs

Fixes: [RHOAIENG-61430](https://issues.redhat.com/browse/RHOAIENG-61430)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added migrations to convert KServe InferenceServices from Serverless/ModelMesh to RawDeployment, add owner references to auth resources, and manage hardware-profile disallowed lists and managed annotation changes across upgrades.
  * Migrations include dry-run, optional confirmation prompts, backups, and controller restarts where needed.
* **Chores**
  * New model-serving migrations are registered and available via the migrate CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->