### PR TITLE
fix(migrate): check CRD storedVersions instead of listing via v1alpha1 GVR

### DIFF
--- a/pkg/migrate/actions/aipipelines/constants.go
+++ b/pkg/migrate/actions/aipipelines/constants.go
@@ -46,6 +46,7 @@ const (
 )
 
 const dspaAPIGroup = "datasciencepipelinesapplications.opendatahub.io"
+const dspaCRDName = "datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io"
 
 const (
 	dirPermissions  fs.FileMode = 0o750

--- a/pkg/migrate/actions/aipipelines/dspa.go
+++ b/pkg/migrate/actions/aipipelines/dspa.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -12,6 +13,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
 
 type dspaInfo struct {
@@ -53,25 +55,20 @@ func migrateDSPAToV1(
 	dspa dspaInfo,
 	opts migrateOpts,
 ) error {
-	gvrAlpha := resources.DataSciencePipelinesApplicationV1Alpha1.GVR()
 	gvrV1 := resources.DataSciencePipelinesApplicationV1.GVR()
 
-	obj, err := c.Dynamic().Resource(gvrAlpha).
+	obj, err := c.Dynamic().Resource(gvrV1).
 		Namespace(dspa.Namespace).
 		Get(ctx, dspa.Name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("getting v1alpha1 DSPA %s/%s: %w", dspa.Namespace, dspa.Name, err)
+		return fmt.Errorf("getting DSPA %s/%s: %w", dspa.Namespace, dspa.Name, err)
 	}
 
-	cleanObj := obj.DeepCopy()
-	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "generation")
-	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "managedFields")
-	unstructured.RemoveNestedField(cleanObj.Object, "metadata", "uid")
-	unstructured.RemoveNestedField(cleanObj.Object, "status")
-
-	cleanObj.SetAPIVersion(resources.DataSciencePipelinesApplicationV1.APIVersion())
-	cleanObj.SetKind(resources.DataSciencePipelinesApplicationV1.Kind)
+	unstructured.RemoveNestedField(obj.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "generation")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(obj.Object, "metadata", "uid")
+	unstructured.RemoveNestedField(obj.Object, "status")
 
 	updateOpts := metav1.UpdateOptions{}
 	if opts.DryRun {
@@ -80,9 +77,91 @@ func migrateDSPAToV1(
 
 	_, err = c.Dynamic().Resource(gvrV1).
 		Namespace(dspa.Namespace).
-		Update(ctx, cleanObj, updateOpts)
+		Update(ctx, obj, updateOpts)
 	if err != nil {
-		return fmt.Errorf("applying v1 DSPA %s/%s: %w", dspa.Namespace, dspa.Name, err)
+		return fmt.Errorf("updating DSPA %s/%s: %w", dspa.Namespace, dspa.Name, err)
+	}
+
+	return nil
+}
+
+// hasV1Alpha1StoredVersion checks the DSPA CRD's status.storedVersions for v1alpha1.
+// Returns (true, nil) if v1alpha1 is present, (false, nil) if not or CRD not found.
+// Returns (false, error) only on unexpected errors; permission errors return (true, nil)
+// to fall through to the existing migration logic as a safe default.
+func hasV1Alpha1StoredVersion(ctx context.Context, c client.Client) (bool, error) {
+	crd, err := c.GetResource(ctx, resources.CustomResourceDefinition, dspaCRDName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("getting CRD %s: %w", dspaCRDName, err)
+	}
+
+	// nil return means permission error — assume v1alpha1 might exist as a safe default
+	if crd == nil {
+		return true, nil
+	}
+
+	storedVersions, err := jq.Query[[]any](crd, ".status.storedVersions")
+	if err != nil {
+		return false, fmt.Errorf("querying status.storedVersions for CRD %s: %w", dspaCRDName, err)
+	}
+
+	for _, v := range storedVersions {
+		if s, ok := v.(string); ok && s == "v1alpha1" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// removeV1Alpha1StoredVersion removes v1alpha1 from the DSPA CRD's status.storedVersions.
+// Kubernetes does not clean up storedVersions automatically after objects are re-written,
+// so this must be done explicitly after a successful migration.
+func removeV1Alpha1StoredVersion(ctx context.Context, c client.Client) error {
+	crd, err := c.GetResource(ctx, resources.CustomResourceDefinition, dspaCRDName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("getting CRD %s: %w", dspaCRDName, err)
+	}
+
+	if crd == nil {
+		return nil
+	}
+
+	storedVersions, err := jq.Query[[]any](crd, ".status.storedVersions")
+	if err != nil {
+		return fmt.Errorf("querying status.storedVersions: %w", err)
+	}
+
+	filtered := make([]any, 0, len(storedVersions))
+
+	for _, v := range storedVersions {
+		if s, ok := v.(string); ok && s == "v1alpha1" {
+			continue
+		}
+
+		filtered = append(filtered, v)
+	}
+
+	if len(filtered) == len(storedVersions) {
+		return nil
+	}
+
+	if err := unstructured.SetNestedSlice(crd.Object, filtered, "status", "storedVersions"); err != nil {
+		return fmt.Errorf("setting status.storedVersions: %w", err)
+	}
+
+	_, err = c.Dynamic().Resource(resources.CustomResourceDefinition.GVR()).
+		UpdateStatus(ctx, crd, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating CRD status: %w", err)
 	}
 
 	return nil
@@ -96,27 +175,52 @@ func migrateAllDSPAsToV1(
 ) error {
 	step := recorder.Child("migrate-v1alpha1-to-v1", "Migrate v1alpha1 DSPAs to v1")
 
-	v1alpha1DSPAs, err := listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
+	// Check the CRD's status.storedVersions to determine if v1alpha1 migration is needed.
+	// Listing via the v1alpha1 GVR is unreliable: the API server converts stored v1 objects
+	// to v1alpha1 on the fly, so that endpoint always returns results regardless of what's
+	// actually stored.
+	needsMigration, err := hasV1Alpha1StoredVersion(ctx, c)
 	if err != nil {
-		step.Completef(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+		step.Completef(result.StepFailed, "Failed to check CRD stored versions: %v", err)
 
 		return err
 	}
 
-	if len(v1alpha1DSPAs) == 0 {
-		step.Completef(result.StepCompleted, "No v1alpha1 DSPAs found")
+	if !needsMigration {
+		step.Completef(result.StepCompleted, "All DSPAs already stored as v1")
 
 		return nil
 	}
 
-	step.Recordf("detected", "Found %d v1alpha1 DSPA(s) to migrate", result.StepCompleted, len(v1alpha1DSPAs))
+	dspas, err := listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list DSPAs: %v", err)
+
+		return err
+	}
+
+	if len(dspas) == 0 {
+		if !opts.DryRun {
+			if err := removeV1Alpha1StoredVersion(ctx, c); err != nil {
+				step.Completef(result.StepFailed, "Failed to clean up storedVersions: %v", err)
+
+				return fmt.Errorf("removing v1alpha1 from storedVersions: %w", err)
+			}
+		}
+
+		step.Completef(result.StepCompleted, "No DSPAs found")
+
+		return nil
+	}
+
+	step.Recordf("detected", "Found %d DSPA(s) to migrate", result.StepCompleted, len(dspas))
 
 	if opts.DryRun {
-		for _, dspa := range v1alpha1DSPAs {
+		for _, dspa := range dspas {
 			step.Recordf(dspa.Name, "Would migrate %s/%s from v1alpha1 to v1", result.StepSkipped, dspa.Namespace, dspa.Name)
 		}
 
-		step.Completef(result.StepSkipped, "Dry-run: %d DSPA(s) would be migrated", len(v1alpha1DSPAs))
+		step.Completef(result.StepSkipped, "Dry-run: %d DSPA(s) would be migrated", len(dspas))
 
 		return nil
 	}
@@ -129,38 +233,41 @@ func migrateAllDSPAsToV1(
 		Cap:      retryMaxDuration,
 	}
 
-	var remaining []dspaInfo
+	migrated := make(map[string]bool, len(dspas))
 
 	retryErr := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		remaining, err = listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
-		if err != nil {
-			return false, fmt.Errorf("re-listing v1alpha1 DSPAs: %w", err)
-		}
+		allSucceeded := true
 
-		if len(remaining) == 0 {
-			return true, nil
-		}
+		for _, dspa := range dspas {
+			key := dspa.Namespace + "/" + dspa.Name
+			if migrated[key] {
+				continue
+			}
 
-		for _, dspa := range remaining {
 			if migrateErr := migrateDSPAToV1(ctx, c, dspa, opts); migrateErr != nil {
 				step.Recordf(dspa.Name, "Migration attempt failed: %v (will retry)", result.StepFailed, migrateErr)
+
+				allSucceeded = false
 			} else {
 				step.Recordf(dspa.Name, "Migrated %s/%s to v1", result.StepCompleted, dspa.Namespace, dspa.Name)
+
+				migrated[key] = true
 			}
 		}
 
-		remaining, err = listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1Alpha1)
-		if err != nil {
-			return false, fmt.Errorf("verifying migration: %w", err)
-		}
-
-		return len(remaining) == 0, nil
+		return allSucceeded, nil
 	})
 
 	if retryErr != nil {
 		step.Completef(result.StepFailed, "Failed to migrate all v1alpha1 DSPAs: %v", retryErr)
 
 		return fmt.Errorf("migrating v1alpha1 DSPAs: %w", retryErr)
+	}
+
+	if err := removeV1Alpha1StoredVersion(ctx, c); err != nil {
+		step.Completef(result.StepFailed, "Failed to remove v1alpha1 from CRD storedVersions: %v", err)
+
+		return fmt.Errorf("removing v1alpha1 from storedVersions: %w", err)
 	}
 
 	step.Completef(result.StepCompleted, "All v1alpha1 DSPAs migrated to v1")

--- a/pkg/migrate/actions/aipipelines/dspa_test.go
+++ b/pkg/migrate/actions/aipipelines/dspa_test.go
@@ -20,8 +20,9 @@ import (
 var dspaListKinds = map[schema.GroupVersionResource]string{
 	resources.DataSciencePipelinesApplicationV1.GVR():       resources.DataSciencePipelinesApplicationV1.ListKind(),
 	resources.DataSciencePipelinesApplicationV1Alpha1.GVR(): resources.DataSciencePipelinesApplicationV1Alpha1.ListKind(),
-	resources.Pod.GVR():  resources.Pod.ListKind(),
-	resources.Role.GVR(): resources.Role.ListKind(),
+	resources.CustomResourceDefinition.GVR():                resources.CustomResourceDefinition.ListKind(),
+	resources.Pod.GVR():                                     resources.Pod.ListKind(),
+	resources.Role.GVR():                                    resources.Role.ListKind(),
 }
 
 func newFakeClient(objects ...runtime.Object) client.Client {
@@ -54,6 +55,26 @@ func makeDSPA(name, namespace, apiVersion string) *unstructured.Unstructured {
 				"namespace": namespace,
 			},
 			"spec": map[string]any{},
+		},
+	}
+}
+
+func makeDSPACRD(storedVersions ...string) *unstructured.Unstructured {
+	versions := make([]any, 0, len(storedVersions))
+	for _, v := range storedVersions {
+		versions = append(versions, v)
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.CustomResourceDefinition.APIVersion(),
+			"kind":       resources.CustomResourceDefinition.Kind,
+			"metadata": map[string]any{
+				"name": "datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io",
+			},
+			"status": map[string]any{
+				"storedVersions": versions,
+			},
 		},
 	}
 }
@@ -92,5 +113,91 @@ func TestListDSPAs(t *testing.T) {
 		dspas, err := aipipelines.ListDSPAs(context.Background(), c, resources.DataSciencePipelinesApplicationV1)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(dspas).To(BeEmpty())
+	})
+}
+
+func TestHasV1Alpha1StoredVersion(t *testing.T) {
+	t.Run("returns false when storedVersions is only v1", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient(makeDSPACRD("v1"))
+
+		has, err := aipipelines.HasV1Alpha1StoredVersion(context.Background(), c)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(has).To(BeFalse())
+	})
+
+	t.Run("returns true when storedVersions contains v1alpha1", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient(makeDSPACRD("v1alpha1", "v1"))
+
+		has, err := aipipelines.HasV1Alpha1StoredVersion(context.Background(), c)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(has).To(BeTrue())
+	})
+
+	t.Run("returns true when storedVersions is only v1alpha1", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient(makeDSPACRD("v1alpha1"))
+
+		has, err := aipipelines.HasV1Alpha1StoredVersion(context.Background(), c)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(has).To(BeTrue())
+	})
+
+	t.Run("returns false when CRD not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient()
+
+		has, err := aipipelines.HasV1Alpha1StoredVersion(context.Background(), c)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(has).To(BeFalse())
+	})
+}
+
+func TestRemoveV1Alpha1StoredVersion(t *testing.T) {
+	t.Run("removes v1alpha1 from storedVersions", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.Background()
+
+		crd := makeDSPACRD("v1alpha1", "v1")
+		c := newFakeClient(crd)
+
+		err := aipipelines.RemoveV1Alpha1StoredVersion(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updated, err := c.GetResource(ctx, resources.CustomResourceDefinition,
+			"datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		versions, _, _ := unstructured.NestedStringSlice(updated.Object, "status", "storedVersions")
+		g.Expect(versions).To(Equal([]string{"v1"}))
+	})
+
+	t.Run("no-op when v1alpha1 not in storedVersions", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.Background()
+
+		crd := makeDSPACRD("v1")
+		c := newFakeClient(crd)
+
+		err := aipipelines.RemoveV1Alpha1StoredVersion(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		has, err := aipipelines.HasV1Alpha1StoredVersion(ctx, c)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(has).To(BeFalse())
+	})
+
+	t.Run("no-op when CRD not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		c := newFakeClient()
+
+		err := aipipelines.RemoveV1Alpha1StoredVersion(context.Background(), c)
+		g.Expect(err).ToNot(HaveOccurred())
 	})
 }

--- a/pkg/migrate/actions/aipipelines/export_test.go
+++ b/pkg/migrate/actions/aipipelines/export_test.go
@@ -4,15 +4,17 @@ import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 //nolint:gochecknoglobals // Test exports only compiled in test builds
 var (
-	GetPodGroup        = getPodGroup
-	ClassifyRole       = classifyRole
-	IsSystemNamespace  = isSystemNamespace
-	DefaultStatePath   = defaultStatePath
-	SavePodHealthState = savePodHealthState
-	LoadPodHealthState = loadPodHealthState
-	HasAnyDegradation  = hasAnyDegradation
-	ExtractStringSlice = extractStringSlice
-	ListDSPAs          = listDSPAs
+	GetPodGroup                 = getPodGroup
+	ClassifyRole                = classifyRole
+	IsSystemNamespace           = isSystemNamespace
+	DefaultStatePath            = defaultStatePath
+	SavePodHealthState          = savePodHealthState
+	LoadPodHealthState          = loadPodHealthState
+	HasAnyDegradation           = hasAnyDegradation
+	ExtractStringSlice          = extractStringSlice
+	ListDSPAs                   = listDSPAs
+	HasV1Alpha1StoredVersion    = hasV1Alpha1StoredVersion
+	RemoveV1Alpha1StoredVersion = removeV1Alpha1StoredVersion
 )
 
 func MakePodUnstructured(name, namespace, phase, readyStatus string) unstructured.Unstructured {

--- a/pkg/migrate/actions/aipipelines/precheck.go
+++ b/pkg/migrate/actions/aipipelines/precheck.go
@@ -87,24 +87,20 @@ func (t *preUpgradeCheckPrepareTask) discover(
 		t.saveState(target, recorder, state)
 	}
 
-	// Step 2: Detect v1alpha1 DSPAs
+	// Step 2: Detect v1alpha1 DSPAs by checking CRD storedVersions
 	v1alpha1Step := recorder.Child("detect-v1alpha1", "Detect deprecated v1alpha1 DSPAs")
 
-	v1alpha1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
+	needsMigration, err := hasV1Alpha1StoredVersion(ctx, target.Client)
 	if err != nil {
-		v1alpha1Step.Completef(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+		v1alpha1Step.Completef(result.StepFailed, "Failed to check CRD stored versions: %v", err)
 
 		return
 	}
 
-	if len(v1alpha1DSPAs) == 0 {
+	if !needsMigration {
 		v1alpha1Step.Completef(result.StepCompleted, "No deprecated v1alpha1 DSPAs found")
 	} else {
-		for _, dspa := range v1alpha1DSPAs {
-			v1alpha1Step.Recordf(dspa.Name, "v1alpha1 DSPA %s/%s needs migration", result.StepCompleted, dspa.Namespace, dspa.Name)
-		}
-
-		v1alpha1Step.Completef(result.StepCompleted, "Found %d v1alpha1 DSPA(s) requiring migration", len(v1alpha1DSPAs))
+		v1alpha1Step.Completef(result.StepCompleted, "v1alpha1 is in CRD storedVersions — migration required")
 	}
 
 	// Step 3: Detect custom roles needing RBAC update
@@ -144,17 +140,17 @@ func (t *preUpgradeCheckRunTask) Validate(ctx context.Context, target action.Tar
 
 	step := recorder.Child("check-v1alpha1", "Check for v1alpha1 DSPAs")
 
-	v1alpha1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
+	needsMigration, err := hasV1Alpha1StoredVersion(ctx, target.Client)
 	if err != nil {
-		step.Completef(result.StepFailed, "Failed to list v1alpha1 DSPAs: %v", err)
+		step.Completef(result.StepFailed, "Failed to check CRD stored versions: %v", err)
 
 		return recorder.Build(), nil
 	}
 
-	if len(v1alpha1DSPAs) == 0 {
+	if !needsMigration {
 		step.Completef(result.StepCompleted, "No v1alpha1 DSPAs found — nothing to migrate")
 	} else {
-		step.Completef(result.StepCompleted, "Found %d v1alpha1 DSPA(s) to migrate", len(v1alpha1DSPAs))
+		step.Completef(result.StepCompleted, "v1alpha1 is in CRD storedVersions — migration needed")
 	}
 
 	return recorder.Build(), nil
@@ -165,20 +161,6 @@ func (t *preUpgradeCheckRunTask) Execute(ctx context.Context, target action.Targ
 
 	if err := migrateAllDSPAsToV1(ctx, target.Client, recorder, migrateOpts{DryRun: target.DryRun}); err != nil {
 		return recorder.Build(), fmt.Errorf("v1alpha1 migration failed: %w", err)
-	}
-
-	// Verify no v1alpha1 DSPAs remain (skip in dry-run — we didn't actually migrate)
-	if !target.DryRun {
-		verifyStep := recorder.Child("verify-migration", "Verify no v1alpha1 DSPAs remain")
-
-		remaining, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1Alpha1)
-		if err != nil {
-			verifyStep.Completef(result.StepFailed, "Failed to verify: %v", err)
-		} else if len(remaining) > 0 {
-			verifyStep.Completef(result.StepFailed, "%d v1alpha1 DSPA(s) still remain", len(remaining))
-		} else {
-			verifyStep.Completef(result.StepCompleted, "All DSPAs are now v1")
-		}
 	}
 
 	return recorder.Build(), nil


### PR DESCRIPTION


## Description

The v1alpha1 DSPA migration always timed out because listing via the v1alpha1 GVR endpoint returns objects regardless of their stored version — the API server converts v1 objects to v1alpha1 on the fly. The retry loop could never observe "zero v1alpha1 DSPAs remaining."

Check the CRD's status.storedVersions instead. If v1alpha1 is not in storedVersions, all objects are already stored as v1 and the migration exits immediately. When migration is needed, verify by tracking Update success rather than re-listing via v1alpha1.

Ref: RHOAIENG-69646

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated DSPA migration detection to rely on CRD `storedVersions` (instead of enumerating v1alpha1 resources), including more resilient handling when CRD data is unavailable.
  * Improved migration retries to follow the initially selected DSPAs and avoid re-scanning on each attempt.
  * After successful migration, the CRD `storedVersions` is explicitly cleaned up to remove the v1alpha1 entry.

* **Tests**
  * Added unit tests covering CRD `storedVersions` detection and removing the v1alpha1 stored version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->