### PR TITLE
feat(deps/stdin): add --from-stdin flag and PipeChecker interface

### DIFF
--- a/pkg/components/commands.go
+++ b/pkg/components/commands.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -70,7 +69,7 @@ func (c *EnableCommand) AddFlags(fs *pflag.FlagSet) {
 	c.flags = fs
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would change without applying")
 	fs.BoolVarP(&c.Yes, "yes", "y", false, "Skip confirmation prompt")
-	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 }
 
 // Complete resolves derived fields after flag parsing.
@@ -100,8 +99,8 @@ func (c *EnableCommand) Complete() error {
 
 // parseStdinConfig reads and applies configuration from stdin.
 func (c *EnableCommand) parseStdinConfig() error {
-	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
-		c.IO.Errorf("%s", warnStdinIsTerminal)
+	if err := stdin.CheckPiped(c.IO.In()); err != nil {
+		return err //nolint:wrapcheck // CheckPiped returns a self-descriptive user-facing error
 	}
 
 	var input StdinInput
@@ -132,25 +131,15 @@ func (c *EnableCommand) applyStdinInput(input *StdinInput) error {
 		c.ComponentNames = input.Components
 	}
 
-	if input.DryRun && !c.flagChanged("dry-run") {
+	if input.DryRun && !stdin.FlagChanged(c.flags, "dry-run") {
 		c.DryRun = true
 	}
 
-	if input.SkipConfirm && !c.flagChanged("yes") {
+	if input.SkipConfirm && !stdin.FlagChanged(c.flags, "yes") {
 		c.Yes = true
 	}
 
 	return nil
-}
-
-// flagChanged returns true if the flag was explicitly set on the command line.
-func (c *EnableCommand) flagChanged(name string) bool {
-	if c.flags == nil {
-		return false
-	}
-	f := c.flags.Lookup(name)
-
-	return f != nil && f.Changed
 }
 
 // Validate checks that all options are valid before execution.
@@ -233,7 +222,7 @@ func (c *DisableCommand) AddFlags(fs *pflag.FlagSet) {
 	c.flags = fs
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would change without applying")
 	fs.BoolVarP(&c.Yes, "yes", "y", false, "Skip confirmation prompt")
-	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 }
 
 // Complete resolves derived fields after flag parsing.
@@ -263,8 +252,8 @@ func (c *DisableCommand) Complete() error {
 
 // parseStdinConfig reads and applies configuration from stdin.
 func (c *DisableCommand) parseStdinConfig() error {
-	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
-		c.IO.Errorf("%s", warnStdinIsTerminal)
+	if err := stdin.CheckPiped(c.IO.In()); err != nil {
+		return err //nolint:wrapcheck // CheckPiped returns a self-descriptive user-facing error
 	}
 
 	var input StdinInput
@@ -295,25 +284,15 @@ func (c *DisableCommand) applyStdinInput(input *StdinInput) error {
 		c.ComponentNames = input.Components
 	}
 
-	if input.DryRun && !c.flagChanged("dry-run") {
+	if input.DryRun && !stdin.FlagChanged(c.flags, "dry-run") {
 		c.DryRun = true
 	}
 
-	if input.SkipConfirm && !c.flagChanged("yes") {
+	if input.SkipConfirm && !stdin.FlagChanged(c.flags, "yes") {
 		c.Yes = true
 	}
 
 	return nil
-}
-
-// flagChanged returns true if the flag was explicitly set on the command line.
-func (c *DisableCommand) flagChanged(name string) bool {
-	if c.flags == nil {
-		return false
-	}
-	f := c.flags.Lookup(name)
-
-	return f != nil && f.Changed
 }
 
 // Validate checks that all options are valid before execution.

--- a/pkg/components/stdin_input.go
+++ b/pkg/components/stdin_input.go
@@ -14,13 +14,3 @@ type StdinInput struct {
 	// Named "skipConfirm" instead of "yes" because "yes" is a reserved YAML 1.1 boolean.
 	SkipConfirm bool `json:"skipConfirm,omitempty" yaml:"skipConfirm,omitempty"`
 }
-
-// Flag descriptions for stdin support.
-const (
-	flagDescFromStdin = "read configuration from stdin (JSON/YAML); CLI flags override stdin values"
-)
-
-// Warning messages.
-const (
-	warnStdinIsTerminal = "Warning: --from-stdin specified but stdin is a terminal"
-)

--- a/pkg/deps/install.go
+++ b/pkg/deps/install.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -25,8 +26,9 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	utilserrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/stdin"
 )
 
 // Verify InstallCommand implements cmd.Command interface at compile time.
@@ -114,12 +116,15 @@ type InstallCommand struct {
 	IncludeOptional bool
 	Timeout         time.Duration
 	TargetDep       string
+	TargetDeps      []string
 	Version         string
 	Refresh         bool
+	FromStdin       bool
 
 	client          client.Client
 	manifestVersion string
 	useColor        bool
+	flags           *pflag.FlagSet
 }
 
 // NewInstallCommand creates a new InstallCommand with defaults.
@@ -133,15 +138,31 @@ func NewInstallCommand(streams genericiooptions.IOStreams, configFlags *genericc
 
 // AddFlags registers command-specific flags with the provided FlagSet.
 func (c *InstallCommand) AddFlags(fs *pflag.FlagSet) {
+	c.flags = fs
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show what would be installed without executing")
 	fs.BoolVar(&c.IncludeOptional, "include-optional", false, "Install optional dependencies in addition to required")
 	fs.DurationVar(&c.Timeout, "timeout", defaultTimeout, "Timeout for waiting on each operator CSV")
 	fs.StringVar(&c.Version, "version", "", "ODH/RHOAI version to install dependencies for")
 	fs.BoolVar(&c.Refresh, "refresh", false, "Fetch latest manifest from odh-gitops")
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 }
 
 // Complete prepares the command for execution.
 func (c *InstallCommand) Complete() error {
+	if c.FromStdin {
+		if err := c.parseStdinConfig(); err != nil {
+			return clierrors.NewExitCodeError(clierrors.ExitValidation, err) //nolint:wrapcheck // NewExitCodeError is a same-module constructor
+		}
+	}
+
+	// Normalize single positional arg into TargetDeps slice.
+	// Must run AFTER parseStdinConfig: applyStdinInput checks c.TargetDep != ""
+	// to detect conflicts, which only works while TargetDep is still populated.
+	if len(c.TargetDeps) == 0 && c.TargetDep != "" {
+		c.TargetDeps = []string{c.TargetDep}
+		c.TargetDep = "" // zero out to prevent stale reads after Complete()
+	}
+
 	c.useColor = shouldUseColor(c.IO.Out())
 
 	if c.DryRun {
@@ -154,6 +175,56 @@ func (c *InstallCommand) Complete() error {
 	}
 
 	c.client = cl
+
+	return nil
+}
+
+func (c *InstallCommand) parseStdinConfig() error {
+	if err := stdin.CheckPiped(c.IO.In()); err != nil {
+		return err //nolint:wrapcheck // CheckPiped returns a self-descriptive user-facing error
+	}
+
+	var input StdinInput
+	if err := stdin.Parse(c.IO.In(), &input); err != nil {
+		return fmt.Errorf("parsing stdin: %w", err)
+	}
+
+	return c.applyStdinInput(&input)
+}
+
+func (c *InstallCommand) applyStdinInput(input *StdinInput) error {
+	for i, name := range input.Deps {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("empty dep name at index %d", i)
+		}
+
+		input.Deps[i] = trimmed
+	}
+
+	if input.Deps != nil && (c.TargetDep != "" || len(c.TargetDeps) > 0) {
+		return errors.New("cannot specify both a positional dependency argument and deps in stdin")
+	}
+
+	if input.Deps != nil {
+		c.TargetDeps = input.Deps
+	}
+
+	if input.Version != "" && !stdin.FlagChanged(c.flags, "version") {
+		c.Version = input.Version
+	}
+
+	if input.DryRun && !stdin.FlagChanged(c.flags, "dry-run") {
+		c.DryRun = true
+	}
+
+	if input.IncludeOptional && !stdin.FlagChanged(c.flags, "include-optional") {
+		c.IncludeOptional = true
+	}
+
+	if input.Refresh && !stdin.FlagChanged(c.flags, "refresh") {
+		c.Refresh = true
+	}
 
 	return nil
 }
@@ -182,7 +253,7 @@ func (c *InstallCommand) Validate() error {
 	c.manifestVersion = manifestVer
 
 	if c.Version != "" && !majorMinorMatch(c.Version, c.manifestVersion) {
-		return utilserrors.NewValidationError(
+		return clierrors.NewValidationError(
 			"VERSION_UNAVAILABLE",
 			fmt.Sprintf("dependencies for version %q are not available; only version %s is supported", c.Version, c.manifestVersion),
 			"Use --refresh to fetch the latest manifest, or omit --version to use the embedded version",
@@ -211,7 +282,7 @@ func (c *InstallCommand) Run(ctx context.Context) error {
 			suggestion = "Omit --version to use the fetched manifest version"
 		}
 
-		return utilserrors.NewValidationError(
+		return clierrors.NewValidationError(
 			"VERSION_UNAVAILABLE",
 			fmt.Sprintf("dependencies for version %q are not available; only version %s is supported", c.Version, c.manifestVersion),
 			suggestion,
@@ -223,9 +294,9 @@ func (c *InstallCommand) Run(ctx context.Context) error {
 
 	deps := result.Manifest.GetDependencies()
 
-	if c.TargetDep != "" {
-		if !c.isValidDependency(deps, c.TargetDep) {
-			return fmt.Errorf(msgUnknownDependency, c.TargetDep)
+	for _, depName := range c.TargetDeps {
+		if !c.isValidDependency(deps, depName) {
+			return fmt.Errorf(msgUnknownDependency, depName)
 		}
 	}
 
@@ -254,7 +325,14 @@ func (c *InstallCommand) runDryRun(_ context.Context, deps []DependencyInfo) err
 
 	toInstall := c.filterDepsForDryRun(deps)
 	if len(toInstall) == 0 {
-		_, _ = fmt.Fprintln(w, msgNoDepsToInstall)
+		switch {
+		case len(c.TargetDeps) == 0 && c.TargetDeps != nil:
+			_, _ = fmt.Fprintln(w, msgNoDepsToInstall)
+		case len(c.TargetDeps) > 0:
+			_, _ = fmt.Fprintf(w, "%s is already installed.\n", strings.Join(c.TargetDeps, ", "))
+		default:
+			_, _ = fmt.Fprintln(w, msgAllInstalled)
+		}
 
 		return nil
 	}
@@ -332,7 +410,14 @@ func (c *InstallCommand) runInstall(ctx context.Context, deps []DependencyInfo) 
 	}
 
 	if len(toInstall) == 0 {
-		_, _ = fmt.Fprintln(w, msgAllInstalled)
+		switch {
+		case len(c.TargetDeps) == 0 && c.TargetDeps != nil:
+			_, _ = fmt.Fprintln(w, msgNoDepsToInstall)
+		case len(c.TargetDeps) > 0:
+			_, _ = fmt.Fprintf(w, "%s is already installed.\n", strings.Join(c.TargetDeps, ", "))
+		default:
+			_, _ = fmt.Fprintln(w, msgAllInstalled)
+		}
 
 		return nil
 	}
@@ -418,10 +503,6 @@ func (c *InstallCommand) filterDepsForDryRun(deps []DependencyInfo) []Dependency
 	var toInstall []DependencyInfo
 
 	for _, dep := range deps {
-		if c.TargetDep != "" && dep.Name != c.TargetDep {
-			continue
-		}
-
 		if !c.shouldInstallDep(dep) {
 			continue
 		}
@@ -436,10 +517,6 @@ func (c *InstallCommand) filterDepsToInstall(ctx context.Context, deps []Depende
 	indices := make([]int, 0, len(deps))
 
 	for i, dep := range deps {
-		if c.TargetDep != "" && dep.Name != c.TargetDep {
-			continue
-		}
-
 		if !c.shouldInstallDep(dep) {
 			continue
 		}
@@ -488,12 +565,13 @@ func (c *InstallCommand) filterDepsToInstall(ctx context.Context, deps []Depende
 }
 
 func (c *InstallCommand) shouldInstallDep(dep DependencyInfo) bool {
-	// If user explicitly named this dependency, always allow it
-	if c.TargetDep != "" && c.TargetDep == dep.Name {
-		return true
+	// If user provided an explicit list (single or batch), only allow those deps.
+	// An explicit empty list means "install nothing".
+	if c.TargetDeps != nil {
+		return slices.Contains(c.TargetDeps, dep.Name)
 	}
 
-	// Required deps (enabled=true) are always installed
+	// Bulk mode: apply enabled/optional filtering
 	if dep.Enabled == enabledTrue {
 		return true
 	}

--- a/pkg/deps/install_internal_test.go
+++ b/pkg/deps/install_internal_test.go
@@ -24,60 +24,78 @@ import (
 func TestShouldInstallDep(t *testing.T) {
 	tests := []struct {
 		name            string
-		targetDep       string
+		targetDeps      []string
 		includeOptional bool
 		dep             DependencyInfo
 		want            bool
 	}{
 		{
-			name:      "target dep matches - always install",
-			targetDep: "cert-manager",
-			dep:       DependencyInfo{Name: "cert-manager", Enabled: "false"},
-			want:      true,
+			name:       "target dep matches - always install",
+			targetDeps: []string{"cert-manager"},
+			dep:        DependencyInfo{Name: "cert-manager", Enabled: "false"},
+			want:       true,
 		},
 		{
-			name:      "target dep matches optional - always install",
-			targetDep: "kueue",
-			dep:       DependencyInfo{Name: "kueue", Enabled: "auto"},
-			want:      true,
+			name:       "target dep matches optional - always install",
+			targetDeps: []string{"kueue"},
+			dep:        DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:       true,
 		},
 		{
-			name:      "required dep - install",
-			targetDep: "",
-			dep:       DependencyInfo{Name: "cert-manager", Enabled: "true"},
-			want:      true,
+			name:       "required dep - install",
+			targetDeps: nil,
+			dep:        DependencyInfo{Name: "cert-manager", Enabled: "true"},
+			want:       true,
 		},
 		{
-			name:      "optional dep without flag - skip",
-			targetDep: "",
-			dep:       DependencyInfo{Name: "kueue", Enabled: "auto"},
-			want:      false,
+			name:       "optional dep without flag - skip",
+			targetDeps: nil,
+			dep:        DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:       false,
 		},
 		{
-			name:      "disabled dep without flag - skip",
-			targetDep: "",
-			dep:       DependencyInfo{Name: "servicemesh", Enabled: "false"},
-			want:      false,
+			name:       "disabled dep without flag - skip",
+			targetDeps: nil,
+			dep:        DependencyInfo{Name: "servicemesh", Enabled: "false"},
+			want:       false,
 		},
 		{
 			name:            "optional dep with flag - install",
-			targetDep:       "",
+			targetDeps:      nil,
 			includeOptional: true,
 			dep:             DependencyInfo{Name: "kueue", Enabled: "auto"},
 			want:            true,
 		},
 		{
 			name:            "disabled dep with flag - still skip",
-			targetDep:       "",
+			targetDeps:      nil,
 			includeOptional: true,
 			dep:             DependencyInfo{Name: "servicemesh", Enabled: "false"},
 			want:            false,
 		},
 		{
-			name:      "different target dep - use normal rules",
-			targetDep: "other-dep",
-			dep:       DependencyInfo{Name: "kueue", Enabled: "auto"},
-			want:      false,
+			name:       "different target dep - use normal rules",
+			targetDeps: []string{"other-dep"},
+			dep:        DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:       false,
+		},
+		{
+			name:       "batch target deps - install matching dep",
+			targetDeps: []string{"cert-manager", "kueue"},
+			dep:        DependencyInfo{Name: "kueue", Enabled: "auto"},
+			want:       true,
+		},
+		{
+			name:       "batch target deps - skip non-matching dep",
+			targetDeps: []string{"cert-manager", "kueue"},
+			dep:        DependencyInfo{Name: "servicemesh", Enabled: "true"},
+			want:       false,
+		},
+		{
+			name:       "explicit empty list - install nothing",
+			targetDeps: []string{},
+			dep:        DependencyInfo{Name: "cert-manager", Enabled: "true"},
+			want:       false,
 		},
 	}
 
@@ -92,7 +110,7 @@ func TestShouldInstallDep(t *testing.T) {
 
 			cmd := &InstallCommand{
 				IO:              iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
-				TargetDep:       tt.targetDep,
+				TargetDeps:      tt.targetDeps,
 				IncludeOptional: tt.includeOptional,
 			}
 
@@ -213,7 +231,7 @@ func TestRunDryRun(t *testing.T) {
 		g.Expect(output).To(ContainSubstring("app.kubernetes.io/managed-by: odh-cli"))
 	})
 
-	t.Run("no deps to install", func(t *testing.T) {
+	t.Run("bulk mode with no eligible deps shows all-installed", func(t *testing.T) {
 		g := NewWithT(t)
 
 		var buf bytes.Buffer
@@ -222,11 +240,11 @@ func TestRunDryRun(t *testing.T) {
 			ErrOut: &bytes.Buffer{},
 		}
 
+		// TargetDeps == nil: bulk mode; optional dep without --include-optional is skipped
 		cmd := &InstallCommand{
 			IO: iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
 		}
 
-		// Optional dep without --include-optional flag
 		deps := []DependencyInfo{
 			{
 				Name:    "kueue",
@@ -240,7 +258,40 @@ func TestRunDryRun(t *testing.T) {
 
 		output := buf.String()
 		g.Expect(output).To(ContainSubstring("[DRY RUN]"))
-		g.Expect(output).To(ContainSubstring("No dependencies to install"))
+		g.Expect(output).To(ContainSubstring(msgAllInstalled))
+		g.Expect(output).ToNot(ContainSubstring(msgNoDepsToInstall))
+	})
+
+	t.Run("explicit empty TargetDeps shows no-deps-to-install", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			Out:    &buf,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		// TargetDeps == []string{}: user explicitly requested nothing
+		cmd := &InstallCommand{
+			IO:         iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+			TargetDeps: []string{},
+		}
+
+		deps := []DependencyInfo{
+			{
+				Name:    "cert-manager",
+				Enabled: "true",
+			},
+		}
+
+		err := cmd.runDryRun(context.Background(), deps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := buf.String()
+		g.Expect(output).To(ContainSubstring("[DRY RUN]"))
+		g.Expect(output).To(ContainSubstring(msgNoDepsToInstall))
+		g.Expect(output).ToNot(ContainSubstring(msgAllInstalled))
 	})
 
 	t.Run("with target dep", func(t *testing.T) {
@@ -253,8 +304,8 @@ func TestRunDryRun(t *testing.T) {
 		}
 
 		cmd := &InstallCommand{
-			IO:        iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
-			TargetDep: "kueue",
+			IO:         iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+			TargetDeps: []string{"kueue"},
 		}
 
 		deps := []DependencyInfo{
@@ -282,6 +333,62 @@ func TestRunDryRun(t *testing.T) {
 		// Should only show kueue, not cert-manager
 		g.Expect(output).To(ContainSubstring("Kueue"))
 		g.Expect(output).ToNot(ContainSubstring("Cert Manager"))
+	})
+}
+
+func TestRunInstall_EmptyToInstall(t *testing.T) {
+	// filterDepsToInstall short-circuits before any API call when shouldInstallDep
+	// returns false for all deps, so these tests need no cluster client.
+
+	t.Run("bulk mode with no eligible deps shows all-installed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			Out:    &buf,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		// TargetDeps == nil: bulk mode; all deps disabled, none reach isAlreadyInstalled
+		cmd := &InstallCommand{
+			IO: iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+		}
+
+		deps := []DependencyInfo{
+			{Name: "servicemesh", Enabled: "false"},
+		}
+
+		err := cmd.runInstall(context.Background(), deps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(buf.String()).To(ContainSubstring(msgAllInstalled))
+		g.Expect(buf.String()).ToNot(ContainSubstring(msgNoDepsToInstall))
+	})
+
+	t.Run("explicit empty TargetDeps shows no-deps-to-install", func(t *testing.T) {
+		g := NewWithT(t)
+
+		var buf bytes.Buffer
+		streams := genericiooptions.IOStreams{
+			Out:    &buf,
+			ErrOut: &bytes.Buffer{},
+		}
+
+		// TargetDeps == []string{}: user explicitly requested nothing
+		cmd := &InstallCommand{
+			IO:         iostreams.NewIOStreams(streams.In, streams.Out, streams.ErrOut),
+			TargetDeps: []string{},
+		}
+
+		deps := []DependencyInfo{
+			{Name: "cert-manager", Enabled: "true"},
+		}
+
+		err := cmd.runInstall(context.Background(), deps)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(buf.String()).To(ContainSubstring(msgNoDepsToInstall))
+		g.Expect(buf.String()).ToNot(ContainSubstring(msgAllInstalled))
 	})
 }
 

--- a/pkg/deps/install_stdin_test.go
+++ b/pkg/deps/install_stdin_test.go
@@ -1,0 +1,336 @@
+package deps_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+
+	. "github.com/onsi/gomega"
+)
+
+// Test fixtures for stdin input parsing.
+const (
+	fixtureStdinInstallJSON = `{"deps": ["cert-manager", "kueue"], "version": "2.19.0", "dryRun": true, "includeOptional": true}`
+
+	fixtureStdinInstallYAML = `
+deps:
+  - cert-manager
+  - kueue
+  - jobset
+version: "2.19.0"
+dryRun: true
+`
+	fixtureStdinInstallSingleDep = `{"deps": ["cert-manager"], "dryRun": true}`
+
+	fixtureStdinInstallFlagsOnly = `{"version": "2.19.0", "dryRun": true, "includeOptional": false}`
+
+	fixtureStdinInstallEmptyDeps     = `{"deps": [], "dryRun": true}`
+	fixtureStdinInstallInvalid       = `{"deps": invalid}`
+	fixtureStdinInstallUnknownFields = `{"deeps": ["cert-manager"]}`
+)
+
+func TestInstallCommand_FromStdinFlag(t *testing.T) {
+	t.Run("AddFlags should register --from-stdin flag", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+
+		flag := fs.Lookup("from-stdin")
+		g.Expect(flag).ToNot(BeNil())
+		g.Expect(flag.DefValue).To(Equal("false"))
+	})
+}
+
+func TestInstallCommand_StdinInput(t *testing.T) {
+	// Tests below set FromStdin directly without calling AddFlags.
+	// This is intentional — they test stdin parsing and error handling only.
+	// CLI-over-stdin precedence is validated by the tests that call AddFlags
+	// and fs.Parse() further below.
+
+	t.Run("Complete should parse stdin JSON and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallJSON)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cmd.TargetDeps).To(Equal([]string{"cert-manager", "kueue"}))
+		g.Expect(cmd.Version).To(Equal("2.19.0"))
+		g.Expect(cmd.DryRun).To(BeTrue())
+		g.Expect(cmd.IncludeOptional).To(BeTrue())
+	})
+
+	t.Run("Complete should parse stdin YAML and apply to command", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallYAML)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cmd.TargetDeps).To(Equal([]string{"cert-manager", "kueue", "jobset"}))
+		g.Expect(cmd.Version).To(Equal("2.19.0"))
+		g.Expect(cmd.DryRun).To(BeTrue())
+	})
+
+	t.Run("Complete should apply flags-only stdin (no deps)", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallFlagsOnly)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cmd.TargetDeps).To(BeEmpty())
+		g.Expect(cmd.Version).To(Equal("2.19.0"))
+		g.Expect(cmd.DryRun).To(BeTrue())
+	})
+
+	t.Run("Complete should keep defaults when stdin fields are omitted", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Single dep with dryRun:true to avoid cluster client creation; other fields test defaults
+		stdin := bytes.NewBufferString(fixtureStdinInstallSingleDep)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cmd.TargetDeps).To(Equal([]string{"cert-manager"}))
+		g.Expect(cmd.Version).To(BeEmpty())
+		g.Expect(cmd.IncludeOptional).To(BeFalse())
+		g.Expect(cmd.Refresh).To(BeFalse())
+	})
+
+	t.Run("Complete should treat explicit empty deps list as install-nothing", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallEmptyDeps)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Non-nil empty slice: explicit empty list means "install nothing", not bulk mode
+		g.Expect(cmd.TargetDeps).ToNot(BeNil())
+		g.Expect(cmd.TargetDeps).To(BeEmpty())
+	})
+
+	t.Run("Complete should fail on invalid stdin JSON", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallInvalid)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should reject unknown fields in stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallUnknownFields)
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("parsing stdin"))
+	})
+
+	t.Run("Complete should fail on empty stdin", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString("")
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+
+		err := cmd.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("empty input"))
+	})
+
+	t.Run("Explicit CLI flags should take precedence over stdin values", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Stdin sets includeOptional=true; CLI flag overrides with false.
+		// DryRun stays true (from stdin, not overridden) so Complete() exits before k8s client creation.
+		stdin := bytes.NewBufferString(fixtureStdinInstallJSON) // has dryRun: true, includeOptional: true
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+		err := fs.Parse([]string{"--include-optional=false", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// CLI flag wins over stdin
+		g.Expect(cmd.IncludeOptional).To(BeFalse())
+		// Stdin values apply for non-explicitly-set flags
+		g.Expect(cmd.TargetDeps).To(Equal([]string{"cert-manager", "kueue"}))
+		g.Expect(cmd.Version).To(Equal("2.19.0"))
+		g.Expect(cmd.DryRun).To(BeTrue())
+	})
+
+	t.Run("CLI --version should take precedence over stdin version", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallJSON) // has version: "2.19.0"
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		cmd.AddFlags(fs)
+		err := fs.Parse([]string{"--version=3.0.0", "--from-stdin"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cmd.Version).To(Equal("3.0.0"))
+		g.Expect(cmd.TargetDeps).To(Equal([]string{"cert-manager", "kueue"}))
+	})
+
+	t.Run("Positional arg and stdin deps should conflict", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallSingleDep) // has deps: ["cert-manager"]
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+		cmd.TargetDep = "kueue" // simulates positional arg set by cobra
+
+		err := cmd.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("cannot specify both"))
+	})
+
+	t.Run("Single positional arg should be normalized into TargetDeps", func(t *testing.T) {
+		g := NewWithT(t)
+
+		streams := genericiooptions.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.TargetDep = "cert-manager"
+		cmd.DryRun = true // avoid cluster client creation
+
+		err := cmd.Complete()
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cmd.TargetDeps).To(Equal([]string{"cert-manager"}))
+		g.Expect(cmd.TargetDep).To(BeEmpty(), "TargetDep must be zeroed after normalization to prevent stale reads")
+	})
+
+	t.Run("Pre-populated TargetDeps and stdin deps should conflict", func(t *testing.T) {
+		g := NewWithT(t)
+
+		stdin := bytes.NewBufferString(fixtureStdinInstallSingleDep) // has deps: ["cert-manager"]
+		streams := genericiooptions.IOStreams{
+			In:     stdin,
+			Out:    &bytes.Buffer{},
+			ErrOut: &bytes.Buffer{},
+		}
+
+		cmd := deps.NewInstallCommand(streams, nil)
+		cmd.FromStdin = true
+		cmd.TargetDeps = []string{"kueue"} // pre-populated, no positional arg
+
+		err := cmd.Complete()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("cannot specify both"))
+	})
+}

--- a/pkg/deps/stdin_input.go
+++ b/pkg/deps/stdin_input.go
@@ -1,0 +1,25 @@
+package deps
+
+// StdinInput defines the JSON/YAML schema for stdin input to deps install.
+// Use with --from-stdin to pass configuration via stdin. Precedence: CLI flags > stdin values > defaults.
+type StdinInput struct {
+	// Deps is the list of dependency names to install.
+	// nil = not provided (bulk mode); []string{} = explicitly empty (install nothing).
+	// Do not use len(Deps) == 0 to gate bulk mode — that collapses both cases.
+	Deps []string `json:"deps" yaml:"deps"`
+
+	// Version is the ODH/RHOAI version to install dependencies for.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	// DryRun shows what would be installed without executing (replaces --dry-run flag).
+	// Only true is meaningful; false is equivalent to omitting the field.
+	DryRun bool `json:"dryRun,omitempty" yaml:"dryRun,omitempty"`
+
+	// IncludeOptional installs optional dependencies as well (replaces --include-optional flag).
+	// Only true is meaningful; false is equivalent to omitting the field.
+	IncludeOptional bool `json:"includeOptional,omitempty" yaml:"includeOptional,omitempty"`
+
+	// Refresh fetches the latest manifest from odh-gitops (replaces --refresh flag).
+	// Only true is meaningful; false is equivalent to omitting the field.
+	Refresh bool `json:"refresh,omitempty" yaml:"refresh,omitempty"`
+}

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
@@ -177,7 +176,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
 	fs.StringVar(&c.ISVCDeploymentMode, "isvc-deployment-mode", "all", flagDescISVCDeploymentMode)
-	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, flagDescQPS)
@@ -189,9 +188,8 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 
 // parseStdinConfig reads and applies configuration from stdin.
 func (c *Command) parseStdinConfig() error {
-	// Only check for TTY if input is an *os.File (skip for bytes.Buffer in tests)
-	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
-		c.IO.Errorf(warnStdinIsTerminal)
+	if err := stdin.CheckPiped(c.IO.In()); err != nil {
+		return err //nolint:wrapcheck // CheckPiped returns a self-descriptive user-facing error
 	}
 
 	var input StdinInput
@@ -211,11 +209,11 @@ func (c *Command) parseStdinConfig() error {
 // Explicit CLI flags take precedence over stdin values.
 // Returns an error if stdin contains invalid values.
 func (c *Command) applyStdinInput(input *StdinInput) error {
-	if len(input.Checks) > 0 && !c.flagChanged("checks") {
+	if len(input.Checks) > 0 && !stdin.FlagChanged(c.flags, "checks") {
 		c.CheckSelectors = input.Checks
 	}
 
-	if input.Severity != "" && !c.flagChanged("severity") {
+	if input.Severity != "" && !stdin.FlagChanged(c.flags, "severity") {
 		level := SeverityLevel(input.Severity)
 		if err := level.Validate(); err != nil {
 			return fmt.Errorf("stdin input: %w", err)
@@ -223,19 +221,19 @@ func (c *Command) applyStdinInput(input *StdinInput) error {
 		c.SeverityLevel = level
 	}
 
-	if input.TargetVersion != "" && !c.flagChanged("target-version") {
+	if input.TargetVersion != "" && !stdin.FlagChanged(c.flags, "target-version") {
 		c.TargetVersion = input.TargetVersion
 	}
 
-	if input.Verbose && !c.flagChanged("verbose") {
+	if input.Verbose && !stdin.FlagChanged(c.flags, "verbose") {
 		c.Verbose = true
 	}
 
-	if input.Quiet && !c.flagChanged("quiet") {
+	if input.Quiet && !stdin.FlagChanged(c.flags, "quiet") {
 		c.Quiet = true
 	}
 
-	if input.Output != "" && !c.flagChanged("output") {
+	if input.Output != "" && !stdin.FlagChanged(c.flags, "output") {
 		format := OutputFormat(input.Output)
 		if err := format.Validate(); err != nil {
 			return fmt.Errorf("stdin input: %w", err)
@@ -244,16 +242,6 @@ func (c *Command) applyStdinInput(input *StdinInput) error {
 	}
 
 	return nil
-}
-
-// flagChanged returns true if the flag was explicitly set on the command line.
-func (c *Command) flagChanged(name string) bool {
-	if c.flags == nil {
-		return false
-	}
-	f := c.flags.Lookup(name)
-
-	return f != nil && f.Changed
 }
 
 // Complete populates Options and performs pre-validation setup.

--- a/pkg/lint/constants.go
+++ b/pkg/lint/constants.go
@@ -13,12 +13,6 @@ const (
 	flagDescBurst              = "Kubernetes API burst capacity"
 	flagDescISVCDeploymentMode = "filter InferenceService display by deployment mode (all|serverless|modelmesh)"
 	flagDescNoColor            = "disable colored output (also respects NO_COLOR env var)"
-	flagDescFromStdin          = "read configuration from stdin (JSON/YAML); stdin values override flag defaults"
-)
-
-// Warning messages for the lint command.
-const (
-	warnStdinIsTerminal = "Warning: --from-stdin specified but stdin is a terminal"
 )
 
 const flagDescChecks = `check selector patterns (glob patterns or categories):

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/pflag"
@@ -63,7 +62,7 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&c.MigrationIDs, "migration", "m", []string{}, flagDescRunMigration)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescRunTargetVersion)
 	fs.StringVar(&c.Phase, "phase", "", flagDescRunPhase)
-	fs.BoolVar(&c.FromStdin, "from-stdin", false, flagDescFromStdin)
+	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")
@@ -73,21 +72,10 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	action.RegisterActionFlags(c.registry, fs)
 }
 
-// flagChanged returns true if the flag was explicitly set on the command line.
-func (c *RunCommand) flagChanged(name string) bool {
-	if c.flags == nil {
-		return false
-	}
-
-	f := c.flags.Lookup(name)
-
-	return f != nil && f.Changed
-}
-
 // parseStdinConfig reads and applies configuration from stdin.
 func (c *RunCommand) parseStdinConfig() error {
-	if f, ok := c.IO.In().(*os.File); ok && !stdin.IsPiped(f) {
-		c.IO.Errorf("%s", warnStdinIsTerminal)
+	if err := stdin.CheckPiped(c.IO.In()); err != nil {
+		return err //nolint:wrapcheck // CheckPiped returns a self-descriptive user-facing error
 	}
 
 	var input StdinInput
@@ -102,26 +90,26 @@ func (c *RunCommand) parseStdinConfig() error {
 // Explicit CLI flags take precedence over stdin values.
 func (c *RunCommand) applyStdinInput(input *StdinInput) error {
 	// Apply migrations if not set via CLI
-	if len(input.Migrations) > 0 && !c.flagChanged("migration") {
+	if len(input.Migrations) > 0 && !stdin.FlagChanged(c.flags, "migration") {
 		c.MigrationIDs = input.Migrations
 	}
 
 	// Apply target version if not set via CLI
-	if input.TargetVersion != "" && !c.flagChanged("target-version") {
+	if input.TargetVersion != "" && !stdin.FlagChanged(c.flags, "target-version") {
 		c.TargetVersion = input.TargetVersion
 	}
 
 	// Apply phase if not set via CLI
-	if input.Phase != "" && !c.flagChanged("phase") {
+	if input.Phase != "" && !stdin.FlagChanged(c.flags, "phase") {
 		c.Phase = input.Phase
 	}
 
 	// Apply boolean flags if not set via CLI
-	if input.DryRun && !c.flagChanged("dry-run") {
+	if input.DryRun && !stdin.FlagChanged(c.flags, "dry-run") {
 		c.DryRun = true
 	}
 
-	if input.SkipConfirm && !c.flagChanged("yes") {
+	if input.SkipConfirm && !stdin.FlagChanged(c.flags, "yes") {
 		c.Yes = true
 	}
 

--- a/pkg/migrate/stdin_input.go
+++ b/pkg/migrate/stdin_input.go
@@ -19,13 +19,3 @@ type StdinInput struct {
 	// Named "skipConfirm" instead of "yes" because "yes" is a reserved YAML 1.1 boolean.
 	SkipConfirm bool `json:"skipConfirm,omitempty" yaml:"skipConfirm,omitempty"`
 }
-
-// Flag descriptions for stdin support.
-const (
-	flagDescFromStdin = "read configuration from stdin (JSON/YAML); CLI flags override stdin values"
-)
-
-// Warning messages.
-const (
-	warnStdinIsTerminal = "Warning: --from-stdin specified but stdin is a terminal"
-)

--- a/pkg/util/stdin/stdin.go
+++ b/pkg/util/stdin/stdin.go
@@ -7,8 +7,51 @@ import (
 	"io"
 	"os"
 
+	"github.com/spf13/pflag"
 	"sigs.k8s.io/yaml"
 )
+
+// FlagDesc is the standard --from-stdin flag description used across all commands.
+const FlagDesc = "read configuration from stdin (JSON/YAML); CLI flags override stdin values"
+
+// PipeChecker is an optional interface for io.Reader implementations that wrap
+// an underlying file descriptor. Implement it on any Reader that wraps os.Stdin
+// so that CheckPiped remains effective even when stdin is layered behind a wrapper.
+type PipeChecker interface {
+	IsPiped() bool
+}
+
+// CheckPiped returns an error if r is connected to an interactive terminal.
+// It handles bare *os.File directly and delegates to PipeChecker for wrappers.
+// Returns nil for other reader types (e.g. *bytes.Buffer in tests).
+// Call this at the start of any --from-stdin handler to fail fast instead of blocking
+// on io.ReadAll when the user forgets to pipe input.
+func CheckPiped(r io.Reader) error {
+	switch v := r.(type) {
+	case *os.File:
+		if !IsPiped(v) {
+			return errors.New("stdin is a terminal; pipe input or omit --from-stdin")
+		}
+	case PipeChecker:
+		if !v.IsPiped() {
+			return errors.New("stdin is a terminal; pipe input or omit --from-stdin")
+		}
+	}
+
+	return nil
+}
+
+// FlagChanged reports whether the named flag was explicitly set on the command line.
+// Returns false if fs is nil (e.g. in tests that bypass AddFlags).
+func FlagChanged(fs *pflag.FlagSet, name string) bool {
+	if fs == nil {
+		return false
+	}
+
+	f := fs.Lookup(name)
+
+	return f != nil && f.Changed
+}
 
 const maxInputBytes = 1 << 20 // 1 MiB
 
@@ -44,8 +87,8 @@ func Parse(r io.Reader, target any) error {
 func IsPiped(f *os.File) bool {
 	stat, err := f.Stat()
 	if err != nil {
-		// Stat failure is rare; return false to assume terminal and show warning.
-		// This is safe: the warning is non-blocking and helps catch user mistakes.
+		// Stat failure is rare; assume terminal so CheckPiped returns an error.
+		// Safer to reject than to block on io.ReadAll against an unknown fd.
 		return false
 	}
 

--- a/pkg/util/stdin/stdin_test.go
+++ b/pkg/util/stdin/stdin_test.go
@@ -177,6 +177,27 @@ func TestParse_InputTooLarge(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("input too large"))
 }
 
+func TestCheckPiped_PipeCheckerInterface(t *testing.T) {
+	t.Run("PipeChecker returning true is treated as piped", func(t *testing.T) {
+		g := NewWithT(t)
+		err := stdin.CheckPiped(fakePipeChecker(true))
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("PipeChecker returning false returns terminal error", func(t *testing.T) {
+		g := NewWithT(t)
+		err := stdin.CheckPiped(fakePipeChecker(false))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("stdin is a terminal"))
+	})
+}
+
+// fakePipeChecker implements both io.Reader and stdin.PipeChecker for testing.
+type fakePipeChecker bool
+
+func (f fakePipeChecker) Read(_ []byte) (int, error) { return 0, nil }
+func (f fakePipeChecker) IsPiped() bool              { return bool(f) }
+
 func TestIsPiped(t *testing.T) {
 	t.Run("pipe returns true", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
**Jira:** [RHOAIENG-66864](https://redhat.atlassian.net/browse/RHOAIENG-66864)

## Description

- Adds `--from-stdin` flag to `deps install`, `components enable/disable`, `lint`, and `migrate run` — reads JSON/YAML config from stdin with CLI flags taking precedence
- Centralises terminal detection in `stdin.CheckPiped` (hard error) and a new `PipeChecker` interface for non-`*os.File` readers in tests
- Adds `stdin.FlagChanged` helper replacing per-command `flagChanged()` methods
- Enforces nil-vs-empty `TargetDeps` semantics: `nil` = bulk mode, `[]string{}` = explicit install-nothing, non-empty = named targets
- Zeroes `TargetDep` after normalization into `TargetDeps` to prevent stale reads post-`Complete()`
- Guards against specifying both a positional dep argument and stdin `deps` field simultaneously

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [X] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced stdin-based configuration via `--from-stdin` (JSON/YAML) across multiple commands, including correct handling of explicit empty dependency lists (“install nothing”).

* **Improvements**
  * Stronger validation to require piped stdin.
  * Consistent CLI-flag precedence over stdin values, with corrected `dry-run`/confirmation behavior.
  * Install behavior and messaging improved for targeted vs empty/no-op cases.

* **Tests**
  * Added and expanded unit tests for stdin parsing, precedence, and install selection edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->