### PR TITLE
feat(events): add --follow flag for real-time event streaming

### DIFF
--- a/cmd/events/events.go
+++ b/cmd/events/events.go
@@ -51,6 +51,12 @@ const cmdExample = `
   # Filter by component
   kubectl odh events --component kserve
 
+  # Stream events in real-time
+  kubectl odh events -f
+
+  # Combine flags
+  kubectl odh events --component dashboard -f
+
   # All ODH namespaces, YAML output
   kubectl odh events -A -o yaml
 `

--- a/pkg/events/command.go
+++ b/pkg/events/command.go
@@ -47,6 +47,7 @@ type Command struct {
 	OutputFormat       string
 	OperatorNSOverride string
 	Component          string
+	Follow             bool
 
 	// Resolved fields (populated during Complete)
 	Namespace         string
@@ -57,6 +58,9 @@ type Command struct {
 
 	// Clusterhealth integration
 	crClient crclient.Client
+
+	// Stream output writer (initialized during watch mode)
+	streamOut *streamWriter
 }
 
 // NewCommand creates a new events Command with defaults.
@@ -80,6 +84,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
 	fs.StringVar(&c.OperatorNSOverride, "operator-namespace", "", "Override the operator namespace (auto-detected from OLM/CSV)")
 	fs.StringVar(&c.Component, "component", "", "Filter events by ODH component (dashboard, kserve, ray, etc.). Only filters core Kubernetes resources (Pods, Deployments, etc.); CRD-specific events are excluded")
+	fs.BoolVarP(&c.Follow, "follow", "f", false, "Stream new events in real-time")
 }
 
 // Complete resolves derived fields after flag parsing.
@@ -170,6 +175,14 @@ func (c *Command) Validate() error {
 		)
 	}
 
+	if c.Follow && c.OutputFormat != outputFormatTable {
+		return clierrors.NewValidationError(
+			"INVALID_FLAGS",
+			"--follow is only supported with table output",
+			"Remove -o json or -o yaml when using -f",
+		)
+	}
+
 	return nil
 }
 
@@ -200,6 +213,10 @@ func ValidComponents() []string {
 func (c *Command) Run(ctx context.Context) error {
 	if err := c.discoverNamespaces(ctx); err != nil {
 		return err
+	}
+
+	if c.Follow {
+		return c.watchEvents(ctx)
 	}
 
 	return c.listEvents(ctx)

--- a/pkg/events/command_test.go
+++ b/pkg/events/command_test.go
@@ -206,3 +206,35 @@ func TestValidComponents(t *testing.T) {
 	// Check that list is sorted
 	g.Expect(slices.IsSorted(components)).To(BeTrue(), "ValidComponents() should be sorted")
 }
+
+func TestCommandValidate_Follow(t *testing.T) {
+	tests := []struct {
+		name         string
+		follow       bool
+		outputFormat string
+		wantErr      bool
+	}{
+		{"follow with table", true, "table", false},
+		{"follow with json", true, "json", true},
+		{"follow with yaml", true, "yaml", true},
+		{"no follow with json", false, "json", false},
+		{"no follow with yaml", false, "yaml", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cmd := &events.Command{
+				OutputFormat: tt.outputFormat,
+				Follow:       tt.follow,
+				ConfigFlags:  genericclioptions.NewConfigFlags(true),
+			}
+			err := cmd.Validate()
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}

--- a/pkg/events/filter.go
+++ b/pkg/events/filter.go
@@ -5,20 +5,26 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
-const eventFetchTimeout = 30 * time.Second
+const (
+	eventFetchTimeout  = 30 * time.Second
+	eventChannelBuffer = 100
+)
 
 // fetchEvents retrieves events using the clusterhealth library.
 func (c *Command) fetchEvents(ctx context.Context) ([]clusterhealth.EventInfo, error) {
@@ -86,34 +92,106 @@ func sortEventsByTime(events []clusterhealth.EventInfo) {
 	})
 }
 
+const maxLabelFetchWorkers = 10
+
+// labelLookup represents an object to check for component labels.
+type labelLookup struct {
+	namespace, kind, name string
+}
+
 // filterEventsByComponent filters events to only those related to a component.
 // It looks up each event's InvolvedObject and checks for the component label.
+// Lookups are parallelized for performance, with up to 10 concurrent API calls.
 // Returns filtered events and any API error encountered (RBAC, timeout, etc.).
 func (c *Command) filterEventsByComponent(ctx context.Context, events []clusterhealth.EventInfo) ([]clusterhealth.EventInfo, error) {
 	targetLabel := resources.GetComponentLabelValue(c.Component)
-	labelCache := make(map[string]bool)
 
+	// Collect unique objects to look up
+	seen := make(map[labelLookup]struct{})
+	var lookups []labelLookup
+
+	for _, event := range events {
+		key := labelLookup{event.Namespace, event.Kind, event.Name}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			lookups = append(lookups, key)
+		}
+	}
+
+	// Fetch labels in parallel
+	labelCache, err := c.fetchComponentLabelsParallel(ctx, lookups, targetLabel)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter events using pre-populated cache
 	var filtered []clusterhealth.EventInfo
 
 	for _, event := range events {
-		cacheKey := fmt.Sprintf("%s/%s/%s/%s", targetLabel, event.Namespace, event.Kind, event.Name)
-
-		hasLabel, found := labelCache[cacheKey]
-		if !found {
-			var err error
-			hasLabel, err = c.checkObjectHasComponentLabel(ctx, event.Namespace, event.Kind, event.Name, targetLabel)
-			if err != nil {
-				return nil, fmt.Errorf("checking component label for %s/%s: %w", event.Kind, event.Name, err)
-			}
-			labelCache[cacheKey] = hasLabel
-		}
-
-		if hasLabel {
+		cacheKey := componentCacheKey(targetLabel, event.Namespace, event.Kind, event.Name)
+		if labelCache[cacheKey] {
 			filtered = append(filtered, event)
 		}
 	}
 
 	return filtered, nil
+}
+
+// fetchComponentLabelsParallel fetches component labels for objects in parallel.
+func (c *Command) fetchComponentLabelsParallel(ctx context.Context, lookups []labelLookup, targetLabel string) (map[string]bool, error) {
+	if len(lookups) == 0 {
+		return make(map[string]bool), nil
+	}
+
+	type result struct {
+		cacheKey string
+		hasLabel bool
+		err      error
+	}
+
+	resultCh := make(chan result, len(lookups))
+	workCh := make(chan labelLookup, len(lookups))
+
+	// Start workers
+	numWorkers := min(maxLabelFetchWorkers, len(lookups))
+
+	var wg sync.WaitGroup
+
+	for range numWorkers {
+		wg.Go(func() {
+			for item := range workCh {
+				hasLabel, err := c.checkObjectHasComponentLabel(ctx, item.namespace, item.kind, item.name, targetLabel)
+				cacheKey := componentCacheKey(targetLabel, item.namespace, item.kind, item.name)
+				resultCh <- result{cacheKey, hasLabel, err}
+			}
+		})
+	}
+
+	// Send work
+	for _, item := range lookups {
+		workCh <- item
+	}
+
+	close(workCh)
+
+	// Wait for completion
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	// Collect results
+	cache := make(map[string]bool, len(lookups))
+
+	for res := range resultCh {
+		if res.err != nil {
+			return nil, fmt.Errorf("checking component label: %w", res.err)
+		}
+
+		cache[res.cacheKey] = res.hasLabel
+	}
+
+	return cache, nil
 }
 
 // checkObjectHasComponentLabel checks if an object has the component label.
@@ -175,4 +253,267 @@ func kindToGVR(kind string) schema.GroupVersionResource {
 	}
 
 	return schema.GroupVersionResource{}
+}
+
+// componentCacheKey builds a cache key for component label lookups.
+func componentCacheKey(targetLabel, namespace, kind, name string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", targetLabel, namespace, kind, name)
+}
+
+// labelCache provides thread-safe caching for component label lookups.
+type labelCache struct {
+	mu    sync.RWMutex
+	cache map[string]bool
+}
+
+func newLabelCache() *labelCache {
+	return &labelCache{cache: make(map[string]bool)}
+}
+
+//nolint:revive // map lookup pattern returns (value, found)
+func (lc *labelCache) lookup(key string) (bool, bool) {
+	lc.mu.RLock()
+	defer lc.mu.RUnlock()
+	v, ok := lc.cache[key]
+
+	return v, ok
+}
+
+func (lc *labelCache) store(key string, val bool) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	lc.cache[key] = val
+}
+
+// watchEvents streams events in real-time using Kubernetes watch.
+func (c *Command) watchEvents(ctx context.Context) error {
+	namespaces, err := c.getTargetNamespaces()
+	if err != nil {
+		return err
+	}
+
+	showNamespace := c.AllNamespaces || !c.NamespaceExplicit
+	if err := c.printStreamHeader(showNamespace); err != nil {
+		return err
+	}
+
+	eventCh := make(chan corev1.Event, eventChannelBuffer)
+	cache := newLabelCache()
+
+	var wg sync.WaitGroup
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, ns := range namespaces {
+		wg.Add(1)
+
+		go func(namespace string) {
+			defer wg.Done()
+			c.watchNamespaceEvents(watchCtx, namespace, eventCh, cache)
+		}(ns)
+	}
+
+	go func() {
+		wg.Wait()
+		close(eventCh)
+	}()
+
+	return c.streamWatchedEvents(watchCtx, eventCh)
+}
+
+const (
+	maxWatchRetries     = 5
+	initialRetryBackoff = time.Second
+	maxRetryBackoff     = 30 * time.Second
+	backoffMultiplier   = 2
+)
+
+// watchNamespaceEvents watches events in a single namespace with automatic reconnection.
+func (c *Command) watchNamespaceEvents(ctx context.Context, namespace string, eventCh chan<- corev1.Event, cache *labelCache) {
+	listOpts := metav1.ListOptions{}
+	if c.EventType != "" {
+		listOpts.FieldSelector = "type=" + c.EventType
+	}
+
+	// sinceCutoff filters initial/existing events only; new events streaming in are always shown
+	var sinceCutoff time.Time
+	if c.Since > 0 {
+		sinceCutoff = time.Now().Add(-c.Since)
+	}
+
+	var consecutiveErrors int
+
+	backoff := initialRetryBackoff
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		watcher, err := c.Client.CoreV1().Events(namespace).Watch(ctx, listOpts)
+		if err != nil {
+			consecutiveErrors++
+			if consecutiveErrors >= maxWatchRetries {
+				_, _ = fmt.Fprintf(c.IO.ErrOut(), "Error: failed to watch events in %s after %d retries: %v\n", namespace, maxWatchRetries, err)
+
+				return
+			}
+
+			_, _ = fmt.Fprintf(c.IO.ErrOut(), "Warning: failed to watch events in %s: %v, retrying in %v...\n", namespace, err, backoff)
+			time.Sleep(backoff)
+			backoff = min(backoff*backoffMultiplier, maxRetryBackoff)
+
+			continue
+		}
+
+		// Reset error state on successful connection
+		consecutiveErrors = 0
+		backoff = initialRetryBackoff
+
+		lastRV := c.processWatchEvents(ctx, watcher, eventCh, cache, sinceCutoff)
+		watcher.Stop()
+
+		// Use last seen ResourceVersion on reconnect to avoid replaying events
+		if lastRV != "" {
+			listOpts.ResourceVersion = lastRV
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			_, _ = fmt.Fprintf(c.IO.ErrOut(), "Warning: watch connection closed for %s, reconnecting...\n", namespace)
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+// processWatchEvents handles events from a watcher until the channel closes.
+// Returns the last seen ResourceVersion for reconnection.
+func (c *Command) processWatchEvents(ctx context.Context, watcher watch.Interface, eventCh chan<- corev1.Event, cache *labelCache, sinceCutoff time.Time) string {
+	var lastRV string
+
+	for {
+		select {
+		case <-ctx.Done():
+			return lastRV
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return lastRV
+			}
+
+			// Advance ResourceVersion before filtering to avoid replaying filtered events on reconnect
+			if e, ok := event.Object.(*corev1.Event); ok && e.ResourceVersion != "" {
+				lastRV = e.ResourceVersion
+			}
+
+			if e := c.extractValidEvent(ctx, event, cache, sinceCutoff); e != nil {
+				select {
+				case eventCh <- *e:
+				case <-ctx.Done():
+					return lastRV
+				}
+			}
+		}
+	}
+}
+
+// extractValidEvent extracts a valid event from a watch event, applying filters.
+func (c *Command) extractValidEvent(ctx context.Context, event watch.Event, cache *labelCache, sinceCutoff time.Time) *corev1.Event {
+	if event.Type != watch.Added && event.Type != watch.Modified {
+		return nil
+	}
+
+	e, ok := event.Object.(*corev1.Event)
+	if !ok {
+		return nil
+	}
+
+	if !sinceCutoff.IsZero() && isEventBeforeCutoff(e, sinceCutoff) {
+		return nil
+	}
+
+	if c.Component != "" && !c.checkEventMatchesComponentCached(ctx, e, cache) {
+		return nil
+	}
+
+	return e
+}
+
+// isEventBeforeCutoff checks if the event occurred before the cutoff time.
+func isEventBeforeCutoff(e *corev1.Event, cutoff time.Time) bool {
+	eventTime := e.LastTimestamp.Time
+	if eventTime.IsZero() {
+		eventTime = e.EventTime.Time
+	}
+
+	if eventTime.IsZero() {
+		return false
+	}
+
+	return eventTime.Before(cutoff)
+}
+
+// streamWatchedEvents outputs events as they arrive.
+func (c *Command) streamWatchedEvents(ctx context.Context, eventCh <-chan corev1.Event) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-eventCh:
+			if !ok {
+				return nil
+			}
+
+			info := eventToEventInfo(event)
+			if err := c.printSingleEvent(info); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// eventToEventInfo converts a corev1.Event to clusterhealth.EventInfo.
+func eventToEventInfo(e corev1.Event) clusterhealth.EventInfo {
+	lastTime := e.LastTimestamp.Time
+	if lastTime.IsZero() {
+		lastTime = e.EventTime.Time
+	}
+
+	return clusterhealth.EventInfo{
+		Namespace: e.Namespace,
+		Name:      e.InvolvedObject.Name,
+		Kind:      e.InvolvedObject.Kind,
+		Reason:    e.Reason,
+		Message:   e.Message,
+		Count:     e.Count,
+		Type:      e.Type,
+		LastTime:  lastTime,
+	}
+}
+
+// checkEventMatchesComponentCached checks if an event's InvolvedObject belongs to a component, using cache.
+func (c *Command) checkEventMatchesComponentCached(ctx context.Context, event *corev1.Event, cache *labelCache) bool {
+	targetLabel := resources.GetComponentLabelValue(c.Component)
+	cacheKey := componentCacheKey(targetLabel, event.InvolvedObject.Namespace, event.InvolvedObject.Kind, event.InvolvedObject.Name)
+
+	if hasLabel, found := cache.lookup(cacheKey); found {
+		return hasLabel
+	}
+
+	hasLabel, err := c.checkObjectHasComponentLabel(ctx, event.InvolvedObject.Namespace,
+		event.InvolvedObject.Kind, event.InvolvedObject.Name, targetLabel)
+	if err != nil {
+		_, _ = fmt.Fprintf(c.IO.ErrOut(), "Warning: failed to check component label for %s/%s: %v\n",
+			event.InvolvedObject.Kind, event.InvolvedObject.Name, err)
+		// Don't cache on error - allow retry on next event for this object
+		return false
+	}
+
+	cache.store(cacheKey, hasLabel)
+
+	return hasLabel
 }

--- a/pkg/events/filter_test.go
+++ b/pkg/events/filter_test.go
@@ -2,20 +2,25 @@
 package events
 
 import (
+	"bytes"
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 
 	. "github.com/onsi/gomega"
 )
@@ -244,6 +249,35 @@ func TestKindToGVR(t *testing.T) {
 	}
 }
 
+// TestKindToGVRMapCompleteness ensures kindToGVRMap includes all expected core Kubernetes
+// resource types. When adding new core resource types to pkg/resources/types.go that should
+// be supported by --component filtering, add them to this list.
+func TestKindToGVRMapCompleteness(t *testing.T) {
+	// expectedCoreKinds lists core/apps Kubernetes kinds that should be in kindToGVRMap.
+	// This test catches drift when new resource types are added to pkg/resources/types.go
+	// but not to kindToGVRMap, which would silently exclude those events from --component filtering.
+	expectedCoreKinds := []string{
+		"Pod",
+		"Deployment",
+		"ReplicaSet",
+		"StatefulSet",
+		"DaemonSet",
+		"Service",
+		"ConfigMap",
+		"Secret",
+		"Job",
+	}
+
+	for _, kind := range expectedCoreKinds {
+		t.Run(kind, func(t *testing.T) {
+			gvr := kindToGVR(kind)
+			if gvr.Resource == "" {
+				t.Errorf("kindToGVRMap missing expected kind %q - add it to support --component filtering for %s events", kind, kind)
+			}
+		})
+	}
+}
+
 // createTestPod creates an unstructured Pod with the given labels.
 func createTestPod(name, namespace string, labels map[string]string) *unstructured.Unstructured {
 	pod := &unstructured.Unstructured{}
@@ -382,4 +416,260 @@ func TestFilterEventsByComponent(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(filtered).To(HaveLen(1))
 	g.Expect(filtered[0].Name).To(Equal("kserve-pod"))
+}
+
+func TestLabelCache(t *testing.T) {
+	g := NewWithT(t)
+	cache := newLabelCache()
+
+	// Empty cache
+	val, found := cache.lookup("key1")
+	g.Expect(found).To(BeFalse())
+	g.Expect(val).To(BeFalse())
+
+	// Store and retrieve
+	cache.store("key1", true)
+	val, found = cache.lookup("key1")
+	g.Expect(found).To(BeTrue())
+	g.Expect(val).To(BeTrue())
+
+	cache.store("key2", false)
+	val, found = cache.lookup("key2")
+	g.Expect(found).To(BeTrue())
+	g.Expect(val).To(BeFalse())
+}
+
+func TestIsEventBeforeCutoff(t *testing.T) {
+	now := time.Now()
+	cutoff := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name  string
+		event *corev1.Event
+		want  bool
+	}{
+		{
+			name:  "event after cutoff",
+			event: &corev1.Event{LastTimestamp: metav1.Time{Time: now.Add(-30 * time.Minute)}},
+			want:  false,
+		},
+		{
+			name:  "event before cutoff",
+			event: &corev1.Event{LastTimestamp: metav1.Time{Time: now.Add(-2 * time.Hour)}},
+			want:  true,
+		},
+		{
+			name:  "zero timestamp",
+			event: &corev1.Event{},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := isEventBeforeCutoff(tt.event, cutoff)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestExtractValidEvent(t *testing.T) {
+	now := time.Now()
+	cmd := &Command{}
+	cache := newLabelCache()
+
+	tests := []struct {
+		name       string
+		watchEvent watch.Event
+		wantNil    bool
+	}{
+		{
+			name: "valid ADDED event",
+			watchEvent: watch.Event{
+				Type:   watch.Added,
+				Object: &corev1.Event{LastTimestamp: metav1.Time{Time: now}},
+			},
+			wantNil: false,
+		},
+		{
+			name: "valid MODIFIED event",
+			watchEvent: watch.Event{
+				Type:   watch.Modified,
+				Object: &corev1.Event{LastTimestamp: metav1.Time{Time: now}},
+			},
+			wantNil: false,
+		},
+		{
+			name: "DELETED event returns nil",
+			watchEvent: watch.Event{
+				Type:   watch.Deleted,
+				Object: &corev1.Event{},
+			},
+			wantNil: true,
+		},
+		{
+			name: "non-Event object returns nil",
+			watchEvent: watch.Event{
+				Type:   watch.Added,
+				Object: &corev1.Pod{},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := cmd.extractValidEvent(context.Background(), tt.watchEvent, cache, time.Time{})
+			if tt.wantNil {
+				g.Expect(got).To(BeNil())
+			} else {
+				g.Expect(got).ToNot(BeNil())
+			}
+		})
+	}
+}
+
+func TestEventToEventInfo(t *testing.T) {
+	g := NewWithT(t)
+	now := time.Now()
+
+	event := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "test-pod",
+		},
+		Reason:        "Created",
+		Message:       "Pod created",
+		Count:         1,
+		Type:          "Normal",
+		LastTimestamp: metav1.Time{Time: now},
+	}
+
+	info := eventToEventInfo(event)
+
+	g.Expect(info.Namespace).To(Equal("test-ns"))
+	g.Expect(info.Name).To(Equal("test-pod"))
+	g.Expect(info.Kind).To(Equal("Pod"))
+	g.Expect(info.Reason).To(Equal("Created"))
+	g.Expect(info.Type).To(Equal("Normal"))
+}
+
+func TestProcessWatchEvents(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	fakeWatcher := watch.NewFake()
+	eventCh := make(chan corev1.Event, 10)
+	cache := newLabelCache()
+	cmd := &Command{}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		cmd.processWatchEvents(ctx, fakeWatcher, eventCh, cache, time.Time{})
+	})
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "event1", Namespace: "test"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "pod1",
+		},
+		LastTimestamp: metav1.Time{Time: time.Now()},
+	}
+
+	fakeWatcher.Add(event)
+
+	g.Eventually(func() int {
+		select {
+		case <-eventCh:
+			return 1
+		default:
+			return 0
+		}
+	}, time.Second, 10*time.Millisecond).Should(Equal(1))
+
+	fakeWatcher.Stop()
+	wg.Wait()
+}
+
+func TestStreamWatchedEvents(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var buf bytes.Buffer
+	io := iostreams.NewIOStreams(nil, &buf, &buf)
+
+	cmd := &Command{
+		IO:        io,
+		streamOut: newStreamWriter(&buf, false),
+	}
+
+	eventCh := make(chan corev1.Event, 5)
+	eventCh <- corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "test-pod",
+		},
+		Reason:        "Created",
+		Type:          "Normal",
+		LastTimestamp: metav1.Time{Time: time.Now()},
+	}
+	close(eventCh)
+
+	err := cmd.streamWatchedEvents(ctx, eventCh)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+	g.Expect(output).To(ContainSubstring("Pod/test-pod"))
+	g.Expect(output).To(ContainSubstring("Created"))
+}
+
+func TestComponentCacheKey(t *testing.T) {
+	g := NewWithT(t)
+
+	key := componentCacheKey("kserve", "odh-apps", "Pod", "my-pod")
+	g.Expect(key).To(Equal("kserve/odh-apps/Pod/my-pod"))
+
+	key2 := componentCacheKey("dashboard", "ns", "Deployment", "deploy")
+	g.Expect(key2).To(Equal("dashboard/ns/Deployment/deploy"))
+}
+
+func TestCheckEventMatchesComponentCached_ErrorNotCached(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Create client with no objects - will return not found (no error)
+	fakeClient := createFakeClient(t)
+	var errBuf bytes.Buffer
+
+	cmd := &Command{
+		Client:    fakeClient,
+		Component: "kserve",
+		IO:        iostreams.NewIOStreams(nil, nil, &errBuf),
+	}
+
+	cache := newLabelCache()
+	event := &corev1.Event{
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "missing-pod",
+			Namespace: "odh-apps",
+		},
+	}
+
+	// First call - object not found returns false, caches result
+	result := cmd.checkEventMatchesComponentCached(ctx, event, cache)
+	g.Expect(result).To(BeFalse())
+
+	// Verify it was cached (not found is not an error, so it's cached)
+	cacheKey := componentCacheKey("kserve", "odh-apps", "Pod", "missing-pod")
+	val, found := cache.lookup(cacheKey)
+	g.Expect(found).To(BeTrue())
+	g.Expect(val).To(BeFalse())
 }

--- a/pkg/events/output.go
+++ b/pkg/events/output.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -94,7 +95,9 @@ func (c *Command) renderOutput(events []clusterhealth.EventInfo) error {
 	case outputFormatYAML:
 		return outputYAML(c.IO.Out(), events)
 	default:
-		return outputTable(c.IO.Out(), events, c.AllNamespaces)
+		showNamespace := c.AllNamespaces || !c.NamespaceExplicit
+
+		return outputTable(c.IO.Out(), events, showNamespace)
 	}
 }
 
@@ -190,4 +193,109 @@ func toEventOutputList(events []clusterhealth.EventInfo) any {
 		"kind":       "EventList",
 		"items":      events,
 	}
+}
+
+// streamWriter writes events with fixed-width columns for streaming output.
+type streamWriter struct {
+	w             io.Writer
+	showNamespace bool
+}
+
+func newStreamWriter(w io.Writer, showNamespace bool) *streamWriter {
+	return &streamWriter{w: w, showNamespace: showNamespace}
+}
+
+const (
+	colWidthNamespace = 20
+	colWidthLastSeen  = 10
+	colWidthType      = 8
+	colWidthReason    = 20
+	colWidthObject    = 40
+	colWidthCount     = 6
+)
+
+func (sw *streamWriter) writeHeader() error {
+	var format string
+	if sw.showNamespace {
+		format = fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%s\n",
+			colWidthNamespace, colWidthLastSeen, colWidthType, colWidthReason, colWidthObject, colWidthCount)
+		if _, err := fmt.Fprintf(sw.w, format, "NAMESPACE", "LAST SEEN", "TYPE", "REASON", "OBJECT", "COUNT", "MESSAGE"); err != nil {
+			return fmt.Errorf("writing header: %w", err)
+		}
+
+		return nil
+	}
+
+	format = fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%s\n",
+		colWidthLastSeen, colWidthType, colWidthReason, colWidthObject, colWidthCount)
+	if _, err := fmt.Fprintf(sw.w, format, "LAST SEEN", "TYPE", "REASON", "OBJECT", "COUNT", "MESSAGE"); err != nil {
+		return fmt.Errorf("writing header: %w", err)
+	}
+
+	return nil
+}
+
+func (sw *streamWriter) writeEvent(e clusterhealth.EventInfo) error {
+	age := formatAge(e.LastTime)
+	eventType := sanitizeForTerminal(e.Type)
+	kind := sanitizeForTerminal(e.Kind)
+	name := sanitizeForTerminal(e.Name)
+	reason := sanitizeForTerminal(e.Reason)
+	message := truncateMessage(sanitizeForTerminal(e.Message))
+	object := truncateField(fmt.Sprintf("%s/%s", kind, name), colWidthObject)
+
+	var format string
+	if sw.showNamespace {
+		namespace := truncateField(sanitizeForTerminal(e.Namespace), colWidthNamespace)
+		format = fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%dd  %%s\n",
+			colWidthNamespace, colWidthLastSeen, colWidthType, colWidthReason, colWidthObject, colWidthCount)
+		if _, err := fmt.Fprintf(sw.w, format, namespace, age, eventType, reason, object, e.Count, message); err != nil {
+			return fmt.Errorf("writing event: %w", err)
+		}
+
+		return nil
+	}
+
+	format = fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%dd  %%s\n",
+		colWidthLastSeen, colWidthType, colWidthReason, colWidthObject, colWidthCount)
+	if _, err := fmt.Fprintf(sw.w, format, age, eventType, reason, object, e.Count, message); err != nil {
+		return fmt.Errorf("writing event: %w", err)
+	}
+
+	return nil
+}
+
+func truncateField(s string, maxWidth int) string {
+	if maxWidth <= 3 {
+		return s
+	}
+
+	r := []rune(s)
+	if len(r) <= maxWidth {
+		return s
+	}
+
+	return string(r[:maxWidth-3]) + "..."
+}
+
+func (c *Command) printStreamHeader(showNamespace bool) error {
+	c.streamOut = newStreamWriter(c.IO.Out(), showNamespace)
+
+	if err := c.streamOut.writeHeader(); err != nil {
+		return clierrors.ErrRenderFailed("header", err)
+	}
+
+	return nil
+}
+
+func (c *Command) printSingleEvent(e clusterhealth.EventInfo) error {
+	if c.streamOut == nil {
+		return clierrors.ErrRenderFailed("stream", errors.New("stream writer not initialized"))
+	}
+
+	if err := c.streamOut.writeEvent(e); err != nil {
+		return clierrors.ErrRenderFailed("stream", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description

Add `-f/--follow` flag to `odh events` for real-time event streaming.

```bash
# Stream events in real-time
kubectl odh events -f

# Combine with other flags
kubectl odh events -f --component kserve -A
```

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream events in real-time with `--follow/-f`, including formatted streamed output and optional namespace column.
  * Use `--component` filtering together with `-f` for targeted live monitoring.
  * Streaming is restricted to table output (validation enforces this).

* **Documentation**
  * Help/examples updated to document real-time streaming and component+follow usage.

* **Tests**
  * Added tests covering streaming, component filtering, caching behavior, and event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->