### PR TITLE
Update Go version to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - use native platform for builder to avoid emulation
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # Build arguments for cross-compilation
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/odh-cli
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Description
This PR updates the Go version to 1.26, as well address some formatting issues that were presented by Go 1.26's stricter rules about non-constants.

JIRA: https://redhat.atlassian.net/browse/RHOAIENG-65496 

<!-- What does this PR do? -->

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go language version to 1.26 in build configuration and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->