### PR TITLE
feat(events): add --component flag to filter events by ODH component

### DIFF
--- a/cmd/events/events.go
+++ b/cmd/events/events.go
@@ -48,6 +48,9 @@ const cmdExample = `
   # Show only warnings
   kubectl odh events --type Warning
 
+  # Filter by component
+  kubectl odh events --component kserve
+
   # All ODH namespaces, YAML output
   kubectl odh events -A -o yaml
 `
@@ -90,6 +93,11 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 	}
 
 	command.AddFlags(cmd.Flags())
+
+	// Shell completion for --component flag
+	_ = cmd.RegisterFlagCompletionFunc("component", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return eventspkg.ValidComponents(), cobra.ShellCompDirectiveNoFileComp
+	})
 
 	root.AddCommand(cmd)
 }

--- a/pkg/events/command.go
+++ b/pkg/events/command.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -14,6 +16,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
@@ -43,6 +46,7 @@ type Command struct {
 	AllNamespaces      bool
 	OutputFormat       string
 	OperatorNSOverride string
+	Component          string
 
 	// Resolved fields (populated during Complete)
 	Namespace         string
@@ -75,6 +79,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.AllNamespaces, "all-namespaces", "A", false, "List events across all ODH namespaces")
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
 	fs.StringVar(&c.OperatorNSOverride, "operator-namespace", "", "Override the operator namespace (auto-detected from OLM/CSV)")
+	fs.StringVar(&c.Component, "component", "", "Filter events by ODH component (dashboard, kserve, ray, etc.). Only filters core Kubernetes resources (Pods, Deployments, etc.); CRD-specific events are excluded")
 }
 
 // Complete resolves derived fields after flag parsing.
@@ -157,7 +162,38 @@ func (c *Command) Validate() error {
 		)
 	}
 
+	if c.Component != "" && resources.GetComponentCR(c.Component) == nil {
+		return clierrors.NewValidationError(
+			"INVALID_COMPONENT",
+			"invalid component "+c.Component,
+			"Use one of: "+strings.Join(ValidComponents(), ", "),
+		)
+	}
+
 	return nil
+}
+
+// validComponents contains sorted list of valid component names.
+//
+//nolint:gochecknoglobals // Static configuration built once at init
+var validComponents []string
+
+//nolint:gochecknoinits // One-time initialization of static component list
+func init() {
+	validComponents = make([]string, 0, len(resources.ComponentCRResourceTypes))
+	for name := range resources.ComponentCRResourceTypes {
+		validComponents = append(validComponents, name)
+	}
+
+	sort.Strings(validComponents)
+}
+
+// ValidComponents returns a copy of the sorted list of valid component names.
+func ValidComponents() []string {
+	result := make([]string, len(validComponents))
+	copy(result, validComponents)
+
+	return result
 }
 
 // Run executes the events command.
@@ -215,6 +251,13 @@ func (c *Command) listEvents(ctx context.Context) error {
 	events, err := c.fetchEvents(ctx)
 	if err != nil {
 		return err
+	}
+
+	if c.Component != "" {
+		events, err = c.filterEventsByComponent(ctx, events)
+		if err != nil {
+			return err
+		}
 	}
 
 	sortEventsByTime(events)

--- a/pkg/events/command_test.go
+++ b/pkg/events/command_test.go
@@ -1,12 +1,15 @@
 package events_test
 
 import (
+	"slices"
 	"testing"
 	"time"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/opendatahub-io/odh-cli/pkg/events"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestCommandValidate_OutputFormat(t *testing.T) {
@@ -153,4 +156,53 @@ func TestNewCommand(t *testing.T) {
 	if cmd.ConfigFlags != flags {
 		t.Error("NewCommand() ConfigFlags not set correctly")
 	}
+}
+
+func TestCommandValidate_Component(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		wantErr   bool
+	}{
+		{"empty component", "", false},
+		{"valid component kserve", "kserve", false},
+		{"valid component dashboard", "dashboard", false},
+		{"valid component ray", "ray", false},
+		{"invalid component", "invalid-component", true},
+		{"typo in component", "kserver", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cmd := &events.Command{
+				OutputFormat: "table",
+				Component:    tt.component,
+				ConfigFlags:  genericclioptions.NewConfigFlags(true),
+			}
+			err := cmd.Validate()
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestValidComponents(t *testing.T) {
+	g := NewWithT(t)
+	components := events.ValidComponents()
+
+	g.Expect(components).ToNot(BeEmpty())
+
+	// Check that known components are present
+	expectedComponents := []string{"kserve", "dashboard", "ray", "workbenches"}
+	for _, expected := range expectedComponents {
+		g.Expect(slices.Contains(components, expected)).To(BeTrue(),
+			"ValidComponents() missing expected component %q", expected)
+	}
+
+	// Check that list is sorted
+	g.Expect(slices.IsSorted(components)).To(BeTrue(), "ValidComponents() should be sorted")
 }

--- a/pkg/events/filter.go
+++ b/pkg/events/filter.go
@@ -3,11 +3,18 @@ package events
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
@@ -77,4 +84,95 @@ func sortEventsByTime(events []clusterhealth.EventInfo) {
 	slices.SortStableFunc(events, func(a, b clusterhealth.EventInfo) int {
 		return cmp.Compare(b.LastTime.UnixNano(), a.LastTime.UnixNano())
 	})
+}
+
+// filterEventsByComponent filters events to only those related to a component.
+// It looks up each event's InvolvedObject and checks for the component label.
+// Returns filtered events and any API error encountered (RBAC, timeout, etc.).
+func (c *Command) filterEventsByComponent(ctx context.Context, events []clusterhealth.EventInfo) ([]clusterhealth.EventInfo, error) {
+	targetLabel := resources.GetComponentLabelValue(c.Component)
+	labelCache := make(map[string]bool)
+
+	var filtered []clusterhealth.EventInfo
+
+	for _, event := range events {
+		cacheKey := fmt.Sprintf("%s/%s/%s/%s", targetLabel, event.Namespace, event.Kind, event.Name)
+
+		hasLabel, found := labelCache[cacheKey]
+		if !found {
+			var err error
+			hasLabel, err = c.checkObjectHasComponentLabel(ctx, event.Namespace, event.Kind, event.Name, targetLabel)
+			if err != nil {
+				return nil, fmt.Errorf("checking component label for %s/%s: %w", event.Kind, event.Name, err)
+			}
+			labelCache[cacheKey] = hasLabel
+		}
+
+		if hasLabel {
+			filtered = append(filtered, event)
+		}
+	}
+
+	return filtered, nil
+}
+
+// checkObjectHasComponentLabel checks if an object has the component label.
+// Returns (false, nil) for unsupported kinds or not-found objects.
+// Returns error for RBAC failures, timeouts, or other API errors.
+func (c *Command) checkObjectHasComponentLabel(ctx context.Context, namespace, kind, name, labelValue string) (bool, error) {
+	gvr := kindToGVR(kind)
+	if gvr.Resource == "" {
+		return false, nil
+	}
+
+	unstr, err := c.getObject(ctx, gvr, namespace, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("getting %s %s/%s: %w", gvr.Resource, namespace, name, err)
+	}
+
+	labels := unstr.GetLabels()
+
+	return labels[resources.ComponentLabelKey] == labelValue, nil
+}
+
+// getObject fetches an object by GVR, namespace, and name.
+// Returns raw error to allow caller to type-check before wrapping.
+func (c *Command) getObject(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+	if namespace != "" {
+		//nolint:wrapcheck // Caller wraps after type-checking (e.g., IsNotFound)
+		return c.Client.Dynamic().Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	}
+
+	//nolint:wrapcheck // Caller wraps after type-checking (e.g., IsNotFound)
+	return c.Client.Dynamic().Resource(gvr).Get(ctx, name, metav1.GetOptions{})
+}
+
+// kindToGVRMap maps Kubernetes Kind to ResourceType for event filtering.
+// Note: Only core/apps kinds are mapped. Events referencing CRD objects
+// (InferenceService, RayCluster, Notebook, etc.) are excluded from --component filtering.
+//
+//nolint:gochecknoglobals // Static mapping configuration
+var kindToGVRMap = map[string]resources.ResourceType{
+	"Pod":         resources.Pod,
+	"Deployment":  resources.Deployment,
+	"ReplicaSet":  resources.ReplicaSet,
+	"StatefulSet": resources.StatefulSet,
+	"DaemonSet":   resources.DaemonSet,
+	"Service":     resources.Service,
+	"ConfigMap":   resources.ConfigMap,
+	"Secret":      resources.Secret,
+	"Job":         resources.Job,
+}
+
+// kindToGVR maps Kubernetes Kind to GroupVersionResource.
+func kindToGVR(kind string) schema.GroupVersionResource {
+	if rt, ok := kindToGVRMap[kind]; ok {
+		return rt.GVR()
+	}
+
+	return schema.GroupVersionResource{}
 }

--- a/pkg/events/filter_test.go
+++ b/pkg/events/filter_test.go
@@ -2,10 +2,22 @@
 package events
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestGetTargetNamespaces(t *testing.T) {
@@ -186,4 +198,188 @@ func TestSortEventsByTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetComponentLabelValue(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		component string
+		want      string
+	}{
+		{"kserve", "kserve"},
+		{"dashboard", "dashboard"},
+		{"aipipelines", "data-science-pipelines-operator"},
+		{"modelregistry", "model-registry-operator"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := resources.GetComponentLabelValue(tt.component)
+		g.Expect(got).To(Equal(tt.want))
+	}
+}
+
+func TestKindToGVR(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		kind     string
+		wantRes  string
+		wantNull bool
+	}{
+		{"Pod", "pods", false},
+		{"Deployment", "deployments", false},
+		{"ReplicaSet", "replicasets", false},
+		{"Unknown", "", true},
+	}
+
+	for _, tt := range tests {
+		got := kindToGVR(tt.kind)
+		if tt.wantNull {
+			g.Expect(got.Resource).To(BeEmpty())
+		} else {
+			g.Expect(got.Resource).To(Equal(tt.wantRes))
+		}
+	}
+}
+
+// createTestPod creates an unstructured Pod with the given labels.
+func createTestPod(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	pod := &unstructured.Unstructured{}
+	pod.SetAPIVersion("v1")
+	pod.SetKind("Pod")
+	pod.SetName(name)
+	pod.SetNamespace(namespace)
+	pod.SetLabels(labels)
+
+	return pod
+}
+
+// createFakeClient creates a fake dynamic client with the given objects.
+func createFakeClient(t *testing.T, objs ...runtime.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.Pod.GVR():        "PodList",
+		resources.Deployment.GVR(): "DeploymentList",
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, objs...)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic: dynamicClient,
+	})
+}
+
+func TestCheckObjectHasComponentLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		namespace  string
+		kind       string
+		objName    string
+		labelValue string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name: "pod with matching label",
+			objects: []runtime.Object{
+				createTestPod("kserve-pod", "odh-apps", map[string]string{
+					resources.ComponentLabelKey: "kserve",
+				}),
+			},
+			namespace:  "odh-apps",
+			kind:       "Pod",
+			objName:    "kserve-pod",
+			labelValue: "kserve",
+			want:       true,
+		},
+		{
+			name: "pod with non-matching label",
+			objects: []runtime.Object{
+				createTestPod("dashboard-pod", "odh-apps", map[string]string{
+					resources.ComponentLabelKey: "dashboard",
+				}),
+			},
+			namespace:  "odh-apps",
+			kind:       "Pod",
+			objName:    "dashboard-pod",
+			labelValue: "kserve",
+			want:       false,
+		},
+		{
+			name:       "object not found returns false without error",
+			objects:    []runtime.Object{},
+			namespace:  "odh-apps",
+			kind:       "Pod",
+			objName:    "missing-pod",
+			labelValue: "kserve",
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:       "unsupported kind returns false without error",
+			objects:    []runtime.Object{},
+			namespace:  "odh-apps",
+			kind:       "Lease",
+			objName:    "test-lease",
+			labelValue: "kserve",
+			want:       false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := createFakeClient(t, tt.objects...)
+			cmd := &Command{Client: fakeClient}
+
+			got, err := cmd.checkObjectHasComponentLabel(ctx, tt.namespace, tt.kind, tt.objName, tt.labelValue)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestFilterEventsByComponent(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	kservePod := createTestPod("kserve-pod", "odh-apps", map[string]string{
+		resources.ComponentLabelKey: "kserve",
+	})
+	dashboardPod := createTestPod("dashboard-pod", "odh-apps", map[string]string{
+		resources.ComponentLabelKey: "dashboard",
+	})
+
+	fakeClient := createFakeClient(t, kservePod, dashboardPod)
+
+	events := []clusterhealth.EventInfo{
+		{Namespace: "odh-apps", Kind: "Pod", Name: "kserve-pod", Reason: "Created"},
+		{Namespace: "odh-apps", Kind: "Pod", Name: "dashboard-pod", Reason: "Created"},
+		{Namespace: "odh-apps", Kind: "Pod", Name: "missing-pod", Reason: "Created"},
+	}
+
+	cmd := &Command{
+		Client:    fakeClient,
+		Component: "kserve",
+	}
+
+	filtered, err := cmd.filterEventsByComponent(ctx, events)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(filtered).To(HaveLen(1))
+	g.Expect(filtered[0].Name).To(Equal("kserve-pod"))
 }

--- a/pkg/resources/component_crs.go
+++ b/pkg/resources/component_crs.go
@@ -1,6 +1,11 @@
 package resources
 
-const componentCRGroup = "components.platform.opendatahub.io"
+const (
+	componentCRGroup = "components.platform.opendatahub.io"
+
+	// ComponentLabelKey is the label key used to identify ODH components.
+	ComponentLabelKey = "app.kubernetes.io/part-of"
+)
 
 // ComponentCRResourceTypes maps DSC component names to their corresponding
 // component CR resource types from the components.platform.opendatahub.io API group.
@@ -42,4 +47,27 @@ func GetComponentCR(name string) *ResourceType {
 	}
 
 	return &rt
+}
+
+// componentLabelOverrides maps component names to their actual label values
+// when they differ from the component name.
+//
+// NOTE: When adding new components to ComponentCRResourceTypes, verify the actual
+// app.kubernetes.io/part-of label value used by that component's resources.
+// If it differs from the CLI name, add an override here to avoid empty --component results.
+//
+//nolint:gochecknoglobals // Static label mapping configuration
+var componentLabelOverrides = map[string]string{
+	"aipipelines":   "data-science-pipelines-operator",
+	"modelregistry": "model-registry-operator",
+}
+
+// GetComponentLabelValue returns the label value used for a component.
+// Some components use different label values than their CLI names.
+func GetComponentLabelValue(component string) string {
+	if override, ok := componentLabelOverrides[component]; ok {
+		return override
+	}
+
+	return component
 }

--- a/pkg/resources/component_crs_test.go
+++ b/pkg/resources/component_crs_test.go
@@ -49,6 +49,75 @@ func TestComponentCRResourceTypes(t *testing.T) {
 	}
 }
 
+func TestGetComponentLabelValue(t *testing.T) {
+	tests := []struct {
+		component string
+		want      string
+	}{
+		{"kserve", "kserve"},
+		{"dashboard", "dashboard"},
+		{"aipipelines", "data-science-pipelines-operator"},
+		{"modelregistry", "model-registry-operator"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.component, func(t *testing.T) {
+			got := resources.GetComponentLabelValue(tt.component)
+			if got != tt.want {
+				t.Errorf("GetComponentLabelValue(%q) = %q, want %q", tt.component, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAllComponentsHaveVerifiedLabels ensures every component in ComponentCRResourceTypes
+// has an explicitly verified label value. Adding a new component requires adding its
+// expected label here, forcing the developer to verify the actual app.kubernetes.io/part-of
+// label used by that component's resources.
+func TestAllComponentsHaveVerifiedLabels(t *testing.T) {
+	// expectedLabels maps component names to their verified app.kubernetes.io/part-of label values.
+	// When adding a new component, verify its actual label by checking deployed resources:
+	//   oc get pods -n opendatahub -l app.kubernetes.io/part-of=<component> --show-labels
+	expectedLabels := map[string]string{
+		"aipipelines":        "data-science-pipelines-operator",
+		"dashboard":          "dashboard",
+		"feastoperator":      "feastoperator",
+		"kserve":             "kserve",
+		"llamastackoperator": "llamastackoperator",
+		"mlflowoperator":     "mlflowoperator",
+		"modelregistry":      "model-registry-operator",
+		"ray":                "ray",
+		"sparkoperator":      "sparkoperator",
+		"trainer":            "trainer",
+		"trainingoperator":   "trainingoperator",
+		"trustyai":           "trustyai",
+		"workbenches":        "workbenches",
+	}
+
+	// Check that every component in ComponentCRResourceTypes has a verified label
+	for name := range resources.ComponentCRResourceTypes {
+		t.Run(name, func(t *testing.T) {
+			expected, ok := expectedLabels[name]
+			if !ok {
+				t.Fatalf("component %q missing from expectedLabels - verify its app.kubernetes.io/part-of label and add it", name)
+			}
+
+			got := resources.GetComponentLabelValue(name)
+			if got != expected {
+				t.Errorf("GetComponentLabelValue(%q) = %q, want %q", name, got, expected)
+			}
+		})
+	}
+
+	// Check that expectedLabels doesn't have stale entries
+	for name := range expectedLabels {
+		if _, ok := resources.ComponentCRResourceTypes[name]; !ok {
+			t.Errorf("expectedLabels has %q but it's not in ComponentCRResourceTypes - remove stale entry", name)
+		}
+	}
+}
+
 func TestGetComponentCR(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Jira: [RHOAIENG-54646](https://redhat.atlassian.net/browse/RHOAIENG-54646)
Follow-up to #74

## Description

Adds `--component` flag to `kubectl odh events` to filter events by ODH component.

### Usage

```bash
# Filter by component
kubectl odh events --component kserve
kubectl odh events --component modelregistry

# Combine with other flags
kubectl odh events --component dashboard --type Warning
kubectl odh events --component ray --since 1h
```

### How it works
- Filters events by looking up each event's InvolvedObject and checking for `app.kubernetes.io/part-of` label
- Handles components with non-standard labels via override mapping (e.g., `modelregistry` -> `model-registry-operator`)
- Caches label lookups to avoid repeated API calls
- Includes shell completion for valid component names

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --component flag to filter events by Open Data Hub component; help now includes a "Filter by component" example.
  * Shell completion for the flag suggests valid component names and disables filename completion.

* **Improvements**
  * Events are now filtered by component label for more accurate ownership matching.
  * Added canonical component label handling for known components.

* **Tests**
  * Added unit tests for component validation, label resolution, kind-to-resource mapping, and event filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->