### PR TITLE
RHOAIENG-61431: Convert AI Pipelines migration scripts to Go actions

### DIFF
--- a/pkg/migrate/actions/aipipelines/constants.go
+++ b/pkg/migrate/actions/aipipelines/constants.go
@@ -1,0 +1,53 @@
+package aipipelines
+
+import (
+	"io/fs"
+	"time"
+)
+
+const (
+	preUpgradeCheckID          = "ai-pipelines.pre-upgrade-check"
+	preUpgradeCheckName        = "AI Pipelines pre-upgrade check"
+	preUpgradeCheckDescription = "Captures DSPA pod health, migrates v1alpha1 resources to v1, and detects RBAC gaps"
+
+	updateDSPRoleID          = "ai-pipelines.update-dsp-role"
+	updateDSPRoleName        = "Update custom DSP roles"
+	updateDSPRoleDescription = "Patches custom RBAC roles to add datasciencepipelinesapplications/api subresource"
+
+	postUpgradeCheckID          = "ai-pipelines.post-upgrade-check"
+	postUpgradeCheckName        = "AI Pipelines post-upgrade check"
+	postUpgradeCheckDescription = "Verifies pipeline server pods are healthy post-upgrade against pre-upgrade baseline"
+)
+
+const (
+	podPrefixDSPipeline = "ds-pipeline-"
+	podPrefixMariaDB    = "mariadb-"
+)
+
+// Uses /tmp because the CLI runs in OpenShift containers with arbitrary UIDs where
+// $HOME (/) and $XDG_CACHE_HOME are not writable. The Dockerfile provisions this
+// directory with chmod 1777.
+const defaultStateDir = "/tmp/rhoai-upgrade-backup/ai_pipelines"
+const stateFileName = "dspa_pre_upgrade_pods.json"
+
+const systemNamespacePattern = `^(kube-system|default|openshift.*|redhat-ods-.*)$`
+
+const (
+	retryMaxSteps        = 10
+	retryInitialDuration = 1 * time.Second
+	retryFactor          = 2.0
+	retryJitter          = 0.1
+	retryMaxDuration     = 30 * time.Second
+)
+
+const (
+	postUpgradePollInterval = 15 * time.Second
+	postUpgradeTimeout      = 120 * time.Second
+)
+
+const dspaAPIGroup = "datasciencepipelinesapplications.opendatahub.io"
+
+const (
+	dirPermissions  fs.FileMode = 0o750
+	filePermissions fs.FileMode = 0o600
+)

--- a/pkg/migrate/actions/aipipelines/dspa.go
+++ b/pkg/migrate/actions/aipipelines/dspa.go
@@ -1,0 +1,169 @@
+package aipipelines
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+type dspaInfo struct {
+	Name      string
+	Namespace string
+}
+
+func listDSPAs(ctx context.Context, c client.Client, rt resources.ResourceType) ([]dspaInfo, error) {
+	return listDSPAsInNamespace(ctx, c, rt, "")
+}
+
+func listDSPAsInNamespace(ctx context.Context, c client.Client, rt resources.ResourceType, namespace string) ([]dspaInfo, error) {
+	list, err := c.Dynamic().Resource(rt.GVR()).
+		Namespace(namespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing %s: %w", rt.Kind, err)
+	}
+
+	dspas := make([]dspaInfo, 0, len(list.Items))
+
+	for _, item := range list.Items {
+		dspas = append(dspas, dspaInfo{
+			Name:      item.GetName(),
+			Namespace: item.GetNamespace(),
+		})
+	}
+
+	return dspas, nil
+}
+
+type migrateOpts struct {
+	DryRun bool
+}
+
+func migrateDSPAToV1(
+	ctx context.Context,
+	c client.Client,
+	dspa dspaInfo,
+	opts migrateOpts,
+) error {
+	gvrAlpha := resources.DataSciencePipelinesApplicationV1Alpha1.GVR()
+	gvrV1 := resources.DataSciencePipelinesApplicationV1.GVR()
+
+	obj, err := c.Dynamic().Resource(gvrAlpha).
+		Namespace(dspa.Namespace).
+		Get(ctx, dspa.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting v1alpha1 DSPA %s/%s: %w", dspa.Namespace, dspa.Name, err)
+	}
+
+	cleanObj := obj.DeepCopy()
+	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "generation")
+	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "uid")
+	unstructured.RemoveNestedField(cleanObj.Object, "status")
+
+	cleanObj.SetAPIVersion(resources.DataSciencePipelinesApplicationV1.APIVersion())
+	cleanObj.SetKind(resources.DataSciencePipelinesApplicationV1.Kind)
+
+	updateOpts := metav1.UpdateOptions{}
+	if opts.DryRun {
+		updateOpts.DryRun = []string{metav1.DryRunAll}
+	}
+
+	_, err = c.Dynamic().Resource(gvrV1).
+		Namespace(dspa.Namespace).
+		Update(ctx, cleanObj, updateOpts)
+	if err != nil {
+		return fmt.Errorf("applying v1 DSPA %s/%s: %w", dspa.Namespace, dspa.Name, err)
+	}
+
+	return nil
+}
+
+func migrateAllDSPAsToV1(
+	ctx context.Context,
+	c client.Client,
+	recorder action.StepRecorder,
+	opts migrateOpts,
+) error {
+	step := recorder.Child("migrate-v1alpha1-to-v1", "Migrate v1alpha1 DSPAs to v1")
+
+	v1alpha1DSPAs, err := listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+
+		return err
+	}
+
+	if len(v1alpha1DSPAs) == 0 {
+		step.Complete(result.StepCompleted, "No v1alpha1 DSPAs found")
+
+		return nil
+	}
+
+	step.Record("detected", "Found %d v1alpha1 DSPA(s) to migrate", result.StepCompleted, len(v1alpha1DSPAs))
+
+	if opts.DryRun {
+		for _, dspa := range v1alpha1DSPAs {
+			step.Record(dspa.Name, "Would migrate %s/%s from v1alpha1 to v1", result.StepSkipped, dspa.Namespace, dspa.Name)
+		}
+
+		step.Complete(result.StepSkipped, "Dry-run: %d DSPA(s) would be migrated", len(v1alpha1DSPAs))
+
+		return nil
+	}
+
+	backoff := wait.Backoff{
+		Duration: retryInitialDuration,
+		Factor:   retryFactor,
+		Jitter:   retryJitter,
+		Steps:    retryMaxSteps,
+		Cap:      retryMaxDuration,
+	}
+
+	var remaining []dspaInfo
+
+	retryErr := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		remaining, err = listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
+		if err != nil {
+			return false, fmt.Errorf("re-listing v1alpha1 DSPAs: %w", err)
+		}
+
+		if len(remaining) == 0 {
+			return true, nil
+		}
+
+		for _, dspa := range remaining {
+			if migrateErr := migrateDSPAToV1(ctx, c, dspa, opts); migrateErr != nil {
+				step.Record(dspa.Name, "Migration attempt failed: %v (will retry)", result.StepFailed, migrateErr)
+			} else {
+				step.Record(dspa.Name, "Migrated %s/%s to v1", result.StepCompleted, dspa.Namespace, dspa.Name)
+			}
+		}
+
+		remaining, err = listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
+		if err != nil {
+			return false, fmt.Errorf("verifying migration: %w", err)
+		}
+
+		return len(remaining) == 0, nil
+	})
+
+	if retryErr != nil {
+		step.Complete(result.StepFailed, "Failed to migrate all v1alpha1 DSPAs: %v", retryErr)
+
+		return fmt.Errorf("migrating v1alpha1 DSPAs: %w", retryErr)
+	}
+
+	step.Complete(result.StepCompleted, "All v1alpha1 DSPAs migrated to v1")
+
+	return nil
+}

--- a/pkg/migrate/actions/aipipelines/dspa_test.go
+++ b/pkg/migrate/actions/aipipelines/dspa_test.go
@@ -1,0 +1,96 @@
+package aipipelines_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoglobals // Test fixture
+var dspaListKinds = map[schema.GroupVersionResource]string{
+	resources.DataSciencePipelinesApplicationV1.GVR():       resources.DataSciencePipelinesApplicationV1.ListKind(),
+	resources.DataSciencePipelinesApplicationV1Alpha1.GVR(): resources.DataSciencePipelinesApplicationV1Alpha1.ListKind(),
+	resources.Pod.GVR():  resources.Pod.ListKind(),
+	resources.Role.GVR(): resources.Role.ListKind(),
+}
+
+func newFakeClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	fakeDynamic := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dspaListKinds, objects...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: fakeDynamic,
+	})
+}
+
+func makeDSPA(name, namespace, apiVersion string) *unstructured.Unstructured {
+	var rt resources.ResourceType
+
+	switch apiVersion {
+	case "v1alpha1":
+		rt = resources.DataSciencePipelinesApplicationV1Alpha1
+	case "v1":
+		rt = resources.DataSciencePipelinesApplicationV1
+	default:
+		panic("unsupported apiVersion in test fixture: " + apiVersion)
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": rt.APIVersion(),
+			"kind":       rt.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{},
+		},
+	}
+}
+
+func TestListDSPAs(t *testing.T) {
+	t.Run("lists v1 DSPAs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient(
+			makeDSPA("dspa1", "ns1", "v1"),
+			makeDSPA("dspa2", "ns2", "v1"),
+		)
+
+		dspas, err := aipipelines.ListDSPAs(context.Background(), c, resources.DataSciencePipelinesApplicationV1)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dspas).To(HaveLen(2))
+	})
+
+	t.Run("lists v1alpha1 DSPAs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient(
+			makeDSPA("dspa1", "ns1", "v1alpha1"),
+		)
+
+		dspas, err := aipipelines.ListDSPAs(context.Background(), c, resources.DataSciencePipelinesApplicationV1Alpha1)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dspas).To(HaveLen(1))
+	})
+
+	t.Run("returns empty when none exist", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient()
+
+		dspas, err := aipipelines.ListDSPAs(context.Background(), c, resources.DataSciencePipelinesApplicationV1)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dspas).To(BeEmpty())
+	})
+}

--- a/pkg/migrate/actions/aipipelines/export_test.go
+++ b/pkg/migrate/actions/aipipelines/export_test.go
@@ -1,0 +1,60 @@
+package aipipelines
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+//nolint:gochecknoglobals // Test exports only compiled in test builds
+var (
+	GetPodGroup        = getPodGroup
+	ClassifyRole       = classifyRole
+	IsSystemNamespace  = isSystemNamespace
+	DefaultStatePath   = defaultStatePath
+	SavePodHealthState = savePodHealthState
+	LoadPodHealthState = loadPodHealthState
+	HasAnyDegradation  = hasAnyDegradation
+	ExtractStringSlice = extractStringSlice
+	ListDSPAs          = listDSPAs
+)
+
+func MakePodUnstructured(name, namespace, phase, readyStatus string) unstructured.Unstructured {
+	conditions := []any{}
+	if readyStatus != "" {
+		conditions = append(conditions, map[string]any{
+			"type":   "Ready",
+			"status": readyStatus,
+		})
+	}
+
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]any{
+				"phase":      phase,
+				"conditions": conditions,
+			},
+		},
+	}
+}
+
+func MakeRoleUnstructured(name, namespace string, rules []map[string]any) unstructured.Unstructured {
+	rulesAny := make([]any, len(rules))
+	for i, r := range rules {
+		rulesAny[i] = r
+	}
+
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "Role",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"rules": rulesAny,
+		},
+	}
+}

--- a/pkg/migrate/actions/aipipelines/pod_health.go
+++ b/pkg/migrate/actions/aipipelines/pod_health.go
@@ -1,0 +1,276 @@
+package aipipelines
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// PodHealthState is the top-level snapshot saved to disk for pre→post comparison.
+type PodHealthState struct {
+	CapturedAt string      `json:"capturedAt"`
+	DSPAs      []DSPAState `json:"dspas"`
+}
+
+type DSPAState struct {
+	Name      string     `json:"dspaName"`
+	Namespace string     `json:"namespace"`
+	PodGroups []PodGroup `json:"podGroups"`
+}
+
+type PodGroup struct {
+	Prefix     string    `json:"prefix"`
+	PodsFound  bool      `json:"podsFound"`
+	AllHealthy bool      `json:"allHealthy"`
+	Pods       []PodInfo `json:"pods"`
+}
+
+type PodInfo struct {
+	Name    string `json:"name"`
+	Phase   string `json:"phase"`
+	Ready   string `json:"ready"`
+	Healthy bool   `json:"healthy"`
+}
+
+type podGroupStatus string
+
+const (
+	podGroupOK       podGroupStatus = "OK"
+	podGroupFail     podGroupStatus = "FAIL"
+	podGroupImproved podGroupStatus = "IMPROVED"
+	podGroupWarn     podGroupStatus = "WARN"
+)
+
+type podGroupComparison struct {
+	DSPAName  string
+	Namespace string
+	Prefix    string
+	Status    podGroupStatus
+	Current   PodGroup
+}
+
+func capturePodHealth(
+	ctx context.Context,
+	c client.Client,
+	recorder action.StepRecorder,
+	dspas []dspaInfo,
+) (PodHealthState, error) {
+	state := PodHealthState{
+		CapturedAt: time.Now().UTC().Format(time.RFC3339),
+		DSPAs:      make([]DSPAState, 0, len(dspas)),
+	}
+
+	for _, dspa := range dspas {
+		step := recorder.Child(
+			"capture-"+dspa.Namespace+"-"+dspa.Name,
+			fmt.Sprintf("DSPA: %s | Namespace: %s", dspa.Name, dspa.Namespace),
+		)
+
+		pods, err := c.Dynamic().Resource(resources.Pod.GVR()).
+			Namespace(dspa.Namespace).
+			List(ctx, metav1.ListOptions{})
+		if err != nil {
+			step.Complete(result.StepFailed, "Failed to list pods: %v", err)
+
+			return state, fmt.Errorf("listing pods in %s: %w", dspa.Namespace, err)
+		}
+
+		dspaState := DSPAState{
+			Name:      dspa.Name,
+			Namespace: dspa.Namespace,
+			PodGroups: make([]PodGroup, 0, 2), //nolint:mnd
+		}
+
+		for _, prefix := range []string{podPrefixDSPipeline + dspa.Name, podPrefixMariaDB + dspa.Name} {
+			group := getPodGroup(pods.Items, prefix)
+			dspaState.PodGroups = append(dspaState.PodGroups, group)
+
+			if !group.PodsFound {
+				step.Record(prefix, "[WARN] No pods found", result.StepCompleted)
+			} else if group.AllHealthy {
+				step.Record(prefix, "[OK] All pods healthy", result.StepCompleted)
+			} else {
+				for _, pod := range group.Pods {
+					if pod.Healthy {
+						step.Record(pod.Name, "[OK] Running, Ready", result.StepCompleted)
+					} else {
+						step.Record(pod.Name, "[FAIL] Phase: %s, Ready: %s", result.StepFailed, pod.Phase, pod.Ready)
+					}
+				}
+			}
+		}
+
+		state.DSPAs = append(state.DSPAs, dspaState)
+		step.Complete(result.StepCompleted, "Captured %d pod groups", len(dspaState.PodGroups))
+	}
+
+	return state, nil
+}
+
+func getPodGroup(pods []unstructured.Unstructured, prefix string) PodGroup {
+	group := PodGroup{
+		Prefix: prefix,
+		Pods:   []PodInfo{},
+	}
+
+	for i := range pods {
+		pod := &pods[i]
+		name := pod.GetName()
+
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+
+		phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+		if phase == "" {
+			phase = "Unknown"
+		}
+
+		ready := "Unknown"
+
+		conditions, found, _ := unstructured.NestedSlice(pod.Object, "status", "conditions")
+		if found {
+			for _, c := range conditions {
+				cond, ok := c.(map[string]any)
+				if !ok {
+					continue
+				}
+
+				if condType, _ := cond["type"].(string); condType == "Ready" {
+					if val, _ := cond["status"].(string); val != "" {
+						ready = val
+					}
+
+					break
+				}
+			}
+		}
+
+		healthy := phase == "Running" && ready == "True"
+
+		group.Pods = append(group.Pods, PodInfo{
+			Name:    name,
+			Phase:   phase,
+			Ready:   ready,
+			Healthy: healthy,
+		})
+	}
+
+	group.PodsFound = len(group.Pods) > 0
+	group.AllHealthy = group.PodsFound
+
+	for _, pod := range group.Pods {
+		if !pod.Healthy {
+			group.AllHealthy = false
+
+			break
+		}
+	}
+
+	return group
+}
+
+func comparePodHealth(
+	ctx context.Context,
+	c client.Client,
+	pre PodHealthState,
+) ([]podGroupComparison, error) {
+	var comparisons []podGroupComparison
+
+	for _, dspa := range pre.DSPAs {
+		pods, err := c.Dynamic().Resource(resources.Pod.GVR()).
+			Namespace(dspa.Namespace).
+			List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("listing pods in %s: %w", dspa.Namespace, err)
+		}
+
+		for _, preGroup := range dspa.PodGroups {
+			curGroup := getPodGroup(pods.Items, preGroup.Prefix)
+
+			var status podGroupStatus
+
+			switch {
+			case curGroup.AllHealthy && preGroup.AllHealthy:
+				status = podGroupOK
+			case curGroup.AllHealthy && !preGroup.AllHealthy:
+				status = podGroupImproved
+			case !curGroup.AllHealthy && !preGroup.AllHealthy:
+				status = podGroupWarn
+			default:
+				status = podGroupFail
+			}
+
+			comparisons = append(comparisons, podGroupComparison{
+				DSPAName:  dspa.Name,
+				Namespace: dspa.Namespace,
+				Prefix:    preGroup.Prefix,
+				Status:    status,
+				Current:   curGroup,
+			})
+		}
+	}
+
+	return comparisons, nil
+}
+
+func hasAnyDegradation(comparisons []podGroupComparison) bool {
+	for _, c := range comparisons {
+		if c.Status == podGroupFail {
+			return true
+		}
+	}
+
+	return false
+}
+
+func savePodHealthState(state PodHealthState, paths ...string) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling state: %w", err)
+	}
+
+	for _, p := range paths {
+		dir := filepath.Dir(p)
+		if err := os.MkdirAll(dir, dirPermissions); err != nil {
+			return fmt.Errorf("creating directory %s: %w", dir, err)
+		}
+
+		if err := os.WriteFile(p, data, filePermissions); err != nil {
+			return fmt.Errorf("writing state to %s: %w", p, err)
+		}
+	}
+
+	return nil
+}
+
+func loadPodHealthState(path string) (PodHealthState, error) {
+	var state PodHealthState
+
+	data, err := os.ReadFile(path) //nolint:gosec // path is from defaultStatePath(), not user input
+	if err != nil {
+		return state, fmt.Errorf("reading state from %s: %w", path, err)
+	}
+
+	if err := json.Unmarshal(data, &state); err != nil {
+		return state, fmt.Errorf("unmarshaling state from %s: %w", path, err)
+	}
+
+	return state, nil
+}
+
+func defaultStatePath() string {
+	return filepath.Join(defaultStateDir, stateFileName)
+}

--- a/pkg/migrate/actions/aipipelines/pod_health_test.go
+++ b/pkg/migrate/actions/aipipelines/pod_health_test.go
@@ -1,0 +1,169 @@
+package aipipelines_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetPodGroup(t *testing.T) {
+	t.Run("healthy pods matching prefix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		pods := []unstructured.Unstructured{
+			aipipelines.MakePodUnstructured("ds-pipeline-mydspa-abc123", "ns1", "Running", "True"),
+			aipipelines.MakePodUnstructured("ds-pipeline-mydspa-def456", "ns1", "Running", "True"),
+			aipipelines.MakePodUnstructured("mariadb-mydspa-0", "ns1", "Running", "True"),
+		}
+
+		group := aipipelines.GetPodGroup(pods, "ds-pipeline-mydspa")
+
+		g.Expect(group.Prefix).To(Equal("ds-pipeline-mydspa"))
+		g.Expect(group.PodsFound).To(BeTrue())
+		g.Expect(group.AllHealthy).To(BeTrue())
+		g.Expect(group.Pods).To(HaveLen(2))
+		g.Expect(group.Pods[0].Name).To(Equal("ds-pipeline-mydspa-abc123"))
+		g.Expect(group.Pods[0].Healthy).To(BeTrue())
+	})
+
+	t.Run("unhealthy pod in group", func(t *testing.T) {
+		g := NewWithT(t)
+
+		pods := []unstructured.Unstructured{
+			aipipelines.MakePodUnstructured("ds-pipeline-mydspa-abc", "ns1", "Running", "True"),
+			aipipelines.MakePodUnstructured("ds-pipeline-mydspa-def", "ns1", "Pending", "False"),
+		}
+
+		group := aipipelines.GetPodGroup(pods, "ds-pipeline-mydspa")
+
+		g.Expect(group.PodsFound).To(BeTrue())
+		g.Expect(group.AllHealthy).To(BeFalse())
+		g.Expect(group.Pods[1].Healthy).To(BeFalse())
+		g.Expect(group.Pods[1].Phase).To(Equal("Pending"))
+	})
+
+	t.Run("no pods matching prefix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		pods := []unstructured.Unstructured{
+			aipipelines.MakePodUnstructured("other-pod-abc", "ns1", "Running", "True"),
+		}
+
+		group := aipipelines.GetPodGroup(pods, "ds-pipeline-mydspa")
+
+		g.Expect(group.PodsFound).To(BeFalse())
+		g.Expect(group.AllHealthy).To(BeFalse())
+		g.Expect(group.Pods).To(BeEmpty())
+	})
+
+	t.Run("pod with missing status", func(t *testing.T) {
+		g := NewWithT(t)
+
+		pods := []unstructured.Unstructured{
+			aipipelines.MakePodUnstructured("ds-pipeline-mydspa-abc", "ns1", "", ""),
+		}
+
+		group := aipipelines.GetPodGroup(pods, "ds-pipeline-mydspa")
+
+		g.Expect(group.PodsFound).To(BeTrue())
+		g.Expect(group.AllHealthy).To(BeFalse())
+		g.Expect(group.Pods[0].Phase).To(Equal("Unknown"))
+		g.Expect(group.Pods[0].Ready).To(Equal("Unknown"))
+		g.Expect(group.Pods[0].Healthy).To(BeFalse())
+	})
+
+	t.Run("empty pod list", func(t *testing.T) {
+		g := NewWithT(t)
+
+		group := aipipelines.GetPodGroup(nil, "ds-pipeline-mydspa")
+
+		g.Expect(group.PodsFound).To(BeFalse())
+		g.Expect(group.AllHealthy).To(BeFalse())
+	})
+}
+
+func TestSaveAndLoadPodHealthState(t *testing.T) {
+	t.Run("round-trip", func(t *testing.T) {
+		g := NewWithT(t)
+
+		state := aipipelines.PodHealthState{
+			CapturedAt: "2026-05-27T10:00:00Z",
+			DSPAs: []aipipelines.DSPAState{
+				{
+					Name:      "mydspa",
+					Namespace: "ns1",
+					PodGroups: []aipipelines.PodGroup{
+						{
+							Prefix:     "ds-pipeline-mydspa",
+							PodsFound:  true,
+							AllHealthy: true,
+							Pods: []aipipelines.PodInfo{
+								{Name: "ds-pipeline-mydspa-abc", Phase: "Running", Ready: "True", Healthy: true},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "state.json")
+
+		err := aipipelines.SavePodHealthState(state, path)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		loaded, err := aipipelines.LoadPodHealthState(path)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(loaded.CapturedAt).To(Equal("2026-05-27T10:00:00Z"))
+		g.Expect(loaded.DSPAs).To(HaveLen(1))
+		g.Expect(loaded.DSPAs[0].Name).To(Equal("mydspa"))
+		g.Expect(loaded.DSPAs[0].PodGroups[0].AllHealthy).To(BeTrue())
+	})
+
+	t.Run("save to multiple paths", func(t *testing.T) {
+		g := NewWithT(t)
+
+		state := aipipelines.PodHealthState{CapturedAt: "2026-01-01T00:00:00Z"}
+
+		dir := t.TempDir()
+		path1 := filepath.Join(dir, "a", "state.json")
+		path2 := filepath.Join(dir, "b", "state.json")
+
+		err := aipipelines.SavePodHealthState(state, path1, path2)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Stat(path1)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, err = os.Stat(path2)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("load from missing file", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := aipipelines.LoadPodHealthState("/nonexistent/path/state.json")
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestHasAnyDegradation(t *testing.T) {
+	t.Skip("cannot construct podGroupComparison from outside the package; tested via postcheck integration tests")
+}
+
+func TestDefaultStatePath(t *testing.T) {
+	t.Run("returns path under /tmp provisioned directory", func(t *testing.T) {
+		g := NewWithT(t)
+
+		path := aipipelines.DefaultStatePath()
+		g.Expect(path).To(ContainSubstring("/tmp/rhoai-upgrade-backup"))
+		g.Expect(path).To(ContainSubstring("ai_pipelines"))
+		g.Expect(path).To(HaveSuffix("dspa_pre_upgrade_pods.json"))
+	})
+}

--- a/pkg/migrate/actions/aipipelines/postcheck.go
+++ b/pkg/migrate/actions/aipipelines/postcheck.go
@@ -1,0 +1,216 @@
+package aipipelines
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// PostUpgradeCheckAction verifies pipeline server pods are healthy post-upgrade.
+type PostUpgradeCheckAction struct{}
+
+func (a *PostUpgradeCheckAction) ID() string          { return postUpgradeCheckID }
+func (a *PostUpgradeCheckAction) Name() string        { return postUpgradeCheckName }
+func (a *PostUpgradeCheckAction) Description() string { return postUpgradeCheckDescription }
+
+func (a *PostUpgradeCheckAction) Group() action.ActionGroup { return action.GroupValidation }
+func (a *PostUpgradeCheckAction) Phase() action.ActionPhase { return action.PhasePostUpgrade }
+
+func (a *PostUpgradeCheckAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion != nil && target.CurrentVersion.Major == 2
+}
+
+func (a *PostUpgradeCheckAction) Prepare() action.Task { return nil }
+func (a *PostUpgradeCheckAction) Run() action.Task     { return &postUpgradeCheckRunTask{} }
+
+type postUpgradeCheckRunTask struct{}
+
+func (t *postUpgradeCheckRunTask) Validate(_ context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	step := recorder.Child("check-state-file", "Check for pre-upgrade state file")
+
+	statePath := defaultStatePath()
+
+	if _, err := loadPodHealthState(statePath); err != nil {
+		step.Complete(result.StepFailed,
+			"Pre-upgrade state not found at %s. Run 'migrate prepare -m %s' before upgrading",
+			statePath, preUpgradeCheckID)
+	} else {
+		step.Complete(result.StepCompleted, "Pre-upgrade state file found at %s", statePath)
+	}
+
+	return recorder.Build(), nil
+}
+
+func (t *postUpgradeCheckRunTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	// Load pre-upgrade state
+	loadStep := recorder.Child("load-state", "Load pre-upgrade state")
+
+	statePath := defaultStatePath()
+
+	preState, err := loadPodHealthState(statePath)
+	if err != nil {
+		loadStep.Complete(result.StepFailed,
+			"Pre-upgrade state not found at %s. Run 'migrate prepare -m %s' before upgrading",
+			statePath, preUpgradeCheckID)
+
+		return recorder.Build(), fmt.Errorf("loading pre-upgrade state: %w", err)
+	}
+
+	loadStep.Complete(result.StepCompleted, "Loaded state captured at %s", preState.CapturedAt)
+
+	if len(preState.DSPAs) == 0 {
+		recorder.Record("no-dspas", "No DSPAs were tracked pre-upgrade", result.StepCompleted)
+
+		return recorder.Build(), nil
+	}
+
+	// Initial check — if no degradation, return immediately
+	comparisons, err := comparePodHealth(ctx, target.Client, preState)
+	if err != nil {
+		recorder.Record("compare-failed", "Failed to compare pod health: %v", result.StepFailed, err)
+
+		return recorder.Build(), fmt.Errorf("comparing pod health: %w", err)
+	}
+
+	if !hasAnyDegradation(comparisons) {
+		t.recordComparisons(recorder, comparisons)
+
+		return recorder.Build(), nil
+	}
+
+	// Degradation detected — poll for recovery
+	target.IO.Errorf("Degradation detected. Waiting up to %s for pods to recover...\n",
+		postUpgradeTimeout)
+
+	comparisons, err = t.pollForRecovery(ctx, target, preState)
+	if err != nil {
+		recorder.Record("poll-failed", "Failed during recovery polling: %v", result.StepFailed, err)
+
+		return recorder.Build(), fmt.Errorf("polling for recovery: %w", err)
+	}
+
+	t.recordComparisons(recorder, comparisons)
+
+	return recorder.Build(), nil
+}
+
+func (t *postUpgradeCheckRunTask) pollForRecovery(
+	ctx context.Context,
+	target action.Target,
+	preState PodHealthState,
+) ([]podGroupComparison, error) {
+	ticker := time.NewTicker(postUpgradePollInterval)
+	defer ticker.Stop()
+
+	deadline := time.After(postUpgradeTimeout)
+
+	for {
+		select {
+		case <-ctx.Done():
+			comparisons, err := comparePodHealthFreshCtx(target.Client, preState) //nolint:contextcheck // parent ctx is cancelled
+			if err != nil {
+				return nil, fmt.Errorf("final comparison after context cancellation: %w", err)
+			}
+
+			return comparisons, nil
+		case <-deadline:
+			target.IO.Errorf("Wait timeout reached (%s). Running final comparison...\n",
+				postUpgradeTimeout)
+
+			comparisons, err := comparePodHealth(ctx, target.Client, preState)
+			if err != nil {
+				return nil, fmt.Errorf("final comparison after timeout: %w", err)
+			}
+
+			return comparisons, nil
+		case <-ticker.C:
+			comparisons, err := comparePodHealth(ctx, target.Client, preState)
+			if err != nil {
+				target.IO.Errorf("Comparison failed: %v, retrying...\n", err)
+
+				continue
+			}
+
+			if !hasAnyDegradation(comparisons) {
+				target.IO.Errorf("All previously-healthy pods recovered\n")
+
+				return comparisons, nil
+			}
+
+			target.IO.Errorf("Not yet fully recovered, retrying...\n")
+		}
+	}
+}
+
+func (t *postUpgradeCheckRunTask) recordComparisons(
+	recorder action.RootRecorder,
+	comparisons []podGroupComparison,
+) {
+	step := recorder.Child("comparison", "Pre vs Post-Upgrade Comparison")
+
+	for _, comp := range comparisons {
+		var status result.StepStatus
+
+		var msg string
+
+		switch comp.Status {
+		case podGroupOK:
+			status = result.StepCompleted
+			msg = "[OK] " + comp.Prefix
+		case podGroupImproved:
+			status = result.StepCompleted
+			msg = fmt.Sprintf("[IMPROVED] %s (was unhealthy, now healthy)", comp.Prefix)
+		case podGroupWarn:
+			status = result.StepCompleted
+			msg = fmt.Sprintf("[WARN] %s (unchanged unhealthy state, pre-existing issue)", comp.Prefix)
+		case podGroupFail:
+			status = result.StepFailed
+			msg = fmt.Sprintf("[FAIL] %s (was healthy, now unhealthy)", comp.Prefix)
+		}
+
+		groupStep := step.Child(comp.Prefix, msg)
+
+		if comp.Status == podGroupFail {
+			recordFailedPodGroup(groupStep, comp.Current)
+		}
+
+		groupStep.Complete(status, msg)
+	}
+
+	if hasAnyDegradation(comparisons) {
+		step.Complete(result.StepFailed, "One or more DSPA pods degraded compared to pre-upgrade state")
+	} else {
+		step.Complete(result.StepCompleted, "All DSPA pods are in an equal or better state than before upgrade")
+	}
+}
+
+func comparePodHealthFreshCtx(c client.Client, preState PodHealthState) ([]podGroupComparison, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), postUpgradePollInterval)
+	defer cancel()
+
+	return comparePodHealth(ctx, c, preState)
+}
+
+func recordFailedPodGroup(groupStep action.StepRecorder, current PodGroup) {
+	if !current.PodsFound {
+		groupStep.Record("missing", "[MISSING] No pods found post-upgrade", result.StepFailed)
+
+		return
+	}
+
+	for _, pod := range current.Pods {
+		if pod.Healthy {
+			groupStep.Record(pod.Name, "[OK] %s (Running, Ready)", result.StepCompleted, pod.Name)
+		} else {
+			groupStep.Record(pod.Name, "[FAIL] %s (Phase: %s, Ready: %s)", result.StepFailed, pod.Name, pod.Phase, pod.Ready)
+		}
+	}
+}

--- a/pkg/migrate/actions/aipipelines/postcheck_test.go
+++ b/pkg/migrate/actions/aipipelines/postcheck_test.go
@@ -1,0 +1,49 @@
+package aipipelines_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPostUpgradeCheckAction(t *testing.T) {
+	t.Run("metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PostUpgradeCheckAction{}
+		g.Expect(a.ID()).To(Equal("ai-pipelines.post-upgrade-check"))
+		g.Expect(a.Name()).To(Equal("AI Pipelines post-upgrade check"))
+		g.Expect(a.Group()).To(Equal(action.GroupValidation))
+		g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
+	})
+
+	t.Run("CanApply returns true for version 2.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PostUpgradeCheckAction{}
+		v2 := semver.MustParse("2.25.0")
+		v3 := semver.MustParse("3.0.0")
+
+		g.Expect(a.CanApply(action.Target{CurrentVersion: &v2})).To(BeTrue())
+		g.Expect(a.CanApply(action.Target{CurrentVersion: &v3})).To(BeFalse())
+	})
+
+	t.Run("Prepare returns nil", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PostUpgradeCheckAction{}
+		g.Expect(a.Prepare()).To(BeNil())
+	})
+
+	t.Run("Run returns non-nil task", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PostUpgradeCheckAction{}
+		g.Expect(a.Run()).ToNot(BeNil())
+	})
+}

--- a/pkg/migrate/actions/aipipelines/precheck.go
+++ b/pkg/migrate/actions/aipipelines/precheck.go
@@ -1,0 +1,185 @@
+package aipipelines
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+// PreUpgradeCheckAction captures DSPA pod health, migrates v1alpha1→v1, and detects RBAC gaps.
+type PreUpgradeCheckAction struct{}
+
+func (a *PreUpgradeCheckAction) ID() string          { return preUpgradeCheckID }
+func (a *PreUpgradeCheckAction) Name() string        { return preUpgradeCheckName }
+func (a *PreUpgradeCheckAction) Description() string { return preUpgradeCheckDescription }
+
+func (a *PreUpgradeCheckAction) Group() action.ActionGroup { return action.GroupMigration }
+func (a *PreUpgradeCheckAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
+
+func (a *PreUpgradeCheckAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion != nil && target.CurrentVersion.Major == 2
+}
+
+func (a *PreUpgradeCheckAction) Prepare() action.Task { return &preUpgradeCheckPrepareTask{} }
+func (a *PreUpgradeCheckAction) Run() action.Task     { return &preUpgradeCheckRunTask{} }
+
+// --- Prepare task: capture pod health state, detect v1alpha1, detect RBAC gaps ---
+
+type preUpgradeCheckPrepareTask struct{}
+
+func (t *preUpgradeCheckPrepareTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	validateTarget := target
+	validateTarget.DryRun = true
+
+	return t.Execute(ctx, validateTarget)
+}
+
+func (t *preUpgradeCheckPrepareTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	t.discover(ctx, target, recorder)
+
+	return recorder.Build(), nil
+}
+
+func (t *preUpgradeCheckPrepareTask) discover(
+	ctx context.Context,
+	target action.Target,
+	recorder action.RootRecorder,
+) {
+	// Step 1: Capture pod health state for v1 DSPAs
+	healthStep := recorder.Child("capture-pod-health", "Capture pre-upgrade DSPA pod health")
+
+	v1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1)
+	if err != nil {
+		healthStep.Complete(result.StepFailed, "Failed to list v1 DSPAs: %v", err)
+
+		return
+	}
+
+	var state PodHealthState
+
+	if len(v1DSPAs) == 0 {
+		healthStep.Complete(result.StepCompleted, "No v1 DSPAs found")
+
+		state = PodHealthState{
+			CapturedAt: time.Now().UTC().Format(time.RFC3339),
+			DSPAs:      []DSPAState{},
+		}
+	} else {
+		var captureErr error
+
+		state, captureErr = capturePodHealth(ctx, target.Client, healthStep, v1DSPAs)
+		if captureErr != nil {
+			healthStep.Complete(result.StepFailed, "Failed to capture pod health: %v", captureErr)
+
+			return
+		}
+
+		healthStep.Complete(result.StepCompleted, "Captured pod health for %d DSPA(s)", len(v1DSPAs))
+	}
+
+	if !target.DryRun {
+		t.saveState(target, recorder, state)
+	}
+
+	// Step 2: Detect v1alpha1 DSPAs
+	v1alpha1Step := recorder.Child("detect-v1alpha1", "Detect deprecated v1alpha1 DSPAs")
+
+	v1alpha1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
+	if err != nil {
+		v1alpha1Step.Complete(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+
+		return
+	}
+
+	if len(v1alpha1DSPAs) == 0 {
+		v1alpha1Step.Complete(result.StepCompleted, "No deprecated v1alpha1 DSPAs found")
+	} else {
+		for _, dspa := range v1alpha1DSPAs {
+			v1alpha1Step.Record(dspa.Name, "v1alpha1 DSPA %s/%s needs migration", result.StepCompleted, dspa.Namespace, dspa.Name)
+		}
+
+		v1alpha1Step.Complete(result.StepCompleted, "Found %d v1alpha1 DSPA(s) requiring migration", len(v1alpha1DSPAs))
+	}
+
+	// Step 3: Detect custom roles needing RBAC update
+	_, _ = findRolesNeedingFix(ctx, target.Client, recorder)
+}
+
+func (t *preUpgradeCheckPrepareTask) saveState(
+	target action.Target,
+	recorder action.StepRecorder,
+	state PodHealthState,
+) {
+	saveStep := recorder.Child("save-state", "Save pre-upgrade state")
+
+	if target.DryRun {
+		saveStep.Complete(result.StepSkipped, "Would save pre-upgrade pod health state")
+
+		return
+	}
+
+	statePath := defaultStatePath()
+
+	if err := savePodHealthState(state, statePath); err != nil {
+		saveStep.Complete(result.StepFailed, "Failed to save state: %v", err)
+
+		return
+	}
+
+	saveStep.Complete(result.StepCompleted, "State saved to %s", statePath)
+}
+
+// --- Run task: migrate v1alpha1 DSPAs to v1 ---
+
+type preUpgradeCheckRunTask struct{}
+
+func (t *preUpgradeCheckRunTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	step := recorder.Child("check-v1alpha1", "Check for v1alpha1 DSPAs")
+
+	v1alpha1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+
+		return recorder.Build(), nil
+	}
+
+	if len(v1alpha1DSPAs) == 0 {
+		step.Complete(result.StepCompleted, "No v1alpha1 DSPAs found — nothing to migrate")
+	} else {
+		step.Complete(result.StepCompleted, "Found %d v1alpha1 DSPA(s) to migrate", len(v1alpha1DSPAs))
+	}
+
+	return recorder.Build(), nil
+}
+
+func (t *preUpgradeCheckRunTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	if err := migrateAllDSPAsToV1(ctx, target.Client, recorder, migrateOpts{DryRun: target.DryRun}); err != nil {
+		return recorder.Build(), fmt.Errorf("v1alpha1 migration failed: %w", err)
+	}
+
+	// Verify no v1alpha1 DSPAs remain (skip in dry-run — we didn't actually migrate)
+	if !target.DryRun {
+		verifyStep := recorder.Child("verify-migration", "Verify no v1alpha1 DSPAs remain")
+
+		remaining, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
+		if err != nil {
+			verifyStep.Complete(result.StepFailed, "Failed to verify: %v", err)
+		} else if len(remaining) > 0 {
+			verifyStep.Complete(result.StepFailed, "%d v1alpha1 DSPA(s) still remain", len(remaining))
+		} else {
+			verifyStep.Complete(result.StepCompleted, "All DSPAs are now v1")
+		}
+	}
+
+	return recorder.Build(), nil
+}

--- a/pkg/migrate/actions/aipipelines/precheck_test.go
+++ b/pkg/migrate/actions/aipipelines/precheck_test.go
@@ -1,0 +1,43 @@
+package aipipelines_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPreUpgradeCheckAction(t *testing.T) {
+	t.Run("metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PreUpgradeCheckAction{}
+		g.Expect(a.ID()).To(Equal("ai-pipelines.pre-upgrade-check"))
+		g.Expect(a.Name()).To(Equal("AI Pipelines pre-upgrade check"))
+		g.Expect(a.Group()).To(Equal(action.GroupMigration))
+		g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	})
+
+	t.Run("CanApply returns true for version 2.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PreUpgradeCheckAction{}
+		v2 := semver.MustParse("2.25.0")
+		v3 := semver.MustParse("3.0.0")
+
+		g.Expect(a.CanApply(action.Target{CurrentVersion: &v2})).To(BeTrue())
+		g.Expect(a.CanApply(action.Target{CurrentVersion: &v3})).To(BeFalse())
+	})
+
+	t.Run("has both Prepare and Run tasks", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.PreUpgradeCheckAction{}
+		g.Expect(a.Prepare()).ToNot(BeNil())
+		g.Expect(a.Run()).ToNot(BeNil())
+	})
+}

--- a/pkg/migrate/actions/aipipelines/role_classifier.go
+++ b/pkg/migrate/actions/aipipelines/role_classifier.go
@@ -1,0 +1,167 @@
+package aipipelines
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+var (
+	systemNamespaceRe   = regexp.MustCompile(systemNamespacePattern)
+	operatorManagedRole = regexp.MustCompile(`^(ds-pipeline-|pipeline-runner-)`)
+)
+
+type roleClassification struct {
+	NeedsFix   bool
+	RoleName   string
+	Namespace  string
+	RouteVerbs []string // verbs from the route.openshift.io rule, used to infer DSPA verbs
+}
+
+func classifyRole(role *unstructured.Unstructured) roleClassification {
+	classification := roleClassification{
+		RoleName:  role.GetName(),
+		Namespace: role.GetNamespace(),
+	}
+
+	if isSystemNamespace(classification.Namespace) {
+		return classification
+	}
+
+	if operatorManagedRole.MatchString(classification.RoleName) {
+		return classification
+	}
+
+	rules, found, _ := unstructured.NestedSlice(role.Object, "rules")
+	if !found {
+		return classification
+	}
+
+	hasRouteAPIGroup := false
+	hasDSPASubresource := false
+
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiGroups, _ := extractStringSlice(rule, "apiGroups")
+		ruleResources, _ := extractStringSlice(rule, "resources")
+		verbs, _ := extractStringSlice(rule, "verbs")
+
+		for _, g := range apiGroups {
+			if g == "route.openshift.io" {
+				hasRouteAPIGroup = true
+				classification.RouteVerbs = mergeStringSlices(classification.RouteVerbs, verbs)
+			}
+		}
+
+		for _, res := range ruleResources {
+			if res == "datasciencepipelinesapplications/api" {
+				hasDSPASubresource = true
+			}
+		}
+	}
+
+	classification.NeedsFix = hasRouteAPIGroup && !hasDSPASubresource
+
+	return classification
+}
+
+func isSystemNamespace(ns string) bool {
+	return systemNamespaceRe.MatchString(ns)
+}
+
+func findRolesNeedingFix(
+	ctx context.Context,
+	c client.Client,
+	recorder action.StepRecorder,
+) ([]roleClassification, error) {
+	step := recorder.Child("scan-roles", "Scan custom roles for RBAC gaps")
+
+	roleList, err := c.Dynamic().Resource(resources.Role.GVR()).
+		Namespace("").
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list roles: %v", err)
+
+		return nil, fmt.Errorf("listing roles: %w", err)
+	}
+
+	var needsFix []roleClassification
+
+	for i := range roleList.Items {
+		classification := classifyRole(&roleList.Items[i])
+		if classification.NeedsFix {
+			needsFix = append(needsFix, classification)
+		}
+	}
+
+	if len(needsFix) == 0 {
+		step.Complete(result.StepCompleted, "No custom roles need updating")
+	} else {
+		for _, r := range needsFix {
+			step.Record(
+				r.RoleName,
+				"Role %s in namespace %s needs datasciencepipelinesapplications/api subresource",
+				result.StepCompleted,
+				r.RoleName,
+				r.Namespace,
+			)
+		}
+
+		step.Complete(result.StepCompleted, "Found %d role(s) needing update", len(needsFix))
+	}
+
+	return needsFix, nil
+}
+
+func extractStringSlice(obj map[string]any, key string) ([]string, bool) {
+	raw, ok := obj[key]
+	if !ok {
+		return nil, false
+	}
+
+	slice, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+
+	out := make([]string, 0, len(slice))
+
+	for _, v := range slice {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+
+	return out, len(out) > 0
+}
+
+func mergeStringSlices(a, b []string) []string {
+	seen := make(map[string]bool, len(a))
+
+	for _, v := range a {
+		seen[v] = true
+	}
+
+	merged := append([]string{}, a...)
+
+	for _, v := range b {
+		if !seen[v] {
+			merged = append(merged, v)
+			seen[v] = true
+		}
+	}
+
+	return merged
+}

--- a/pkg/migrate/actions/aipipelines/role_classifier_test.go
+++ b/pkg/migrate/actions/aipipelines/role_classifier_test.go
@@ -1,0 +1,193 @@
+package aipipelines_test
+
+import (
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestClassifyRole(t *testing.T) {
+	t.Run("role needing fix — has route.openshift.io but missing dspa subresource", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get", "list"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeTrue())
+		g.Expect(result.RoleName).To(Equal("my-custom-role"))
+		g.Expect(result.Namespace).To(Equal("user-ns"))
+		g.Expect(result.RouteVerbs).To(Equal([]string{"get", "list"}))
+	})
+
+	t.Run("role needing fix — infers verbs including create and update", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get", "list", "create", "update", "delete"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeTrue())
+		g.Expect(result.RouteVerbs).To(Equal([]string{"get", "list", "create", "update", "delete"}))
+	})
+
+	t.Run("role already has dspa subresource — no fix needed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+			{
+				"apiGroups": []any{"datasciencepipelinesapplications.opendatahub.io"},
+				"resources": []any{"datasciencepipelinesapplications/api"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
+	t.Run("role without route.openshift.io — no fix needed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("my-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{""},
+				"resources": []any{"pods"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
+	t.Run("operator-managed role is excluded — ds-pipeline prefix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("ds-pipeline-mydspa", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
+	t.Run("operator-managed role is excluded — pipeline-runner prefix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("pipeline-runner-mydspa", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
+	t.Run("system namespace is excluded", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("my-role", "kube-system", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
+	t.Run("role with no rules", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := aipipelines.MakeRoleUnstructured("empty-role", "user-ns", nil)
+
+		result := aipipelines.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+}
+
+func TestIsSystemNamespace(t *testing.T) {
+	tests := []struct {
+		ns       string
+		expected bool
+	}{
+		{"kube-system", true},
+		{"default", true},
+		{"openshift", true},
+		{"openshift-operators", true},
+		{"openshift-monitoring", true},
+		{"redhat-ods-applications", true},
+		{"redhat-ods-monitoring", true},
+		{"user-namespace", false},
+		{"my-project", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ns, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(aipipelines.IsSystemNamespace(tt.ns)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestExtractStringSlice(t *testing.T) {
+	t.Run("extracts string slice", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := map[string]any{
+			"verbs": []any{"get", "list", "watch"},
+		}
+
+		result, ok := aipipelines.ExtractStringSlice(obj, "verbs")
+		g.Expect(ok).To(BeTrue())
+		g.Expect(result).To(Equal([]string{"get", "list", "watch"}))
+	})
+
+	t.Run("key not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := map[string]any{}
+
+		_, ok := aipipelines.ExtractStringSlice(obj, "verbs")
+		g.Expect(ok).To(BeFalse())
+	})
+
+	t.Run("not a slice", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := map[string]any{
+			"verbs": "get",
+		}
+
+		_, ok := aipipelines.ExtractStringSlice(obj, "verbs")
+		g.Expect(ok).To(BeFalse())
+	})
+}

--- a/pkg/migrate/actions/aipipelines/updatedsprole.go
+++ b/pkg/migrate/actions/aipipelines/updatedsprole.go
@@ -1,0 +1,206 @@
+package aipipelines
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+// UpdateDSPRoleAction patches custom RBAC roles to add the datasciencepipelinesapplications/api subresource.
+type UpdateDSPRoleAction struct{}
+
+func (a *UpdateDSPRoleAction) ID() string          { return updateDSPRoleID }
+func (a *UpdateDSPRoleAction) Name() string        { return updateDSPRoleName }
+func (a *UpdateDSPRoleAction) Description() string { return updateDSPRoleDescription }
+
+func (a *UpdateDSPRoleAction) Group() action.ActionGroup { return action.GroupMigration }
+func (a *UpdateDSPRoleAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
+
+func (a *UpdateDSPRoleAction) CanApply(target action.Target) bool {
+	return target.CurrentVersion != nil && target.CurrentVersion.Major == 2
+}
+
+func (a *UpdateDSPRoleAction) Prepare() action.Task { return &updateDSPRolePrepareTask{} }
+func (a *UpdateDSPRoleAction) Run() action.Task     { return &updateDSPRoleRunTask{} }
+
+// --- Prepare task: scan and report roles needing the fix ---
+
+type updateDSPRolePrepareTask struct{}
+
+func (t *updateDSPRolePrepareTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	return t.Execute(ctx, target)
+}
+
+func (t *updateDSPRolePrepareTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	_, _ = findRolesNeedingFix(ctx, target.Client, recorder)
+
+	return recorder.Build(), nil
+}
+
+// --- Run task: patch roles ---
+
+type updateDSPRoleRunTask struct{}
+
+func (t *updateDSPRoleRunTask) Validate(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	_, _ = findRolesNeedingFix(ctx, target.Client, recorder)
+
+	return recorder.Build(), nil
+}
+
+func (t *updateDSPRoleRunTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	roles, err := findRolesNeedingFix(ctx, target.Client, recorder)
+	if err != nil {
+		return recorder.Build(), fmt.Errorf("scanning roles: %w", err)
+	}
+
+	if len(roles) == 0 {
+		return recorder.Build(), nil
+	}
+
+	patchStep := recorder.Child("patch-roles", "Patch custom roles")
+
+	for _, role := range roles {
+		t.patchRole(ctx, target, patchStep, role)
+	}
+
+	patchStep.Complete(result.StepCompleted, "Processed %d role(s)", len(roles))
+
+	return recorder.Build(), nil
+}
+
+func (t *updateDSPRoleRunTask) patchRole(
+	ctx context.Context,
+	target action.Target,
+	recorder action.StepRecorder,
+	role roleClassification,
+) {
+	step := recorder.Child(
+		"patch-"+role.Namespace+"-"+role.RoleName,
+		fmt.Sprintf("Patch role %s/%s", role.Namespace, role.RoleName),
+	)
+
+	namespaceDSPAs, err := listDSPAsInNamespace(ctx, target.Client, resources.DataSciencePipelinesApplicationV1, role.Namespace)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to list DSPAs in %s: %v", role.Namespace, err)
+
+		return
+	}
+
+	if len(namespaceDSPAs) == 0 {
+		step.Complete(result.StepCompleted, "No DSPAs found in namespace %s — skipping", role.Namespace)
+
+		return
+	}
+
+	for _, dspa := range namespaceDSPAs {
+		t.patchRoleForDSPA(ctx, target, step, role, dspa)
+	}
+
+	step.Complete(result.StepCompleted, "Role %s/%s processed", role.Namespace, role.RoleName)
+}
+
+func (t *updateDSPRoleRunTask) patchRoleForDSPA(
+	ctx context.Context,
+	target action.Target,
+	recorder action.StepRecorder,
+	role roleClassification,
+	dspa dspaInfo,
+) {
+	stepID := "add-rule-" + dspa.Name
+	step := recorder.Child(stepID,
+		"Add datasciencepipelinesapplications/api rule for DSPA "+dspa.Name)
+
+	// Infer verbs from the existing route.openshift.io rule
+	verbs := role.RouteVerbs
+	if len(verbs) == 0 {
+		verbs = []string{"get", "list", "watch"}
+	}
+
+	// Build the JSON patch
+	patchOps := []map[string]any{
+		{
+			"op":   "add",
+			"path": "/rules/-",
+			"value": map[string]any{
+				"apiGroups":     []string{dspaAPIGroup},
+				"resources":     []string{"datasciencepipelinesapplications/api"},
+				"resourceNames": []string{dspa.Name},
+				"verbs":         verbs,
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(patchOps)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to marshal patch: %v", err)
+
+		return
+	}
+
+	if !target.DryRun && !target.SkipConfirm {
+		target.IO.Errorf("\nAbout to patch role %s/%s to add datasciencepipelinesapplications/api for DSPA %s (verbs: %v)\n",
+			role.Namespace, role.RoleName, dspa.Name, verbs)
+
+		if !confirmation.Prompt(target.IO, "Proceed with role patch?") {
+			step.Complete(result.StepSkipped, "User cancelled patch")
+
+			return
+		}
+	}
+
+	patchOpts := metav1.PatchOptions{}
+	if target.DryRun {
+		patchOpts.DryRun = []string{metav1.DryRunAll}
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.Role.GVR()).
+		Namespace(role.Namespace).
+		Patch(ctx, role.RoleName, types.JSONPatchType, patchData, patchOpts)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to patch role: %v", err)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Complete(result.StepSkipped,
+			"Would add datasciencepipelinesapplications/api rule for DSPA %s (verbs: %v)", dspa.Name, verbs)
+
+		return
+	}
+
+	// Validate: re-read the role and confirm the rule was added
+	updatedRole, err := target.Client.Dynamic().Resource(resources.Role.GVR()).
+		Namespace(role.Namespace).
+		Get(ctx, role.RoleName, metav1.GetOptions{})
+	if err != nil {
+		step.Complete(result.StepFailed, "Patch succeeded but validation failed — could not re-read role: %v", err)
+
+		return
+	}
+
+	validated := classifyRole(updatedRole)
+	if validated.NeedsFix {
+		step.Complete(result.StepFailed,
+			"Patch succeeded but validation failed — datasciencepipelinesapplications/api rule not found in re-read")
+
+		return
+	}
+
+	step.Complete(result.StepCompleted,
+		"Added datasciencepipelinesapplications/api rule for DSPA %s (verbs: %v)", dspa.Name, verbs)
+}

--- a/pkg/migrate/actions/aipipelines/updatedsprole_test.go
+++ b/pkg/migrate/actions/aipipelines/updatedsprole_test.go
@@ -1,0 +1,43 @@
+package aipipelines_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestUpdateDSPRoleAction(t *testing.T) {
+	t.Run("metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.UpdateDSPRoleAction{}
+		g.Expect(a.ID()).To(Equal("ai-pipelines.update-dsp-role"))
+		g.Expect(a.Name()).To(Equal("Update custom DSP roles"))
+		g.Expect(a.Group()).To(Equal(action.GroupMigration))
+		g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	})
+
+	t.Run("CanApply returns true for version 2.x", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.UpdateDSPRoleAction{}
+		v2 := semver.MustParse("2.25.0")
+		v3 := semver.MustParse("3.0.0")
+
+		g.Expect(a.CanApply(action.Target{CurrentVersion: &v2})).To(BeTrue())
+		g.Expect(a.CanApply(action.Target{CurrentVersion: &v3})).To(BeFalse())
+	})
+
+	t.Run("has both Prepare and Run tasks", func(t *testing.T) {
+		g := NewWithT(t)
+
+		a := &aipipelines.UpdateDSPRoleAction{}
+		g.Expect(a.Prepare()).ToNot(BeNil())
+		g.Expect(a.Run()).ToNot(BeNil())
+	})
+}

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -14,9 +14,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -48,20 +45,10 @@ type ListCommand struct {
 
 func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 	shared := NewSharedOptions(streams)
-	registry := action.NewActionRegistry()
-
-	// Explicitly register all actions (no global state, full test isolation)
-	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
-	registry.MustRegister(&modelserving.ServerlessToRawAction{})
-	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
-	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
-	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
-	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
-	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 
 	return &ListCommand{
 		SharedOptions: shared,
-		registry:      registry,
+		registry:      newDefaultRegistry(),
 	}
 }
 

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -15,9 +15,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -43,20 +40,10 @@ type PrepareCommand struct {
 
 func NewPrepareCommand(streams genericiooptions.IOStreams) *PrepareCommand {
 	shared := NewSharedOptions(streams)
-	registry := action.NewActionRegistry()
-
-	// Explicitly register all actions (no global state, full test isolation)
-	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
-	registry.MustRegister(&modelserving.ServerlessToRawAction{})
-	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
-	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
-	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
-	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
-	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 
 	return &PrepareCommand{
 		SharedOptions: shared,
-		registry:      registry,
+		registry:      newDefaultRegistry(),
 	}
 }
 

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -12,9 +12,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -39,20 +36,10 @@ type RunCommand struct {
 
 func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
 	shared := NewSharedOptions(streams)
-	registry := action.NewActionRegistry()
-
-	// Explicitly register all actions (no global state, full test isolation)
-	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
-	registry.MustRegister(&modelserving.ServerlessToRawAction{})
-	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
-	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
-	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
-	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
-	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 
 	return &RunCommand{
 		SharedOptions: shared,
-		registry:      registry,
+		registry:      newDefaultRegistry(),
 	}
 }
 

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -1,0 +1,26 @@
+package migrate
+
+import (
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
+)
+
+func newDefaultRegistry() *action.ActionRegistry {
+	registry := action.NewActionRegistry()
+
+	registry.MustRegister(&rhbok.RHBOKMigrationAction{})
+	registry.MustRegister(&aipipelines.PreUpgradeCheckAction{})
+	registry.MustRegister(&aipipelines.UpdateDSPRoleAction{})
+	registry.MustRegister(&aipipelines.PostUpgradeCheckAction{})
+	registry.MustRegister(&modelserving.ServerlessToRawAction{})
+	registry.MustRegister(&modelserving.ModelMeshToRawAction{})
+	registry.MustRegister(&modelserving.HardwareProfilesIgnorelistAction{})
+	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
+	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
+	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
+
+	return registry
+}


### PR DESCRIPTION
Add three migrate actions converting the AI Pipelines shell scripts (check_before_upgrade.sh, update_dsp_role.sh, post_upgrade_check.sh) into the rhai-cli migrate framework:

- ai-pipelines.pre-upgrade-check: captures DSPA pod health state, migrates v1alpha1 resources to v1 with retry/backoff, detects custom roles missing datasciencepipelinesapplications/api subresource
- ai-pipelines.update-dsp-role: auto-detects and patches custom RBAC roles, inferring verbs from existing route.openshift.io rules
- ai-pipelines.post-upgrade-check: compares post-upgrade pod health against saved baseline with polling for recovery

Also introduces a shared registry (registry.go) so action registration is defined once instead of duplicated across list/prepare/run commands.

## Description

<!-- What does this PR do? -->

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre- and post-upgrade checks for AI Pipelines: pod-health snapshots, recovery polling, and comparison reporting.
  * Automatic detection and optional remediation of RBAC gaps for AI Pipelines.
  * API-version migration for AI Pipelines resources with dry-run support.

* **Chores**
  * Migrate commands now initialize a default action set by default.

* **Tests**
  * Added comprehensive unit tests covering migration, pod-health, role classification, and upgrade checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->