### PR TITLE
feat(components): add --from-stdin support for components(enable,disable) command 

### DIFF
--- a/cmd/components/components.go
+++ b/cmd/components/components.go
@@ -60,6 +60,7 @@ type command interface {
 type mutateCommand interface {
 	command
 	SetComponentName(name string)
+	IsFromStdin() bool
 }
 
 // runCommand executes the Complete/Validate/Run lifecycle with error handling.
@@ -150,9 +151,18 @@ func addMutateCommand(parent *cobra.Command, command mutateCommand, use, short s
 		Short:         short,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Args:          cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			// Allow 0 args when --from-stdin is set
+			if command.IsFromStdin() {
+				return cobra.MaximumNArgs(1)(cmd, args)
+			}
+
+			return cobra.ExactArgs(1)(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			command.SetComponentName(args[0])
+			if len(args) > 0 {
+				command.SetComponentName(args[0])
+			}
 
 			return runCommand(cmd, command, "")
 		},

--- a/pkg/components/commands.go
+++ b/pkg/components/commands.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -13,7 +15,9 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/stdin"
 )
 
 var (
@@ -27,9 +31,17 @@ type EnableCommand struct {
 	ConfigFlags *genericclioptions.ConfigFlags
 	Client      client.Client
 
+	// ComponentName is the single component name from positional arg (legacy).
 	ComponentName string
-	DryRun        bool
-	Yes           bool
+	// ComponentNames is the list of components to enable (from stdin or single name).
+	ComponentNames []string
+
+	DryRun    bool
+	Yes       bool
+	FromStdin bool
+
+	// flags stores the FlagSet for checking explicit flag usage.
+	flags *pflag.FlagSet
 }
 
 // NewEnableCommand creates a new EnableCommand with defaults.
@@ -48,14 +60,34 @@ func (c *EnableCommand) SetComponentName(name string) {
 	c.ComponentName = name
 }
 
+// IsFromStdin returns true if the command is reading from stdin.
+func (c *EnableCommand) IsFromStdin() bool {
+	return c.FromStdin
+}
+
 // AddFlags registers command-specific flags.
 func (c *EnableCommand) AddFlags(fs *pflag.FlagSet) {
+	c.flags = fs
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would change without applying")
 	fs.BoolVarP(&c.Yes, "yes", "y", false, "Skip confirmation prompt")
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
 }
 
 // Complete resolves derived fields after flag parsing.
 func (c *EnableCommand) Complete() error {
+	// Parse stdin configuration if --from-stdin is specified
+	if c.FromStdin {
+		if err := c.parseStdinConfig(); err != nil {
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation, err)
+		}
+	}
+
+	// Build ComponentNames from stdin input or single positional arg
+	if len(c.ComponentNames) == 0 && c.ComponentName != "" {
+		c.ComponentNames = []string{c.ComponentName}
+	}
+
 	k8sClient, err := client.NewClient(c.ConfigFlags)
 	if err != nil {
 		return fmt.Errorf("creating Kubernetes client: %w", err)
@@ -66,10 +98,65 @@ func (c *EnableCommand) Complete() error {
 	return nil
 }
 
+// parseStdinConfig reads and applies configuration from stdin.
+func (c *EnableCommand) parseStdinConfig() error {
+	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
+		c.IO.Errorf("%s", warnStdinIsTerminal)
+	}
+
+	var input StdinInput
+	if err := stdin.Parse(c.IO.In(), &input); err != nil {
+		return fmt.Errorf("parsing stdin: %w", err)
+	}
+
+	return c.applyStdinInput(&input)
+}
+
+// applyStdinInput merges stdin configuration into command options.
+// Explicit CLI flags take precedence over stdin values.
+func (c *EnableCommand) applyStdinInput(input *StdinInput) error {
+	for i, name := range input.Components {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("empty component name at index %d", i)
+		}
+
+		input.Components[i] = trimmed
+	}
+
+	if len(input.Components) > 0 && c.ComponentName != "" {
+		return errors.New("cannot specify both positional component and components in stdin")
+	}
+
+	if len(input.Components) > 0 {
+		c.ComponentNames = input.Components
+	}
+
+	if input.DryRun && !c.flagChanged("dry-run") {
+		c.DryRun = true
+	}
+
+	if input.SkipConfirm && !c.flagChanged("yes") {
+		c.Yes = true
+	}
+
+	return nil
+}
+
+// flagChanged returns true if the flag was explicitly set on the command line.
+func (c *EnableCommand) flagChanged(name string) bool {
+	if c.flags == nil {
+		return false
+	}
+	f := c.flags.Lookup(name)
+
+	return f != nil && f.Changed
+}
+
 // Validate checks that all options are valid before execution.
 func (c *EnableCommand) Validate() error {
-	if c.ComponentName == "" {
-		return errors.New("component name is required")
+	if len(c.ComponentNames) == 0 {
+		return errors.New("at least one component name is required")
 	}
 
 	return nil
@@ -77,15 +164,28 @@ func (c *EnableCommand) Validate() error {
 
 // Run executes the enable command.
 func (c *EnableCommand) Run(ctx context.Context) error {
-	return MutateComponentState(ctx, MutateConfig{
-		IO:            c.IO,
-		Client:        c.Client,
-		ComponentName: c.ComponentName,
-		TargetState:   constants.ManagementStateManaged,
-		ActionVerb:    "enable",
-		DryRun:        c.DryRun,
-		SkipConfirm:   c.Yes,
-	})
+	var failed []string
+
+	for _, componentName := range c.ComponentNames {
+		if err := MutateComponentState(ctx, MutateConfig{
+			IO:            c.IO,
+			Client:        c.Client,
+			ComponentName: componentName,
+			TargetState:   constants.ManagementStateManaged,
+			ActionVerb:    "enable",
+			DryRun:        c.DryRun,
+			SkipConfirm:   c.Yes,
+		}); err != nil {
+			c.IO.Errorf("Error enabling '%s': %v", componentName, err)
+			failed = append(failed, componentName)
+		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to enable %d component(s): %s", len(failed), strings.Join(failed, ", "))
+	}
+
+	return nil
 }
 
 // DisableCommand contains the disable subcommand configuration.
@@ -94,9 +194,17 @@ type DisableCommand struct {
 	ConfigFlags *genericclioptions.ConfigFlags
 	Client      client.Client
 
+	// ComponentName is the single component name from positional arg (legacy).
 	ComponentName string
-	DryRun        bool
-	Yes           bool
+	// ComponentNames is the list of components to disable (from stdin or single name).
+	ComponentNames []string
+
+	DryRun    bool
+	Yes       bool
+	FromStdin bool
+
+	// flags stores the FlagSet for checking explicit flag usage.
+	flags *pflag.FlagSet
 }
 
 // NewDisableCommand creates a new DisableCommand with defaults.
@@ -115,14 +223,34 @@ func (c *DisableCommand) SetComponentName(name string) {
 	c.ComponentName = name
 }
 
+// IsFromStdin returns true if the command is reading from stdin.
+func (c *DisableCommand) IsFromStdin() bool {
+	return c.FromStdin
+}
+
 // AddFlags registers command-specific flags.
 func (c *DisableCommand) AddFlags(fs *pflag.FlagSet) {
+	c.flags = fs
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would change without applying")
 	fs.BoolVarP(&c.Yes, "yes", "y", false, "Skip confirmation prompt")
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
 }
 
 // Complete resolves derived fields after flag parsing.
 func (c *DisableCommand) Complete() error {
+	// Parse stdin configuration if --from-stdin is specified
+	if c.FromStdin {
+		if err := c.parseStdinConfig(); err != nil {
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation, err)
+		}
+	}
+
+	// Build ComponentNames from stdin input or single positional arg
+	if len(c.ComponentNames) == 0 && c.ComponentName != "" {
+		c.ComponentNames = []string{c.ComponentName}
+	}
+
 	k8sClient, err := client.NewClient(c.ConfigFlags)
 	if err != nil {
 		return fmt.Errorf("creating Kubernetes client: %w", err)
@@ -133,10 +261,65 @@ func (c *DisableCommand) Complete() error {
 	return nil
 }
 
+// parseStdinConfig reads and applies configuration from stdin.
+func (c *DisableCommand) parseStdinConfig() error {
+	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
+		c.IO.Errorf("%s", warnStdinIsTerminal)
+	}
+
+	var input StdinInput
+	if err := stdin.Parse(c.IO.In(), &input); err != nil {
+		return fmt.Errorf("parsing stdin: %w", err)
+	}
+
+	return c.applyStdinInput(&input)
+}
+
+// applyStdinInput merges stdin configuration into command options.
+// Explicit CLI flags take precedence over stdin values.
+func (c *DisableCommand) applyStdinInput(input *StdinInput) error {
+	for i, name := range input.Components {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("empty component name at index %d", i)
+		}
+
+		input.Components[i] = trimmed
+	}
+
+	if len(input.Components) > 0 && c.ComponentName != "" {
+		return errors.New("cannot specify both positional component and components in stdin")
+	}
+
+	if len(input.Components) > 0 {
+		c.ComponentNames = input.Components
+	}
+
+	if input.DryRun && !c.flagChanged("dry-run") {
+		c.DryRun = true
+	}
+
+	if input.SkipConfirm && !c.flagChanged("yes") {
+		c.Yes = true
+	}
+
+	return nil
+}
+
+// flagChanged returns true if the flag was explicitly set on the command line.
+func (c *DisableCommand) flagChanged(name string) bool {
+	if c.flags == nil {
+		return false
+	}
+	f := c.flags.Lookup(name)
+
+	return f != nil && f.Changed
+}
+
 // Validate checks that all options are valid before execution.
 func (c *DisableCommand) Validate() error {
-	if c.ComponentName == "" {
-		return errors.New("component name is required")
+	if len(c.ComponentNames) == 0 {
+		return errors.New("at least one component name is required")
 	}
 
 	return nil
@@ -144,13 +327,26 @@ func (c *DisableCommand) Validate() error {
 
 // Run executes the disable command.
 func (c *DisableCommand) Run(ctx context.Context) error {
-	return MutateComponentState(ctx, MutateConfig{
-		IO:            c.IO,
-		Client:        c.Client,
-		ComponentName: c.ComponentName,
-		TargetState:   constants.ManagementStateRemoved,
-		ActionVerb:    "disable",
-		DryRun:        c.DryRun,
-		SkipConfirm:   c.Yes,
-	})
+	var failed []string
+
+	for _, componentName := range c.ComponentNames {
+		if err := MutateComponentState(ctx, MutateConfig{
+			IO:            c.IO,
+			Client:        c.Client,
+			ComponentName: componentName,
+			TargetState:   constants.ManagementStateRemoved,
+			ActionVerb:    "disable",
+			DryRun:        c.DryRun,
+			SkipConfirm:   c.Yes,
+		}); err != nil {
+			c.IO.Errorf("Error disabling '%s': %v", componentName, err)
+			failed = append(failed, componentName)
+		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to disable %d component(s): %s", len(failed), strings.Join(failed, ", "))
+	}
+
+	return nil
 }

--- a/pkg/components/commands_stdin_test.go
+++ b/pkg/components/commands_stdin_test.go
@@ -1,0 +1,408 @@
+package components_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+
+	. "github.com/onsi/gomega"
+)
+
+// Test fixtures for stdin input parsing.
+const (
+	fixtureStdinJSON = `{"components": ["dashboard", "kserve"], "dryRun": true, "skipConfirm": true}`
+
+	fixtureStdinYAML = `
+components:
+  - dashboard
+  - kserve
+  - ray
+dryRun: true
+`
+	fixtureStdinInvalid       = `{"components": invalid}`
+	fixtureStdinUnknownFields = `{"kompnents": ["dashboard"]}`
+	fixtureStdinMinimal       = `{"components": ["dashboard"]}`
+	fixtureStdinEmpty         = `{}`
+	fixtureStdinOnlyFlags     = `{"dryRun": true, "skipConfirm": true}`
+)
+
+// testConfigFlags creates ConfigFlags for testing.
+func testConfigFlags() *genericclioptions.ConfigFlags {
+	return genericclioptions.NewConfigFlags(true)
+}
+
+func TestEnableCommand_FromStdinFlag(t *testing.T) {
+	t.Run("AddFlags should register --from-stdin flag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+
+		flag := fs.Lookup("from-stdin")
+		g.Expect(flag).ToNot(BeNil())
+		g.Expect(flag.DefValue).To(Equal("false"))
+	})
+}
+
+func TestEnableCommand_StdinInput(t *testing.T) {
+	t.Run("Complete should parse stdin JSON and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard", "kserve"}))
+		g.Expect(command.DryRun).To(BeTrue())
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("Complete should parse stdin YAML and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinYAML)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard", "kserve", "ray"}))
+		g.Expect(command.DryRun).To(BeTrue())
+	})
+
+	t.Run("Complete should fail on invalid stdin JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInvalid)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should reject unknown fields in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinUnknownFields)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should keep defaults when stdin fields are omitted", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinMinimal)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard"}))
+		g.Expect(command.DryRun).To(BeFalse())
+		g.Expect(command.Yes).To(BeFalse())
+	})
+
+	t.Run("Explicit CLI flags should take precedence over stdin values", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Stdin sets dryRun=true, but CLI flag sets dry-run=false
+		stdin := bytes.NewBufferString(fixtureStdinJSON) // has dryRun: true
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+		err := fs.Parse([]string{"--dry-run=false", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag should win over stdin
+		g.Expect(command.DryRun).To(BeFalse())
+
+		// Stdin values should apply for non-explicitly-set flags
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard", "kserve"}))
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("ComponentName from positional arg should be used when stdin has no components", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinOnlyFlags)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+		command.ComponentName = "dashboard" // Set via positional arg
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard"}))
+		g.Expect(command.DryRun).To(BeTrue())
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("Validate should fail when no components provided via stdin or positional arg", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinEmpty)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewEnableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("at least one component name is required"))
+	})
+}
+
+func TestDisableCommand_FromStdinFlag(t *testing.T) {
+	t.Run("AddFlags should register --from-stdin flag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+
+		flag := fs.Lookup("from-stdin")
+		g.Expect(flag).ToNot(BeNil())
+		g.Expect(flag.DefValue).To(Equal("false"))
+	})
+}
+
+func TestDisableCommand_StdinInput(t *testing.T) {
+	t.Run("Complete should parse stdin JSON and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard", "kserve"}))
+		g.Expect(command.DryRun).To(BeTrue())
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("Complete should parse stdin YAML and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinYAML)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard", "kserve", "ray"}))
+		g.Expect(command.DryRun).To(BeTrue())
+	})
+
+	t.Run("Complete should fail on invalid stdin JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInvalid)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should reject unknown fields in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinUnknownFields)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Explicit CLI flags should take precedence over stdin values", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+		err := fs.Parse([]string{"--yes=false", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag should win over stdin
+		g.Expect(command.Yes).To(BeFalse())
+
+		// Stdin values should apply for non-explicitly-set flags
+		g.Expect(command.ComponentNames).To(Equal([]string{"dashboard", "kserve"}))
+		g.Expect(command.DryRun).To(BeTrue())
+	})
+
+	t.Run("Validate should fail when no components provided", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinEmpty)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := components.NewDisableCommand(streams, testConfigFlags())
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("at least one component name is required"))
+	})
+}

--- a/pkg/components/commands_test.go
+++ b/pkg/components/commands_test.go
@@ -48,10 +48,11 @@ func TestEnableCommand_Validate(t *testing.T) {
 
 		cmd, _ := newEnableCommand()
 		cmd.ComponentName = ""
+		cmd.ComponentNames = nil
 
 		err := cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("component name is required"))
+		g.Expect(err.Error()).To(ContainSubstring("at least one component name is required"))
 	})
 }
 
@@ -61,9 +62,10 @@ func TestDisableCommand_Validate(t *testing.T) {
 
 		cmd, _ := newDisableCommand()
 		cmd.ComponentName = ""
+		cmd.ComponentNames = nil
 
 		err := cmd.Validate()
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("component name is required"))
+		g.Expect(err.Error()).To(ContainSubstring("at least one component name is required"))
 	})
 }

--- a/pkg/components/stdin_input.go
+++ b/pkg/components/stdin_input.go
@@ -1,0 +1,26 @@
+package components
+
+// StdinInput defines the JSON/YAML schema for stdin input to components enable/disable commands.
+// Use with --from-stdin to pass configuration via stdin.
+// Precedence: CLI flags > stdin values > defaults.
+type StdinInput struct {
+	// Components is a list of component names to enable/disable.
+	Components []string `json:"components,omitempty" yaml:"components,omitempty"`
+
+	// DryRun shows what would change without applying (replaces --dry-run flag).
+	DryRun bool `json:"dryRun,omitempty" yaml:"dryRun,omitempty"`
+
+	// SkipConfirm skips confirmation prompts (replaces --yes flag).
+	// Named "skipConfirm" instead of "yes" because "yes" is a reserved YAML 1.1 boolean.
+	SkipConfirm bool `json:"skipConfirm,omitempty" yaml:"skipConfirm,omitempty"`
+}
+
+// Flag descriptions for stdin support.
+const (
+	flagDescFromStdin = "read configuration from stdin (JSON/YAML); CLI flags override stdin values"
+)
+
+// Warning messages.
+const (
+	warnStdinIsTerminal = "Warning: --from-stdin specified but stdin is a terminal"
+)


### PR DESCRIPTION
## Description

Jira: [RHOAIENG-54672](https://redhat.atlassian.net/browse/RHOAIENG-54672)

Follow-up to #86, which added `--from-stdin` to the `lint` command with reusable `pkg/util/stdin` utilities.

This PR extends the same pattern to `components enable` and `components disable` commands, enabling batch operations via piped input for scripted/automated workflows.

**Features:**
- Enable/disable multiple components in a single command
- Accepts JSON or YAML input via stdin
- CLI flags take precedence over stdin values
- Supports hybrid mode: positional arg + stdin flags

**Example usage:**
```bash
# Batch enable via JSON
echo '{"components": ["dashboard", "kserve", "ray"]}' | odh components enable --from-stdin

# Batch disable via YAML file (components.yaml)
# components:
#   - dashboard
#   - kserve
# dryRun: true
# skipConfirm: true
odh components disable --from-stdin < components.yaml

# Hybrid: component from arg, flags from stdin
echo '{"dryRun": true, "skipConfirm": true}' | odh components enable dashboard --from-stdin
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed

## Future work

A follow-up PR will add `--from-stdin` support to other commands as needed (e.g., `deps install`, `migrate run`).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --from-stdin option to enable/disable for bulk component lists and options via JSON/YAML stdin; introduced structured stdin input support.

* **Bug Fixes**
  * Commands now accept 0 or 1 positional component when stdin is used, require at least one component overall, and only set the positional name when present.

* **Tests**
  * Added tests for stdin parsing, validation, error cases, and CLI-flag override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->