### PR TITLE
feat(lint): add LlamaStackDistribution CR migration check for 3.4→3.5

### DIFF
--- a/pkg/lint/checks/workloads/llamastack/migration.go
+++ b/pkg/lint/checks/workloads/llamastack/migration.go
@@ -1,0 +1,110 @@
+package llamastack
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	ConditionTypeRequiresMigration = "RequiresMigration"
+)
+
+// MigrationCheck validates LlamaStackDistribution resources for 3.4→3.5 upgrade.
+// In 3.5, LlamaStackDistribution CRs are replaced by OGXServer v1beta1.
+type MigrationCheck struct {
+	check.BaseCheck
+}
+
+func NewMigrationCheck() *MigrationCheck {
+	return &MigrationCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             "migration",
+			CheckID:          "workloads.llamastack.migration",
+			CheckName:        "Workloads :: LlamaStack :: CR Migration (3.4 to 3.5)",
+			CheckDescription: "Identifies LlamaStackDistribution resources that must be migrated to OGXServer v1beta1 for RHOAI 3.5 upgrade",
+			CheckRemediation: "Back up LlamaStack resources using 'odh-cli migrate prepare --migration llamastack.backup', then recreate as OGXServer v1beta1 CRs after upgrade following the OGX migration guide",
+		},
+	}
+}
+
+// CanApply returns whether this check should run for the given target.
+// This check only applies when upgrading FROM 3.4.x TO 3.5.x and LlamaStack Operator is Managed.
+func (c *MigrationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom34To35(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, "llamastackoperator", constants.ManagementStateManaged), nil
+}
+
+// Validate executes the check against the provided target.
+func (c *MigrationCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.Workloads(c, target, resources.LlamaStackDistribution).
+		Run(ctx, c.validateDistributions)
+}
+
+func (c *MigrationCheck) validateDistributions(
+	_ context.Context,
+	req *validate.WorkloadRequest[*unstructured.Unstructured],
+) error {
+	count := len(req.Items)
+
+	if count == 0 {
+		req.Result.SetCondition(check.NewCondition(
+			ConditionTypeRequiresMigration,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("No LlamaStackDistribution resources found - no CR migration needed for 3.5 upgrade"),
+		))
+
+		return nil
+	}
+
+	req.Result.SetCondition(check.NewCondition(
+		ConditionTypeRequiresMigration,
+		metav1.ConditionFalse,
+		check.WithReason("CRTypeMigration"),
+		check.WithMessage("Found %d LlamaStackDistribution(s) that must be migrated to OGXServer v1beta1 after RHOAI 3.5 upgrade. The LlamaStackDistribution CRD is removed in 3.5 and replaced by OGXServer.", count),
+		check.WithImpact(result.ImpactBlocking),
+		check.WithRemediation(c.CheckRemediation),
+	))
+
+	req.Result.ImpactedObjects = make([]metav1.PartialObjectMetadata, 0, len(req.Items))
+
+	for _, llsd := range req.Items {
+		req.Result.ImpactedObjects = append(req.Result.ImpactedObjects, metav1.PartialObjectMetadata{
+			TypeMeta: resources.LlamaStackDistribution.TypeMeta(),
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: llsd.GetNamespace(),
+				Name:      llsd.GetName(),
+				Annotations: map[string]string{
+					"upgrade.action": "requires-migration-to-ogxserver",
+				},
+			},
+		})
+	}
+
+	return nil
+}

--- a/pkg/lint/checks/workloads/llamastack/migration_test.go
+++ b/pkg/lint/checks/workloads/llamastack/migration_test.go
@@ -1,0 +1,196 @@
+package llamastack_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/llamastack"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestMigrationCheck_CanApply(t *testing.T) {
+	g := NewWithT(t)
+
+	testCases := []struct {
+		name           string
+		currentVersion string
+		targetVersion  string
+		componentState string
+		expected       bool
+	}{
+		{
+			name:           "3.4 to 3.5 upgrade with component Managed",
+			currentVersion: "3.4.0",
+			targetVersion:  "3.5.0",
+			componentState: "Managed",
+			expected:       true,
+		},
+		{
+			name:           "3.4.1 to 3.5.0 upgrade with component Managed",
+			currentVersion: "3.4.1",
+			targetVersion:  "3.5.0",
+			componentState: "Managed",
+			expected:       true,
+		},
+		{
+			name:           "3.4 to 3.5 upgrade with component Removed",
+			currentVersion: "3.4.0",
+			targetVersion:  "3.5.0",
+			componentState: "Removed",
+			expected:       false,
+		},
+		{
+			name:           "3.4 to 3.5 upgrade with component Unmanaged",
+			currentVersion: "3.4.0",
+			targetVersion:  "3.5.0",
+			componentState: "Unmanaged",
+			expected:       false,
+		},
+		{
+			name:           "3.3 to 3.5 upgrade — wrong source version",
+			currentVersion: "3.3.0",
+			targetVersion:  "3.5.0",
+			componentState: "Managed",
+			expected:       false,
+		},
+		{
+			name:           "3.5 to 3.6 upgrade — wrong target version",
+			currentVersion: "3.5.0",
+			targetVersion:  "3.6.0",
+			componentState: "Managed",
+			expected:       false,
+		},
+		{
+			name:           "2.25 to 3.5 upgrade — wrong source major",
+			currentVersion: "2.25.0",
+			targetVersion:  "3.5.0",
+			componentState: "Managed",
+			expected:       false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dsc := newDSC(map[string]string{"llamastackoperator": tc.componentState})
+			target := testutil.NewTarget(t, testutil.TargetConfig{
+				ListKinds:      listKinds,
+				Objects:        []*unstructured.Unstructured{dsc},
+				CurrentVersion: tc.currentVersion,
+				TargetVersion:  tc.targetVersion,
+			})
+
+			chk := llamastack.NewMigrationCheck()
+			canApply, err := chk.CanApply(t.Context(), target)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(canApply).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestMigrationCheck_NoWorkloads(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSC(map[string]string{"llamastackoperator": "Managed"})
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewMigrationCheck()
+	res, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.Status.Conditions).To(HaveLen(1))
+	g.Expect(res.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal("RequiresMigration"),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(res.Status.Conditions[0].Condition.Message).To(ContainSubstring("No LlamaStackDistribution resources found"))
+	g.Expect(res.Status.Conditions[0].Impact).To(Equal(result.ImpactNone))
+	g.Expect(res.ImpactedObjects).To(BeEmpty())
+}
+
+func TestMigrationCheck_WorkloadsFound(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSC(map[string]string{"llamastackoperator": "Managed"})
+	llsd1 := newLLSD("llsd-1", "ns-a")
+	llsd2 := newLLSD("llsd-2", "ns-b")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{dsc, llsd1, llsd2},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewMigrationCheck()
+	res, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.Status.Conditions).To(HaveLen(1))
+
+	g.Expect(res.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal("RequiresMigration"),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal("CRTypeMigration"),
+	}))
+	g.Expect(res.Status.Conditions[0].Condition.Message).To(ContainSubstring("Found 2 LlamaStackDistribution(s)"))
+	g.Expect(res.Status.Conditions[0].Condition.Message).To(ContainSubstring("migrated to OGXServer v1beta1"))
+	g.Expect(res.Status.Conditions[0].Impact).To(Equal(result.ImpactBlocking))
+	g.Expect(res.Status.Conditions[0].Remediation).To(ContainSubstring("odh-cli migrate prepare"))
+
+	g.Expect(res.ImpactedObjects).To(HaveLen(2))
+	g.Expect(res.ImpactedObjects[0].Name).To(Equal("llsd-1"))
+	g.Expect(res.ImpactedObjects[0].Namespace).To(Equal("ns-a"))
+	g.Expect(res.ImpactedObjects[0].Annotations).To(HaveKeyWithValue("upgrade.action", "requires-migration-to-ogxserver"))
+	g.Expect(res.ImpactedObjects[1].Name).To(Equal("llsd-2"))
+	g.Expect(res.ImpactedObjects[1].Namespace).To(Equal("ns-b"))
+}
+
+func TestMigrationCheck_SingleWorkload(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSC(map[string]string{"llamastackoperator": "Managed"})
+	llsd := newLLSD("my-distribution", "test-ns")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{dsc, llsd},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := llamastack.NewMigrationCheck()
+	res, err := chk.Validate(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.Status.Conditions).To(HaveLen(1))
+	g.Expect(res.Status.Conditions[0].Condition.Message).To(ContainSubstring("Found 1 LlamaStackDistribution(s)"))
+	g.Expect(res.ImpactedObjects).To(HaveLen(1))
+	g.Expect(res.ImpactedObjects[0].Name).To(Equal("my-distribution"))
+}
+
+func TestMigrationCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := llamastack.NewMigrationCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.llamastack.migration"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: LlamaStack :: CR Migration (3.4 to 3.5)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+	g.Expect(chk.CheckKind()).To(Equal("llamastackdistribution"))
+	g.Expect(chk.CheckType()).To(Equal("migration"))
+}

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -128,7 +128,7 @@ func NewCommand(
 	registry.MustRegister(openshift.NewCheck())
 	registry.MustRegister(servicemesh.NewCheck())
 
-	// Workloads (20)
+	// Workloads (21)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
@@ -140,6 +140,7 @@ func NewCommand(
 	registry.MustRegister(kserveworkloads.NewImpactedWorkloadsCheck())
 	registry.MustRegister(kueueworkloads.NewDataIntegrityCheck())
 	registry.MustRegister(llamastackworkloads.NewConfigCheck())
+	registry.MustRegister(llamastackworkloads.NewMigrationCheck())
 	registry.MustRegister(notebook.NewAcceleratorMigrationCheck())
 	registry.MustRegister(notebook.NewContainerNameCheck())
 	registry.MustRegister(notebook.NewHardwareProfileMigrationCheck())


### PR DESCRIPTION
## Description

JIRA: [RHOAIENG-63077](https://redhat.atlassian.net/browse/RHOAIENG-63077)

Adding a workload-level lint check that detects `LlamaStackDistribution` CRs when upgrading from RHOAI 3.4 to 3.5. The `LlamaStackDistribution` CRD is removed in 3.5 and replaced by `OGXServer` v1beta1.

This complements:
- [PR #78](https://github.com/opendatahub-io/odh-cli/pull/78) — component-level check for `llamastackoperator: Managed` in DSC (already merged)
- [PR #98](https://github.com/opendatahub-io/odh-cli/pull/98) — `llamastack.backup` migrate action for backing up CRs before upgrade

### Example output

```
$ ./bin/kubectl-odh lint --target-version 3.5

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ STATUS  KIND                    GROUP       CHECK                IMPACT    MESSAGE                                                                                      │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✗       cert-manager            dependency  installed            critical  cert-manager Operator for Red Hat OpenShift is not installed                                 │
│ ✓       openshift-platform      dependency  version-requirement  info      OpenShift 4.19.26 meets RHOAI 3.5 minimum version requirement (4.19.9+)                      │
│ ✓       dsc                     platform    readiness            info      DataScienceCluster is ready                                                                  │
│ ✓       dsci                    platform    readiness            info      DSCInitialization is ready                                                                   │
│ ✗       llamastackoperator      component   removal              critical  LlamaStack Operator is enabled (state: Managed) but is replaced by ogx in RHOAI 3.5          │
│ ✗       llamastackdistribution  workload    migration            critical  Found 1 LlamaStackDistribution(s) that must be migrated to OGXServer v1beta1 after RHOAI 3.5 │
│                                                                            upgrade. The LlamaStackDistribution CRD is removed in 3.5 and replaced by OGXServer.         │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Environment:
  OpenShift AI version: 3.4.1 -> 3.5
  OpenShift version:    4.19.26

Summary:
  Total: 6 | Passed: 3 | Warnings: 0 | Failed: 3 | Prohibited: 0

Result:
  FAIL - blocking findings detected


Environment:
  OpenShift AI version: 3.4.1 -> 3.5
  OpenShift version:    4.19.26

Summary:
  Total: 13 | Passed: 9 | Warnings: 1 | Failed: 3 | Prohibited: 0

Result:
  FAIL - blocking findings detected
```

Verbose mode shows impacted objects:

```
$ odh-cli lint --target-version 3.5 -v

Impacted Objects:

┌───────────────────────────────────────────────────────────────┐
│ STATUS  KIND                    GROUP     CHECK      IMPACT   │
├───────────────────────────────────────────────────────────────┤
│ ✗       llamastackdistribution  workload  migration  critical │
│                                                               │
│     upgrade-test-lint:                                        │
│       - llama-stack-upgrade-test (LlamaStackDistribution)     │
│                                                               │
│                                                               │
└───────────────────────────────────────────────────────────────┘
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests
- [x] Tested on live RHOAI 3.4.1 cluster with LlamaStackDistribution CR

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed

[RHOAIENG-63077]: https://redhat.atlassian.net/browse/RHOAIENG-63077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ