### PR TITLE
Rename Complete/Record to Completef/Recordf for Go printf convention

### DIFF
--- a/pkg/migrate/action/recorder.go
+++ b/pkg/migrate/action/recorder.go
@@ -9,16 +9,14 @@ type StepRecorder interface {
 	// The child automatically nests under this recorder's step.
 	Child(name string, description string) StepRecorder
 
-	// Complete marks this step as complete with status and message.
-	// Supports printf-style formatting with variadic arguments.
-	Complete(status result.StepStatus, messageFormat string, args ...any)
+	// Completef marks this step as complete with status and a printf-style formatted message.
+	Completef(status result.StepStatus, messageFormat string, args ...any)
 
 	// AddDetail adds structured data to this step (for JSON/YAML output).
 	AddDetail(key string, value any)
 
-	// Record adds a simple completed sub-step (convenience method for quick recordings).
-	// Supports printf-style formatting with variadic arguments.
-	Record(name string, messageFormat string, status result.StepStatus, args ...any)
+	// Recordf adds a simple completed sub-step with a printf-style formatted message.
+	Recordf(name string, messageFormat string, status result.StepStatus, args ...any)
 }
 
 // RootRecorder is the top-level recorder that can build the final ActionResult.

--- a/pkg/migrate/action/recorder_impl.go
+++ b/pkg/migrate/action/recorder_impl.go
@@ -72,9 +72,8 @@ func (r *stepRecorderImpl) Child(name string, description string) StepRecorder {
 	return child
 }
 
-// Complete marks this step as complete with status and message.
-// Supports printf-style formatting with variadic arguments.
-func (r *stepRecorderImpl) Complete(status result.StepStatus, messageFormat string, args ...any) {
+// Completef marks this step as complete with status and a printf-style formatted message.
+func (r *stepRecorderImpl) Completef(status result.StepStatus, messageFormat string, args ...any) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -122,16 +121,15 @@ func (r *stepRecorderImpl) AddDetail(key string, value any) {
 	}
 }
 
-// Record adds a simple completed sub-step (convenience method).
-// Supports printf-style formatting with variadic arguments.
-func (r *stepRecorderImpl) Record(name string, messageFormat string, status result.StepStatus, args ...any) {
+// Recordf adds a simple completed sub-step with a printf-style formatted message.
+func (r *stepRecorderImpl) Recordf(name string, messageFormat string, status result.StepStatus, args ...any) {
 	message := messageFormat
 	if len(args) > 0 {
 		message = fmt.Sprintf(messageFormat, args...)
 	}
 
 	child := r.Child(name, message)
-	child.Complete(status, message)
+	child.Completef(status, "%s", message)
 }
 
 // Build constructs the final ActionResult with all recorded steps.

--- a/pkg/migrate/action/recorder_test.go
+++ b/pkg/migrate/action/recorder_test.go
@@ -18,7 +18,7 @@ func TestRecorder_Child(t *testing.T) {
 	step1 := recorder.Child("step1", "First Step")
 	g.Expect(step1).ToNot(BeNil())
 
-	step1.Complete(result.StepCompleted, "Step 1 completed")
+	step1.Completef(result.StepCompleted, "Step 1 completed")
 
 	actionResult := recorder.Build()
 	g.Expect(actionResult).ToNot(BeNil())
@@ -38,9 +38,9 @@ func TestRecorder_NestedChildren(t *testing.T) {
 	child1 := parent.Child("child1", "Child 1")
 	child2 := parent.Child("child2", "Child 2")
 
-	child1.Complete(result.StepCompleted, "Child 1 done")
-	child2.Complete(result.StepFailed, "Child 2 failed")
-	parent.Complete(result.StepFailed, "Parent failed due to child")
+	child1.Completef(result.StepCompleted, "Child 1 done")
+	child2.Completef(result.StepFailed, "Child 2 failed")
+	parent.Completef(result.StepFailed, "Parent failed due to child")
 
 	actionResult := recorder.Build()
 	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
@@ -62,7 +62,7 @@ func TestRecorder_AddDetail(t *testing.T) {
 
 	step.AddDetail("key1", "value1")
 	step.AddDetail("key2", 42)
-	step.Complete(result.StepCompleted, "Done")
+	step.Completef(result.StepCompleted, "Done")
 
 	actionResult := recorder.Build()
 	g.Expect(actionResult.Status.Steps).To(HaveLen(1))
@@ -76,7 +76,7 @@ func TestRecorder_Record(t *testing.T) {
 	g := NewWithT(t)
 
 	recorder := action.NewRootRecorder()
-	recorder.Record("quick-step", "Quick step message", result.StepCompleted)
+	recorder.Recordf("quick-step", "Quick step message", result.StepCompleted)
 
 	actionResult := recorder.Build()
 	g.Expect(actionResult.Status.Steps).To(HaveLen(1))

--- a/pkg/migrate/actions/aipipelines/dspa.go
+++ b/pkg/migrate/actions/aipipelines/dspa.go
@@ -98,25 +98,25 @@ func migrateAllDSPAsToV1(
 
 	v1alpha1DSPAs, err := listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+		step.Completef(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
 
 		return err
 	}
 
 	if len(v1alpha1DSPAs) == 0 {
-		step.Complete(result.StepCompleted, "No v1alpha1 DSPAs found")
+		step.Completef(result.StepCompleted, "No v1alpha1 DSPAs found")
 
 		return nil
 	}
 
-	step.Record("detected", "Found %d v1alpha1 DSPA(s) to migrate", result.StepCompleted, len(v1alpha1DSPAs))
+	step.Recordf("detected", "Found %d v1alpha1 DSPA(s) to migrate", result.StepCompleted, len(v1alpha1DSPAs))
 
 	if opts.DryRun {
 		for _, dspa := range v1alpha1DSPAs {
-			step.Record(dspa.Name, "Would migrate %s/%s from v1alpha1 to v1", result.StepSkipped, dspa.Namespace, dspa.Name)
+			step.Recordf(dspa.Name, "Would migrate %s/%s from v1alpha1 to v1", result.StepSkipped, dspa.Namespace, dspa.Name)
 		}
 
-		step.Complete(result.StepSkipped, "Dry-run: %d DSPA(s) would be migrated", len(v1alpha1DSPAs))
+		step.Completef(result.StepSkipped, "Dry-run: %d DSPA(s) would be migrated", len(v1alpha1DSPAs))
 
 		return nil
 	}
@@ -143,9 +143,9 @@ func migrateAllDSPAsToV1(
 
 		for _, dspa := range remaining {
 			if migrateErr := migrateDSPAToV1(ctx, c, dspa, opts); migrateErr != nil {
-				step.Record(dspa.Name, "Migration attempt failed: %v (will retry)", result.StepFailed, migrateErr)
+				step.Recordf(dspa.Name, "Migration attempt failed: %v (will retry)", result.StepFailed, migrateErr)
 			} else {
-				step.Record(dspa.Name, "Migrated %s/%s to v1", result.StepCompleted, dspa.Namespace, dspa.Name)
+				step.Recordf(dspa.Name, "Migrated %s/%s to v1", result.StepCompleted, dspa.Namespace, dspa.Name)
 			}
 		}
 
@@ -158,12 +158,12 @@ func migrateAllDSPAsToV1(
 	})
 
 	if retryErr != nil {
-		step.Complete(result.StepFailed, "Failed to migrate all v1alpha1 DSPAs: %v", retryErr)
+		step.Completef(result.StepFailed, "Failed to migrate all v1alpha1 DSPAs: %v", retryErr)
 
 		return fmt.Errorf("migrating v1alpha1 DSPAs: %w", retryErr)
 	}
 
-	step.Complete(result.StepCompleted, "All v1alpha1 DSPAs migrated to v1")
+	step.Completef(result.StepCompleted, "All v1alpha1 DSPAs migrated to v1")
 
 	return nil
 }

--- a/pkg/migrate/actions/aipipelines/pod_health.go
+++ b/pkg/migrate/actions/aipipelines/pod_health.go
@@ -82,7 +82,7 @@ func capturePodHealth(
 			Namespace(dspa.Namespace).
 			List(ctx, metav1.ListOptions{})
 		if err != nil {
-			step.Complete(result.StepFailed, "Failed to list pods: %v", err)
+			step.Completef(result.StepFailed, "Failed to list pods: %v", err)
 
 			return state, fmt.Errorf("listing pods in %s: %w", dspa.Namespace, err)
 		}
@@ -98,22 +98,22 @@ func capturePodHealth(
 			dspaState.PodGroups = append(dspaState.PodGroups, group)
 
 			if !group.PodsFound {
-				step.Record(prefix, "[WARN] No pods found", result.StepCompleted)
+				step.Recordf(prefix, "[WARN] No pods found", result.StepCompleted)
 			} else if group.AllHealthy {
-				step.Record(prefix, "[OK] All pods healthy", result.StepCompleted)
+				step.Recordf(prefix, "[OK] All pods healthy", result.StepCompleted)
 			} else {
 				for _, pod := range group.Pods {
 					if pod.Healthy {
-						step.Record(pod.Name, "[OK] Running, Ready", result.StepCompleted)
+						step.Recordf(pod.Name, "[OK] Running, Ready", result.StepCompleted)
 					} else {
-						step.Record(pod.Name, "[FAIL] Phase: %s, Ready: %s", result.StepFailed, pod.Phase, pod.Ready)
+						step.Recordf(pod.Name, "[FAIL] Phase: %s, Ready: %s", result.StepFailed, pod.Phase, pod.Ready)
 					}
 				}
 			}
 		}
 
 		state.DSPAs = append(state.DSPAs, dspaState)
-		step.Complete(result.StepCompleted, "Captured %d pod groups", len(dspaState.PodGroups))
+		step.Completef(result.StepCompleted, "Captured %d pod groups", len(dspaState.PodGroups))
 	}
 
 	return state, nil

--- a/pkg/migrate/actions/aipipelines/postcheck.go
+++ b/pkg/migrate/actions/aipipelines/postcheck.go
@@ -37,11 +37,11 @@ func (t *postUpgradeCheckRunTask) Validate(_ context.Context, target action.Targ
 	statePath := defaultStatePath()
 
 	if _, err := loadPodHealthState(statePath); err != nil {
-		step.Complete(result.StepFailed,
+		step.Completef(result.StepFailed,
 			"Pre-upgrade state not found at %s. Run 'migrate prepare -m %s' before upgrading",
 			statePath, preUpgradeCheckID)
 	} else {
-		step.Complete(result.StepCompleted, "Pre-upgrade state file found at %s", statePath)
+		step.Completef(result.StepCompleted, "Pre-upgrade state file found at %s", statePath)
 	}
 
 	return recorder.Build(), nil
@@ -57,17 +57,17 @@ func (t *postUpgradeCheckRunTask) Execute(ctx context.Context, target action.Tar
 
 	preState, err := loadPodHealthState(statePath)
 	if err != nil {
-		loadStep.Complete(result.StepFailed,
+		loadStep.Completef(result.StepFailed,
 			"Pre-upgrade state not found at %s. Run 'migrate prepare -m %s' before upgrading",
 			statePath, preUpgradeCheckID)
 
 		return recorder.Build(), fmt.Errorf("loading pre-upgrade state: %w", err)
 	}
 
-	loadStep.Complete(result.StepCompleted, "Loaded state captured at %s", preState.CapturedAt)
+	loadStep.Completef(result.StepCompleted, "Loaded state captured at %s", preState.CapturedAt)
 
 	if len(preState.DSPAs) == 0 {
-		recorder.Record("no-dspas", "No DSPAs were tracked pre-upgrade", result.StepCompleted)
+		recorder.Recordf("no-dspas", "No DSPAs were tracked pre-upgrade", result.StepCompleted)
 
 		return recorder.Build(), nil
 	}
@@ -75,7 +75,7 @@ func (t *postUpgradeCheckRunTask) Execute(ctx context.Context, target action.Tar
 	// Initial check — if no degradation, return immediately
 	comparisons, err := comparePodHealth(ctx, target.Client, preState)
 	if err != nil {
-		recorder.Record("compare-failed", "Failed to compare pod health: %v", result.StepFailed, err)
+		recorder.Recordf("compare-failed", "Failed to compare pod health: %v", result.StepFailed, err)
 
 		return recorder.Build(), fmt.Errorf("comparing pod health: %w", err)
 	}
@@ -92,7 +92,7 @@ func (t *postUpgradeCheckRunTask) Execute(ctx context.Context, target action.Tar
 
 	comparisons, err = t.pollForRecovery(ctx, target, preState)
 	if err != nil {
-		recorder.Record("poll-failed", "Failed during recovery polling: %v", result.StepFailed, err)
+		recorder.Recordf("poll-failed", "Failed during recovery polling: %v", result.StepFailed, err)
 
 		return recorder.Build(), fmt.Errorf("polling for recovery: %w", err)
 	}
@@ -182,13 +182,13 @@ func (t *postUpgradeCheckRunTask) recordComparisons(
 			recordFailedPodGroup(groupStep, comp.Current)
 		}
 
-		groupStep.Complete(status, msg)
+		groupStep.Completef(status, "%s", msg)
 	}
 
 	if hasAnyDegradation(comparisons) {
-		step.Complete(result.StepFailed, "One or more DSPA pods degraded compared to pre-upgrade state")
+		step.Completef(result.StepFailed, "One or more DSPA pods degraded compared to pre-upgrade state")
 	} else {
-		step.Complete(result.StepCompleted, "All DSPA pods are in an equal or better state than before upgrade")
+		step.Completef(result.StepCompleted, "All DSPA pods are in an equal or better state than before upgrade")
 	}
 }
 
@@ -201,16 +201,16 @@ func comparePodHealthFreshCtx(c client.Client, preState PodHealthState) ([]podGr
 
 func recordFailedPodGroup(groupStep action.StepRecorder, current PodGroup) {
 	if !current.PodsFound {
-		groupStep.Record("missing", "[MISSING] No pods found post-upgrade", result.StepFailed)
+		groupStep.Recordf("missing", "[MISSING] No pods found post-upgrade", result.StepFailed)
 
 		return
 	}
 
 	for _, pod := range current.Pods {
 		if pod.Healthy {
-			groupStep.Record(pod.Name, "[OK] %s (Running, Ready)", result.StepCompleted, pod.Name)
+			groupStep.Recordf(pod.Name, "[OK] %s (Running, Ready)", result.StepCompleted, pod.Name)
 		} else {
-			groupStep.Record(pod.Name, "[FAIL] %s (Phase: %s, Ready: %s)", result.StepFailed, pod.Name, pod.Phase, pod.Ready)
+			groupStep.Recordf(pod.Name, "[FAIL] %s (Phase: %s, Ready: %s)", result.StepFailed, pod.Name, pod.Phase, pod.Ready)
 		}
 	}
 }

--- a/pkg/migrate/actions/aipipelines/precheck.go
+++ b/pkg/migrate/actions/aipipelines/precheck.go
@@ -56,7 +56,7 @@ func (t *preUpgradeCheckPrepareTask) discover(
 
 	v1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1)
 	if err != nil {
-		healthStep.Complete(result.StepFailed, "Failed to list v1 DSPAs: %v", err)
+		healthStep.Completef(result.StepFailed, "Failed to list v1 DSPAs: %v", err)
 
 		return
 	}
@@ -64,7 +64,7 @@ func (t *preUpgradeCheckPrepareTask) discover(
 	var state PodHealthState
 
 	if len(v1DSPAs) == 0 {
-		healthStep.Complete(result.StepCompleted, "No v1 DSPAs found")
+		healthStep.Completef(result.StepCompleted, "No v1 DSPAs found")
 
 		state = PodHealthState{
 			CapturedAt: time.Now().UTC().Format(time.RFC3339),
@@ -75,12 +75,12 @@ func (t *preUpgradeCheckPrepareTask) discover(
 
 		state, captureErr = capturePodHealth(ctx, target.Client, healthStep, v1DSPAs)
 		if captureErr != nil {
-			healthStep.Complete(result.StepFailed, "Failed to capture pod health: %v", captureErr)
+			healthStep.Completef(result.StepFailed, "Failed to capture pod health: %v", captureErr)
 
 			return
 		}
 
-		healthStep.Complete(result.StepCompleted, "Captured pod health for %d DSPA(s)", len(v1DSPAs))
+		healthStep.Completef(result.StepCompleted, "Captured pod health for %d DSPA(s)", len(v1DSPAs))
 	}
 
 	if !target.DryRun {
@@ -92,19 +92,19 @@ func (t *preUpgradeCheckPrepareTask) discover(
 
 	v1alpha1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
 	if err != nil {
-		v1alpha1Step.Complete(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+		v1alpha1Step.Completef(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
 
 		return
 	}
 
 	if len(v1alpha1DSPAs) == 0 {
-		v1alpha1Step.Complete(result.StepCompleted, "No deprecated v1alpha1 DSPAs found")
+		v1alpha1Step.Completef(result.StepCompleted, "No deprecated v1alpha1 DSPAs found")
 	} else {
 		for _, dspa := range v1alpha1DSPAs {
-			v1alpha1Step.Record(dspa.Name, "v1alpha1 DSPA %s/%s needs migration", result.StepCompleted, dspa.Namespace, dspa.Name)
+			v1alpha1Step.Recordf(dspa.Name, "v1alpha1 DSPA %s/%s needs migration", result.StepCompleted, dspa.Namespace, dspa.Name)
 		}
 
-		v1alpha1Step.Complete(result.StepCompleted, "Found %d v1alpha1 DSPA(s) requiring migration", len(v1alpha1DSPAs))
+		v1alpha1Step.Completef(result.StepCompleted, "Found %d v1alpha1 DSPA(s) requiring migration", len(v1alpha1DSPAs))
 	}
 
 	// Step 3: Detect custom roles needing RBAC update
@@ -119,7 +119,7 @@ func (t *preUpgradeCheckPrepareTask) saveState(
 	saveStep := recorder.Child("save-state", "Save pre-upgrade state")
 
 	if target.DryRun {
-		saveStep.Complete(result.StepSkipped, "Would save pre-upgrade pod health state")
+		saveStep.Completef(result.StepSkipped, "Would save pre-upgrade pod health state")
 
 		return
 	}
@@ -127,12 +127,12 @@ func (t *preUpgradeCheckPrepareTask) saveState(
 	statePath := defaultStatePath()
 
 	if err := savePodHealthState(state, statePath); err != nil {
-		saveStep.Complete(result.StepFailed, "Failed to save state: %v", err)
+		saveStep.Completef(result.StepFailed, "Failed to save state: %v", err)
 
 		return
 	}
 
-	saveStep.Complete(result.StepCompleted, "State saved to %s", statePath)
+	saveStep.Completef(result.StepCompleted, "State saved to %s", statePath)
 }
 
 // --- Run task: migrate v1alpha1 DSPAs to v1 ---
@@ -146,15 +146,15 @@ func (t *preUpgradeCheckRunTask) Validate(ctx context.Context, target action.Tar
 
 	v1alpha1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+		step.Completef(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
 
 		return recorder.Build(), nil
 	}
 
 	if len(v1alpha1DSPAs) == 0 {
-		step.Complete(result.StepCompleted, "No v1alpha1 DSPAs found — nothing to migrate")
+		step.Completef(result.StepCompleted, "No v1alpha1 DSPAs found — nothing to migrate")
 	} else {
-		step.Complete(result.StepCompleted, "Found %d v1alpha1 DSPA(s) to migrate", len(v1alpha1DSPAs))
+		step.Completef(result.StepCompleted, "Found %d v1alpha1 DSPA(s) to migrate", len(v1alpha1DSPAs))
 	}
 
 	return recorder.Build(), nil
@@ -173,11 +173,11 @@ func (t *preUpgradeCheckRunTask) Execute(ctx context.Context, target action.Targ
 
 		remaining, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
 		if err != nil {
-			verifyStep.Complete(result.StepFailed, "Failed to verify: %v", err)
+			verifyStep.Completef(result.StepFailed, "Failed to verify: %v", err)
 		} else if len(remaining) > 0 {
-			verifyStep.Complete(result.StepFailed, "%d v1alpha1 DSPA(s) still remain", len(remaining))
+			verifyStep.Completef(result.StepFailed, "%d v1alpha1 DSPA(s) still remain", len(remaining))
 		} else {
-			verifyStep.Complete(result.StepCompleted, "All DSPAs are now v1")
+			verifyStep.Completef(result.StepCompleted, "All DSPAs are now v1")
 		}
 	}
 

--- a/pkg/migrate/actions/aipipelines/role_classifier.go
+++ b/pkg/migrate/actions/aipipelines/role_classifier.go
@@ -92,7 +92,7 @@ func findRolesNeedingFix(
 		Namespace("").
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list roles: %v", err)
+		step.Completef(result.StepFailed, "Failed to list roles: %v", err)
 
 		return nil, fmt.Errorf("listing roles: %w", err)
 	}
@@ -107,10 +107,10 @@ func findRolesNeedingFix(
 	}
 
 	if len(needsFix) == 0 {
-		step.Complete(result.StepCompleted, "No custom roles need updating")
+		step.Completef(result.StepCompleted, "No custom roles need updating")
 	} else {
 		for _, r := range needsFix {
-			step.Record(
+			step.Recordf(
 				r.RoleName,
 				"Role %s in namespace %s needs datasciencepipelinesapplications/api subresource",
 				result.StepCompleted,
@@ -119,7 +119,7 @@ func findRolesNeedingFix(
 			)
 		}
 
-		step.Complete(result.StepCompleted, "Found %d role(s) needing update", len(needsFix))
+		step.Completef(result.StepCompleted, "Found %d role(s) needing update", len(needsFix))
 	}
 
 	return needsFix, nil

--- a/pkg/migrate/actions/aipipelines/updatedsprole.go
+++ b/pkg/migrate/actions/aipipelines/updatedsprole.go
@@ -77,7 +77,7 @@ func (t *updateDSPRoleRunTask) Execute(ctx context.Context, target action.Target
 		t.patchRole(ctx, target, patchStep, role)
 	}
 
-	patchStep.Complete(result.StepCompleted, "Processed %d role(s)", len(roles))
+	patchStep.Completef(result.StepCompleted, "Processed %d role(s)", len(roles))
 
 	return recorder.Build(), nil
 }
@@ -95,13 +95,13 @@ func (t *updateDSPRoleRunTask) patchRole(
 
 	namespaceDSPAs, err := listDSPAsInNamespace(ctx, target.Client, resources.DataSciencePipelinesApplicationV1, role.Namespace)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list DSPAs in %s: %v", role.Namespace, err)
+		step.Completef(result.StepFailed, "Failed to list DSPAs in %s: %v", role.Namespace, err)
 
 		return
 	}
 
 	if len(namespaceDSPAs) == 0 {
-		step.Complete(result.StepCompleted, "No DSPAs found in namespace %s — skipping", role.Namespace)
+		step.Completef(result.StepCompleted, "No DSPAs found in namespace %s — skipping", role.Namespace)
 
 		return
 	}
@@ -110,7 +110,7 @@ func (t *updateDSPRoleRunTask) patchRole(
 		t.patchRoleForDSPA(ctx, target, step, role, dspa)
 	}
 
-	step.Complete(result.StepCompleted, "Role %s/%s processed", role.Namespace, role.RoleName)
+	step.Completef(result.StepCompleted, "Role %s/%s processed", role.Namespace, role.RoleName)
 }
 
 func (t *updateDSPRoleRunTask) patchRoleForDSPA(
@@ -146,7 +146,7 @@ func (t *updateDSPRoleRunTask) patchRoleForDSPA(
 
 	patchData, err := json.Marshal(patchOps)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to marshal patch: %v", err)
+		step.Completef(result.StepFailed, "Failed to marshal patch: %v", err)
 
 		return
 	}
@@ -156,7 +156,7 @@ func (t *updateDSPRoleRunTask) patchRoleForDSPA(
 			role.Namespace, role.RoleName, dspa.Name, verbs)
 
 		if !confirmation.Prompt(target.IO, "Proceed with role patch?") {
-			step.Complete(result.StepSkipped, "User cancelled patch")
+			step.Completef(result.StepSkipped, "User cancelled patch")
 
 			return
 		}
@@ -171,13 +171,13 @@ func (t *updateDSPRoleRunTask) patchRoleForDSPA(
 		Namespace(role.Namespace).
 		Patch(ctx, role.RoleName, types.JSONPatchType, patchData, patchOpts)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to patch role: %v", err)
+		step.Completef(result.StepFailed, "Failed to patch role: %v", err)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped,
+		step.Completef(result.StepSkipped,
 			"Would add datasciencepipelinesapplications/api rule for DSPA %s (verbs: %v)", dspa.Name, verbs)
 
 		return
@@ -188,19 +188,19 @@ func (t *updateDSPRoleRunTask) patchRoleForDSPA(
 		Namespace(role.Namespace).
 		Get(ctx, role.RoleName, metav1.GetOptions{})
 	if err != nil {
-		step.Complete(result.StepFailed, "Patch succeeded but validation failed — could not re-read role: %v", err)
+		step.Completef(result.StepFailed, "Patch succeeded but validation failed — could not re-read role: %v", err)
 
 		return
 	}
 
 	validated := classifyRole(updatedRole)
 	if validated.NeedsFix {
-		step.Complete(result.StepFailed,
+		step.Completef(result.StepFailed,
 			"Patch succeeded but validation failed — datasciencepipelinesapplications/api rule not found in re-read")
 
 		return
 	}
 
-	step.Complete(result.StepCompleted,
+	step.Completef(result.StepCompleted,
 		"Added datasciencepipelinesapplications/api rule for DSPA %s (verbs: %v)", dspa.Name, verbs)
 }

--- a/pkg/migrate/actions/kueue/rhbok/prepare_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/prepare_task.go
@@ -47,7 +47,7 @@ func (t *prepareTask) Execute(
 			"backup-skipped",
 			"Backup skipped (Kueue not managed)",
 		)
-		step.Complete(result.StepSkipped, "Kueue is not managed by DataScienceCluster")
+		step.Completef(result.StepSkipped, "Kueue is not managed by DataScienceCluster")
 	}
 
 	rootRecorder, ok := target.Recorder.(action.RootRecorder)
@@ -68,7 +68,7 @@ func (t *prepareTask) backupKueueResources(
 	)
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would backup ClusterQueues and ConfigMap to %s", target.OutputDir)
+		step.Completef(result.StepSkipped, "Would backup ClusterQueues and ConfigMap to %s", target.OutputDir)
 
 		return
 	}
@@ -76,7 +76,7 @@ func (t *prepareTask) backupKueueResources(
 	t.backupClusterQueues(ctx, target, step)
 	t.backupConfigMap(ctx, target, step)
 
-	step.Complete(result.StepCompleted, "Backup complete in %s", target.OutputDir)
+	step.Completef(result.StepCompleted, "Backup complete in %s", target.OutputDir)
 }
 
 func (t *prepareTask) backupClusterQueues(
@@ -92,30 +92,30 @@ func (t *prepareTask) backupClusterQueues(
 	clusterQueues, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepSkipped, "No ClusterQueue CRD found")
+			step.Completef(result.StepSkipped, "No ClusterQueue CRD found")
 
 			return
 		}
 
-		step.Complete(result.StepFailed, "Failed to list ClusterQueues: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ClusterQueues: %v", err)
 
 		return
 	}
 
 	if len(clusterQueues) == 0 {
-		step.Complete(result.StepSkipped, "No ClusterQueues found")
+		step.Completef(result.StepSkipped, "No ClusterQueues found")
 
 		return
 	}
 
 	// Write cluster-scoped resources to root directory
 	if err := backup.WriteResourcesToDir(target.OutputDir, resources.ClusterQueue.GVR(), clusterQueues); err != nil {
-		step.Complete(result.StepFailed, "Failed to write ClusterQueues: %v", err)
+		step.Completef(result.StepFailed, "Failed to write ClusterQueues: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "Backed up %d ClusterQueues to %s", len(clusterQueues), target.OutputDir)
+	step.Completef(result.StepCompleted, "Backed up %d ClusterQueues to %s", len(clusterQueues), target.OutputDir)
 }
 
 func (t *prepareTask) backupConfigMap(
@@ -134,21 +134,21 @@ func (t *prepareTask) backupConfigMap(
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepSkipped, "ConfigMap not found")
+			step.Completef(result.StepSkipped, "ConfigMap not found")
 
 			return
 		}
 
-		step.Complete(result.StepFailed, "Failed to get ConfigMap: %v", err)
+		step.Completef(result.StepFailed, "Failed to get ConfigMap: %v", err)
 
 		return
 	}
 
 	if err := backup.WriteResourcesToDir(target.OutputDir, resources.ConfigMap.GVR(), []*unstructured.Unstructured{obj}); err != nil {
-		step.Complete(result.StepFailed, "Failed to write ConfigMap: %v", err)
+		step.Completef(result.StepFailed, "Failed to write ConfigMap: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "Backed up ConfigMap %s to %s", configMapName, target.OutputDir)
+	step.Completef(result.StepCompleted, "Backed up ConfigMap %s to %s", configMapName, target.OutputDir)
 }

--- a/pkg/migrate/actions/kueue/rhbok/rhbok.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok.go
@@ -103,26 +103,26 @@ func (a *RHBOKMigrationAction) checkKueueManaged(
 	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
+		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
 
 		return false
 	}
 
 	managementState, err := jq.Query[string](dsc, kueueComponentPath)
 	if err != nil {
-		step.Complete(result.StepCompleted,
+		step.Completef(result.StepCompleted,
 			"Kueue component not found in DataScienceCluster (not managed)")
 
 		return false
 	}
 
 	if managementState == managementStateManaged {
-		step.Complete(result.StepCompleted, "Kueue is managed (managementState=%s)", managementState)
+		step.Completef(result.StepCompleted, "Kueue is managed (managementState=%s)", managementState)
 
 		return true
 	}
 
-	step.Complete(result.StepCompleted, "Kueue is not managed (managementState=%s)", managementState)
+	step.Completef(result.StepCompleted, "Kueue is not managed (managementState=%s)", managementState)
 
 	return false
 }
@@ -147,13 +147,13 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 		Get(ctx, configMapName, metav1.GetOptions{})
 
 	if err != nil {
-		checkStep.Complete(result.StepCompleted, "ConfigMap not found")
-		step.Complete(result.StepSkipped, "ConfigMap %s not found (skipped): %v", configMapName, err)
+		checkStep.Completef(result.StepCompleted, "ConfigMap not found")
+		step.Completef(result.StepSkipped, "ConfigMap %s not found (skipped): %v", configMapName, err)
 
 		return
 	}
 
-	checkStep.Complete(result.StepCompleted, "ConfigMap exists")
+	checkStep.Completef(result.StepCompleted, "ConfigMap exists")
 
 	// Apply annotation
 	annotateStep := step.Child(
@@ -162,8 +162,8 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 	)
 
 	if target.DryRun {
-		annotateStep.Complete(result.StepSkipped, "Would annotate ConfigMap %s/%s", applicationsNamespace, configMapName)
-		step.Complete(result.StepSkipped, "Dry-run: ConfigMap annotation skipped")
+		annotateStep.Completef(result.StepSkipped, "Would annotate ConfigMap %s/%s", applicationsNamespace, configMapName)
+		step.Completef(result.StepSkipped, "Dry-run: ConfigMap annotation skipped")
 
 		return
 	}
@@ -177,15 +177,15 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 
 	annotationsJSON, err := json.Marshal(annotations)
 	if err != nil {
-		annotateStep.Complete(result.StepFailed, "Failed to marshal annotations: %v", err)
-		step.Complete(result.StepFailed, "Failed to annotate ConfigMap")
+		annotateStep.Completef(result.StepFailed, "Failed to marshal annotations: %v", err)
+		step.Completef(result.StepFailed, "Failed to annotate ConfigMap")
 
 		return
 	}
 
 	if err := jq.Transform(configMap, ".metadata.annotations = %s", annotationsJSON); err != nil {
-		annotateStep.Complete(result.StepFailed, "Failed to set annotations: %v", err)
-		step.Complete(result.StepFailed, "Failed to annotate ConfigMap")
+		annotateStep.Completef(result.StepFailed, "Failed to set annotations: %v", err)
+		step.Completef(result.StepFailed, "Failed to annotate ConfigMap")
 
 		return
 	}
@@ -195,14 +195,14 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 		Update(ctx, configMap, metav1.UpdateOptions{})
 
 	if err != nil {
-		annotateStep.Complete(result.StepFailed, "Failed to update ConfigMap: %v", err)
-		step.Complete(result.StepFailed, "Failed to annotate ConfigMap")
+		annotateStep.Completef(result.StepFailed, "Failed to update ConfigMap: %v", err)
+		step.Completef(result.StepFailed, "Failed to annotate ConfigMap")
 
 		return
 	}
 
-	annotateStep.Complete(result.StepCompleted, "Annotation applied successfully")
-	step.Complete(result.StepCompleted, "ConfigMap %s annotated for preservation", configMapName)
+	annotateStep.Completef(result.StepCompleted, "Annotation applied successfully")
+	step.Completef(result.StepCompleted, "ConfigMap %s annotated for preservation", configMapName)
 }
 
 func (a *RHBOKMigrationAction) installRHBOKOperator(
@@ -226,7 +226,7 @@ func (a *RHBOKMigrationAction) installRHBOKOperator(
 		target.IO.Fprintln()
 		target.IO.Errorf("About to install Red Hat Build of Kueue Operator")
 		if !confirmation.Prompt(target.IO, "Proceed with operator installation?") {
-			step.Complete(result.StepSkipped, "User cancelled installation")
+			step.Completef(result.StepSkipped, "User cancelled installation")
 
 			return
 		}
@@ -248,17 +248,17 @@ func (a *RHBOKMigrationAction) installRHBOKOperator(
 	})
 
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to install operator: %v", err)
+		step.Completef(result.StepFailed, "Failed to install operator: %v", err)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Operator installation checks completed")
+		step.Completef(result.StepSkipped, "Operator installation checks completed")
 	} else if subscriptionExists {
-		step.Complete(result.StepCompleted, "Red Hat build of Kueue operator already installed and ready")
+		step.Completef(result.StepCompleted, "Red Hat build of Kueue operator already installed and ready")
 	} else {
-		step.Complete(result.StepCompleted, "Red Hat build of Kueue operator installed successfully")
+		step.Completef(result.StepCompleted, "Red Hat build of Kueue operator installed successfully")
 	}
 }
 
@@ -273,7 +273,7 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 
 	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
+		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
 
 		return
 	}
@@ -281,13 +281,13 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 	// Check if already set to Unmanaged
 	currentState, err := jq.Query[string](dsc, ".spec.components.kueue.managementState")
 	if err == nil && currentState == managementStateUnmanaged {
-		step.Complete(result.StepSkipped, "DataScienceCluster Kueue already set to Unmanaged")
+		step.Completef(result.StepSkipped, "DataScienceCluster Kueue already set to Unmanaged")
 
 		return
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would set %s=%s", kueueComponentPath, managementStateUnmanaged)
+		step.Completef(result.StepSkipped, "Would set %s=%s", kueueComponentPath, managementStateUnmanaged)
 
 		return
 	}
@@ -296,7 +296,7 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 		target.IO.Fprintln()
 		target.IO.Errorf("About to update DataScienceCluster Kueue managementState to %s", managementStateUnmanaged)
 		if !confirmation.Prompt(target.IO, "Proceed with configuration update?") {
-			step.Complete(result.StepSkipped, "User cancelled update")
+			step.Completef(result.StepSkipped, "User cancelled update")
 
 			return
 		}
@@ -337,12 +337,12 @@ func (a *RHBOKMigrationAction) updateDataScienceCluster(
 	})
 
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to update DataScienceCluster: %v", err)
+		step.Completef(result.StepFailed, "Failed to update DataScienceCluster: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "DataScienceCluster updated successfully")
+	step.Completef(result.StepCompleted, "DataScienceCluster updated successfully")
 }
 
 func (a *RHBOKMigrationAction) verifyResourcesPreserved(
@@ -355,7 +355,7 @@ func (a *RHBOKMigrationAction) verifyResourcesPreserved(
 	)
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would verify ClusterQueue and LocalQueue resources are preserved")
+		step.Completef(result.StepSkipped, "Would verify ClusterQueue and LocalQueue resources are preserved")
 
 		return
 	}
@@ -364,12 +364,12 @@ func (a *RHBOKMigrationAction) verifyResourcesPreserved(
 	if err != nil {
 		// If the CRD doesn't exist, that's fine - it means there are no Kueue resources
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepCompleted, "No ClusterQueue CRD found (no resources to preserve)")
+			step.Completef(result.StepCompleted, "No ClusterQueue CRD found (no resources to preserve)")
 
 			return
 		}
 
-		step.Complete(result.StepFailed, "Failed to list ClusterQueues: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ClusterQueues: %v", err)
 
 		return
 	}
@@ -378,17 +378,17 @@ func (a *RHBOKMigrationAction) verifyResourcesPreserved(
 	if err != nil {
 		// If the CRD doesn't exist, that's fine - it means there are no Kueue resources
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepCompleted, "No LocalQueue CRD found (%d ClusterQueues preserved)", len(clusterQueues))
+			step.Completef(result.StepCompleted, "No LocalQueue CRD found (%d ClusterQueues preserved)", len(clusterQueues))
 
 			return
 		}
 
-		step.Complete(result.StepFailed, "Failed to list LocalQueues: %v", err)
+		step.Completef(result.StepFailed, "Failed to list LocalQueues: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted,
+	step.Completef(result.StepCompleted,
 		"All %d ClusterQueues and %d LocalQueues preserved",
 		len(clusterQueues), len(localQueues))
 }

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
@@ -52,7 +52,7 @@ func (a *RHBOKMigrationAction) verifyRBAC(
 
 	denied, err := rbac.CheckPermissions(ctx, target.Client.AuthorizationV1(), checks)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to verify RBAC permissions: %v", err)
+		step.Completef(result.StepFailed, "Failed to verify RBAC permissions: %v", err)
 
 		return
 	}
@@ -62,15 +62,15 @@ func (a *RHBOKMigrationAction) verifyRBAC(
 			step.Child(
 				fmt.Sprintf("denied-%s-%s", d.Verb, d.Resource),
 				fmt.Sprintf("Missing permission: %s", d),
-			).Complete(result.StepFailed, "Permission denied: %s", d)
+			).Completef(result.StepFailed, "Permission denied: %s", d)
 		}
 
-		step.Complete(result.StepFailed, "%d required permission(s) denied", len(denied))
+		step.Completef(result.StepFailed, "%d required permission(s) denied", len(denied))
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "All %d required permissions verified", len(checks))
+	step.Completef(result.StepCompleted, "All %d required permissions verified", len(checks))
 }
 
 func (a *RHBOKMigrationAction) checkCurrentKueueState(
@@ -85,30 +85,30 @@ func (a *RHBOKMigrationAction) checkCurrentKueueState(
 	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepFailed, "DataScienceCluster not found - OpenShift AI may not be installed")
+			step.Completef(result.StepFailed, "DataScienceCluster not found - OpenShift AI may not be installed")
 
 			return
 		}
 
-		step.Complete(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
+		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
 
 		return
 	}
 
 	managementState, err := jq.Query[string](dsc, ".spec.components.kueue.managementState")
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to query Kueue managementState: %v", err)
+		step.Completef(result.StepFailed, "Failed to query Kueue managementState: %v", err)
 
 		return
 	}
 
 	if managementState == "" {
-		step.Complete(result.StepFailed, "Kueue component not configured in DataScienceCluster")
+		step.Completef(result.StepFailed, "Kueue component not configured in DataScienceCluster")
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "Current Kueue state verified (managementState: %s)", managementState)
+	step.Completef(result.StepCompleted, "Current Kueue state verified (managementState: %s)", managementState)
 }
 
 func (a *RHBOKMigrationAction) checkNoRHBOKConflicts(
@@ -125,18 +125,18 @@ func (a *RHBOKMigrationAction) checkNoRHBOKConflicts(
 		Get(ctx, "kueue-operator", metav1.GetOptions{})
 
 	if err == nil && subscription != nil {
-		step.Complete(result.StepCompleted, "Red Hat build of Kueue operator already installed - migration may be partially complete")
+		step.Completef(result.StepCompleted, "Red Hat build of Kueue operator already installed - migration may be partially complete")
 
 		return
 	}
 
 	if !apierrors.IsNotFound(err) {
-		step.Complete(result.StepFailed, "Failed to check Red Hat build of Kueue subscription: %v", err)
+		step.Completef(result.StepFailed, "Failed to check Red Hat build of Kueue subscription: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "No Red Hat build of Kueue conflicts detected")
+	step.Completef(result.StepCompleted, "No Red Hat build of Kueue conflicts detected")
 }
 
 func (a *RHBOKMigrationAction) verifyKueueResources(
@@ -150,7 +150,7 @@ func (a *RHBOKMigrationAction) verifyKueueResources(
 
 	clusterQueues, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list ClusterQueues: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ClusterQueues: %v", err)
 
 		return
 	}
@@ -158,19 +158,19 @@ func (a *RHBOKMigrationAction) verifyKueueResources(
 	localQueues, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR())
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepCompleted,
+			step.Completef(result.StepCompleted,
 				"Kueue resources found: %d ClusterQueues (LocalQueue CRD not found)",
 				len(clusterQueues))
 
 			return
 		}
 
-		step.Complete(result.StepFailed, "Failed to list LocalQueues: %v", err)
+		step.Completef(result.StepFailed, "Failed to list LocalQueues: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted,
+	step.Completef(result.StepCompleted,
 		"Kueue resources found: %d ClusterQueues, %d LocalQueues",
 		len(clusterQueues), len(localQueues))
 }

--- a/pkg/migrate/actions/modelserving/add_owner_references.go
+++ b/pkg/migrate/actions/modelserving/add_owner_references.go
@@ -76,18 +76,18 @@ func (a *AddOwnerReferencesAction) addOwnerReferences(
 
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeRawDeployment)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list InferenceServices: %v", err)
 
 		return
 	}
 
 	if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgOwnerRefNoISVCs)
+		step.Completef(result.StepSkipped, msgOwnerRefNoISVCs)
 
 		return
 	}
 
-	step.Record("list-isvcs", msgOwnerRefFoundISVCs, result.StepCompleted, len(isvcs))
+	step.Recordf("list-isvcs", msgOwnerRefFoundISVCs, result.StepCompleted, len(isvcs))
 
 	patchedCount := 0
 
@@ -101,7 +101,7 @@ func (a *AddOwnerReferencesAction) addOwnerReferences(
 		patchedCount++
 	}
 
-	step.Complete(result.StepCompleted, msgOwnerRefComplete, patchedCount)
+	step.Completef(result.StepCompleted, msgOwnerRefComplete, patchedCount)
 }
 
 func (a *AddOwnerReferencesAction) patchAuthResourceOwnerRefs(
@@ -128,7 +128,7 @@ func (a *AddOwnerReferencesAction) patchAuthResourceOwnerRefs(
 		},
 	})
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to marshal owner reference patch: %v", err)
+		step.Completef(result.StepFailed, "Failed to marshal owner reference patch: %v", err)
 
 		return
 	}
@@ -160,7 +160,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Record(
+			step.Recordf(
 				"patch-"+resourceName,
 				msgOwnerRefNotFound,
 				result.StepSkipped,
@@ -170,7 +170,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 			return
 		}
 
-		step.Record(
+		step.Recordf(
 			"patch-"+resourceName,
 			msgOwnerRefPatchFailed,
 			result.StepFailed,
@@ -181,7 +181,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 	}
 
 	if target.DryRun {
-		step.Record(
+		step.Recordf(
 			"patch-"+resourceName,
 			msgOwnerRefPatchDryRun,
 			result.StepSkipped,
@@ -196,7 +196,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 		Patch(ctx, resourceName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
 
 	if err != nil {
-		step.Record(
+		step.Recordf(
 			"patch-"+resourceName,
 			msgOwnerRefPatchFailed,
 			result.StepFailed,
@@ -206,7 +206,7 @@ func (a *AddOwnerReferencesAction) patchResourceOwnerRef(
 		return
 	}
 
-	step.Record(
+	step.Recordf(
 		"patch-"+resourceName,
 		msgOwnerRefPatched,
 		result.StepCompleted,

--- a/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist.go
+++ b/pkg/migrate/actions/modelserving/hardwareprofiles_ignorelist.go
@@ -91,12 +91,12 @@ func (a *HardwareProfilesIgnorelistAction) updateConfigMap(
 	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepSkipped, msgHPConfigMapNotFound, namespace)
+			step.Completef(result.StepSkipped, msgHPConfigMapNotFound, namespace)
 
 			return
 		}
 
-		step.Complete(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
+		step.Completef(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
 
 		return
 	}
@@ -108,7 +108,7 @@ func (a *HardwareProfilesIgnorelistAction) updateConfigMap(
 	a.updateDisallowedList(target, configMap, step)
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgHPCompleteDryRun)
+		step.Completef(result.StepSkipped, msgHPCompleteDryRun)
 
 		return
 	}
@@ -119,12 +119,12 @@ func (a *HardwareProfilesIgnorelistAction) updateConfigMap(
 		Update(ctx, configMap, metav1.UpdateOptions{})
 
 	if err != nil {
-		step.Complete(result.StepFailed, msgHPUpdateFailed, namespace, inferenceServiceConfigName, err)
+		step.Completef(result.StepFailed, msgHPUpdateFailed, namespace, inferenceServiceConfigName, err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, msgHPComplete)
+	step.Completef(result.StepCompleted, msgHPComplete)
 }
 
 func (a *HardwareProfilesIgnorelistAction) setManagedAnnotation(
@@ -135,7 +135,7 @@ func (a *HardwareProfilesIgnorelistAction) setManagedAnnotation(
 	step := parentStep.Child("set-managed-annotation", "Set managed annotation")
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgHPManagedAnnotationDryRun, annotationManaged, managedFalse, inferenceServiceConfigName)
+		step.Completef(result.StepSkipped, msgHPManagedAnnotationDryRun, annotationManaged, managedFalse, inferenceServiceConfigName)
 
 		return
 	}
@@ -148,7 +148,7 @@ func (a *HardwareProfilesIgnorelistAction) setManagedAnnotation(
 	annotations[annotationManaged] = managedFalse
 	configMap.SetAnnotations(annotations)
 
-	step.Complete(result.StepCompleted, msgHPManagedAnnotationSet, annotationManaged, managedFalse, inferenceServiceConfigName)
+	step.Completef(result.StepCompleted, msgHPManagedAnnotationSet, annotationManaged, managedFalse, inferenceServiceConfigName)
 }
 
 func (a *HardwareProfilesIgnorelistAction) updateDisallowedList(
@@ -160,14 +160,14 @@ func (a *HardwareProfilesIgnorelistAction) updateDisallowedList(
 
 	cfg, err := parseISVCConfigData(configMap)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to parse inferenceService config: %v", err)
+		step.Completef(result.StepFailed, "Failed to parse inferenceService config: %v", err)
 
 		return
 	}
 
 	currentList, err := cfg.disallowedList()
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to read disallowed list: %v", err)
+		step.Completef(result.StepFailed, "Failed to read disallowed list: %v", err)
 
 		return
 	}
@@ -181,38 +181,38 @@ func (a *HardwareProfilesIgnorelistAction) updateDisallowedList(
 	}
 
 	if len(missing) == 0 {
-		step.Complete(result.StepCompleted, msgHPDisallowedListCurrent)
+		step.Completef(result.StepCompleted, msgHPDisallowedListCurrent)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgHPDisallowedListDryRun, len(missing), missing)
+		step.Completef(result.StepSkipped, msgHPDisallowedListDryRun, len(missing), missing)
 
 		return
 	}
 
 	// Add missing annotations and serialize back (preserves all other fields)
 	if err := cfg.setDisallowedList(append(currentList, missing...)); err != nil {
-		step.Complete(result.StepFailed, "Failed to update disallowed list: %v", err)
+		step.Completef(result.StepFailed, "Failed to update disallowed list: %v", err)
 
 		return
 	}
 
 	updatedJSON, err := json.Marshal(cfg)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to marshal updated config: %v", err)
+		step.Completef(result.StepFailed, "Failed to marshal updated config: %v", err)
 
 		return
 	}
 
 	if err := jq.Transform(configMap, ".data.%s = %q", inferenceServiceDataKey, string(updatedJSON)); err != nil {
-		step.Complete(result.StepFailed, "Failed to update ConfigMap data: %v", err)
+		step.Completef(result.StepFailed, "Failed to update ConfigMap data: %v", err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, msgHPDisallowedListUpdated, len(missing), missing)
+	step.Completef(result.StepCompleted, msgHPDisallowedListUpdated, len(missing), missing)
 }
 
 // restartKServeController restarts the KServe controller deployment.
@@ -253,13 +253,13 @@ func (t *hpIgnorelistPrepareTask) Execute(
 
 	namespace, err := getApplicationsNamespace(ctx, target)
 	if err != nil {
-		step.Complete(result.StepFailed, msgGetAppNamespaceFailed, err)
+		step.Completef(result.StepFailed, msgGetAppNamespaceFailed, err)
 
 		return buildResult(target)
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would backup ConfigMap %s from namespace %s", inferenceServiceConfigName, namespace)
+		step.Completef(result.StepSkipped, "Would backup ConfigMap %s from namespace %s", inferenceServiceConfigName, namespace)
 
 		return buildResult(target)
 	}
@@ -267,9 +267,9 @@ func (t *hpIgnorelistPrepareTask) Execute(
 	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepSkipped, msgHPConfigMapNotFound, namespace)
+			step.Completef(result.StepSkipped, msgHPConfigMapNotFound, namespace)
 		} else {
-			step.Complete(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
+			step.Completef(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
 		}
 
 		return buildResult(target)
@@ -278,9 +278,9 @@ func (t *hpIgnorelistPrepareTask) Execute(
 	outputDir := filepath.Join(target.OutputDir, namespace)
 
 	if err := backup.WriteResourcesToDir(outputDir, resources.ConfigMap.GVR(), []*unstructured.Unstructured{configMap}); err != nil {
-		step.Complete(result.StepFailed, "Failed to write ConfigMap backup: %v", err)
+		step.Completef(result.StepFailed, "Failed to write ConfigMap backup: %v", err)
 	} else {
-		step.Complete(result.StepCompleted, "Backed up ConfigMap %s to %s", inferenceServiceConfigName, outputDir)
+		step.Completef(result.StepCompleted, "Backed up ConfigMap %s to %s", inferenceServiceConfigName, outputDir)
 	}
 
 	return buildResult(target)
@@ -306,7 +306,7 @@ func (t *hpIgnorelistRunTask) Execute(
 	namespace, err := getApplicationsNamespace(ctx, target)
 	if err != nil {
 		step := target.Recorder.Child("get-namespace", "Get applications namespace")
-		step.Complete(result.StepFailed, msgGetAppNamespaceFailed, err)
+		step.Completef(result.StepFailed, msgGetAppNamespaceFailed, err)
 
 		return buildResult(target)
 	}

--- a/pkg/migrate/actions/modelserving/managed_isvc_config.go
+++ b/pkg/migrate/actions/modelserving/managed_isvc_config.go
@@ -74,18 +74,18 @@ func (a *ManagedISVCConfigAction) setManagedTrue(
 	configMap, err := getInferenceServiceConfig(ctx, target, namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			step.Complete(result.StepSkipped, msgConfigMapNotFound, inferenceServiceConfigName, namespace)
+			step.Completef(result.StepSkipped, msgConfigMapNotFound, inferenceServiceConfigName, namespace)
 
 			return false
 		}
 
-		step.Complete(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
+		step.Completef(result.StepFailed, msgGetConfigMapFailed, namespace, inferenceServiceConfigName, err)
 
 		return false
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgManagedAnnotationDryRun, annotationManaged, managedTrue, inferenceServiceConfigName)
+		step.Completef(result.StepSkipped, msgManagedAnnotationDryRun, annotationManaged, managedTrue, inferenceServiceConfigName)
 
 		return false
 	}
@@ -103,12 +103,12 @@ func (a *ManagedISVCConfigAction) setManagedTrue(
 		Update(ctx, configMap, metav1.UpdateOptions{})
 
 	if err != nil {
-		step.Complete(result.StepFailed, msgManagedUpdateFailed, namespace, inferenceServiceConfigName, err)
+		step.Completef(result.StepFailed, msgManagedUpdateFailed, namespace, inferenceServiceConfigName, err)
 
 		return false
 	}
 
-	step.Complete(result.StepCompleted, msgManagedAnnotationSet, annotationManaged, managedTrue, inferenceServiceConfigName)
+	step.Completef(result.StepCompleted, msgManagedAnnotationSet, annotationManaged, managedTrue, inferenceServiceConfigName)
 
 	return true
 }
@@ -133,7 +133,7 @@ func (t *managedISVCConfigRunTask) Execute(
 	namespace, err := getApplicationsNamespace(ctx, target)
 	if err != nil {
 		step := target.Recorder.Child("get-namespace", "Get applications namespace")
-		step.Complete(result.StepFailed, msgGetAppNamespaceFailed, err)
+		step.Completef(result.StepFailed, msgGetAppNamespaceFailed, err)
 
 		return buildResult(target)
 	}

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
@@ -76,18 +76,18 @@ func (a *ModelMeshToRawAction) convertISVCs(
 
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeModelMesh)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
 
 		return
 	}
 
 	if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgModelMeshNoISVCs)
+		step.Completef(result.StepSkipped, msgModelMeshNoISVCs)
 
 		return
 	}
 
-	step.Record("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeModelMesh)
+	step.Recordf("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeModelMesh)
 
 	// Confirm with user
 	if !target.SkipConfirm && !target.DryRun {
@@ -95,7 +95,7 @@ func (a *ModelMeshToRawAction) convertISVCs(
 		target.IO.Errorf(msgModelMeshConfirm, len(isvcs))
 
 		if !confirmation.Prompt(target.IO, "Proceed with conversion?") {
-			step.Complete(result.StepSkipped, msgModelMeshCancelled)
+			step.Completef(result.StepSkipped, msgModelMeshCancelled)
 
 			return
 		}
@@ -122,9 +122,9 @@ func (a *ModelMeshToRawAction) convertISVCs(
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgModelMeshDryRun, convertedCount)
+		step.Completef(result.StepSkipped, msgModelMeshDryRun, convertedCount)
 	} else {
-		step.Complete(result.StepCompleted, msgModelMeshComplete, convertedCount)
+		step.Completef(result.StepCompleted, msgModelMeshComplete, convertedCount)
 	}
 }
 
@@ -151,7 +151,7 @@ func (a *ModelMeshToRawAction) updateServingRuntime(
 		Get(ctx, runtimeName, metav1.GetOptions{})
 
 	if err != nil {
-		step.Complete(result.StepSkipped, "ServingRuntime %s/%s not found (skipped)", ns, runtimeName)
+		step.Completef(result.StepSkipped, "ServingRuntime %s/%s not found (skipped)", ns, runtimeName)
 
 		return
 	}
@@ -159,19 +159,19 @@ func (a *ModelMeshToRawAction) updateServingRuntime(
 	// Check if multi-model
 	multiModel, err := jq.Query[bool](runtime, ".spec.multiModel")
 	if err != nil || !multiModel {
-		step.Complete(result.StepSkipped, "ServingRuntime %s/%s is not multi-model (skipped)", ns, runtimeName)
+		step.Completef(result.StepSkipped, "ServingRuntime %s/%s is not multi-model (skipped)", ns, runtimeName)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would set multiModel=false on ServingRuntime %s/%s", ns, runtimeName)
+		step.Completef(result.StepSkipped, "Would set multiModel=false on ServingRuntime %s/%s", ns, runtimeName)
 
 		return
 	}
 
 	if err := jq.Transform(runtime, ".spec.multiModel = false"); err != nil {
-		step.Complete(result.StepFailed, "Failed to update ServingRuntime %s/%s: %v", ns, runtimeName, err)
+		step.Completef(result.StepFailed, "Failed to update ServingRuntime %s/%s: %v", ns, runtimeName, err)
 
 		return
 	}
@@ -181,12 +181,12 @@ func (a *ModelMeshToRawAction) updateServingRuntime(
 		Update(ctx, runtime, metav1.UpdateOptions{})
 
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to update ServingRuntime %s/%s: %v", ns, runtimeName, err)
+		step.Completef(result.StepFailed, "Failed to update ServingRuntime %s/%s: %v", ns, runtimeName, err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, "Set multiModel=false on ServingRuntime %s/%s", ns, runtimeName)
+	step.Completef(result.StepCompleted, "Set multiModel=false on ServingRuntime %s/%s", ns, runtimeName)
 }
 
 // --- Prepare Task ---
@@ -214,19 +214,19 @@ func (t *modelMeshToRawPrepareTask) Execute(
 	// Backup ISVCs
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeModelMesh)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
 
 		return buildResult(target)
 	}
 
 	if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgModelMeshNoISVCs)
+		step.Completef(result.StepSkipped, msgModelMeshNoISVCs)
 
 		return buildResult(target)
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would backup %d ModelMesh InferenceServices and associated ServingRuntimes", len(isvcs))
+		step.Completef(result.StepSkipped, "Would backup %d ModelMesh InferenceServices and associated ServingRuntimes", len(isvcs))
 
 		return buildResult(target)
 	}
@@ -237,7 +237,7 @@ func (t *modelMeshToRawPrepareTask) Execute(
 	for ns, nsISVCs := range byNamespace {
 		outputDir := filepath.Join(target.OutputDir, ns)
 		if err := backup.WriteResourcesToDir(outputDir, resources.InferenceService.GVR(), nsISVCs); err != nil {
-			step.Complete(result.StepFailed, "Failed to backup InferenceServices in namespace %s: %v", ns, err)
+			step.Completef(result.StepFailed, "Failed to backup InferenceServices in namespace %s: %v", ns, err)
 
 			return buildResult(target)
 		}
@@ -250,7 +250,7 @@ func (t *modelMeshToRawPrepareTask) Execute(
 		ctx, target.Client, resources.ServingRuntime, multiModelFilter,
 	)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list ServingRuntimes: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ServingRuntimes: %v", err)
 
 		return buildResult(target)
 	}
@@ -258,13 +258,13 @@ func (t *modelMeshToRawPrepareTask) Execute(
 	for ns, nsSRs := range groupByNamespace(servingRuntimes) {
 		outputDir := filepath.Join(target.OutputDir, ns)
 		if writeErr := backup.WriteResourcesToDir(outputDir, resources.ServingRuntime.GVR(), nsSRs); writeErr != nil {
-			step.Complete(result.StepFailed, "Failed to backup ServingRuntimes in namespace %s: %v", ns, writeErr)
+			step.Completef(result.StepFailed, "Failed to backup ServingRuntimes in namespace %s: %v", ns, writeErr)
 
 			return buildResult(target)
 		}
 	}
 
-	step.Complete(result.StepCompleted, msgModelMeshBackupDone, len(isvcs), target.OutputDir)
+	step.Completef(result.StepCompleted, msgModelMeshBackupDone, len(isvcs), target.OutputDir)
 
 	return buildResult(target)
 }
@@ -283,11 +283,11 @@ func (t *modelMeshToRawRunTask) Validate(
 
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeModelMesh)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list ModelMesh InferenceServices: %v", err)
 	} else if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgModelMeshNoISVCs)
+		step.Completef(result.StepSkipped, msgModelMeshNoISVCs)
 	} else {
-		step.Complete(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeModelMesh)
+		step.Completef(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeModelMesh)
 	}
 
 	return buildResult(target)

--- a/pkg/migrate/actions/modelserving/serverless_to_raw.go
+++ b/pkg/migrate/actions/modelserving/serverless_to_raw.go
@@ -71,18 +71,18 @@ func (a *ServerlessToRawAction) convertISVCs(
 
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeServerless)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
 
 		return
 	}
 
 	if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgServerlessNoISVCs)
+		step.Completef(result.StepSkipped, msgServerlessNoISVCs)
 
 		return
 	}
 
-	step.Record("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeServerless)
+	step.Recordf("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeServerless)
 
 	// Confirm with user
 	if !target.SkipConfirm && !target.DryRun {
@@ -90,7 +90,7 @@ func (a *ServerlessToRawAction) convertISVCs(
 		target.IO.Errorf(msgServerlessConfirm, len(isvcs))
 
 		if !confirmation.Prompt(target.IO, "Proceed with conversion?") {
-			step.Complete(result.StepSkipped, msgServerlessCancelled)
+			step.Completef(result.StepSkipped, msgServerlessCancelled)
 
 			return
 		}
@@ -113,9 +113,9 @@ func (a *ServerlessToRawAction) convertISVCs(
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgServerlessDryRun, convertedCount)
+		step.Completef(result.StepSkipped, msgServerlessDryRun, convertedCount)
 	} else {
-		step.Complete(result.StepCompleted, msgServerlessComplete, convertedCount)
+		step.Completef(result.StepCompleted, msgServerlessComplete, convertedCount)
 	}
 }
 
@@ -143,19 +143,19 @@ func (t *serverlessToRawPrepareTask) Execute(
 
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeServerless)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
 
 		return buildResult(target)
 	}
 
 	if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgServerlessNoISVCs)
+		step.Completef(result.StepSkipped, msgServerlessNoISVCs)
 
 		return buildResult(target)
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would backup %d Serverless InferenceServices", len(isvcs))
+		step.Completef(result.StepSkipped, "Would backup %d Serverless InferenceServices", len(isvcs))
 
 		return buildResult(target)
 	}
@@ -166,13 +166,13 @@ func (t *serverlessToRawPrepareTask) Execute(
 	for ns, nsISVCs := range byNamespace {
 		outputDir := filepath.Join(target.OutputDir, ns)
 		if err := backup.WriteResourcesToDir(outputDir, resources.InferenceService.GVR(), nsISVCs); err != nil {
-			step.Complete(result.StepFailed, "Failed to write InferenceServices backup for namespace %s: %v", ns, err)
+			step.Completef(result.StepFailed, "Failed to write InferenceServices backup for namespace %s: %v", ns, err)
 
 			return buildResult(target)
 		}
 	}
 
-	step.Complete(result.StepCompleted, msgServerlessBackupDone, len(isvcs), target.OutputDir)
+	step.Completef(result.StepCompleted, msgServerlessBackupDone, len(isvcs), target.OutputDir)
 
 	return buildResult(target)
 }
@@ -191,11 +191,11 @@ func (t *serverlessToRawRunTask) Validate(
 
 	isvcs, err := listISVCsByDeploymentMode(ctx, target, deploymentModeServerless)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
+		step.Completef(result.StepFailed, "Failed to list Serverless InferenceServices: %v", err)
 	} else if len(isvcs) == 0 {
-		step.Complete(result.StepSkipped, msgServerlessNoISVCs)
+		step.Completef(result.StepSkipped, msgServerlessNoISVCs)
 	} else {
-		step.Complete(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeServerless)
+		step.Completef(result.StepCompleted, msgFoundISVCs, len(isvcs), deploymentModeServerless)
 	}
 
 	return buildResult(target)

--- a/pkg/migrate/actions/modelserving/support.go
+++ b/pkg/migrate/actions/modelserving/support.go
@@ -123,7 +123,7 @@ func patchISVCDeploymentMode(
 	oldMode := getDeploymentMode(isvc)
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgPatchDeploymentModeDryRun, ns, name, oldMode, newMode)
+		step.Completef(result.StepSkipped, msgPatchDeploymentModeDryRun, ns, name, oldMode, newMode)
 
 		return
 	}
@@ -135,12 +135,12 @@ func patchISVCDeploymentMode(
 		Patch(ctx, name, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 
 	if err != nil {
-		step.Complete(result.StepFailed, msgPatchDeploymentModeFailed, ns, name, err)
+		step.Completef(result.StepFailed, msgPatchDeploymentModeFailed, ns, name, err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, msgPatchDeploymentModeSuccess, ns, name, newMode)
+	step.Completef(result.StepCompleted, msgPatchDeploymentModeSuccess, ns, name, newMode)
 }
 
 // getDeploymentMode returns the deployment mode annotation value, or empty string if not set.
@@ -178,7 +178,7 @@ func restartDeployment(
 	step action.StepRecorder,
 ) {
 	if target.DryRun {
-		step.Complete(result.StepSkipped, msgRestartDeploymentDryRun, namespace, name)
+		step.Completef(result.StepSkipped, msgRestartDeploymentDryRun, namespace, name)
 
 		return
 	}
@@ -194,12 +194,12 @@ func restartDeployment(
 		Patch(ctx, name, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
 
 	if err != nil {
-		step.Complete(result.StepFailed, msgRestartDeploymentFailed, namespace, name, err)
+		step.Completef(result.StepFailed, msgRestartDeploymentFailed, namespace, name, err)
 
 		return
 	}
 
-	step.Complete(result.StepCompleted, msgRestartDeploymentSuccess, namespace, name)
+	step.Completef(result.StepCompleted, msgRestartDeploymentSuccess, namespace, name)
 }
 
 // getApplicationsNamespace retrieves the applications namespace from DSCI.
@@ -282,13 +282,13 @@ func ensureServiceAccount(
 	}
 
 	if !apierrors.IsNotFound(err) {
-		step.Record("create-sa", "Failed to check ServiceAccount %s/%s: %v", result.StepFailed, namespace, name, err)
+		step.Recordf("create-sa", "Failed to check ServiceAccount %s/%s: %v", result.StepFailed, namespace, name, err)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Record("create-sa", "Would create ServiceAccount %s/%s", result.StepSkipped, namespace, name)
+		step.Recordf("create-sa", "Would create ServiceAccount %s/%s", result.StepSkipped, namespace, name)
 
 		return
 	}
@@ -309,12 +309,12 @@ func ensureServiceAccount(
 		Create(ctx, sa, metav1.CreateOptions{})
 
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		step.Record("create-sa", "Failed to create ServiceAccount %s/%s: %v", result.StepFailed, namespace, name, err)
+		step.Recordf("create-sa", "Failed to create ServiceAccount %s/%s: %v", result.StepFailed, namespace, name, err)
 
 		return
 	}
 
-	step.Record("create-sa", "Created ServiceAccount %s/%s", result.StepCompleted, namespace, name)
+	step.Recordf("create-sa", "Created ServiceAccount %s/%s", result.StepCompleted, namespace, name)
 }
 
 func ensureRole(
@@ -333,13 +333,13 @@ func ensureRole(
 	}
 
 	if !apierrors.IsNotFound(err) {
-		step.Record("create-role", "Failed to check Role %s/%s: %v", result.StepFailed, namespace, name, err)
+		step.Recordf("create-role", "Failed to check Role %s/%s: %v", result.StepFailed, namespace, name, err)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Record("create-role", "Would create Role %s/%s", result.StepSkipped, namespace, name)
+		step.Recordf("create-role", "Would create Role %s/%s", result.StepSkipped, namespace, name)
 
 		return
 	}
@@ -367,12 +367,12 @@ func ensureRole(
 		Create(ctx, role, metav1.CreateOptions{})
 
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		step.Record("create-role", "Failed to create Role %s/%s: %v", result.StepFailed, namespace, name, err)
+		step.Recordf("create-role", "Failed to create Role %s/%s: %v", result.StepFailed, namespace, name, err)
 
 		return
 	}
 
-	step.Record("create-role", "Created Role %s/%s", result.StepCompleted, namespace, name)
+	step.Recordf("create-role", "Created Role %s/%s", result.StepCompleted, namespace, name)
 }
 
 func ensureRoleBinding(
@@ -393,13 +393,13 @@ func ensureRoleBinding(
 	}
 
 	if !apierrors.IsNotFound(err) {
-		step.Record("create-rolebinding", "Failed to check RoleBinding %s/%s: %v", result.StepFailed, namespace, name, err)
+		step.Recordf("create-rolebinding", "Failed to check RoleBinding %s/%s: %v", result.StepFailed, namespace, name, err)
 
 		return
 	}
 
 	if target.DryRun {
-		step.Record("create-rolebinding", "Would create RoleBinding %s/%s", result.StepSkipped, namespace, name)
+		step.Recordf("create-rolebinding", "Would create RoleBinding %s/%s", result.StepSkipped, namespace, name)
 
 		return
 	}
@@ -432,12 +432,12 @@ func ensureRoleBinding(
 		Create(ctx, rb, metav1.CreateOptions{})
 
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		step.Record("create-rolebinding", "Failed to create RoleBinding %s/%s: %v", result.StepFailed, namespace, name, err)
+		step.Recordf("create-rolebinding", "Failed to create RoleBinding %s/%s: %v", result.StepFailed, namespace, name, err)
 
 		return
 	}
 
-	step.Record("create-rolebinding", "Created RoleBinding %s/%s", result.StepCompleted, namespace, name)
+	step.Recordf("create-rolebinding", "Created RoleBinding %s/%s", result.StepCompleted, namespace, name)
 }
 
 // buildResult extracts the RootRecorder from target and builds the ActionResult.

--- a/pkg/migrate/actions/workbenches/upgrade/prepare_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/prepare_task.go
@@ -23,11 +23,11 @@ func (t *prepareTask) Validate(
 
 	notebooks, err := t.action.listNotebooks(ctx, target)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
 	} else if len(notebooks) == 0 {
-		step.Complete(result.StepCompleted, "No Notebook instances found")
+		step.Completef(result.StepCompleted, "No Notebook instances found")
 	} else {
-		step.Complete(result.StepCompleted, "Found %d Notebook(s) across the cluster", len(notebooks))
+		step.Completef(result.StepCompleted, "Found %d Notebook(s) across the cluster", len(notebooks))
 	}
 
 	return buildResult(target.Recorder)
@@ -44,13 +44,13 @@ func (t *prepareTask) Execute(
 
 	notebooks, err := t.action.listNotebooks(ctx, target)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
 
 		return buildResult(target.Recorder)
 	}
 
 	if len(notebooks) == 0 {
-		step.Complete(result.StepCompleted, "No Notebook instances found, nothing to back up")
+		step.Completef(result.StepCompleted, "No Notebook instances found, nothing to back up")
 
 		return buildResult(target.Recorder)
 	}
@@ -64,7 +64,7 @@ func (t *prepareTask) Execute(
 		return r, fmt.Errorf("prepare backup failed: %w", err)
 	}
 
-	step.Complete(result.StepCompleted, "Backup phase complete")
+	step.Completef(result.StepCompleted, "Backup phase complete")
 
 	return buildResult(target.Recorder)
 }

--- a/pkg/migrate/actions/workbenches/upgrade/run_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/run_task.go
@@ -25,13 +25,13 @@ func (t *runTask) Validate(
 
 	notebooks, err := t.action.listNotebooks(ctx, target)
 	if err != nil {
-		step.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
 
 		return buildResult(target.Recorder)
 	}
 
 	if len(notebooks) == 0 {
-		step.Complete(result.StepCompleted, "No Notebook instances found, nothing to migrate")
+		step.Completef(result.StepCompleted, "No Notebook instances found, nothing to migrate")
 
 		return buildResult(target.Recorder)
 	}
@@ -44,7 +44,7 @@ func (t *runTask) Validate(
 	for _, nb := range stopped {
 		hasMismatch, checkErr := hasContainerNameMismatch(nb)
 		if checkErr != nil {
-			step.Record("check-error",
+			step.Recordf("check-error",
 				fmt.Sprintf("Failed to inspect Notebook %s/%s: %v", nb.GetNamespace(), nb.GetName(), checkErr),
 				result.StepFailed)
 			checkErrCount++
@@ -58,13 +58,13 @@ func (t *runTask) Validate(
 	}
 
 	if checkErrCount > 0 {
-		step.Complete(result.StepFailed,
+		step.Completef(result.StepFailed,
 			"Failed to inspect %d Notebook(s); resolve validation errors first", checkErrCount)
 	} else if mismatchCount > 0 {
-		step.Complete(result.StepCompleted,
+		step.Completef(result.StepCompleted,
 			"Found %d Notebook(s) with container name mismatches requiring update", mismatchCount)
 	} else {
-		step.Complete(result.StepCompleted,
+		step.Completef(result.StepCompleted,
 			"All %d stopped Notebook(s) have correct container names", len(stopped))
 	}
 
@@ -82,23 +82,23 @@ func (t *runTask) Execute(
 
 	notebooks, err := t.action.listNotebooks(ctx, target)
 	if err != nil {
-		listStep.Complete(result.StepFailed, "Failed to list Notebooks: %v", err)
+		listStep.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
 
 		return buildResult(target.Recorder)
 	}
 
 	if len(notebooks) == 0 {
-		listStep.Complete(result.StepCompleted, "No Notebook instances found, nothing to migrate")
+		listStep.Completef(result.StepCompleted, "No Notebook instances found, nothing to migrate")
 
 		return buildResult(target.Recorder)
 	}
 
-	listStep.Complete(result.StepCompleted, "Found %d Notebook(s)", len(notebooks))
+	listStep.Completef(result.StepCompleted, "Found %d Notebook(s)", len(notebooks))
 
 	stopped := t.action.handleNonStoppedNotebooks(target, notebooks, target.Recorder)
 
 	if len(stopped) == 0 {
-		target.Recorder.Record("no-eligible-notebooks",
+		target.Recorder.Recordf("no-eligible-notebooks",
 			"No eligible Notebook(s) to migrate (all non-stopped)", result.StepSkipped)
 
 		return buildResult(target.Recorder)
@@ -126,7 +126,7 @@ func (t *runTask) fixContainerNames(
 	for _, nb := range notebooks {
 		hasMismatch, err := hasContainerNameMismatch(nb)
 		if err != nil {
-			step.Record("check-error",
+			step.Recordf("check-error",
 				fmt.Sprintf("Error checking %s/%s: %v", nb.GetNamespace(), nb.GetName(), err),
 				result.StepFailed)
 			checkErrCount++
@@ -140,14 +140,14 @@ func (t *runTask) fixContainerNames(
 	}
 
 	if len(toFix) == 0 && checkErrCount > 0 {
-		step.Complete(result.StepFailed,
+		step.Completef(result.StepFailed,
 			"Failed to inspect %d Notebook(s), no fixable mismatches found", checkErrCount)
 
 		return
 	}
 
 	if len(toFix) == 0 {
-		step.Complete(result.StepCompleted,
+		step.Completef(result.StepCompleted,
 			"All %d Notebook(s) have correct container names, no changes needed", len(notebooks))
 
 		return
@@ -157,7 +157,7 @@ func (t *runTask) fixContainerNames(
 		for _, nb := range toFix {
 			containers, _ := extractWorkloadContainers(nb)
 			if len(containers) > 0 {
-				step.Record("would-fix",
+				step.Recordf("would-fix",
 					fmt.Sprintf("Would rename container %q to %q in %s/%s",
 						containers[0].Name, nb.GetName(), nb.GetNamespace(), nb.GetName()),
 					result.StepSkipped)
@@ -165,11 +165,11 @@ func (t *runTask) fixContainerNames(
 		}
 
 		if checkErrCount > 0 {
-			step.Complete(result.StepFailed,
+			step.Completef(result.StepFailed,
 				"Would fix %d Notebook(s), but failed to inspect %d",
 				len(toFix), checkErrCount)
 		} else {
-			step.Complete(result.StepSkipped,
+			step.Completef(result.StepSkipped,
 				"Would fix container names in %d Notebook(s)", len(toFix))
 		}
 
@@ -177,7 +177,7 @@ func (t *runTask) fixContainerNames(
 	}
 
 	if !t.action.promptBeforeModification(target, len(toFix)) {
-		step.Complete(result.StepSkipped, "User cancelled modification")
+		step.Completef(result.StepSkipped, "User cancelled modification")
 
 		return
 	}
@@ -185,11 +185,11 @@ func (t *runTask) fixContainerNames(
 	successCount, failCount := t.applyContainerFixes(ctx, target, toFix, step)
 
 	if failCount > 0 || checkErrCount > 0 {
-		step.Complete(result.StepFailed,
+		step.Completef(result.StepFailed,
 			"Fixed %d/%d Notebook(s), %d update failure(s), %d inspection failure(s)",
 			successCount, len(toFix), failCount, checkErrCount)
 	} else {
-		step.Complete(result.StepCompleted,
+		step.Completef(result.StepCompleted,
 			"Fixed container names in %d/%d Notebook(s)", successCount, len(toFix))
 	}
 }
@@ -214,21 +214,21 @@ func (t *runTask) applyContainerFixes(
 
 		oldName, err := fixContainerName(patched)
 		if err != nil {
-			nbStep.Complete(result.StepFailed, "Failed to fix container name: %v", err)
+			nbStep.Completef(result.StepFailed, "Failed to fix container name: %v", err)
 			failCount++
 
 			continue
 		}
 
 		if err := t.action.updateNotebook(ctx, target, patched); err != nil {
-			nbStep.Complete(result.StepFailed,
+			nbStep.Completef(result.StepFailed,
 				"Failed to update Notebook %s/%s: %v", nb.GetNamespace(), nb.GetName(), err)
 			failCount++
 
 			continue
 		}
 
-		nbStep.Complete(result.StepCompleted,
+		nbStep.Completef(result.StepCompleted,
 			"Renamed container %q to %q", oldName, nb.GetName())
 		successCount++
 	}

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade.go
@@ -247,7 +247,7 @@ func (a *WorkbenchUpgradeAction) backupNotebooks(
 	)
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped, "Would backup %d Notebook(s) to %s", len(notebooks), target.OutputDir)
+		step.Completef(result.StepSkipped, "Would backup %d Notebook(s) to %s", len(notebooks), target.OutputDir)
 
 		return nil
 	}
@@ -264,7 +264,7 @@ func (a *WorkbenchUpgradeAction) backupNotebooks(
 		outputDir := filepath.Join(target.OutputDir, ns)
 
 		if err := backup.WriteResourcesToDir(outputDir, resources.Notebook.GVR(), nbs); err != nil {
-			step.Complete(result.StepFailed, "Failed to write Notebooks in namespace %s: %v", ns, err)
+			step.Completef(result.StepFailed, "Failed to write Notebooks in namespace %s: %v", ns, err)
 
 			return fmt.Errorf("backup failed for namespace %s: %w", ns, err)
 		}
@@ -272,7 +272,7 @@ func (a *WorkbenchUpgradeAction) backupNotebooks(
 		totalBacked += len(nbs)
 	}
 
-	step.Complete(result.StepCompleted, "Backed up %d Notebook(s) across %d namespace(s) to %s", totalBacked, len(byNamespace), target.OutputDir)
+	step.Completef(result.StepCompleted, "Backed up %d Notebook(s) across %d namespace(s) to %s", totalBacked, len(byNamespace), target.OutputDir)
 
 	return nil
 }
@@ -300,7 +300,7 @@ func (a *WorkbenchUpgradeAction) handleNonStoppedNotebooks(
 	}
 
 	if len(nonStopped) == 0 {
-		step.Complete(result.StepCompleted, "All %d Notebook(s) are stopped", len(notebooks))
+		step.Completef(result.StepCompleted, "All %d Notebook(s) are stopped", len(notebooks))
 
 		return stopped
 	}
@@ -313,7 +313,7 @@ func (a *WorkbenchUpgradeAction) handleNonStoppedNotebooks(
 	step.AddDetail("non_stopped_notebooks", names)
 
 	if a.ForceNonStopped {
-		step.Complete(result.StepCompleted,
+		step.Completef(result.StepCompleted,
 			"Including %d non-stopped Notebook(s) (--force-non-stopped): %s",
 			len(nonStopped), strings.Join(names, ", "))
 
@@ -321,7 +321,7 @@ func (a *WorkbenchUpgradeAction) handleNonStoppedNotebooks(
 	}
 
 	if target.DryRun {
-		step.Complete(result.StepSkipped,
+		step.Completef(result.StepSkipped,
 			"Found %d non-stopped Notebook(s) (would skip in dry-run): %s",
 			len(nonStopped), strings.Join(names, ", "))
 
@@ -340,7 +340,7 @@ func (a *WorkbenchUpgradeAction) handleNonStoppedNotebooks(
 		target.IO.Errorf("Use --force-non-stopped to include them (unsafe).")
 	}
 
-	step.Complete(result.StepCompleted,
+	step.Completef(result.StepCompleted,
 		"Skipping %d non-stopped Notebook(s), proceeding with %d stopped Notebook(s)",
 		len(nonStopped), len(stopped))
 

--- a/pkg/util/kube/olm/install.go
+++ b/pkg/util/kube/olm/install.go
@@ -106,22 +106,22 @@ func dryRunOperatorInstall(
 
 	switch {
 	case err == nil:
-		checkStep.Complete(result.StepCompleted, "Subscription already exists, skipping creation")
+		checkStep.Completef(result.StepCompleted, "Subscription already exists, skipping creation")
 
 		// Verify CSV is ready (read-only operation, safe to run in dry-run)
 		verifyStep := config.Recorder.Child("verify-csv",
 			fmt.Sprintf("Verifying operator CSV '%s' is ready in namespace '%s'", config.CSVNamePrefix, config.Namespace))
 
 		if err := WaitForCSV(ctx, k8sClient, config.Namespace, config.CSVNamePrefix, config.PollInterval, config.Timeout); err != nil {
-			verifyStep.Complete(result.StepFailed, fmt.Sprintf("CSV verification failed: %v", err))
+			verifyStep.Completef(result.StepFailed, "CSV verification failed: %v", err)
 
 			return fmt.Errorf("failed waiting for operator CSV: %w", err)
 		}
 
-		verifyStep.Complete(result.StepCompleted, "Operator CSV is ready")
+		verifyStep.Completef(result.StepCompleted, "Operator CSV is ready")
 
 	case apierrors.IsNotFound(err):
-		checkStep.Complete(result.StepCompleted, "Subscription not found")
+		checkStep.Completef(result.StepCompleted, "Subscription not found")
 
 		createStep := config.Recorder.Child("create-subscription", "Would create Subscription")
 		createStep.AddDetail("name", config.Name)
@@ -133,15 +133,15 @@ func dryRunOperatorInstall(
 		if config.StartingCSV != "" {
 			createStep.AddDetail("startingCSV", config.StartingCSV)
 		}
-		createStep.Complete(result.StepSkipped,
-			fmt.Sprintf("Would create subscription %s/%s", config.Namespace, config.Name))
+		createStep.Completef(result.StepSkipped,
+			"Would create subscription %s/%s", config.Namespace, config.Name)
 
 		waitStep := config.Recorder.Child("wait-csv",
 			fmt.Sprintf("Would wait for CSV '%s' to reach 'Succeeded' phase", config.CSVNamePrefix))
-		waitStep.Complete(result.StepSkipped, fmt.Sprintf("Timeout: %v", config.Timeout))
+		waitStep.Completef(result.StepSkipped, "Timeout: %v", config.Timeout)
 
 	default:
-		checkStep.Complete(result.StepFailed, fmt.Sprintf("Failed to check subscription: %v", err))
+		checkStep.Completef(result.StepFailed, "Failed to check subscription: %v", err)
 
 		return fmt.Errorf("failed to check subscription: %w", err)
 	}


### PR DESCRIPTION
Follow Go's f-suffix naming convention (Printf, Errorf, Sprintf) for methods that accept printf-style format strings. Also removes redundant fmt.Sprintf wrappers in install.go where format args can be passed directly to Completef. Prepares for Go 1.26 which extends govet's non-constant format string check to interface methods.

Go 1.26 PR: https://github.com/opendatahub-io/odh-cli/pull/97

## Description

<!-- What does this PR do? -->

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated progress reporting infrastructure to use consistent message formatting across all migration workflows for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->