### PR TITLE
RHOAIENG-66869: feat(api): add self-describing command manifest for agent discovery

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	apipkg "github.com/opendatahub-io/odh-cli/pkg/api"
+)
+
+const (
+	cmdName  = "api"
+	cmdShort = "Output a JSON manifest describing all CLI commands and flags"
+)
+
+// AddCommand adds the api subcommand to the root command.
+func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
+	cmd := &cobra.Command{
+		Use:           cmdName,
+		Short:         cmdShort,
+		Hidden:        true,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return apipkg.Run(root, cmd.OutOrStdout())
+		},
+	}
+
+	root.AddCommand(cmd)
+}

--- a/cmd/components/components.go
+++ b/cmd/components/components.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	componentspkg "github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
@@ -141,6 +142,7 @@ func addDescribeCommand(parent *cobra.Command, flags *genericclioptions.ConfigFl
 		},
 	}
 
+	cmd.ValidArgs = resources.ComponentNames()
 	describeCommand.AddFlags(cmd.Flags())
 	parent.AddCommand(cmd)
 }
@@ -168,6 +170,7 @@ func addMutateCommand(parent *cobra.Command, command mutateCommand, use, short s
 		},
 	}
 
+	cmd.ValidArgs = resources.ComponentNames()
 	command.AddFlags(cmd.Flags())
 	parent.AddCommand(cmd)
 }

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -73,6 +73,7 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 
 			return cobra.RangeArgs(1, maxArgs)(cmd, args)
 		},
+		ValidArgs: getpkg.Names(),
 		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return getpkg.Names(), cobra.ShellCompDirectiveNoFileComp

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -75,6 +75,7 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.ExactArgs(1),
+		ValidArgs:     logspkg.ValidTargets,
 		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
 				return logspkg.ValidTargets, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/opendatahub-io/odh-cli/cmd/api"
 	"github.com/opendatahub-io/odh-cli/cmd/completion"
 	"github.com/opendatahub-io/odh-cli/cmd/components"
 	"github.com/opendatahub-io/odh-cli/cmd/deps"
@@ -35,6 +36,7 @@ func main() {
 	// --client-certificate, --client-key, --insecure-skip-tls-verify, etc.
 	flags.AddFlags(cmd.PersistentFlags())
 
+	api.AddCommand(cmd, flags)
 	version.AddCommand(cmd, flags)
 	lint.AddCommand(cmd, flags)
 	get.AddCommand(cmd, flags)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/opendatahub-io/odh-cli/internal/version"
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/schema"
 )
 
@@ -111,6 +112,7 @@ func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
 	}
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text|json)")
+	_ = cmd.Flags().SetAnnotation("output", api.AnnotationValidValues, []string{"text", "json"})
 	cmd.Flags().BoolVar(&outputSchema, "schema", false, "Output JSON Schema for the command's structured output format")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress all output")

--- a/pkg/api/command.go
+++ b/pkg/api/command.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/internal/version"
+)
+
+func Run(root *cobra.Command, out io.Writer) error {
+	manifest := Manifest{
+		Version:     version.GetVersion(),
+		GlobalFlags: collectFlags(root.PersistentFlags()),
+		Commands:    walkCommands(root),
+	}
+
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(manifest); err != nil {
+		return fmt.Errorf("encoding API manifest: %w", err)
+	}
+
+	return nil
+}
+
+func collectFlags(fs *pflag.FlagSet) []FlagDescriptor {
+	flags := []FlagDescriptor{}
+
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Deprecated != "" {
+			return
+		}
+
+		flags = append(flags, buildFlagDescriptor(f))
+	})
+
+	return flags
+}
+
+func walkCommands(parent *cobra.Command) []CommandDescriptor {
+	descriptors := []CommandDescriptor{}
+
+	for _, child := range parent.Commands() {
+		if child.Hidden {
+			continue
+		}
+
+		if child.Deprecated != "" {
+			continue
+		}
+
+		if child.Name() == "help" {
+			continue
+		}
+
+		descriptors = append(descriptors, CommandDescriptor{
+			Name:        child.Name(),
+			Description: child.Short,
+			Args:        buildArgsDescriptor(child),
+			Flags:       collectFlags(child.NonInheritedFlags()),
+			HasSchema:   child.Flags().Lookup("schema") != nil,
+			Examples:    parseExamples(child.Example),
+			Subcommands: walkCommands(child),
+		})
+	}
+
+	return descriptors
+}
+
+func buildArgsDescriptor(cmd *cobra.Command) *ArgsDescriptor {
+	pattern := ""
+	if i := strings.IndexByte(cmd.Use, ' '); i != -1 {
+		pattern = cmd.Use[i+1:]
+	}
+
+	if pattern == "" && len(cmd.ValidArgs) == 0 {
+		return nil
+	}
+
+	return &ArgsDescriptor{
+		Pattern:     pattern,
+		ValidValues: cmd.ValidArgs,
+	}
+}
+
+func buildFlagDescriptor(f *pflag.Flag) FlagDescriptor {
+	return FlagDescriptor{
+		Name:        f.Name,
+		Shorthand:   f.Shorthand,
+		Type:        f.Value.Type(),
+		Default:     f.DefValue,
+		Required:    isRequiredFlag(f),
+		Description: f.Usage,
+		ValidValues: validValuesFromAnnotation(f),
+	}
+}
+
+func validValuesFromAnnotation(f *pflag.Flag) []string {
+	if f.Annotations == nil {
+		return nil
+	}
+
+	return f.Annotations[AnnotationValidValues]
+}
+
+func isRequiredFlag(f *pflag.Flag) bool {
+	if f.Annotations == nil {
+		return false
+	}
+
+	_, ok := f.Annotations[cobra.BashCompOneRequiredFlag]
+
+	return ok
+}
+
+func parseExamples(examples string) []string {
+	if examples == "" {
+		return []string{}
+	}
+
+	result := []string{}
+
+	for line := range strings.SplitSeq(examples, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		result = append(result, line)
+	}
+
+	return result
+}

--- a/pkg/api/command_test.go
+++ b/pkg/api/command_test.go
@@ -1,0 +1,320 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/opendatahub-io/odh-cli/pkg/api"
+
+	. "github.com/onsi/gomega"
+)
+
+func runManifest(t *testing.T, root *cobra.Command) api.Manifest {
+	t.Helper()
+
+	g := NewWithT(t)
+
+	var buf bytes.Buffer
+	err := api.Run(root, &buf)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var manifest api.Manifest
+	err = json.Unmarshal(buf.Bytes(), &manifest)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	return manifest
+}
+
+func TestRun_BasicCommandTree(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh", Short: "test root"}
+	root.PersistentFlags().String("kubeconfig", "", "path to kubeconfig")
+
+	child := &cobra.Command{
+		Use:     "lint",
+		Short:   "Validate installation",
+		Example: "  # Validate\n  kubectl odh lint\n\n  # JSON output\n  kubectl odh lint -o json",
+	}
+	child.Flags().StringP("output", "o", "table", "output format (table|json|yaml)")
+	child.Flags().Bool("schema", false, "output JSON Schema")
+	root.AddCommand(child)
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Name).To(Equal("lint"))
+	g.Expect(manifest.Commands[0].Description).To(Equal("Validate installation"))
+	g.Expect(manifest.Commands[0].HasSchema).To(BeTrue())
+	g.Expect(manifest.Commands[0].Examples).To(Equal([]string{
+		"kubectl odh lint",
+		"kubectl odh lint -o json",
+	}))
+
+	g.Expect(manifest.GlobalFlags).To(HaveLen(1))
+	g.Expect(manifest.GlobalFlags[0].Name).To(Equal("kubeconfig"))
+}
+
+func TestRun_FlagDetails(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	child := &cobra.Command{Use: "test", Short: "test cmd"}
+	child.Flags().StringP("output", "o", "table", "output format")
+	_ = child.Flags().SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
+	child.Flags().String("target-version", "", "target version for upgrade readiness checks")
+	root.AddCommand(child)
+
+	manifest := runManifest(t, root)
+
+	var outputFlag, targetFlag api.FlagDescriptor
+	for _, f := range manifest.Commands[0].Flags {
+		switch f.Name {
+		case "output":
+			outputFlag = f
+		case "target-version":
+			targetFlag = f
+		}
+	}
+
+	g.Expect(outputFlag.Shorthand).To(Equal("o"))
+	g.Expect(outputFlag.Type).To(Equal("string"))
+	g.Expect(outputFlag.Default).To(Equal("table"))
+	g.Expect(outputFlag.ValidValues).To(Equal([]string{"table", "json", "yaml"}))
+
+	g.Expect(targetFlag.Shorthand).To(BeEmpty())
+	g.Expect(targetFlag.Default).To(BeEmpty())
+	g.Expect(targetFlag.ValidValues).To(BeNil())
+}
+
+func TestRun_NestedSubcommands(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	parent := &cobra.Command{Use: "migrate", Short: "Manage migrations"}
+	listCmd := &cobra.Command{Use: "list", Short: "List migrations"}
+	listCmd.Flags().String("phase", "", "lifecycle phase")
+	_ = listCmd.Flags().SetAnnotation("phase", api.AnnotationValidValues, []string{"pre-upgrade", "post-upgrade"})
+	parent.AddCommand(listCmd)
+	root.AddCommand(parent)
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Name).To(Equal("migrate"))
+	g.Expect(manifest.Commands[0].Subcommands).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Subcommands[0].Name).To(Equal("list"))
+	g.Expect(manifest.Commands[0].Subcommands[0].Flags).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Subcommands[0].Flags[0].ValidValues).To(
+		Equal([]string{"pre-upgrade", "post-upgrade"}))
+}
+
+func TestRun_HiddenCommandsExcluded(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "lint", Short: "Validate"})
+	root.AddCommand(&cobra.Command{Use: "secret", Short: "Hidden cmd", Hidden: true})
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Name).To(Equal("lint"))
+}
+
+func TestRun_HiddenCommandsExcludedIncludingAPI(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "lint", Short: "Validate"})
+	root.AddCommand(&cobra.Command{Use: "api", Short: "API manifest", Hidden: true})
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Name).To(Equal("lint"))
+}
+
+func TestRun_DeprecatedFlagsExcluded(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	child := &cobra.Command{Use: "test", Short: "test cmd"}
+	child.Flags().String("good-flag", "", "a valid flag")
+	child.Flags().String("old-flag", "", "deprecated")
+	_ = child.Flags().MarkDeprecated("old-flag", "use --good-flag instead")
+	root.AddCommand(child)
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands[0].Flags).To(HaveLen(1))
+	g.Expect(manifest.Commands[0].Flags[0].Name).To(Equal("good-flag"))
+}
+
+func TestRun_GlobalFlagsNotDuplicatedPerCommand(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.PersistentFlags().String("kubeconfig", "", "path to kubeconfig")
+	child := &cobra.Command{Use: "lint", Short: "Validate"}
+	child.Flags().String("output", "table", "output format (table|json|yaml)")
+	root.AddCommand(child)
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.GlobalFlags).To(HaveLen(1))
+	g.Expect(manifest.GlobalFlags[0].Name).To(Equal("kubeconfig"))
+
+	for _, f := range manifest.Commands[0].Flags {
+		g.Expect(f.Name).ToNot(Equal("kubeconfig"))
+	}
+}
+
+func TestRun_CommandWithNoFlagsOrExamples(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "simple", Short: "no flags"})
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands[0].Flags).To(BeEmpty())
+	g.Expect(manifest.Commands[0].Examples).To(BeEmpty())
+	g.Expect(manifest.Commands[0].Subcommands).To(BeEmpty())
+	g.Expect(manifest.Commands[0].HasSchema).To(BeFalse())
+}
+
+func TestRun_EmptySlicesSerializeAsArrays(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "bare", Short: "bare"})
+
+	var buf bytes.Buffer
+	err := api.Run(root, &buf)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	raw := buf.String()
+	g.Expect(raw).To(ContainSubstring(`"flags": []`))
+	g.Expect(raw).To(ContainSubstring(`"examples": []`))
+	g.Expect(raw).To(ContainSubstring(`"subcommands": []`))
+	g.Expect(raw).ToNot(ContainSubstring(`"validValues"`))
+}
+
+func TestRun_HelpCommandExcluded(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "lint", Short: "Validate"})
+
+	manifest := runManifest(t, root)
+
+	for _, cmd := range manifest.Commands {
+		g.Expect(cmd.Name).ToNot(Equal("help"))
+	}
+}
+
+func TestRun_ValidValuesOmittedWhenEmpty(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	child := &cobra.Command{Use: "test", Short: "test"}
+	child.Flags().String("plain", "", "a plain flag")
+	child.Flags().String("enum", "", "output format")
+	_ = child.Flags().SetAnnotation("enum", api.AnnotationValidValues, []string{"table", "json"})
+	root.AddCommand(child)
+
+	var buf bytes.Buffer
+	err := api.Run(root, &buf)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var raw map[string]any
+	err = json.Unmarshal(buf.Bytes(), &raw)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	commands := raw["commands"].([]any)
+	flags := commands[0].(map[string]any)["flags"].([]any)
+
+	for _, f := range flags {
+		flag := f.(map[string]any)
+		if flag["name"] == "plain" {
+			_, hasValidValues := flag["validValues"]
+			g.Expect(hasValidValues).To(BeFalse())
+		}
+		if flag["name"] == "enum" {
+			g.Expect(flag["validValues"]).To(Equal([]any{"table", "json"}))
+		}
+	}
+}
+
+func TestRun_ArgsPattern(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "get RESOURCE [NAME]", Short: "Get resources"})
+	root.AddCommand(&cobra.Command{Use: "lint", Short: "Validate"})
+
+	manifest := runManifest(t, root)
+
+	var getCmd, lintCmd api.CommandDescriptor
+	for _, c := range manifest.Commands {
+		switch c.Name {
+		case "get":
+			getCmd = c
+		case "lint":
+			lintCmd = c
+		}
+	}
+
+	g.Expect(getCmd.Args).ToNot(BeNil())
+	g.Expect(getCmd.Args.Pattern).To(Equal("RESOURCE [NAME]"))
+	g.Expect(lintCmd.Args).To(BeNil())
+}
+
+func TestRun_ArgsValidValues(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{
+		Use:       "logs TARGET",
+		Short:     "Show logs",
+		ValidArgs: []string{"operator", "dashboard", "kserve"},
+	})
+
+	manifest := runManifest(t, root)
+
+	g.Expect(manifest.Commands[0].Args).ToNot(BeNil())
+	g.Expect(manifest.Commands[0].Args.Pattern).To(Equal("TARGET"))
+	g.Expect(manifest.Commands[0].Args.ValidValues).To(Equal([]string{"operator", "dashboard", "kserve"}))
+}
+
+func TestRun_ArgsOmittedWhenNoPattern(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.AddCommand(&cobra.Command{Use: "status", Short: "Show status"})
+
+	var buf bytes.Buffer
+	err := api.Run(root, &buf)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(buf.String()).ToNot(ContainSubstring(`"args"`))
+}
+
+func TestRun_DeprecatedGlobalFlagsExcluded(t *testing.T) {
+	g := NewWithT(t)
+
+	root := &cobra.Command{Use: "kubectl-odh"}
+	root.PersistentFlags().String("password", "", "password for basic auth")
+	_ = root.PersistentFlags().MarkDeprecated("password", "use --token instead")
+	root.AddCommand(&cobra.Command{Use: "test", Short: "test"})
+
+	manifest := runManifest(t, root)
+
+	for _, f := range manifest.GlobalFlags {
+		g.Expect(f.Name).ToNot(Equal("password"))
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,41 @@
+package api
+
+// AnnotationValidValues is the pflag annotation key used to declare
+// valid values for a flag. The api command reads this annotation to
+// populate the validValues field in the manifest.
+const AnnotationValidValues = "odh_valid_values"
+
+// Manifest is the top-level output of the api command.
+type Manifest struct {
+	Version     string              `json:"version"`
+	GlobalFlags []FlagDescriptor    `json:"globalFlags"`
+	Commands    []CommandDescriptor `json:"commands"`
+}
+
+// CommandDescriptor describes a single CLI command or subcommand.
+type CommandDescriptor struct {
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Args        *ArgsDescriptor     `json:"args,omitempty"`
+	Flags       []FlagDescriptor    `json:"flags"`
+	HasSchema   bool                `json:"hasSchema"`
+	Examples    []string            `json:"examples"`
+	Subcommands []CommandDescriptor `json:"subcommands"`
+}
+
+// ArgsDescriptor describes a command's positional arguments.
+type ArgsDescriptor struct {
+	Pattern     string   `json:"pattern"`
+	ValidValues []string `json:"validValues,omitempty"`
+}
+
+// FlagDescriptor describes a single command flag.
+type FlagDescriptor struct {
+	Name        string   `json:"name"`
+	Shorthand   string   `json:"shorthand,omitempty"`
+	Type        string   `json:"type"`
+	Default     string   `json:"default"`
+	Required    bool     `json:"required"`
+	Description string   `json:"description"`
+	ValidValues []string `json:"validValues,omitempty"`
+}

--- a/pkg/components/describe.go
+++ b/pkg/components/describe.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
 	printeryaml "github.com/opendatahub-io/odh-cli/pkg/printer/yaml"
@@ -64,6 +65,7 @@ func NewDescribeCommand(
 // AddFlags registers command-specific flags.
 func (c *DescribeCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
 	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 	c.OutputOptions.AddFlags(fs)

--- a/pkg/components/list.go
+++ b/pkg/components/list.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	printerjson "github.com/opendatahub-io/odh-cli/pkg/printer/json"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
@@ -63,6 +64,7 @@ func NewListCommand(
 // AddFlags registers command-specific flags.
 func (c *ListCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
 	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 	c.OutputOptions.AddFlags(fs)

--- a/pkg/deps/command.go
+++ b/pkg/deps/command.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/schema"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -87,6 +88,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.Refresh, "refresh", false, "Fetch latest manifest from odh-gitops")
 	fs.BoolVar(&c.DryRun, "dry-run", false, "Show manifest data without querying cluster")
 	fs.StringVarP(&c.Output, "output", "o", outputTable, "Output format: table, json, yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.StringVar(&c.Version, "version", "", "ODH/RHOAI version to show dependencies for")
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
 	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")

--- a/pkg/events/command.go
+++ b/pkg/events/command.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -82,6 +83,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&c.Since, "since", defaultSinceDuration, "Only show events newer than this duration (e.g., 5m, 1h, 30s)")
 	fs.BoolVarP(&c.AllNamespaces, "all-namespaces", "A", false, "List events across all ODH namespaces")
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.StringVar(&c.OperatorNSOverride, "operator-namespace", "", "Override the operator namespace (auto-detected from OLM/CSV)")
 	fs.StringVar(&c.Component, "component", "", "Filter events by ODH component (dashboard, kserve, ray, etc.). Only filters core Kubernetes resources (Pods, Deployments, etc.); CRD-specific events are excluded")
 	fs.BoolVarP(&c.Follow, "follow", "f", false, "Stream new events in real-time")

--- a/pkg/get/command.go
+++ b/pkg/get/command.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/schema"
@@ -77,6 +78,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&c.AllNamespaces, "all-namespaces", "A", false, "List resources across all namespaces")
 	fs.StringVarP(&c.LabelSelector, "selector", "l", "", "Label selector to filter resources (e.g. app=my-model)")
 	fs.StringVarP(&c.OutputFormat, "output", "o", outputFormatTable, "Output format: table, json, or yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, "Enable verbose output")
 	fs.BoolVarP(&c.Quiet, "quiet", "q", false, "Suppress all non-essential output")
 	c.OutputOptions.AddFlags(fs)

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
@@ -168,7 +169,9 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	c.flags = fs // Store for checking explicitly set flags in applyStdinInput
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescTargetVersion)
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescOutput)
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.StringVar((*string)(&c.SeverityLevel), "severity", string(SeverityLevelInfo), flagDescSeverity)
+	_ = fs.SetAnnotation("severity", api.AnnotationValidValues, []string{"prohibited", "critical", "warning", "info"})
 	fs.StringArrayVar(&c.CheckSelectors, "checks", []string{"*"}, flagDescChecks)
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.BoolVarP(&c.Quiet, "quiet", "q", false, flagDescQuiet)
@@ -176,6 +179,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.NoColor, "no-color", false, flagDescNoColor)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescTimeout)
 	fs.StringVar(&c.ISVCDeploymentMode, "isvc-deployment-mode", "all", flagDescISVCDeploymentMode)
+	_ = fs.SetAnnotation("isvc-deployment-mode", api.AnnotationValidValues, []string{"all", "serverless", "modelmesh"})
 	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 
 	// Throttling settings

--- a/pkg/migrate/command_list.go
+++ b/pkg/migrate/command_list.go
@@ -12,6 +12,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/printer/table"
@@ -54,10 +55,13 @@ func NewListCommand(streams genericiooptions.IOStreams) *ListCommand {
 
 func (c *ListCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescListOutput)
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescListVerbose)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescListTargetVersion)
 	fs.BoolVar(&c.ShowAll, "all", false, flagDescListAll)
 	fs.StringVar(&c.Phase, "phase", "", flagDescListPhase)
+	// Empty string is intentionally excluded: it means "flag not provided" (the default), not a user-selectable value.
+	_ = fs.SetAnnotation("phase", api.AnnotationValidValues, []string{"pre-upgrade", "post-upgrade", "pre-enablement"})
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -60,6 +61,8 @@ func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&c.MigrationIDs, "migration", "m", []string{}, flagDescPrepareMigration)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescPrepareTargetVersion)
 	fs.StringVar(&c.Phase, "phase", "", flagDescPreparePhase)
+	// Empty string is intentionally excluded: it means "flag not provided" (the default), not a user-selectable value.
+	_ = fs.SetAnnotation("phase", api.AnnotationValidValues, []string{"pre-upgrade", "post-upgrade", "pre-enablement"})
 
 	// Throttling settings
 	fs.Float32Var(&c.QPS, "qps", c.QPS, "Kubernetes API QPS limit (queries per second)")

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
@@ -62,6 +63,8 @@ func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&c.MigrationIDs, "migration", "m", []string{}, flagDescRunMigration)
 	fs.StringVar(&c.TargetVersion, "target-version", "", flagDescRunTargetVersion)
 	fs.StringVar(&c.Phase, "phase", "", flagDescRunPhase)
+	// Empty string is intentionally excluded: it means "flag not provided" (the default), not a user-selectable value.
+	_ = fs.SetAnnotation("phase", api.AnnotationValidValues, []string{"pre-upgrade", "post-upgrade", "pre-enablement"})
 	fs.BoolVar(&c.FromStdin, "from-stdin", false, stdin.FlagDesc)
 
 	// Throttling settings

--- a/pkg/resources/component_crs.go
+++ b/pkg/resources/component_crs.go
@@ -1,5 +1,7 @@
 package resources
 
+import "sort"
+
 const (
 	componentCRGroup = "components.platform.opendatahub.io"
 
@@ -27,6 +29,18 @@ var ComponentCRResourceTypes = map[string]ResourceType{
 	"trainingoperator":   newComponentCR("trainingoperators", "TrainingOperator"),
 	"trustyai":           newComponentCR("trustyais", "TrustyAI"),
 	"workbenches":        newComponentCR("workbenches", "Workbenches"),
+}
+
+// ComponentNames returns a sorted list of all valid component names.
+func ComponentNames() []string {
+	names := make([]string, 0, len(ComponentCRResourceTypes))
+	for name := range ComponentCRResourceTypes {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
 }
 
 func newComponentCR(resource, kind string) ResourceType {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest"
 
+	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/deps"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -110,6 +111,7 @@ func NewCommand(
 // AddFlags registers command-specific flags with the provided FlagSet.
 func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), flagDescOutput)
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescVerbose)
 	fs.StringArrayVar(&c.Sections, "section", nil, flagDescSection)
 	fs.StringArrayVar(&c.Layers, "layer", nil, flagDescLayer)


### PR DESCRIPTION
## Description

Adds a new `kubectl odh api` command that outputs a machine-readable JSON manifest of all CLI commands, flags, positional arguments, and their valid values. This enables agents and tooling to discover available operations without parsing help text.

**Jira:** [RHOAIENG-66869](https://redhat.atlassian.net/browse/RHOAIENG-66869)

### What it does

- **New `api` command** (`cmd/api/`, `pkg/api/`) — walks the Cobra command tree at runtime and serializes it as JSON. No cluster connection needed. The command is hidden from `--help` output (tooling-only).
- **Flag valid values via annotations** — each command declares its enum flag values using `pflag.SetAnnotation` with a well-known key (`api.AnnotationValidValues`). 
- **Positional argument metadata** — the manifest includes arg patterns (e.g., `RESOURCE [NAME]`, `COMPONENT`, `TARGET`) and their valid values extracted from Cobra's `ValidArgs` field.
- **`resources.ComponentNames()` helper** — new exported function returning sorted component names, used by `components describe/enable/disable` and reusable elsewhere.

### Manifest output structure

```json
{
  "version": "0.5.0",
  "globalFlags": [{ "name": "kubeconfig", "type": "string", ... }],
  "commands": [
    {
      "name": "lint",
      "description": "Validate current OpenShift AI installation",
      "args": null,
      "flags": [
        { "name": "output", "shorthand": "o", "type": "string", "default": "table",
          "validValues": ["table", "json", "yaml"] }
      ],
      "hasSchema": true,
      "examples": ["kubectl odh lint --target-version 3.0"],
      "subcommands": []
    },
    {
      "name": "components",
      "subcommands": [
        { "name": "enable",
          "args": { "pattern": "COMPONENT",
                    "validValues": ["dashboard", "kserve", "ray", ...] } }
      ]
    }
  ]
}
```

## Testing

- [x] Unit tests pass (`make test`) — 15 test cases covering tree walking, flag extraction, arg patterns, valid values, hidden/deprecated exclusion, JSON serialization
- [x] Linter passes (`make lint`) — 0 issues
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `api` command that generates a JSON manifest describing CLI commands, arguments, and flags for programmatic access.

* **Improvements**
  * Enhanced shell argument auto-completion and validation across multiple commands.
  * Added flag value annotations to standardize command output and configuration options across the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->