### PR TITLE
feat(migrate): add llamastack.backup action

### DIFF
--- a/pkg/backup/resource_writer.go
+++ b/pkg/backup/resource_writer.go
@@ -23,19 +23,39 @@ func WriteResourceToFile(
 	if namespace == "" {
 		namespace = "cluster-scoped"
 	}
-	name := obj.GetName()
 
 	nsDir := filepath.Join(outputDir, namespace)
 	if err := os.MkdirAll(nsDir, dirPermissions); err != nil {
 		return fmt.Errorf("creating namespace directory: %w", err)
 	}
 
+	return writeResourceToDir(nsDir, gvr, obj)
+}
+
+// WriteResourceFlat writes a resource to $dir/$GVR-$name.yaml without creating
+// a namespace subdirectory. Use this when the directory structure already encodes
+// the namespace (e.g. $outputDir/$namespace/$name/).
+func WriteResourceFlat(
+	dir string,
+	gvr schema.GroupVersionResource,
+	obj *unstructured.Unstructured,
+) error {
+	return writeResourceToDir(dir, gvr, obj)
+}
+
+// writeResourceToDir writes a resource YAML directly to the given directory.
+func writeResourceToDir(
+	dir string,
+	gvr schema.GroupVersionResource,
+	obj *unstructured.Unstructured,
+) error {
 	gvrStr := gvr.Resource
 	if gvr.Group != "" {
 		gvrStr = gvr.Resource + "." + gvr.Group
 	}
-	filename := fmt.Sprintf("%s-%s.yaml", gvrStr, name)
-	filePath := filepath.Join(nsDir, filename)
+
+	filename := fmt.Sprintf("%s-%s.yaml", gvrStr, obj.GetName())
+	filePath := filepath.Join(dir, filename)
 
 	data, err := yaml.Marshal(obj.Object)
 	if err != nil {

--- a/pkg/backup/resource_writer_test.go
+++ b/pkg/backup/resource_writer_test.go
@@ -1,0 +1,109 @@
+package backup_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoglobals
+var coreGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "configmaps",
+}
+
+//nolint:gochecknoglobals
+var groupedGVR = schema.GroupVersionResource{
+	Group:    "llamastack.io",
+	Version:  "v1alpha1",
+	Resource: "llamastackdistributions",
+}
+
+func TestWriteResourceFlat(t *testing.T) {
+	t.Run("writes grouped resource without namespace subdirectory", func(t *testing.T) {
+		g := NewWithT(t)
+		dir := t.TempDir()
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "llamastack.io/v1alpha1",
+				"kind":       "LlamaStackDistribution",
+				"metadata": map[string]any{
+					"name":      "my-llsd",
+					"namespace": "test-ns",
+				},
+			},
+		}
+
+		err := backup.WriteResourceFlat(dir, groupedGVR, obj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		expectedFile := filepath.Join(dir, "llamastackdistributions.llamastack.io-my-llsd.yaml")
+		g.Expect(expectedFile).To(BeAnExistingFile())
+
+		// Verify no namespace subdirectory was created
+		entries, err := os.ReadDir(dir)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(entries).To(HaveLen(1))
+		g.Expect(entries[0].Name()).To(Equal("llamastackdistributions.llamastack.io-my-llsd.yaml"))
+	})
+
+	t.Run("writes core resource with correct filename format", func(t *testing.T) {
+		g := NewWithT(t)
+		dir := t.TempDir()
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "my-config",
+					"namespace": "test-ns",
+				},
+			},
+		}
+
+		err := backup.WriteResourceFlat(dir, coreGVR, obj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Core resources have no group, so filename is resource-name.yaml
+		expectedFile := filepath.Join(dir, "configmaps-my-config.yaml")
+		g.Expect(expectedFile).To(BeAnExistingFile())
+	})
+
+	t.Run("file contains valid YAML content", func(t *testing.T) {
+		g := NewWithT(t)
+		dir := t.TempDir()
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]any{
+					"name":      "my-config",
+					"namespace": "test-ns",
+				},
+				"data": map[string]any{
+					"key": "value",
+				},
+			},
+		}
+
+		err := backup.WriteResourceFlat(dir, coreGVR, obj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		filePath := filepath.Join(dir, "configmaps-my-config.yaml")
+		content, err := os.ReadFile(filePath) //nolint:gosec // test file with controlled path
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(string(content)).To(ContainSubstring("kind: ConfigMap"))
+		g.Expect(string(content)).To(ContainSubstring("name: my-config"))
+	})
+}

--- a/pkg/migrate/actions/llamastack/backup/backup.go
+++ b/pkg/migrate/actions/llamastack/backup/backup.go
@@ -1,0 +1,547 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	actionID          = "llamastack.backup"
+	actionName        = "Backup LlamaStack Resources"
+	actionDescription = "Backup all LlamaStack resources before upgrade (LlamaStack->OGX rename in 3.5)"
+
+	dirPerms  = 0o700
+	filePerms = 0o600
+
+	podDataPath = "/opt/app-root/src/.llama/distributions/rh"
+
+	msgErrNotRootRecorder    = "recorder is not a RootRecorder"
+	msgErrCreateBackupDir    = "Failed to create backup directory: %v"
+	msgErrListDistributions  = "Failed to list LlamaStackDistributions: %v"
+	msgErrCreateLLSDDir      = "Failed to create directory: %v"
+	msgErrBackupLLSD         = "Failed to write LlamaStackDistribution %s/%s: %v"
+	msgErrBackupConfigMap    = "Failed to write ConfigMap %s/%s: %v"
+	msgErrGetConfigMap       = "Failed to get ConfigMap: %v"
+	msgErrGetConfigMapData   = "Failed to read ConfigMap data: %v"
+	msgErrGetDeployment      = "Failed to get Deployment: %v"
+	msgErrListPods           = "Failed to list pods in %s: %v"
+	msgErrBackupPod          = "Failed to write Pod %s/%s: %v"
+	msgErrCreatePodDataDir   = "Failed to create pod data directory: %v"
+	msgErrWriteExtractedYAML = "Failed to write extracted %s: %v"
+	msgErrBackupDeployment   = "Failed to write Deployment %s/%s: %v"
+	msgErrBackupFailedFor    = "Backup failed for %s"
+	msgErrCLIPath            = "Failed to find 'oc' or 'kubectl' in PATH for pod data backup: %v"
+	msgErrTarPath            = "Failed to find 'tar' in PATH for pod data backup: %v"
+	msgErrTarStart           = "Failed to start local tar process: %v"
+	msgErrExecRun            = "Failed to execute 'oc exec' in pod %s: %v\nstderr: %s"
+	msgErrTarWait            = "Failed to complete local tar extraction: %v\nstderr: %s"
+	msgErrStdoutPipe         = "Failed to create stdout pipe: %v"
+	msgErrEnforcePerms       = "Failed to set permissions on extracted pod data: %v"
+	msgErrDirCheck           = "Failed to check data directory in pod %s: %v"
+	msgInfoPodDataDirMissing = "Data directory not found in pod %s (may be empty or using different path)"
+	msgInfoConfigMapNotFound = "ConfigMap not found"
+	msgInfoBackedUpConfigMap = "Backed up ConfigMap"
+	msgInfoBackedUpPodData   = "Backed up pod data"
+	msgStepBackupAll         = "Backup LlamaStack resources"
+	msgStepBackupLLSD        = "Backup %s/%s"
+	msgStepBackupConfigMap   = "Backup ConfigMap %s"
+	msgStepBackupPodData     = "Backup pod data for %s"
+	msgInfoNoCRDPresent      = "No LlamaStackDistribution resources found (CRD not present)"
+	msgInfoNoResourcesFound  = "No LlamaStackDistribution resources found"
+	msgInfoBackedUpLLSD      = "Backed up %s"
+	msgInfoBackedUpCount     = "Backed up %d LlamaStackDistributions"
+	msgPreRenameNotice       = "Note: Backing up pre-rename resources (LlamaStack to OGX in 3.5)"
+	msgCustomConfigWarning   = "\n⚠️  CUSTOM CONFIG WARNINGS"
+	msgCustomConfigLine1     = "▸ %s\n"
+	msgCustomConfigLine2     = "  This distribution was using a custom config.\n"
+	msgCustomConfigLine3     = "  State was backed up from the default location: /opt/app-root/src/.llama/distributions/rh\n"
+	msgCustomConfigLine4     = "  VERIFY in the config that this location was correct, as it may have been altered in the custom config.\n\n"
+)
+
+type LlamaStackBackupAction struct{}
+
+func (a *LlamaStackBackupAction) ID() string                { return actionID }
+func (a *LlamaStackBackupAction) Name() string              { return actionName }
+func (a *LlamaStackBackupAction) Description() string       { return actionDescription }
+func (a *LlamaStackBackupAction) Group() action.ActionGroup { return action.GroupBackup }
+func (a *LlamaStackBackupAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
+
+func (a *LlamaStackBackupAction) CanApply(_ action.Target) bool {
+	return true
+}
+
+func (a *LlamaStackBackupAction) Prepare() action.Task {
+	return &prepareTask{action: a}
+}
+
+func (a *LlamaStackBackupAction) Run() action.Task {
+	return nil
+}
+
+type prepareTask struct {
+	action *LlamaStackBackupAction
+}
+
+func (t *prepareTask) Validate(_ context.Context, target action.Target) (*result.ActionResult, error) {
+	rootRecorder, ok := target.Recorder.(action.RootRecorder)
+	if !ok {
+		return nil, errors.New(msgErrNotRootRecorder)
+	}
+
+	return rootRecorder.Build(), nil
+}
+
+func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
+	rootRecorder, ok := target.Recorder.(action.RootRecorder)
+	if !ok {
+		return nil, errors.New(msgErrNotRootRecorder)
+	}
+
+	step := target.Recorder.Child("llamastack-backup", msgStepBackupAll)
+
+	// Create main backup directory
+	if !target.DryRun {
+		if err := os.MkdirAll(target.OutputDir, dirPerms); err != nil {
+			step.Completef(result.StepFailed, msgErrCreateBackupDir, err)
+
+			return rootRecorder.Build(), nil
+		}
+	}
+
+	llsdList, err := target.Client.Dynamic().Resource(resources.LlamaStackDistribution.GVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			step.Completef(result.StepCompleted, msgInfoNoCRDPresent)
+
+			return rootRecorder.Build(), nil
+		}
+		step.Completef(result.StepFailed, msgErrListDistributions, err)
+
+		return rootRecorder.Build(), nil
+	}
+
+	if len(llsdList.Items) == 0 {
+		step.Completef(result.StepCompleted, msgInfoNoResourcesFound)
+
+		return rootRecorder.Build(), nil
+	}
+
+	target.IO.Errorf(msgPreRenameNotice)
+	target.IO.Errorln()
+
+	customConfigs := []string{}
+
+	for _, llsd := range llsdList.Items {
+		if cfg, ok := processLLSD(ctx, target, llsd, step); ok {
+			customConfigs = append(customConfigs, cfg)
+		}
+	}
+
+	if len(customConfigs) > 0 {
+		target.IO.Errorf(msgCustomConfigWarning)
+		target.IO.Errorln()
+		for _, cfg := range customConfigs {
+			target.IO.Errorf(msgCustomConfigLine1, cfg)
+			target.IO.Errorf(msgCustomConfigLine2)
+			target.IO.Errorf(msgCustomConfigLine3)
+			target.IO.Errorf(msgCustomConfigLine4)
+		}
+	}
+
+	step.Completef(result.StepCompleted, msgInfoBackedUpCount, len(llsdList.Items))
+
+	return rootRecorder.Build(), nil
+}
+
+//nolint:nonamedreturns // named returns clarify the two-purpose return value
+func processLLSD(ctx context.Context, target action.Target, llsd unstructured.Unstructured, step action.StepRecorder) (customConfig string, hasCustomConfig bool) {
+	name := llsd.GetName()
+	ns := llsd.GetNamespace()
+
+	llsdStep := step.Child(fmt.Sprintf("backup-%s-%s", ns, name), fmt.Sprintf(msgStepBackupLLSD, ns, name))
+
+	llsdDir := filepath.Join(target.OutputDir, ns, name)
+	if !target.DryRun {
+		if err := os.MkdirAll(llsdDir, dirPerms); err != nil {
+			llsdStep.Completef(result.StepFailed, msgErrCreateLLSDDir, err)
+
+			return "", false
+		}
+
+		// 1. Backup YAML
+		if err := backup.WriteResourceFlat(llsdDir, resources.LlamaStackDistribution.GVR(), &llsd); err != nil {
+			llsdStep.Completef(result.StepFailed, msgErrBackupLLSD, ns, name, err)
+
+			return "", false
+		}
+	}
+
+	failed := false
+
+	// 2. ConfigMap
+	isCustomConfig, ok := backupConfigMap(ctx, target, llsd, llsdDir, ns, llsdStep)
+	if !ok {
+		failed = true
+	}
+
+	// 3. Pod Data
+	if !backupPodData(ctx, target, llsdDir, ns, name, llsdStep) {
+		failed = true
+	}
+
+	if failed {
+		llsdStep.Completef(result.StepFailed, msgErrBackupFailedFor, name)
+
+		return "", false
+	}
+
+	llsdStep.Completef(result.StepCompleted, msgInfoBackedUpLLSD, name)
+
+	if isCustomConfig {
+		return fmt.Sprintf("%s/%s", ns, name), true
+	}
+
+	return "", false
+}
+
+//nolint:nonamedreturns // required to avoid revive complaining about identical unnamed boolean returns
+func backupConfigMap(ctx context.Context, target action.Target, llsd unstructured.Unstructured, llsdDir, ns string, step action.StepRecorder) (hasCustomConfig, ok bool) {
+	configMapName, _ := jq.Query[string](&llsd, ".spec.server.userConfig.configMapName")
+	if configMapName == "" {
+		return false, true
+	}
+
+	cmStep := step.Child("configmap-"+configMapName, fmt.Sprintf(msgStepBackupConfigMap, configMapName))
+
+	cm, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).Namespace(ns).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			cmStep.Completef(result.StepSkipped, msgInfoConfigMapNotFound)
+
+			return true, true
+		}
+		cmStep.Completef(result.StepFailed, msgErrGetConfigMap, err)
+
+		return true, false
+	}
+
+	if target.DryRun {
+		cmStep.Completef(result.StepCompleted, msgInfoBackedUpConfigMap)
+
+		return true, true
+	}
+
+	if err := backup.WriteResourceFlat(llsdDir, resources.ConfigMap.GVR(), cm); err != nil {
+		cmStep.Completef(result.StepFailed, msgErrBackupConfigMap, ns, configMapName, err)
+
+		return true, false
+	}
+
+	data, err := jq.Query[map[string]any](cm, ".data")
+	if err != nil && !errors.Is(err, jq.ErrNotFound) {
+		cmStep.Completef(result.StepFailed, msgErrGetConfigMapData, err)
+
+		return true, false
+	}
+
+	if runYaml, ok := data["run.yaml"].(string); ok {
+		if err := os.WriteFile(filepath.Join(llsdDir, "run.yaml"), []byte(runYaml), filePerms); err != nil {
+			cmStep.Completef(result.StepFailed, msgErrWriteExtractedYAML, "run.yaml", err)
+
+			return true, false
+		}
+	}
+	if configYaml, ok := data["config.yaml"].(string); ok {
+		if err := os.WriteFile(filepath.Join(llsdDir, "config.yaml"), []byte(configYaml), filePerms); err != nil {
+			cmStep.Completef(result.StepFailed, msgErrWriteExtractedYAML, "config.yaml", err)
+
+			return true, false
+		}
+	}
+
+	cmStep.Completef(result.StepCompleted, msgInfoBackedUpConfigMap)
+
+	return true, true
+}
+
+func backupPodData(ctx context.Context, target action.Target, llsdDir, ns, name string, step action.StepRecorder) bool {
+	pods, err := target.Client.Dynamic().Resource(resources.Pod.GVR()).Namespace(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/instance=" + name,
+	})
+	if err != nil {
+		podStep := step.Child("pod-data-"+name, fmt.Sprintf(msgStepBackupPodData, name))
+		podStep.Completef(result.StepFailed, msgErrListPods, ns, err)
+
+		return false
+	}
+
+	if len(pods.Items) == 0 {
+		return true
+	}
+
+	pod := selectReadyPod(pods.Items)
+	podName := pod.GetName()
+
+	podStep := step.Child("pod-data-"+name, fmt.Sprintf(msgStepBackupPodData, name))
+
+	if !target.DryRun {
+		if err := backup.WriteResourceFlat(llsdDir, resources.Pod.GVR(), &pod); err != nil {
+			podStep.Completef(result.StepFailed, msgErrBackupPod, ns, podName, err)
+
+			return false
+		}
+	}
+
+	if !backupDeploymentForPod(ctx, target, pod, llsdDir, ns, podStep) {
+		return false
+	}
+
+	if !backupPodDataExecTar(ctx, target, podName, ns, llsdDir, podStep) {
+		return false
+	}
+
+	podStep.Completef(result.StepCompleted, msgInfoBackedUpPodData)
+
+	return true
+}
+
+func backupDeploymentForPod(ctx context.Context, target action.Target, pod unstructured.Unstructured, llsdDir, ns string, step action.StepRecorder) bool {
+	ownerRefs := pod.GetOwnerReferences()
+	for _, ref := range ownerRefs {
+		if ref.Kind != "ReplicaSet" {
+			continue
+		}
+
+		// Infer deployment name by removing hash
+		rsName := ref.Name
+		lastDash := strings.LastIndex(rsName, "-")
+		if lastDash <= 0 {
+			continue
+		}
+
+		deployName := rsName[:lastDash]
+		deploy, err := target.Client.Dynamic().Resource(resources.Deployment.GVR()).Namespace(ns).Get(ctx, deployName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			step.Completef(result.StepFailed, msgErrGetDeployment, err)
+
+			return false
+		}
+
+		if !target.DryRun {
+			if err := backup.WriteResourceFlat(llsdDir, resources.Deployment.GVR(), deploy); err != nil {
+				step.Completef(result.StepFailed, msgErrBackupDeployment, ns, deployName, err)
+
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func backupPodDataExecTar(ctx context.Context, target action.Target, podName, ns, llsdDir string, step action.StepRecorder) bool {
+	if target.DryRun {
+		return true
+	}
+
+	podDataDir := filepath.Join(llsdDir, "pod-data")
+	if err := os.MkdirAll(podDataDir, dirPerms); err != nil {
+		step.Completef(result.StepFailed, msgErrCreatePodDataDir, err)
+
+		return false
+	}
+
+	cliBin, err := findCLI()
+	if err != nil {
+		step.Completef(result.StepFailed, msgErrCLIPath, err)
+
+		return false
+	}
+
+	if _, err := exec.LookPath("tar"); err != nil {
+		step.Completef(result.StepFailed, msgErrTarPath, err)
+
+		return false
+	}
+
+	exists, err := checkPodDataDir(ctx, cliBin, ns, podName)
+	if err != nil {
+		step.Completef(result.StepFailed, msgErrDirCheck, podName, err)
+
+		return false
+	}
+
+	if !exists {
+		step.Completef(result.StepSkipped, msgInfoPodDataDirMissing, podName)
+
+		return true
+	}
+
+	var execStderr, tarStderr bytes.Buffer
+
+	//nolint:gosec // cliBin is resolved from LookPath, not user input
+	cmdExec := exec.CommandContext(ctx, cliBin, "exec", "-n", ns, podName, "-c", "llama-stack", "--", "tar", "--warning=no-file-changed", "--ignore-failed-read", "-czf", "-", "-C", podDataPath, ".")
+	cmdExec.Stderr = &execStderr
+
+	//nolint:gosec // controlled inputs for podDataDir
+	cmdTar := exec.CommandContext(ctx, "tar", "-xzf", "-", "-C", podDataDir)
+	cmdTar.Stderr = &tarStderr
+
+	stdout, err := cmdExec.StdoutPipe()
+	if err != nil {
+		step.Completef(result.StepFailed, msgErrStdoutPipe, err)
+
+		return false
+	}
+
+	if err := cmdExec.Start(); err != nil {
+		step.Completef(result.StepFailed, msgErrExecRun, podName, err, execStderr.String())
+
+		return false
+	}
+
+	cmdTar.Stdin = stdout
+	if err := cmdTar.Start(); err != nil {
+		// Prevent leaving cmdExec as a zombie process when tar fails to start.
+		_ = cmdExec.Process.Kill()
+		_ = cmdExec.Wait()
+
+		step.Completef(result.StepFailed, msgErrTarStart, err)
+
+		return false
+	}
+
+	// Wait for the reader to finish reading from the pipe before waiting for the writer.
+	// This prevents cmdExec.Wait() from closing the pipe while tar is still reading.
+	tarErr := cmdTar.Wait()
+	execErr := cmdExec.Wait()
+
+	if execErr != nil {
+		step.Completef(result.StepFailed, msgErrExecRun, podName, execErr, execStderr.String())
+
+		return false
+	}
+
+	if tarErr != nil {
+		step.Completef(result.StepFailed, msgErrTarWait, tarErr, tarStderr.String())
+
+		return false
+	}
+
+	if err := enforcePermissions(podDataDir); err != nil {
+		step.Completef(result.StepFailed, msgErrEnforcePerms, err)
+
+		return false
+	}
+
+	return true
+}
+
+// enforcePermissions walks a directory tree and sets restrictive permissions
+// on all files and directories. Symlinks are skipped to prevent os.Chmod from
+// following them and modifying files outside the tree (CWE-59).
+func enforcePermissions(dir string) error {
+	if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip symlinks to prevent os.Chmod from following them and modifying
+		// files outside the directory tree (CWE-59).
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		if d.IsDir() {
+			return os.Chmod(path, dirPerms)
+		}
+
+		return os.Chmod(path, filePerms)
+	}); err != nil {
+		return fmt.Errorf("walking directory %s: %w", dir, err)
+	}
+
+	return nil
+}
+
+// selectReadyPod returns the first Running+Ready pod from the list.
+// Falls back to the first pod if none are Ready.
+func selectReadyPod(pods []unstructured.Unstructured) unstructured.Unstructured {
+	for i := range pods {
+		phase, _ := jq.Query[string](&pods[i], ".status.phase")
+		if phase != "Running" {
+			continue
+		}
+
+		conditions, err := jq.Query[[]any](&pods[i], ".status.conditions")
+		if err != nil {
+			continue
+		}
+
+		for _, c := range conditions {
+			cond, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			condType, _ := cond["type"].(string)
+			condStatus, _ := cond["status"].(string)
+
+			if condType == "Ready" && condStatus == "True" {
+				return pods[i]
+			}
+		}
+	}
+
+	return pods[0]
+}
+
+// findCLI returns "oc" or "kubectl", preferring "oc".
+func findCLI() (string, error) {
+	if _, err := exec.LookPath("oc"); err == nil {
+		return "oc", nil
+	}
+
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		return "", fmt.Errorf("looking up kubectl: %w", err)
+	}
+
+	return "kubectl", nil
+}
+
+// checkPodDataDir checks whether podDataPath exists inside a pod.
+// Returns (true, nil) if the directory exists, (false, nil) if it does not,
+// and (false, err) if the exec command itself failed.
+func checkPodDataDir(ctx context.Context, cliBin, ns, podName string) (bool, error) {
+	cmd := exec.CommandContext(ctx, cliBin, "exec", "-n", ns, podName, "-c", "llama-stack", "--", "test", "-d", podDataPath)
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("exec in pod %s: %w", podName, err)
+	}
+
+	return true, nil
+}

--- a/pkg/migrate/actions/llamastack/backup/backup.go
+++ b/pkg/migrate/actions/llamastack/backup/backup.go
@@ -32,7 +32,6 @@ const (
 
 	podDataPath = "/opt/app-root/src/.llama/distributions/rh"
 
-	msgErrNotRootRecorder    = "recorder is not a RootRecorder"
 	msgErrCreateBackupDir    = "Failed to create backup directory: %v"
 	msgErrListDistributions  = "Failed to list LlamaStackDistributions: %v"
 	msgErrCreateLLSDDir      = "Failed to create directory: %v"
@@ -83,8 +82,13 @@ func (a *LlamaStackBackupAction) Description() string       { return actionDescr
 func (a *LlamaStackBackupAction) Group() action.ActionGroup { return action.GroupBackup }
 func (a *LlamaStackBackupAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
 
-func (a *LlamaStackBackupAction) CanApply(_ action.Target) bool {
-	return true
+func (a *LlamaStackBackupAction) CanApply(target action.Target) bool {
+	if target.TargetVersion == nil {
+		return false
+	}
+
+	// LlamaStack→OGX rename lands in 3.5; after that the CRDs no longer exist.
+	return target.TargetVersion.Major == 3 && target.TargetVersion.Minor <= 5
 }
 
 func (a *LlamaStackBackupAction) Prepare() action.Task {
@@ -100,20 +104,10 @@ type prepareTask struct {
 }
 
 func (t *prepareTask) Validate(_ context.Context, target action.Target) (*result.ActionResult, error) {
-	rootRecorder, ok := target.Recorder.(action.RootRecorder)
-	if !ok {
-		return nil, errors.New(msgErrNotRootRecorder)
-	}
-
-	return rootRecorder.Build(), nil
+	return action.BuildResult(target)
 }
 
 func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
-	rootRecorder, ok := target.Recorder.(action.RootRecorder)
-	if !ok {
-		return nil, errors.New(msgErrNotRootRecorder)
-	}
-
 	step := target.Recorder.Child("llamastack-backup", msgStepBackupAll)
 
 	// Create main backup directory
@@ -121,7 +115,7 @@ func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*resul
 		if err := os.MkdirAll(target.OutputDir, dirPerms); err != nil {
 			step.Completef(result.StepFailed, msgErrCreateBackupDir, err)
 
-			return rootRecorder.Build(), nil
+			return action.BuildResult(target)
 		}
 	}
 
@@ -130,17 +124,17 @@ func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*resul
 		if client.IsResourceTypeNotFound(err) {
 			step.Completef(result.StepCompleted, msgInfoNoCRDPresent)
 
-			return rootRecorder.Build(), nil
+			return action.BuildResult(target)
 		}
 		step.Completef(result.StepFailed, msgErrListDistributions, err)
 
-		return rootRecorder.Build(), nil
+		return action.BuildResult(target)
 	}
 
 	if len(llsdList.Items) == 0 {
 		step.Completef(result.StepCompleted, msgInfoNoResourcesFound)
 
-		return rootRecorder.Build(), nil
+		return action.BuildResult(target)
 	}
 
 	target.IO.Errorf(msgPreRenameNotice)
@@ -167,7 +161,7 @@ func (t *prepareTask) Execute(ctx context.Context, target action.Target) (*resul
 
 	step.Completef(result.StepCompleted, msgInfoBackedUpCount, len(llsdList.Items))
 
-	return rootRecorder.Build(), nil
+	return action.BuildResult(target)
 }
 
 //nolint:nonamedreturns // named returns clarify the two-purpose return value
@@ -193,6 +187,10 @@ func processLLSD(ctx context.Context, target action.Target, llsd unstructured.Un
 		}
 	}
 
+	// ConfigMap and pod data backups are independent; attempt both even if one
+	// fails so we capture as much data as possible. Individual failures are
+	// recorded immediately via child steps and the parent step is marked failed
+	// after both have been attempted.
 	failed := false
 
 	// 2. ConfigMap

--- a/pkg/migrate/actions/llamastack/backup/backup_test.go
+++ b/pkg/migrate/actions/llamastack/backup/backup_test.go
@@ -1,0 +1,591 @@
+package backup_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega/gstruct"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/llamastack/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoglobals
+var llsd = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "llamastack.io/v1alpha1",
+		"kind":       "LlamaStackDistribution",
+		"metadata": map[string]any{
+			"name":      "test-llsd",
+			"namespace": "test-ns",
+		},
+		"spec": map[string]any{
+			"server": map[string]any{
+				"userConfig": map[string]any{
+					"configMapName": "test-configmap",
+				},
+			},
+		},
+	},
+}
+
+//nolint:gochecknoglobals
+var cm = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "test-configmap",
+			"namespace": "test-ns",
+		},
+		"data": map[string]any{
+			"run.yaml":    "run_content",
+			"config.yaml": "config_content",
+		},
+	},
+}
+
+//nolint:gochecknoglobals
+var pod = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "test-pod",
+			"namespace": "test-ns",
+			"labels": map[string]any{
+				"app.kubernetes.io/instance": "test-llsd",
+			},
+			"ownerReferences": []any{
+				map[string]any{
+					"kind": "ReplicaSet",
+					"name": "test-deploy-hash123",
+				},
+			},
+		},
+		"status": map[string]any{
+			"phase": "Running",
+			"conditions": []any{
+				map[string]any{
+					"type":   "Ready",
+					"status": "True",
+				},
+			},
+		},
+	},
+}
+
+//nolint:gochecknoglobals
+var podTerminating = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      "test-pod-terminating",
+			"namespace": "test-ns",
+			"labels": map[string]any{
+				"app.kubernetes.io/instance": "test-llsd",
+			},
+			"ownerReferences": []any{
+				map[string]any{
+					"kind": "ReplicaSet",
+					"name": "test-deploy-oldhash",
+				},
+			},
+		},
+		"status": map[string]any{
+			"phase": "Running",
+			"conditions": []any{
+				map[string]any{
+					"type":   "Ready",
+					"status": "False",
+				},
+			},
+		},
+	},
+}
+
+//nolint:gochecknoglobals
+var deploy = &unstructured.Unstructured{
+	Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "test-deploy",
+			"namespace": "test-ns",
+		},
+	},
+}
+
+const (
+	stepNameBackup     = "llamastack-backup"
+	stepNameBackupLLSD = "backup-test-ns-test-llsd"
+)
+
+// hasFailedStep checks whether a given child step under the backup parent step has failed.
+func hasFailedStep(res *result.ActionResult, parentName, childName string) bool {
+	for _, step := range res.Status.Steps {
+		if step.Name != parentName {
+			continue
+		}
+
+		for _, child := range step.Children {
+			if child.Name == childName && child.Status == result.StepFailed {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func TestLlamaStackBackupAction_Validate(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	_, in, out, errOut := genericiooptions.NewTestIOStreams()
+	ioStreams := iostreams.NewIOStreams(in, out, errOut)
+	recorder := action.NewVerboseRootRecorder(ioStreams)
+
+	target := action.Target{
+		Recorder: recorder,
+	}
+
+	a := &backup.LlamaStackBackupAction{}
+	prepareTask := a.Prepare()
+
+	res, err := prepareTask.Validate(ctx, target)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(res).NotTo(BeNil())
+}
+
+func TestLlamaStackBackupAction_Execute(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "llamastack.io", Version: "v1alpha1", Resource: "llamastackdistributions"}: "LlamaStackDistributionList",
+		{Group: "", Version: "v1", Resource: "pods"}:                                       "PodList",
+	}
+
+	t.Run("successfully backs up resources", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, pod, deploy)
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		outDir := t.TempDir()
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true, // use dry-run to avoid trying to exec oc/kubectl in tests
+			OutputDir: outDir,
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		g.Expect(prepareTask).NotTo(BeNil())
+
+		res, err := prepareTask.Execute(ctx, target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Completed": BeTrue(),
+			}),
+		})))
+	})
+
+	t.Run("selects Ready pod over non-Ready pod", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// Place the terminating pod before the ready pod to verify selectReadyPod
+		// skips the non-Ready pod instead of blindly taking the first list item.
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, podTerminating, pod, deploy)
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		outDir := t.TempDir()
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: outDir,
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		g.Expect(prepareTask).NotTo(BeNil())
+
+		res, err := prepareTask.Execute(ctx, target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Completed": BeTrue(),
+			}),
+		})))
+	})
+
+	t.Run("successfully backs up resources to disk (non-dry-run)", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// Do not include pod and deploy so that we do not test exec tar logic
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm)
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		outDir := t.TempDir()
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    false,
+			OutputDir: outDir,
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		g.Expect(prepareTask).NotTo(BeNil())
+
+		res, err := prepareTask.Execute(ctx, target)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Completed": BeTrue(),
+			}),
+		})))
+
+		// Verify files on disk
+		nsDir := filepath.Join(outDir, "test-ns", "test-llsd")
+
+		// 1. LLSD YAML
+		llsdPath := filepath.Join(nsDir, "llamastackdistributions.llamastack.io-test-llsd.yaml")
+		g.Expect(llsdPath).To(BeAnExistingFile())
+
+		// 2. ConfigMap YAML
+		cmPath := filepath.Join(nsDir, "configmaps-test-configmap.yaml")
+		g.Expect(cmPath).To(BeAnExistingFile())
+
+		// 3. Extracted YAMLs
+		runPath := filepath.Join(nsDir, "run.yaml")
+		g.Expect(runPath).To(BeAnExistingFile())
+
+		configPath := filepath.Join(nsDir, "config.yaml")
+		g.Expect(configPath).To(BeAnExistingFile())
+	})
+
+	t.Run("no LLSD CRD present", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+		dynamicClient.PrependReactor("list", "llamastackdistributions", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{Group: "llamastack.io", Resource: "llamastackdistributions"}}
+		})
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: t.TempDir(),
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Completed": BeTrue(),
+			}),
+		})))
+	})
+
+	t.Run("no LLSD resources found", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: t.TempDir(),
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Completed": BeTrue(),
+			}),
+		})))
+	})
+
+	t.Run("API error listing LLSDs", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+		dynamicClient.PrependReactor("list", "llamastackdistributions", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("fake api error")
+		})
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: t.TempDir(),
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Completed": BeTrue(),
+			}),
+		})))
+	})
+
+	t.Run("API error getting ConfigMap fails the backup step", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, pod, deploy)
+		dynamicClient.PrependReactor("get", "configmaps", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("fake api error")
+		})
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: t.TempDir(),
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
+			"Expected to find a failed step for "+stepNameBackupLLSD)
+	})
+
+	t.Run("API error getting Deployment fails the backup step", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, pod, deploy)
+		dynamicClient.PrependReactor("get", "deployments", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("fake api error")
+		})
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: t.TempDir(),
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
+			"Expected to find a failed step for "+stepNameBackupLLSD)
+	})
+
+	t.Run("API error listing pods fails the backup step", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, pod, deploy)
+		dynamicClient.PrependReactor("list", "pods", func(clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("fake api error")
+		})
+
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    true,
+			OutputDir: t.TempDir(),
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
+			"Expected to find a failed step for "+stepNameBackupLLSD)
+	})
+
+	t.Run("exec tar fails when oc and kubectl not in PATH", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, pod, deploy)
+		testClient := client.NewForTesting(client.TestClientConfig{
+			Dynamic: dynamicClient,
+		})
+
+		_, in, out, errOut := genericiooptions.NewTestIOStreams()
+		ioStreams := iostreams.NewIOStreams(in, out, errOut)
+		recorder := action.NewVerboseRootRecorder(ioStreams)
+
+		outDir := t.TempDir()
+
+		target := action.Target{
+			Client:    testClient,
+			DryRun:    false,
+			OutputDir: outDir,
+			Recorder:  recorder,
+			IO:        ioStreams,
+		}
+
+		// Set PATH to an empty directory so exec.LookPath cannot find oc or kubectl
+		emptyDir := t.TempDir()
+		t.Setenv("PATH", emptyDir)
+
+		a := &backup.LlamaStackBackupAction{}
+		prepareTask := a.Prepare()
+		res, err := prepareTask.Execute(ctx, target)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res.Status.Completed).To(BeTrue())
+		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeTrue(),
+			"Expected backup to fail when oc/kubectl are not in PATH")
+	})
+}
+
+func TestEnforcePermissions_SkipsSymlinks(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a target file outside the walked directory to detect symlink following.
+	targetFile := filepath.Join(t.TempDir(), "outside-target.txt")
+	g.Expect(os.WriteFile(targetFile, []byte("secret"), 0o600)).To(Succeed())
+
+	// Widen permissions so we can detect if enforcePermissions changes them.
+	g.Expect(os.Chmod(targetFile, 0o755)).To(Succeed()) //nolint:gosec // intentionally wide perms for test detection
+
+	originalInfo, err := os.Stat(targetFile)
+	g.Expect(err).NotTo(HaveOccurred())
+	originalMode := originalInfo.Mode().Perm()
+
+	// Create the directory tree to walk, containing a symlink to the target.
+	walkDir := filepath.Join(t.TempDir(), "pod-data")
+	g.Expect(os.MkdirAll(walkDir, 0o700)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(walkDir, "regular.txt"), []byte("data"), 0o600)).To(Succeed())
+	g.Expect(os.Symlink(targetFile, filepath.Join(walkDir, "evil-link"))).To(Succeed())
+
+	g.Expect(backup.EnforcePermissions(walkDir)).To(Succeed())
+
+	// The symlink target's permissions must be unchanged.
+	afterInfo, err := os.Stat(targetFile)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(afterInfo.Mode().Perm()).To(Equal(originalMode),
+		"enforcePermissions must not chmod through symlinks")
+}

--- a/pkg/migrate/actions/llamastack/backup/backup_test.go
+++ b/pkg/migrate/actions/llamastack/backup/backup_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/onsi/gomega/gstruct"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -222,9 +223,30 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		// Place the terminating pod before the ready pod to verify selectReadyPod
-		// skips the non-Ready pod instead of blindly taking the first list item.
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, podTerminating, pod, deploy)
+		// Use per-test pod fixtures so wrong selection becomes observable.
+		// The terminating pod's ownerReference points to a ReplicaSet whose
+		// inferred deployment ("wrong-deploy") does not exist. If selectReadyPod
+		// picks this pod, backupDeploymentForPod will look up "wrong-deploy"
+		// instead of "test-deploy".
+		terminatingPod := podTerminating.DeepCopy()
+		terminatingPod.Object["metadata"].(map[string]any)["ownerReferences"] = []any{
+			map[string]any{"kind": "ReplicaSet", "name": "wrong-deploy-oldhash"},
+		}
+		readyPod := pod.DeepCopy()
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, llsd, cm, terminatingPod, readyPod, deploy)
+
+		// Track which deployment names are looked up to verify pod selection.
+		var requestedDeployments []string
+		dynamicClient.PrependReactor("get", "deployments", func(a clienttesting.Action) (bool, runtime.Object, error) {
+			getAction, ok := a.(clienttesting.GetAction)
+			if ok {
+				requestedDeployments = append(requestedDeployments, getAction.GetName())
+			}
+
+			return false, nil, nil // fall through to default behavior
+		})
+
 		testClient := client.NewForTesting(client.TestClientConfig{
 			Dynamic: dynamicClient,
 		})
@@ -254,6 +276,12 @@ func TestLlamaStackBackupAction_Execute(t *testing.T) {
 				"Completed": BeTrue(),
 			}),
 		})))
+		g.Expect(hasFailedStep(res, stepNameBackup, stepNameBackupLLSD)).To(BeFalse(),
+			"ready pod should be selected; selecting terminating pod would look up wrong-deploy")
+		g.Expect(requestedDeployments).To(ContainElement("test-deploy"),
+			"should look up deployment for the ready pod")
+		g.Expect(requestedDeployments).NotTo(ContainElement("wrong-deploy"),
+			"should not look up deployment for the terminating pod")
 	})
 
 	t.Run("successfully backs up resources to disk (non-dry-run)", func(t *testing.T) {
@@ -588,4 +616,40 @@ func TestEnforcePermissions_SkipsSymlinks(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(afterInfo.Mode().Perm()).To(Equal(originalMode),
 		"enforcePermissions must not chmod through symlinks")
+}
+
+func TestLlamaStackBackupAction_CanApply(t *testing.T) {
+	v30 := semver.MustParse("3.0.0")
+	v34 := semver.MustParse("3.4.0")
+	v35 := semver.MustParse("3.5.0")
+	v36 := semver.MustParse("3.6.0")
+	v40 := semver.MustParse("4.0.0")
+	v225 := semver.MustParse("2.25.0")
+
+	tests := []struct {
+		name          string
+		targetVersion *semver.Version
+		expected      bool
+	}{
+		{"applies for target 3.0", &v30, true},
+		{"applies for target 3.4", &v34, true},
+		{"applies for target 3.5", &v35, true},
+		{"does not apply for target 3.6", &v36, false},
+		{"does not apply for target 4.0", &v40, false},
+		{"does not apply for target 2.25", &v225, false},
+		{"does not apply for nil target version", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			a := &backup.LlamaStackBackupAction{}
+			target := action.Target{
+				TargetVersion: tt.targetVersion,
+			}
+
+			g.Expect(a.CanApply(target)).To(Equal(tt.expected))
+		})
+	}
 }

--- a/pkg/migrate/actions/llamastack/backup/export_test.go
+++ b/pkg/migrate/actions/llamastack/backup/export_test.go
@@ -1,0 +1,4 @@
+package backup
+
+//nolint:gochecknoglobals // Test exports only compiled in test builds
+var EnforcePermissions = enforcePermissions

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/llamastack/backup"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/training"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/data"
@@ -33,6 +34,7 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&metrics.MetricsAction{})
 	registry.MustRegister(&data.DataAction{})
 	registry.MustRegister(&training.VerifyWorkloadsAction{})
+	registry.MustRegister(&backup.LlamaStackBackupAction{})
 
 	return registry
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
https://issues.redhat.com/browse/RHOAIENG-61437

Converts backup-all-llamastack.sh to a migrate action. Backs up LlamaStackDistribution CRs, ConfigMaps, Deployments, Pods, and pod data before the LlamaStack->OGX rename in 3.5.

Also extracts WriteResourceFlat helper from resource_writer.go to support flat directory writes without namespace subdirectory.

### Example output

```
➜ ./bin/kubectl-odh migrate prepare --target-version 3.5.0 --phase pre-upgrade --migration llamastack.backup
Current OpenShift AI version: 2.25.6
Target OpenShift AI version: 3.5.0
Phase: pre-upgrade
Backup directory: backup-migrate-20260609-153623


llamastack.backup:

  → Backup LlamaStack resources
Note: Backing up pre-rename resources (LlamaStack to OGX in 3.5)

  → Backup grdryn-ogx/llamastack-custom-distribution
  → Backup pod data for llamastack-custom-distribution
    → Data directory not found in pod llamastack-custom-distribution-5cbcfff8f7-qnd6z (may be empty or using different path)
    ✓ Backed up pod data
    ✓ Backed up llamastack-custom-distribution
    ✓ Backed up 1 LlamaStackDistributions

Preparation llamastack.backup completed successfully!

All preparations completed successfully!
Backups saved to: backup-migrate-20260609-153623

Run 'migrate run' to execute the migration.
➜ tree backup-migrate-20260609-153623/
backup-migrate-20260609-153623/
└── grdryn-ogx
    └── llamastack-custom-distribution
        ├── deployments.apps-llamastack-custom-distribution.yaml
        ├── llamastackdistributions.llamastack.io-llamastack-custom-distribution.yaml
        ├── pod-data
        └── pods-llamastack-custom-distribution-5cbcfff8f7-qnd6z.yaml

4 directories, 3 files
```
## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LlamaStack backup migration action to capture distributions, related config data, and pod artifacts during pre-upgrade.
  * Added an option to write resource YAML as flat files directly into a target directory (no namespace subfolders).

* **Tests**
  * Added extensive tests for the backup action (version gating, dry-run, error paths, pod selection, artifact extraction).
  * Added tests for flat resource writing and permission handling that skip symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->