### PR TITLE
feat(migrate): add --from-stdin flag and dynamic v1/v2 API detection

### DIFF
--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/pflag"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/stdin"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -25,6 +28,7 @@ type RunCommand struct {
 	MigrationIDs  []string
 	TargetVersion string
 	Phase         string
+	FromStdin     bool
 
 	parsedTargetVersion *semver.Version
 	parsedPhase         action.ActionPhase
@@ -32,6 +36,9 @@ type RunCommand struct {
 	// registry is the action registry for this command instance.
 	// Explicitly populated to avoid global state and enable test isolation.
 	registry *action.ActionRegistry
+
+	// flags stores the FlagSet for checking explicit flag usage.
+	flags *pflag.FlagSet
 }
 
 func NewRunCommand(streams genericiooptions.IOStreams) *RunCommand {
@@ -48,6 +55,7 @@ func (c *RunCommand) ActionIDs() []string {
 }
 
 func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
+	c.flags = fs
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescRunVerbose)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescRunTimeout)
 	fs.BoolVar(&c.DryRun, "dry-run", false, flagDescRunDryRun)
@@ -55,6 +63,7 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&c.MigrationIDs, "migration", "m", []string{}, flagDescRunMigration)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescRunTargetVersion)
 	fs.StringVar(&c.Phase, "phase", "", flagDescRunPhase)
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
@@ -64,7 +73,70 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	action.RegisterActionFlags(c.registry, fs)
 }
 
+// flagChanged returns true if the flag was explicitly set on the command line.
+func (c *RunCommand) flagChanged(name string) bool {
+	if c.flags == nil {
+		return false
+	}
+
+	f := c.flags.Lookup(name)
+
+	return f != nil && f.Changed
+}
+
+// parseStdinConfig reads and applies configuration from stdin.
+func (c *RunCommand) parseStdinConfig() error {
+	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
+		c.IO.Errorf("%s", warnStdinIsTerminal)
+	}
+
+	var input StdinInput
+	if err := stdin.Parse(c.IO.In(), &input); err != nil {
+		return fmt.Errorf("parsing stdin: %w", err)
+	}
+
+	return c.applyStdinInput(&input)
+}
+
+// applyStdinInput merges stdin configuration into command options.
+// Explicit CLI flags take precedence over stdin values.
+func (c *RunCommand) applyStdinInput(input *StdinInput) error {
+	// Apply migrations if not set via CLI
+	if len(input.Migrations) > 0 && !c.flagChanged("migration") {
+		c.MigrationIDs = input.Migrations
+	}
+
+	// Apply target version if not set via CLI
+	if input.TargetVersion != "" && !c.flagChanged("target-version") {
+		c.TargetVersion = input.TargetVersion
+	}
+
+	// Apply phase if not set via CLI
+	if input.Phase != "" && !c.flagChanged("phase") {
+		c.Phase = input.Phase
+	}
+
+	// Apply boolean flags if not set via CLI
+	if input.DryRun && !c.flagChanged("dry-run") {
+		c.DryRun = true
+	}
+
+	if input.SkipConfirm && !c.flagChanged("yes") {
+		c.Yes = true
+	}
+
+	return nil
+}
+
 func (c *RunCommand) Complete() error {
+	// Parse stdin configuration if --from-stdin is specified
+	if c.FromStdin {
+		if err := c.parseStdinConfig(); err != nil {
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation, err)
+		}
+	}
+
 	if err := c.SharedOptions.Complete(); err != nil {
 		return fmt.Errorf("completing shared options: %w", err)
 	}

--- a/pkg/migrate/command_run_stdin_test.go
+++ b/pkg/migrate/command_run_stdin_test.go
@@ -1,0 +1,349 @@
+package migrate_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+
+	. "github.com/onsi/gomega"
+)
+
+// Test fixtures for stdin input parsing.
+const (
+	fixtureStdinJSON = `{"migrations": ["kueue.rhbok.migrate", "modelserving.serverless-to-raw"], "targetVersion": "3.0.0", "dryRun": true, "skipConfirm": true}`
+
+	fixtureStdinYAML = `
+migrations:
+  - kueue.rhbok.migrate
+  - modelserving.serverless-to-raw
+  - modelserving.modelmesh-to-raw
+targetVersion: "3.0.0"
+dryRun: true
+`
+	fixtureStdinWithPhase = `{
+		"phase": "pre-upgrade",
+		"targetVersion": "3.0.0",
+		"skipConfirm": true
+	}`
+	fixtureStdinInvalid       = `{"migrations": invalid}`
+	fixtureStdinUnknownFields = `{"migrashuns": ["kueue.rhbok.migrate"]}`
+	fixtureStdinMinimal       = `{"migrations": ["kueue.rhbok.migrate"], "targetVersion": "3.0.0"}`
+)
+
+func TestRunCommand_FromStdinFlag(t *testing.T) {
+	t.Run("AddFlags should register --from-stdin flag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+
+		// Verify --from-stdin flag is registered
+		flag := fs.Lookup("from-stdin")
+		g.Expect(flag).ToNot(BeNil())
+		g.Expect(flag.DefValue).To(Equal("false"))
+	})
+}
+
+func TestRunCommand_StdinInput(t *testing.T) {
+	t.Run("Complete should parse stdin JSON and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.MigrationIDs).To(Equal([]string{"kueue.rhbok.migrate", "modelserving.serverless-to-raw"}))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.DryRun).To(BeTrue())
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("Complete should parse stdin YAML and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinYAML)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.MigrationIDs).To(Equal([]string{"kueue.rhbok.migrate", "modelserving.serverless-to-raw", "modelserving.modelmesh-to-raw"}))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.DryRun).To(BeTrue())
+	})
+
+	t.Run("Complete should parse stdin with phase", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinWithPhase)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.Phase).To(Equal("pre-upgrade"))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("Complete should fail on invalid stdin JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInvalid)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should reject unknown fields in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinUnknownFields)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should keep defaults when stdin fields are omitted", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinMinimal)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(command.MigrationIDs).To(Equal([]string{"kueue.rhbok.migrate"}))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.DryRun).To(BeFalse())
+		g.Expect(command.Yes).To(BeFalse())
+	})
+
+	t.Run("Explicit CLI flags should take precedence over stdin values", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Stdin sets dryRun=true, but CLI flag sets dry-run=false
+		stdin := bytes.NewBufferString(fixtureStdinJSON) // has dryRun: true
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+		err := fs.Parse([]string{"--dry-run=false", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag should win over stdin
+		g.Expect(command.DryRun).To(BeFalse())
+
+		// Stdin values should apply for non-explicitly-set flags
+		g.Expect(command.MigrationIDs).To(Equal([]string{"kueue.rhbok.migrate", "modelserving.serverless-to-raw"}))
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(command.Yes).To(BeTrue())
+	})
+
+	t.Run("CLI migration flags should take precedence over stdin migrations", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+		err := fs.Parse([]string{"--migration=different.migration", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag should win over stdin
+		g.Expect(command.MigrationIDs).To(Equal([]string{"different.migration"}))
+
+		// Stdin values should apply for non-explicitly-set flags
+		g.Expect(command.TargetVersion).To(Equal("3.0.0"))
+	})
+
+	t.Run("CLI target-version should take precedence over stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinJSON) // has targetVersion: "3.0.0"
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		command.AddFlags(fs)
+		err := fs.Parse([]string{"--target-version=4.0.0", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag should win over stdin
+		g.Expect(command.TargetVersion).To(Equal("4.0.0"))
+	})
+
+	t.Run("Validate should fail when no migrations or phase provided via stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Only flags, no migrations or phase
+		stdin := bytes.NewBufferString(`{"targetVersion": "3.0.0", "dryRun": true}`)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--migration flag is required"))
+	})
+
+	t.Run("Validate should fail when no target-version provided", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Missing targetVersion
+		stdin := bytes.NewBufferString(`{"migrations": ["kueue.rhbok.migrate"]}`)
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = command.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("--target-version flag is required"))
+	})
+
+	t.Run("Complete should fail on empty stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString("")
+
+		var out, errOut bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &out,
+			ErrOut: &errOut,
+		}
+
+		command := migrate.NewRunCommand(streams)
+		command.FromStdin = true
+
+		err := command.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("empty input"))
+	})
+}

--- a/pkg/migrate/stdin_input.go
+++ b/pkg/migrate/stdin_input.go
@@ -1,0 +1,31 @@
+package migrate
+
+// StdinInput defines the JSON/YAML schema for stdin input to migrate run command.
+// Use with --from-stdin to pass configuration via stdin. Precedence: CLI flags > stdin values > defaults.
+type StdinInput struct {
+	// Migrations is a list of migration IDs to execute.
+	Migrations []string `json:"migrations,omitempty" yaml:"migrations,omitempty"`
+
+	// TargetVersion is the target version for migration.
+	TargetVersion string `json:"targetVersion,omitempty" yaml:"targetVersion,omitempty"`
+
+	// Phase is the lifecycle phase to execute (pre-upgrade|post-upgrade|pre-enablement).
+	Phase string `json:"phase,omitempty" yaml:"phase,omitempty"`
+
+	// DryRun shows what would change without applying (replaces --dry-run flag).
+	DryRun bool `json:"dryRun,omitempty" yaml:"dryRun,omitempty"`
+
+	// SkipConfirm skips confirmation prompts (replaces --yes flag).
+	// Named "skipConfirm" instead of "yes" because "yes" is a reserved YAML 1.1 boolean.
+	SkipConfirm bool `json:"skipConfirm,omitempty" yaml:"skipConfirm,omitempty"`
+}
+
+// Flag descriptions for stdin support.
+const (
+	flagDescFromStdin = "read configuration from stdin (JSON/YAML); CLI flags override stdin values"
+)
+
+// Warning messages.
+const (
+	warnStdinIsTerminal = "Warning: --from-stdin specified but stdin is a terminal"
+)

--- a/pkg/util/version/detector.go
+++ b/pkg/util/version/detector.go
@@ -13,7 +13,7 @@ import (
 // Detect performs priority-based version detection from multiple sources
 // Priority order: DataScienceCluster > DSCInitialization > OLM
 // Returns parsed semver.TargetVersion or error if version cannot be determined from any source.
-func Detect(ctx context.Context, c client.Reader) (*semver.Version, error) {
+func Detect(ctx context.Context, c client.Client) (*semver.Version, error) {
 	// Priority 1: DataScienceCluster
 	if versionStr, found, err := DetectFromDataScienceCluster(ctx, c); err != nil {
 		return nil, fmt.Errorf("detecting from DataScienceCluster: %w", err)

--- a/pkg/util/version/detector_test.go
+++ b/pkg/util/version/detector_test.go
@@ -12,7 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	coretesting "k8s.io/client-go/testing"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -21,10 +23,32 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// newFakeDiscoveryWithResources creates a fake discovery client that reports the given group/versions.
+func newFakeDiscoveryWithResources(groupVersions ...string) *discoveryfake.FakeDiscovery {
+	fakeDiscovery := &discoveryfake.FakeDiscovery{Fake: &coretesting.Fake{}}
+
+	apiResourceLists := make([]*metav1.APIResourceList, 0, len(groupVersions))
+	for _, gv := range groupVersions {
+		apiResourceLists = append(apiResourceLists, &metav1.APIResourceList{
+			GroupVersion: gv,
+			APIResources: []metav1.APIResource{
+				{Name: "datascienceclusters", Kind: "DataScienceCluster"},
+				{Name: "dscinitializations", Kind: "DSCInitialization"},
+			},
+		})
+	}
+
+	fakeDiscovery.Resources = apiResourceLists
+
+	return fakeDiscovery
+}
+
 //nolint:gochecknoglobals // Test fixture - shared across test functions
 var listKinds = map[schema.GroupVersionResource]string{
 	resources.DataScienceCluster.GVR():    resources.DataScienceCluster.ListKind(),
+	resources.DataScienceClusterV1.GVR():  resources.DataScienceClusterV1.ListKind(),
 	resources.DSCInitialization.GVR():     resources.DSCInitialization.ListKind(),
+	resources.DSCInitializationV1.GVR():   resources.DSCInitializationV1.ListKind(),
 	resources.ClusterServiceVersion.GVR(): resources.ClusterServiceVersion.ListKind(),
 }
 
@@ -32,11 +56,11 @@ func TestDetect_FromDataScienceCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	// Create fake DataScienceCluster with version
+	// Create fake DataScienceCluster with version (using v1 API - fallback when Discovery is nil)
 	dsc := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resources.DataScienceCluster.APIVersion(),
-			"kind":       resources.DataScienceCluster.Kind,
+			"apiVersion": resources.DataScienceClusterV1.APIVersion(),
+			"kind":       resources.DataScienceClusterV1.Kind,
 			"metadata": map[string]any{
 				"name": "default-dsc",
 			},
@@ -64,15 +88,100 @@ func TestDetect_FromDataScienceCluster(t *testing.T) {
 	g.Expect(clusterVersion.Patch).To(Equal(uint64(0)))
 }
 
+func TestDetect_FromDataScienceCluster_V2(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Create fake DataScienceCluster with version (using v2 API - when Discovery finds v2)
+	dsc := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"status": map[string]any{
+				"release": map[string]any{
+					"version": "3.5.0",
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsc)
+
+	// Create a fake discovery client that returns v2 resources
+	fakeDiscovery := newFakeDiscoveryWithResources(
+		resources.DataScienceCluster.Group + "/v2",
+	)
+
+	c := client.NewForTesting(client.TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: fakeDiscovery,
+	})
+
+	clusterVersion, err := version.Detect(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(clusterVersion).ToNot(BeNil())
+	g.Expect(clusterVersion.String()).To(Equal("3.5.0"))
+	g.Expect(clusterVersion.Major).To(Equal(uint64(3)))
+	g.Expect(clusterVersion.Minor).To(Equal(uint64(5)))
+}
+
+func TestDetect_MidUpgrade_V2CRDExistsButOnlyV1Instance(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Mid-upgrade scenario: v2 CRD is registered but only v1 instance exists
+	// This tests the fallback from v2 NotFound to v1
+	dsc := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceClusterV1.APIVersion(),
+			"kind":       resources.DataScienceClusterV1.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"status": map[string]any{
+				"release": map[string]any{
+					"version": "2.35.0",
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	// Only register the v1 instance - no v2 instance exists
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsc)
+
+	// Discovery reports v2 API exists (CRD installed during upgrade)
+	fakeDiscovery := newFakeDiscoveryWithResources(
+		resources.DataScienceCluster.Group + "/v2",
+	)
+
+	c := client.NewForTesting(client.TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: fakeDiscovery,
+	})
+
+	// Should fall back to v1 and find the instance
+	clusterVersion, err := version.Detect(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(clusterVersion).ToNot(BeNil())
+	g.Expect(clusterVersion.String()).To(Equal("2.35.0"))
+	g.Expect(clusterVersion.Major).To(Equal(uint64(2)))
+	g.Expect(clusterVersion.Minor).To(Equal(uint64(35)))
+}
+
 func TestDetect_FromDSCInitialization(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	// Create fake DSCInitialization with version (no DataScienceCluster)
+	// Create fake DSCInitialization with version (using v1 API - fallback when Discovery is nil)
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resources.DSCInitialization.APIVersion(),
-			"kind":       resources.DSCInitialization.Kind,
+			"apiVersion": resources.DSCInitializationV1.APIVersion(),
+			"kind":       resources.DSCInitializationV1.Kind,
 			"metadata": map[string]any{
 				"name": "default-dsci",
 			},
@@ -98,6 +207,47 @@ func TestDetect_FromDSCInitialization(t *testing.T) {
 	g.Expect(clusterVersion.Major).To(Equal(uint64(2)))
 	g.Expect(clusterVersion.Minor).To(Equal(uint64(16)))
 	g.Expect(clusterVersion.Patch).To(Equal(uint64(0)))
+}
+
+func TestDetect_FromDSCInitialization_V2(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Create fake DSCInitialization with version (using v2 API - when Discovery finds v2)
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitialization.APIVersion(),
+			"kind":       resources.DSCInitialization.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsci",
+			},
+			"status": map[string]any{
+				"release": map[string]any{
+					"version": "3.6.0",
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsci)
+
+	// Create a fake discovery client that returns v2 resources
+	fakeDiscovery := newFakeDiscoveryWithResources(
+		resources.DSCInitialization.Group + "/v2",
+	)
+
+	c := client.NewForTesting(client.TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: fakeDiscovery,
+	})
+
+	clusterVersion, err := version.Detect(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(clusterVersion).ToNot(BeNil())
+	g.Expect(clusterVersion.String()).To(Equal("3.6.0"))
+	g.Expect(clusterVersion.Major).To(Equal(uint64(3)))
+	g.Expect(clusterVersion.Minor).To(Equal(uint64(6)))
 }
 
 func TestDetect_FromOLM(t *testing.T) {
@@ -140,11 +290,11 @@ func TestDetect_PriorityOrder(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	// Create all three sources - should prefer DataScienceCluster
+	// Create all three sources - should prefer DataScienceCluster (using v1 API)
 	dsc := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resources.DataScienceCluster.APIVersion(),
-			"kind":       resources.DataScienceCluster.Kind,
+			"apiVersion": resources.DataScienceClusterV1.APIVersion(),
+			"kind":       resources.DataScienceClusterV1.Kind,
 			"metadata": map[string]any{
 				"name": "default-dsc",
 			},
@@ -158,8 +308,8 @@ func TestDetect_PriorityOrder(t *testing.T) {
 
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": resources.DSCInitialization.APIVersion(),
-			"kind":       resources.DSCInitialization.Kind,
+			"apiVersion": resources.DSCInitializationV1.APIVersion(),
+			"kind":       resources.DSCInitializationV1.Kind,
 			"metadata": map[string]any{
 				"name": "default-dsci",
 			},

--- a/pkg/util/version/sources.go
+++ b/pkg/util/version/sources.go
@@ -6,16 +6,91 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/discovery"
 )
 
-// DetectFromDataScienceCluster attempts to detect version from DataScienceCluster resource
+// getSingletonWithDiscovery dynamically detects the available API version and retrieves
+// a singleton resource. Tries v2 first, falls back to v1.
+// This avoids code duplication for resources that exist in both v1 and v2 API versions.
+func getSingletonWithDiscovery(
+	ctx context.Context,
+	c client.Client,
+	v2Resource, v1Resource resources.ResourceType,
+) (*unstructured.Unstructured, error) {
+	// Try v2 first if Discovery is available
+	obj, fallbackToV1, err := tryGetV2Singleton(ctx, c, v2Resource)
+	if err != nil {
+		return nil, fmt.Errorf("getting %s (v2): %w", v2Resource.Kind, err)
+	}
+
+	if !fallbackToV1 {
+		return obj, nil
+	}
+
+	// Fallback to v1 (ODH/RHOAI 2.x) - used when:
+	// - Discovery is not available
+	// - v2 API doesn't exist on cluster
+	// - v2 API exists but no v2 instance found (mid-upgrade scenario)
+	obj, err = client.GetSingleton(ctx, c, v1Resource)
+	if err != nil {
+		return nil, fmt.Errorf("getting %s (v1): %w", v1Resource.Kind, err)
+	}
+
+	return obj, nil
+}
+
+// tryGetV2Singleton attempts to get the v2 singleton if the v2 API exists.
+// Returns:
+//   - (obj, false, nil) if v2 singleton found
+//   - (nil, true, nil) if should fall back to v1 (v2 API absent or v2 instance not found)
+//   - (nil, false, err) if a real error occurred (403, timeout, unexpected count, etc.)
+func tryGetV2Singleton(
+	ctx context.Context,
+	c client.Client,
+	v2Resource resources.ResourceType,
+) (*unstructured.Unstructured, bool, error) {
+	if c.Discovery() == nil {
+		return nil, true, nil // No discovery available, fall back to v1
+	}
+
+	v2Resources, err := discovery.GetGroupVersionResources(
+		c.Discovery(),
+		schema.GroupVersion{Group: v2Resource.Group, Version: "v2"},
+	)
+	if err != nil {
+		// Discovery error is not fatal - fall back to v1
+		return nil, true, nil
+	}
+
+	if len(v2Resources) == 0 {
+		return nil, true, nil // v2 API doesn't exist, fall back to v1
+	}
+
+	obj, err := client.GetSingleton(ctx, c, v2Resource)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// v2 instance not found (mid-upgrade scenario) - fall back to v1
+			return nil, true, nil
+		}
+		// Real error (403, timeout, "expected single, found 2", etc.) - propagate
+		return nil, false, fmt.Errorf("getting v2 singleton: %w", err)
+	}
+
+	return obj, false, nil
+}
+
+// DetectFromDataScienceCluster attempts to detect version from DataScienceCluster resource.
+// Dynamically detects whether to use v1 or v2 API based on cluster capabilities.
 // Returns version string and true if found, empty string and false otherwise.
-func DetectFromDataScienceCluster(ctx context.Context, c client.Reader) (string, bool, error) {
-	// Get the DataScienceCluster singleton
-	dsc, err := client.GetDataScienceCluster(ctx, c)
+func DetectFromDataScienceCluster(ctx context.Context, c client.Client) (string, bool, error) {
+	// Get the DataScienceCluster singleton using discovery-based version detection
+	dsc, err := getSingletonWithDiscovery(ctx, c, resources.DataScienceCluster, resources.DataScienceClusterV1)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", false, nil
@@ -37,11 +112,12 @@ func DetectFromDataScienceCluster(ctx context.Context, c client.Reader) (string,
 	return versionStr, true, nil
 }
 
-// DetectFromDSCInitialization attempts to detect version from DSCInitialization resource
+// DetectFromDSCInitialization attempts to detect version from DSCInitialization resource.
+// Dynamically detects whether to use v1 or v2 API based on cluster capabilities.
 // Returns version string and true if found, empty string and false otherwise.
-func DetectFromDSCInitialization(ctx context.Context, c client.Reader) (string, bool, error) {
-	// Get the DSCInitialization singleton
-	dsci, err := client.GetDSCInitialization(ctx, c)
+func DetectFromDSCInitialization(ctx context.Context, c client.Client) (string, bool, error) {
+	// Get the DSCInitialization singleton using discovery-based version detection
+	dsci, err := getSingletonWithDiscovery(ctx, c, resources.DSCInitialization, resources.DSCInitializationV1)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", false, nil


### PR DESCRIPTION
## Description

Add `--from-stdin` flag to `migrate run` command for batch/scripted migrations and fix dynamic v1/v2 API version detection.

Jira: [RHOAIENG-54672](https://redhat.atlassian.net/browse/RHOAIENG-54672)

### --from-stdin support

Enables running migrations in automated pipelines by accepting configuration via stdin instead of CLI flags.

- Accepts both JSON and YAML formats
- Supports fields: `migrations`, `targetVersion`, `phase`, `dryRun`, `skipConfirm`
- CLI flags take precedence over stdin values for flexibility
- Warns when stdin is a terminal (likely user error)

Example usage:
```bash
echo '{"migrations": ["kueue.rhbok.migrate"], "targetVersion": "3.0.0", "dryRun": true}' | \
  kubectl odh migrate run --from-stdin
```

### v1/v2 API detection fix

Previously, version detection hardcoded v2 API which failed on ODH/RHOAI 2.x clusters that only have v1 API.

- Uses Kubernetes Discovery API to detect available API version dynamically
- Tries v2 first, falls back to v1 if not available
- Handles mid-upgrade scenario: when v2 CRD exists but only v1 instance is present, correctly falls back to v1
- Changed `Detect()` parameter from `client.Reader` to `client.Client` to access Discovery API

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --from-stdin support for migration runs to supply migrations, target version, phase, dry-run and confirm behavior via stdin.
  * Detect cluster versions from v2 APIs with automatic fallback to v1 when needed.

* **Improvements**
  * Explicit CLI flags now take precedence over stdin values; clearer validation and error reporting for stdin parsing.

* **Tests**
  * Comprehensive tests added for stdin handling and v2/v1 detection and upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->