### PR TITLE
feat: add RBAC pre-flight checks and unit test coverage for Kueue migrate

### DIFF
--- a/pkg/migrate/actions/kueue/rhbok/export_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/export_test.go
@@ -1,0 +1,32 @@
+package rhbok
+
+import (
+	"context"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/rbac"
+)
+
+//nolint:gochecknoglobals // export_test.go exposes internals for external test package
+var (
+	ExportCheckCurrentKueueState = (*RHBOKMigrationAction).checkCurrentKueueState
+	ExportCheckNoRHBOKConflicts  = (*RHBOKMigrationAction).checkNoRHBOKConflicts
+	ExportVerifyKueueResources   = (*RHBOKMigrationAction).verifyKueueResources
+	ExportCheckKueueManaged      = (*RHBOKMigrationAction).checkKueueManaged
+	ExportPreserveKueueConfig    = (*RHBOKMigrationAction).preserveKueueConfig
+	ExportInstallRHBOKOperator   = (*RHBOKMigrationAction).installRHBOKOperator
+	ExportUpdateDSC              = (*RHBOKMigrationAction).updateDataScienceCluster
+	ExportVerifyResources        = (*RHBOKMigrationAction).verifyResourcesPreserved
+	ExportPreparePermissions     = preparePermissions
+	ExportRunPermissions         = runPermissions
+
+	ExportConfigMapName         = configMapName
+	ExportApplicationsNamespace = applicationsNamespace
+	ExportOperatorNamespace     = operatorNamespace
+	ExportSubscriptionName      = subscriptionName
+	ExportCSVNamePrefix         = csvNamePrefix
+)
+
+func ExportVerifyRBAC(a *RHBOKMigrationAction, ctx context.Context, target action.Target, checks []rbac.PermissionCheck) {
+	a.verifyRBAC(ctx, target, checks)
+}

--- a/pkg/migrate/actions/kueue/rhbok/helpers_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/helpers_test.go
@@ -1,0 +1,196 @@
+package rhbok_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+//nolint:gochecknoglobals // test-only GVR→ListKind mapping for fake dynamic client
+var testListKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceClusterV1.GVR(): resources.DataScienceClusterV1.ListKind(),
+	resources.ClusterQueue.GVR():         resources.ClusterQueue.ListKind(),
+	resources.LocalQueue.GVR():           resources.LocalQueue.ListKind(),
+	resources.Subscription.GVR():         resources.Subscription.ListKind(),
+	resources.ConfigMap.GVR():            resources.ConfigMap.ListKind(),
+}
+
+type targetOpts struct {
+	dryRun         bool
+	skipConfirm    bool
+	outputDir      string
+	olmObjects     []runtime.Object
+	rbacAllowed    bool
+	dynamicReactor func(k8stesting.Action) (bool, runtime.Object, error)
+}
+
+func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOpts) action.Target {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	if opts.dynamicReactor != nil {
+		dynamicClient.PrependReactor("*", "*", opts.dynamicReactor)
+	}
+
+	olmClient := operatorfake.NewSimpleClientset(opts.olmObjects...) //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+
+	kubeClient := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+	kubeClient.PrependReactor("create", "selfsubjectaccessreviews",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{Allowed: opts.rbacAllowed},
+			}, nil
+		},
+	)
+
+	testClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic:    dynamicClient,
+		OLM:        olmClient,
+		Kubernetes: kubeClient,
+	})
+
+	outputDir := opts.outputDir
+	if outputDir == "" {
+		outputDir = t.TempDir()
+	}
+
+	currentVersion := semver.MustParse("2.25.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	return action.Target{
+		Client:         testClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         opts.dryRun,
+		SkipConfirm:    opts.skipConfirm,
+		OutputDir:      outputDir,
+		Recorder:       action.NewRootRecorder(),
+		IO:             iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}),
+	}
+}
+
+type objOption func(*unstructured.Unstructured)
+
+func withComponent(name, state string) objOption {
+	return func(obj *unstructured.Unstructured) {
+		components, _, _ := unstructured.NestedMap(obj.Object, "spec", "components")
+		if components == nil {
+			components = map[string]any{}
+		}
+
+		components[name] = map[string]any{"managementState": state}
+		_ = unstructured.SetNestedField(obj.Object, components, "spec", "components")
+	}
+}
+
+func inNamespace(ns string) objOption {
+	return func(obj *unstructured.Unstructured) {
+		obj.SetNamespace(ns)
+	}
+}
+
+func withAnnotation(key, value string) objOption {
+	return func(obj *unstructured.Unstructured) {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		annotations[key] = value
+		obj.SetAnnotations(annotations)
+	}
+}
+
+func makeObj(rt resources.ResourceType, name string, opts ...objOption) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": rt.APIVersion(),
+			"kind":       rt.Kind,
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return obj
+}
+
+func makeDSCV1(name string, opts ...objOption) *unstructured.Unstructured {
+	return makeObj(resources.DataScienceClusterV1, name, opts...)
+}
+
+func makeConfigMap(name string, opts ...objOption) *unstructured.Unstructured {
+	obj := makeObj(resources.ConfigMap, name, opts...)
+	if _, ok, _ := unstructured.NestedMap(obj.Object, "data"); !ok {
+		_ = unstructured.SetNestedField(obj.Object, map[string]any{"config.yaml": "test-config-data"}, "data")
+	}
+
+	return obj
+}
+
+func makeClusterQueue(name string, opts ...objOption) *unstructured.Unstructured {
+	return makeObj(resources.ClusterQueue, name, opts...)
+}
+
+func makeLocalQueue(name string, opts ...objOption) *unstructured.Unstructured {
+	return makeObj(resources.LocalQueue, name, opts...)
+}
+
+func makeSubscription(name string, opts ...objOption) *unstructured.Unstructured {
+	return makeObj(resources.Subscription, name, opts...)
+}
+
+func newOLMSubscription(name, namespace string) *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func newOLMCSV(name, namespace string) *operatorsv1alpha1.ClusterServiceVersion {
+	return &operatorsv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: operatorsv1alpha1.ClusterServiceVersionStatus{
+			Phase: operatorsv1alpha1.CSVPhaseSucceeded,
+		},
+	}
+}

--- a/pkg/migrate/actions/kueue/rhbok/prepare_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/prepare_task.go
@@ -3,7 +3,6 @@ package rhbok
 import (
 	"context"
 	"errors"
-	"path/filepath"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +22,7 @@ func (t *prepareTask) Validate(
 	ctx context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
+	t.action.verifyRBAC(ctx, target, preparePermissions())
 	t.action.checkCurrentKueueState(ctx, target)
 	t.action.verifyKueueResources(ctx, target)
 
@@ -144,14 +144,11 @@ func (t *prepareTask) backupConfigMap(
 		return
 	}
 
-	// Write namespaced resources to namespace directory
-	outputDir := filepath.Join(target.OutputDir, applicationsNamespace)
-
-	if err := backup.WriteResourcesToDir(outputDir, resources.ConfigMap.GVR(), []*unstructured.Unstructured{obj}); err != nil {
+	if err := backup.WriteResourcesToDir(target.OutputDir, resources.ConfigMap.GVR(), []*unstructured.Unstructured{obj}); err != nil {
 		step.Complete(result.StepFailed, "Failed to write ConfigMap: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "Backed up ConfigMap %s to %s", configMapName, outputDir)
+	step.Complete(result.StepCompleted, "Backed up ConfigMap %s to %s", configMapName, target.OutputDir)
 }

--- a/pkg/migrate/actions/kueue/rhbok/prepare_task_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/prepare_task_test.go
@@ -1,0 +1,331 @@
+package rhbok_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPrepareTask_Validate(t *testing.T) {
+	t.Run("runs preflight checks and builds result", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cq}, targetOpts{rbacAllowed: true})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Validate(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+		g.Expect(res.Status.Steps).To(HaveLen(3))
+	})
+
+	t.Run("reports failure when DSC not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Validate(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		dscStep := findStep(res.Status.Steps, "check-kueue-state")
+		g.Expect(dscStep).ToNot(BeNil())
+		g.Expect(dscStep.Status).To(Equal(result.StepFailed))
+	})
+}
+
+func TestPrepareTask_Execute(t *testing.T) {
+	t.Run("backs up ClusterQueues and ConfigMap when Kueue is Managed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		outputDir := t.TempDir()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cq := makeClusterQueue("test-cq")
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cq, cm}, targetOpts{
+			rbacAllowed: true,
+			outputDir:   outputDir,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+
+		cqFiles, err := filepath.Glob(filepath.Join(outputDir, "cluster-scoped", "clusterqueues*"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cqFiles).To(HaveLen(1))
+
+		cmFiles, err := filepath.Glob(filepath.Join(outputDir, rhbok.ExportApplicationsNamespace, "configmaps*"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmFiles).To(HaveLen(1))
+	})
+
+	t.Run("skips backup when Kueue is not managed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		outputDir := t.TempDir()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			outputDir:   outputDir,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Find the backup-skipped step
+		found := false
+		for _, step := range res.Status.Steps {
+			if step.Name == "backup-skipped" {
+				found = true
+				g.Expect(step.Status).To(Equal(result.StepSkipped))
+			}
+		}
+		g.Expect(found).To(BeTrue())
+
+		entries, err := os.ReadDir(outputDir)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(entries).To(BeEmpty())
+	})
+
+	t.Run("dry-run skips backup writes", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		outputDir := t.TempDir()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cq}, targetOpts{
+			dryRun:      true,
+			rbacAllowed: true,
+			outputDir:   outputDir,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+
+		entries, err := os.ReadDir(outputDir)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(entries).To(BeEmpty())
+	})
+
+	t.Run("no ClusterQueues skips ClusterQueue backup", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		outputDir := t.TempDir()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm}, targetOpts{
+			rbacAllowed: true,
+			outputDir:   outputDir,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+
+		cqFiles, err := filepath.Glob(filepath.Join(outputDir, "cluster-scoped", "clusterqueues*"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cqFiles).To(BeEmpty())
+	})
+
+	t.Run("ConfigMap not found skips ConfigMap backup", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		outputDir := t.TempDir()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cq}, targetOpts{
+			rbacAllowed: true,
+			outputDir:   outputDir,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+
+		cmFiles, err := filepath.Glob(filepath.Join(outputDir, rhbok.ExportApplicationsNamespace, "configmaps*"))
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmFiles).To(BeEmpty())
+	})
+}
+
+func TestPrepareTask_Execute_BackupNotFound(t *testing.T) {
+	t.Run("ClusterQueue CRD not found skips backup", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "clusterqueues" {
+					return true, nil, apierrors.NewNotFound(
+						schema.GroupResource{Group: "kueue.x-k8s.io", Resource: "clusterqueues"}, "")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		backupStep := findStepRecursive(res.Status.Steps, "backup-clusterqueues")
+		g.Expect(backupStep).ToNot(BeNil())
+		g.Expect(backupStep.Status).To(Equal(result.StepSkipped))
+		g.Expect(backupStep.Message).To(ContainSubstring("No ClusterQueue CRD found"))
+	})
+
+	t.Run("ConfigMap not found skips backup", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cq := makeClusterQueue("cq-1")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cq}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "configmaps" && act.GetVerb() == "get" {
+					return true, nil, apierrors.NewNotFound(
+						schema.GroupResource{Resource: "configmaps"}, rhbok.ExportConfigMapName)
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cmStep := findStepRecursive(res.Status.Steps, "backup-configmap")
+		g.Expect(cmStep).ToNot(BeNil())
+		g.Expect(cmStep.Status).To(Equal(result.StepSkipped))
+	})
+}
+
+func TestPrepareTask_Execute_BackupErrors(t *testing.T) {
+	t.Run("ClusterQueue list error fails backup", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "clusterqueues" {
+					return true, nil, errors.New("forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		backupStep := findStepRecursive(res.Status.Steps, "backup-clusterqueues")
+		g.Expect(backupStep).ToNot(BeNil())
+		g.Expect(backupStep.Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("ConfigMap get error fails backup", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "configmaps" && act.GetVerb() == "get" {
+					return true, nil, errors.New("forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cmStep := findStepRecursive(res.Status.Steps, "backup-configmap")
+		g.Expect(cmStep).ToNot(BeNil())
+		g.Expect(cmStep.Status).To(Equal(result.StepFailed))
+	})
+}
+
+func findStep(steps []result.ActionStep, name string) *result.ActionStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+	}
+
+	return nil
+}
+
+func findStepRecursive(steps []result.ActionStep, name string) *result.ActionStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+
+		if found := findStepRecursive(steps[i].Children, name); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok.go
@@ -76,6 +76,10 @@ func (a *RHBOKMigrationAction) Phase() action.ActionPhase {
 }
 
 func (a *RHBOKMigrationAction) CanApply(target action.Target) bool {
+	if target.CurrentVersion == nil {
+		return false
+	}
+
 	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
 }
 
@@ -96,9 +100,7 @@ func (a *RHBOKMigrationAction) checkKueueManaged(
 		"Check if Kueue is managed by DataScienceCluster",
 	)
 
-	dsc, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
-		Namespace("").
-		Get(ctx, "default-dsc", metav1.GetOptions{})
+	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 
 	if err != nil {
 		step.Complete(result.StepFailed, "Failed to get DataScienceCluster: %v", err)

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
@@ -2,6 +2,7 @@ package rhbok
 
 import (
 	"context"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,7 +12,66 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/rbac"
 )
+
+func preparePermissions() []rbac.PermissionCheck {
+	return []rbac.PermissionCheck{
+		{Verb: "get", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
+		{Verb: "list", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
+		{Verb: "list", Group: resources.ClusterQueue.Group, Resource: resources.ClusterQueue.Resource},
+		{Verb: "list", Group: resources.LocalQueue.Group, Resource: resources.LocalQueue.Resource},
+		{Verb: "get", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
+	}
+}
+
+func runPermissions() []rbac.PermissionCheck {
+	return []rbac.PermissionCheck{
+		{Verb: "get", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
+		{Verb: "list", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
+		{Verb: "update", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
+		{Verb: "get", Group: resources.Subscription.Group, Resource: resources.Subscription.Resource, Namespace: operatorNamespace},
+		{Verb: "create", Group: resources.Subscription.Group, Resource: resources.Subscription.Resource, Namespace: operatorNamespace},
+		{Verb: "list", Group: resources.ClusterServiceVersion.Group, Resource: resources.ClusterServiceVersion.Resource, Namespace: operatorNamespace},
+		{Verb: "list", Group: resources.ClusterQueue.Group, Resource: resources.ClusterQueue.Resource},
+		{Verb: "list", Group: resources.LocalQueue.Group, Resource: resources.LocalQueue.Resource},
+		{Verb: "get", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
+		{Verb: "update", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
+	}
+}
+
+func (a *RHBOKMigrationAction) verifyRBAC(
+	ctx context.Context,
+	target action.Target,
+	checks []rbac.PermissionCheck,
+) {
+	step := target.Recorder.Child(
+		"verify-rbac",
+		"Verify RBAC permissions",
+	)
+
+	denied, err := rbac.CheckPermissions(ctx, target.Client.AuthorizationV1(), checks)
+	if err != nil {
+		step.Complete(result.StepFailed, "Failed to verify RBAC permissions: %v", err)
+
+		return
+	}
+
+	if len(denied) > 0 {
+		for _, d := range denied {
+			step.Child(
+				fmt.Sprintf("denied-%s-%s", d.Verb, d.Resource),
+				fmt.Sprintf("Missing permission: %s", d),
+			).Complete(result.StepFailed, "Permission denied: %s", d)
+		}
+
+		step.Complete(result.StepFailed, "%d required permission(s) denied", len(denied))
+
+		return
+	}
+
+	step.Complete(result.StepCompleted, "All %d required permissions verified", len(checks))
+}
 
 func (a *RHBOKMigrationAction) checkCurrentKueueState(
 	ctx context.Context,

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight_test.go
@@ -1,0 +1,377 @@
+package rhbok_test
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/rbac"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCheckCurrentKueueState(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("DSC with Kueue Managed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckCurrentKueueState(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Managed"))
+	})
+
+	t.Run("DSC with Kueue Unmanaged", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckCurrentKueueState(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Unmanaged"))
+	})
+
+	t.Run("DSC not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckCurrentKueueState(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("not found"))
+	})
+
+	t.Run("Kueue component missing in DSC", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("codeflare", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckCurrentKueueState(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("empty managementState", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", ""))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckCurrentKueueState(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("not configured"))
+	})
+}
+
+func TestCheckNoRHBOKConflicts(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("no subscription exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckNoRHBOKConflicts(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("No"))
+	})
+
+	t.Run("subscription already exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		sub := makeSubscription("kueue-operator", inNamespace("openshift-kueue-operator"))
+		target := newTarget(t, []*unstructured.Unstructured{sub}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportCheckNoRHBOKConflicts(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("already installed"))
+	})
+}
+
+func TestVerifyKueueResources(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("ClusterQueues and LocalQueues exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		cq := makeClusterQueue("test-cq")
+		lq := makeLocalQueue("test-lq", inNamespace("default"))
+		target := newTarget(t, []*unstructured.Unstructured{cq, lq}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportVerifyKueueResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("1 ClusterQueues"))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("1 LocalQueues"))
+	})
+
+	t.Run("no resources", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportVerifyKueueResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("0 ClusterQueues"))
+	})
+}
+
+func TestVerifyRBAC(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("all permissions allowed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		checks := []rbac.PermissionCheck{
+			{Verb: "get", Group: "apps", Resource: "deployments"},
+		}
+		rhbok.ExportVerifyRBAC(a, ctx, target, checks)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("1 required permissions verified"))
+	})
+
+	t.Run("some permissions denied", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		target := newTarget(t, nil, targetOpts{rbacAllowed: false})
+
+		checks := []rbac.PermissionCheck{
+			{Verb: "get", Group: "apps", Resource: "deployments"},
+			{Verb: "create", Group: "apps", Resource: "deployments"},
+		}
+		rhbok.ExportVerifyRBAC(a, ctx, target, checks)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("2 required permission(s) denied"))
+		g.Expect(res.Status.Steps[0].Children).To(HaveLen(2))
+	})
+}
+
+func TestCheckCurrentKueueState_APIError(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("non-NotFound error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "datascienceclusters" && act.GetVerb() == "list" {
+					return true, nil, errors.New("server timeout")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		rhbok.ExportCheckCurrentKueueState(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Failed to get"))
+	})
+}
+
+func TestCheckNoRHBOKConflicts_APIError(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("non-NotFound error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "subscriptions" && act.GetVerb() == "get" {
+					return true, nil, errors.New("server unavailable")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		rhbok.ExportCheckNoRHBOKConflicts(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Failed to check"))
+	})
+}
+
+func TestVerifyKueueResources_ListErrors(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("ClusterQueue list error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "clusterqueues" && act.GetVerb() == "list" {
+					return true, nil, errors.New("forbidden: cluster admin required")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		rhbok.ExportVerifyKueueResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Failed to list ClusterQueues"))
+	})
+
+	t.Run("LocalQueue list error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{cq}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "localqueues" && act.GetVerb() == "list" {
+					return true, nil, errors.New("forbidden: cluster admin required")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		rhbok.ExportVerifyKueueResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Failed to list LocalQueues"))
+	})
+}
+
+func TestVerifyKueueResources_MultipleResources(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("multiple ClusterQueues and LocalQueues", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		cq1 := makeClusterQueue("cq-1")
+		cq2 := makeClusterQueue("cq-2")
+		lq1 := makeLocalQueue("lq-1", inNamespace("default"))
+		lq2 := makeLocalQueue("lq-2", inNamespace("team-a"))
+		lq3 := makeLocalQueue("lq-3", inNamespace("team-b"))
+		target := newTarget(t, []*unstructured.Unstructured{cq1, cq2, lq1, lq2, lq3}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportVerifyKueueResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("2 ClusterQueues"))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("3 LocalQueues"))
+	})
+
+	t.Run("only ClusterQueues no LocalQueues", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		cq := makeClusterQueue("cq-1")
+		target := newTarget(t, []*unstructured.Unstructured{cq}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportVerifyKueueResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("1 ClusterQueues"))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("0 LocalQueues"))
+	})
+}
+
+func TestCheckKueueManaged(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("Kueue is Managed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		result := rhbok.ExportCheckKueueManaged(a, ctx, target)
+		g.Expect(result).To(BeTrue())
+	})
+
+	t.Run("Kueue is Unmanaged", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		result := rhbok.ExportCheckKueueManaged(a, ctx, target)
+		g.Expect(result).To(BeFalse())
+	})
+
+	t.Run("DSC not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		result := rhbok.ExportCheckKueueManaged(a, ctx, target)
+		g.Expect(result).To(BeFalse())
+	})
+
+	t.Run("Kueue component not in DSC", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("codeflare", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
+
+		result := rhbok.ExportCheckKueueManaged(a, ctx, target)
+		g.Expect(result).To(BeFalse())
+	})
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_test.go
@@ -1,0 +1,60 @@
+package rhbok_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRHBOKMigrationAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+	a := &rhbok.RHBOKMigrationAction{}
+
+	g.Expect(a.ID()).To(Equal("kueue.rhbok.migrate"))
+	g.Expect(a.Name()).ToNot(BeEmpty())
+	g.Expect(a.Description()).ToNot(BeEmpty())
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.Prepare()).ToNot(BeNil())
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestRHBOKMigrationAction_CanApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected bool
+	}{
+		{name: "2.24 too old", version: "2.24.0", expected: false},
+		{name: "2.25 minimum", version: "2.25.0", expected: true},
+		{name: "2.26", version: "2.26.0", expected: true},
+		{name: "2.99", version: "2.99.0", expected: true},
+		{name: "3.0 wrong major", version: "3.0.0", expected: false},
+		{name: "1.0 wrong major", version: "1.0.0", expected: false},
+	}
+
+	t.Run("nil CurrentVersion", func(t *testing.T) {
+		g := NewWithT(t)
+		a := &rhbok.RHBOKMigrationAction{}
+
+		target := action.Target{CurrentVersion: nil}
+		g.Expect(a.CanApply(target)).To(BeFalse())
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			a := &rhbok.RHBOKMigrationAction{}
+
+			v := semver.MustParse(tt.version)
+			target := action.Target{CurrentVersion: &v}
+
+			g.Expect(a.CanApply(target)).To(Equal(tt.expected))
+		})
+	}
+}

--- a/pkg/migrate/actions/kueue/rhbok/run_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/run_task.go
@@ -16,6 +16,7 @@ func (t *runTask) Validate(
 	ctx context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
+	t.action.verifyRBAC(ctx, target, runPermissions())
 	t.action.checkCurrentKueueState(ctx, target)
 	t.action.checkNoRHBOKConflicts(ctx, target)
 	t.action.verifyKueueResources(ctx, target)

--- a/pkg/migrate/actions/kueue/rhbok/run_task_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/run_task_test.go
@@ -1,0 +1,941 @@
+package rhbok_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRunTask_Validate(t *testing.T) {
+	t.Run("runs all preflight checks", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cq}, targetOpts{rbacAllowed: true})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Validate(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+		// checkCurrentKueueState + checkNoRHBOKConflicts + verifyKueueResources + verifyRBAC
+		g.Expect(res.Status.Steps).To(HaveLen(4))
+	})
+
+	t.Run("reports RBAC failure", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: false})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Validate(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		rbacStep := findStep(res.Status.Steps, "verify-rbac")
+		g.Expect(rbacStep).ToNot(BeNil())
+		g.Expect(rbacStep.Status).To(Equal(result.StepFailed))
+	})
+}
+
+func TestRunTask_Execute(t *testing.T) {
+	t.Run("dry-run reports all steps as skipped", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm, cq}, targetOpts{
+			dryRun:      true,
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).ToNot(BeNil())
+
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepSkipped))
+
+		installStep := findStep(res.Status.Steps, "install-rhbok-operator")
+		g.Expect(installStep).ToNot(BeNil())
+		g.Expect(installStep.Status).To(Equal(result.StepSkipped))
+
+		updateStep := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(updateStep).ToNot(BeNil())
+		g.Expect(updateStep.Status).To(Equal(result.StepSkipped))
+
+		verifyStep := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(verifyStep).ToNot(BeNil())
+		g.Expect(verifyStep.Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("skips preserveKueueConfig when Kueue is not managed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			dryRun:      true,
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).To(BeNil())
+	})
+
+	t.Run("DSC already Unmanaged skips update", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		sub := makeSubscription(rhbok.ExportSubscriptionName, inNamespace(rhbok.ExportOperatorNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, sub}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updateStep := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(updateStep).ToNot(BeNil())
+		g.Expect(updateStep.Status).To(Equal(result.StepSkipped))
+		g.Expect(updateStep.Message).To(ContainSubstring("already set to Unmanaged"))
+	})
+
+	t.Run("preserveKueueConfig annotates ConfigMap", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm}, targetOpts{
+			dryRun:      true,
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepSkipped))
+		g.Expect(configStep.Message).To(ContainSubstring("Dry-run"))
+	})
+
+	t.Run("preserveKueueConfig skips when ConfigMap not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepSkipped))
+		g.Expect(configStep.Message).To(ContainSubstring("not found"))
+	})
+
+	t.Run("verifyResourcesPreserved reports counts", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq1 := makeClusterQueue("cq-1")
+		cq2 := makeClusterQueue("cq-2")
+		lq := makeLocalQueue("lq-1", inNamespace("default"))
+		target := newTarget(t, []*unstructured.Unstructured{cq1, cq2, lq}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("2 ClusterQueues"))
+		g.Expect(step.Message).To(ContainSubstring("1 LocalQueues"))
+	})
+
+	t.Run("verifyResourcesPreserved dry-run skips", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			dryRun:      true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("updateDataScienceCluster updates to Unmanaged", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportUpdateDSC(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("updated successfully"))
+	})
+
+	t.Run("updateDataScienceCluster dry-run skips", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			dryRun:      true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportUpdateDSC(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+		g.Expect(step.Message).To(ContainSubstring("Would set"))
+	})
+
+	t.Run("updateDataScienceCluster fails when DSC not found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportUpdateDSC(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("preserveKueueConfig annotates ConfigMap in non-dry-run", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{cm}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepCompleted))
+		g.Expect(configStep.Message).To(ContainSubstring("annotated for preservation"))
+	})
+
+	t.Run("installRHBOKOperator with existing subscription and CSV", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportInstallRHBOKOperator(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "install-rhbok-operator")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("already installed"))
+	})
+
+	t.Run("installRHBOKOperator dry-run no subscription", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			dryRun:      true,
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportInstallRHBOKOperator(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "install-rhbok-operator")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("installRHBOKOperator dry-run with existing subscription and CSV", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			dryRun:      true,
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportInstallRHBOKOperator(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "install-rhbok-operator")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("preserveKueueConfig annotates ConfigMap with existing annotations", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace), withAnnotation("existing-key", "existing-value"))
+		target := newTarget(t, []*unstructured.Unstructured{cm}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepCompleted))
+
+		annotateStep := findStepRecursive(res.Status.Steps, "apply-annotation")
+		g.Expect(annotateStep).ToNot(BeNil())
+		g.Expect(annotateStep.Status).To(Equal(result.StepCompleted))
+	})
+
+	t.Run("preserveKueueConfig with ConfigMap no annotations", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{cm}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepCompleted))
+	})
+
+	t.Run("verifyResourcesPreserved with ClusterQueues only", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{cq}, targetOpts{
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("1 ClusterQueues"))
+		g.Expect(step.Message).To(ContainSubstring("0 LocalQueues"))
+	})
+
+	t.Run("verifyResourcesPreserved no resources returns completed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+	})
+
+	t.Run("verifyResourcesPreserved ClusterQueue list error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "clusterqueues" {
+					return true, nil, errors.New("connection refused")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("Failed to list ClusterQueues"))
+	})
+
+	t.Run("preserveKueueConfig update error fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{cm}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "configmaps" && act.GetVerb() == "update" {
+					return true, nil, errors.New("update forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("updateDataScienceCluster update error fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "datascienceclusters" && act.GetVerb() == "update" {
+					return true, nil, errors.New("update forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportUpdateDSC(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("installRHBOKOperator user cancels prompt", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		inBuf := bytes.NewBufferString("n\n")
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+		})
+		target.IO = iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportInstallRHBOKOperator(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "install-rhbok-operator")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+		g.Expect(step.Message).To(ContainSubstring("cancelled"))
+	})
+
+	t.Run("updateDataScienceCluster user cancels prompt", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		inBuf := bytes.NewBufferString("n\n")
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+		})
+		target.IO = iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportUpdateDSC(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+		g.Expect(step.Message).To(ContainSubstring("cancelled"))
+	})
+
+	t.Run("full flow with existing operator", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		cq := makeClusterQueue("cq-1")
+		lq := makeLocalQueue("lq-1", inNamespace("default"))
+		sub := makeSubscription(rhbok.ExportSubscriptionName, inNamespace(rhbok.ExportOperatorNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm, cq, lq, sub}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepCompleted))
+
+		installStep := findStep(res.Status.Steps, "install-rhbok-operator")
+		g.Expect(installStep).ToNot(BeNil())
+		g.Expect(installStep.Status).To(Equal(result.StepCompleted))
+
+		updateStep := findStep(res.Status.Steps, "update-datasciencecluster")
+		g.Expect(updateStep).ToNot(BeNil())
+		g.Expect(updateStep.Status).To(Equal(result.StepCompleted))
+
+		verifyStep := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(verifyStep).ToNot(BeNil())
+		g.Expect(verifyStep.Status).To(Equal(result.StepCompleted))
+	})
+
+	t.Run("verifyResourcesPreserved LocalQueue list error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq := makeClusterQueue("cq-1")
+		target := newTarget(t, []*unstructured.Unstructured{cq}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "localqueues" {
+					return true, nil, errors.New("connection refused")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("Failed to list LocalQueues"))
+	})
+
+	t.Run("verifyResourcesPreserved ClusterQueue NotFound returns completed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "clusterqueues" {
+					return true, nil, apierrors.NewNotFound(
+						schema.GroupResource{Group: "kueue.x-k8s.io", Resource: "clusterqueues"}, "")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("No ClusterQueue CRD found"))
+	})
+
+	t.Run("verifyResourcesPreserved LocalQueue NotFound returns completed with CQ count", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq := makeClusterQueue("cq-1")
+		target := newTarget(t, []*unstructured.Unstructured{cq}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "localqueues" {
+					return true, nil, apierrors.NewNotFound(
+						schema.GroupResource{Group: "kueue.x-k8s.io", Resource: "localqueues"}, "")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("No LocalQueue CRD found"))
+		g.Expect(step.Message).To(ContainSubstring("1 ClusterQueues"))
+	})
+
+	t.Run("updateDataScienceCluster verifies DSC state mutated", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportUpdateDSC(a, ctx, target)
+
+		fetched, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
+			Get(ctx, "default-dsc", metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		state, err := jq.Query[string](fetched, ".spec.components.kueue.managementState")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal("Unmanaged"))
+	})
+
+	t.Run("preserveKueueConfig verifies annotation written", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{cm}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		fetched, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+			Namespace(rhbok.ExportApplicationsNamespace).
+			Get(ctx, rhbok.ExportConfigMapName, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := fetched.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("opendatahub.io/managed", "false"))
+	})
+
+	t.Run("preserveKueueConfig preserves existing annotations", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace), withAnnotation("existing-key", "existing-value"))
+		target := newTarget(t, []*unstructured.Unstructured{cm}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		fetched, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+			Namespace(rhbok.ExportApplicationsNamespace).
+			Get(ctx, rhbok.ExportConfigMapName, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := fetched.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("opendatahub.io/managed", "false"))
+		g.Expect(annotations).To(HaveKeyWithValue("existing-key", "existing-value"))
+	})
+
+	t.Run("dry-run does not mutate DSC state", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		cq := makeClusterQueue("test-cq")
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm, cq}, targetOpts{
+			dryRun:      true,
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		_, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		fetchedDSC, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
+			Get(ctx, "default-dsc", metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		state, err := jq.Query[string](fetchedDSC, ".spec.components.kueue.managementState")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal("Managed"))
+
+		fetchedCM, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+			Namespace(rhbok.ExportApplicationsNamespace).
+			Get(ctx, rhbok.ExportConfigMapName, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(fetchedCM.GetAnnotations()).ToNot(HaveKey("opendatahub.io/managed"))
+	})
+
+	t.Run("full flow verifies k8s state after execution", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		cq := makeClusterQueue("cq-1")
+		lq := makeLocalQueue("lq-1", inNamespace("default"))
+		sub := makeSubscription(rhbok.ExportSubscriptionName, inNamespace(rhbok.ExportOperatorNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm, cq, lq, sub}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		_, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// DSC should now have Kueue set to Unmanaged
+		fetchedDSC, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
+			Get(ctx, "default-dsc", metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		state, err := jq.Query[string](fetchedDSC, ".spec.components.kueue.managementState")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal("Unmanaged"))
+
+		// ConfigMap should have the preservation annotation
+		fetchedCM, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
+			Namespace(rhbok.ExportApplicationsNamespace).
+			Get(ctx, rhbok.ExportConfigMapName, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(fetchedCM.GetAnnotations()).To(HaveKeyWithValue("opendatahub.io/managed", "false"))
+
+		// Kueue resources should still exist
+		cqs, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cqs).To(HaveLen(1))
+
+		lqs, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(lqs).To(HaveLen(1))
+	})
+
+	t.Run("idempotent: second run on already-migrated cluster is a no-op", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
+		cq := makeClusterQueue("cq-1")
+		sub := makeSubscription(rhbok.ExportSubscriptionName, inNamespace(rhbok.ExportOperatorNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, cm, cq, sub}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		// First run — performs the migration
+		res1, err := task.Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updateStep1 := findStep(res1.Status.Steps, "update-datasciencecluster")
+		g.Expect(updateStep1).ToNot(BeNil())
+		g.Expect(updateStep1.Status).To(Equal(result.StepCompleted))
+
+		// Second run on the same target — DSC is already Unmanaged, operator already installed
+		target2 := newTarget(t, nil, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+		// Re-use the same dynamic client so we see the mutated state from run 1
+		target2.Client = target.Client
+		target2.IO = target.IO
+
+		task2 := a.Run()
+		res2, err := task2.Execute(ctx, target2)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// DSC update should be skipped — already Unmanaged
+		updateStep2 := findStep(res2.Status.Steps, "update-datasciencecluster")
+		g.Expect(updateStep2).ToNot(BeNil())
+		g.Expect(updateStep2.Status).To(Equal(result.StepSkipped))
+		g.Expect(updateStep2.Message).To(ContainSubstring("already set to Unmanaged"))
+
+		// Operator install should report already installed
+		installStep2 := findStep(res2.Status.Steps, "install-rhbok-operator")
+		g.Expect(installStep2).ToNot(BeNil())
+		g.Expect(installStep2.Status).To(Equal(result.StepCompleted))
+		g.Expect(installStep2.Message).To(ContainSubstring("already installed"))
+
+		// Resources should still be preserved
+		verifyStep2 := findStep(res2.Status.Steps, "verify-resources-preserved")
+		g.Expect(verifyStep2).ToNot(BeNil())
+		g.Expect(verifyStep2.Status).To(Equal(result.StepCompleted))
+
+		// Verify final k8s state is unchanged from first run
+		fetchedDSC, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
+			Get(ctx, "default-dsc", metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		state, err := jq.Query[string](fetchedDSC, ".spec.components.kueue.managementState")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal("Unmanaged"))
+	})
+
+	t.Run("preserveKueueConfig get error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "configmaps" && act.GetVerb() == "get" {
+					return true, nil, errors.New("server error")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		rhbok.ExportPreserveKueueConfig(a, ctx, target)
+
+		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
+		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
+		g.Expect(configStep).ToNot(BeNil())
+		g.Expect(configStep.Status).To(Equal(result.StepSkipped))
+	})
+}

--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
@@ -55,6 +56,14 @@ func (c *defaultClient) CoreV1() corev1client.CoreV1Interface {
 	}
 
 	return c.kubernetes.CoreV1()
+}
+
+func (c *defaultClient) AuthorizationV1() authorizationv1client.AuthorizationV1Interface {
+	if c.kubernetes == nil {
+		panic("AuthorizationV1 called on a client with no kubernetes client configured")
+	}
+
+	return c.kubernetes.AuthorizationV1()
 }
 
 // NewClientWithConfig creates a client from a pre-configured REST config.

--- a/pkg/util/client/interfaces.go
+++ b/pkg/util/client/interfaces.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
 
@@ -116,6 +117,9 @@ type Client interface {
 
 	// CoreV1 returns the typed CoreV1 client for pod operations like GetLogs.
 	CoreV1() corev1client.CoreV1Interface
+
+	// AuthorizationV1 returns the typed AuthorizationV1 client for RBAC permission checks.
+	AuthorizationV1() authorizationv1client.AuthorizationV1Interface
 }
 
 // OLMReader provides read-only access to OLM resources.

--- a/pkg/util/kube/rbac/check.go
+++ b/pkg/util/kube/rbac/check.go
@@ -1,0 +1,71 @@
+package rbac
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+// PermissionCheck describes a single Kubernetes RBAC permission to verify.
+type PermissionCheck struct {
+	Verb      string
+	Group     string
+	Resource  string
+	Namespace string // empty = cluster-scoped
+}
+
+func (p PermissionCheck) String() string {
+	scope := "cluster"
+	if p.Namespace != "" {
+		scope = p.Namespace
+	}
+
+	groupSuffix := ""
+	if p.Group != "" {
+		groupSuffix = "." + p.Group
+	}
+
+	return fmt.Sprintf("%s %s%s [%s]", p.Verb, p.Resource, groupSuffix, scope)
+}
+
+// CheckPermissions verifies that the current user has all the specified permissions.
+// Returns the list of denied checks. An empty slice means all permissions are granted.
+func CheckPermissions(
+	ctx context.Context,
+	authClient authorizationv1client.AuthorizationV1Interface,
+	checks []PermissionCheck,
+) ([]PermissionCheck, error) {
+	if authClient == nil {
+		return nil, errors.New("authorization client is nil")
+	}
+
+	var denied []PermissionCheck
+
+	for _, check := range checks {
+		review := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Verb:      check.Verb,
+					Group:     check.Group,
+					Resource:  check.Resource,
+					Namespace: check.Namespace,
+				},
+			},
+		}
+
+		result, err := authClient.SelfSubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to check permission %s: %w", check, err)
+		}
+
+		if !result.Status.Allowed {
+			denied = append(denied, check)
+		}
+	}
+
+	return denied, nil
+}

--- a/pkg/util/kube/rbac/check_test.go
+++ b/pkg/util/kube/rbac/check_test.go
@@ -1,0 +1,134 @@
+package rbac_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/rbac"
+)
+
+func TestCheckPermissions_AllAllowed(t *testing.T) {
+	client := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+	client.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+			}, nil
+		},
+	)
+
+	checks := []rbac.PermissionCheck{
+		{Verb: "get", Group: "apps", Resource: "deployments"},
+		{Verb: "list", Group: "", Resource: "configmaps", Namespace: "default"},
+	}
+
+	denied, err := rbac.CheckPermissions(context.Background(), client.AuthorizationV1(), checks)
+	require.NoError(t, err)
+	assert.Empty(t, denied)
+}
+
+func TestCheckPermissions_SomeDenied(t *testing.T) {
+	client := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+	client.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			createAction := action.(k8stesting.CreateAction)
+			review := createAction.GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			allowed := review.Spec.ResourceAttributes.Verb != "create"
+
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{Allowed: allowed},
+			}, nil
+		},
+	)
+
+	checks := []rbac.PermissionCheck{
+		{Verb: "get", Group: "apps", Resource: "deployments"},
+		{Verb: "create", Group: "operators.coreos.com", Resource: "subscriptions", Namespace: "openshift-kueue-operator"},
+		{Verb: "list", Group: "", Resource: "configmaps"},
+	}
+
+	denied, err := rbac.CheckPermissions(context.Background(), client.AuthorizationV1(), checks)
+	require.NoError(t, err)
+	require.Len(t, denied, 1)
+	assert.Equal(t, "create", denied[0].Verb)
+	assert.Equal(t, "subscriptions", denied[0].Resource)
+}
+
+func TestCheckPermissions_AllDenied(t *testing.T) {
+	client := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+	client.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false},
+			}, nil
+		},
+	)
+
+	checks := []rbac.PermissionCheck{
+		{Verb: "get", Group: "apps", Resource: "deployments"},
+		{Verb: "create", Group: "apps", Resource: "deployments"},
+	}
+
+	denied, err := rbac.CheckPermissions(context.Background(), client.AuthorizationV1(), checks)
+	require.NoError(t, err)
+	assert.Len(t, denied, 2)
+}
+
+func TestCheckPermissions_APIError(t *testing.T) {
+	client := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+	client.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, assert.AnError
+		},
+	)
+
+	checks := []rbac.PermissionCheck{
+		{Verb: "get", Group: "apps", Resource: "deployments"},
+	}
+
+	denied, err := rbac.CheckPermissions(context.Background(), client.AuthorizationV1(), checks)
+	require.Error(t, err)
+	assert.Nil(t, denied)
+	assert.Contains(t, err.Error(), "failed to check permission")
+}
+
+func TestCheckPermissions_EmptyChecks(t *testing.T) {
+	client := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+
+	denied, err := rbac.CheckPermissions(context.Background(), client.AuthorizationV1(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, denied)
+}
+
+func TestPermissionCheck_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		check    rbac.PermissionCheck
+		expected string
+	}{
+		{
+			name:     "cluster-scoped",
+			check:    rbac.PermissionCheck{Verb: "list", Group: "kueue.x-k8s.io", Resource: "clusterqueues"},
+			expected: "list clusterqueues.kueue.x-k8s.io [cluster]",
+		},
+		{
+			name:     "namespaced",
+			check:    rbac.PermissionCheck{Verb: "get", Group: "", Resource: "configmaps", Namespace: "default"},
+			expected: "get configmaps [default]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.check.String())
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds unit test coverage to the existing Kueue migrate implementation
Adds RBAC check to `Validate()`

JIRA ref: [RHOAIENG-61429](https://redhat.atlassian.net/browse/RHOAIENG-61429)

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests
- [x] Manual test of commands against OpenShift cluster with RHOAI 2.25.6 installed 

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-based access control (RBAC) permission verification checks during migration preparation and execution to ensure required cluster permissions are available before proceeding with operations.
  * Enhanced version compatibility validation with improved null-value handling and better error detection.

* **Bug Fixes**
  * Corrected backup file location for configuration data during migration operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->