### PR TITLE
[RHOAIENG-66868] feat(wait): add centralized --wait-for polling for operation chaining

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -53,6 +53,12 @@ DSCInitialization resource and OLM ClusterServiceVersions. Use
 By default, also checks required operator dependencies (ServiceMesh,
 Serverless, etc.) and shows which components need them.
 
+Use --wait-for=healthy to poll until the platform reaches healthy status.
+This is useful for automation and agent workflows that need to wait for
+the platform to stabilize after changes. The --timeout flag controls
+how long to wait (default 30s; use --timeout=0 for no timeout).
+Exit code 5 indicates a timeout.
+
 Examples:
   # Show platform health summary
   kubectl odh status
@@ -93,6 +99,15 @@ const cmdExample = `
 
   # Override namespace detection
   kubectl odh status --apps-namespace my-apps --operator-namespace my-operator
+
+  # Wait until the platform is healthy (5 minute timeout)
+  kubectl odh status --wait-for=healthy --timeout=300s
+
+  # Wait with custom poll interval
+  kubectl odh status --wait-for=healthy --timeout=300s --poll-interval=5s
+
+  # Wait indefinitely (no timeout)
+  kubectl odh status --wait-for=healthy --timeout=0
 `
 
 // AddCommand adds the status command to the root command.

--- a/pkg/cmd/wait.go
+++ b/pkg/cmd/wait.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/opendatahub-io/odh-cli/pkg/api"
+)
+
+const (
+	DefaultPollInterval = 10 * time.Second
+	MaxPollInterval     = 5 * time.Minute
+	MaxWaitTimeout      = 30 * time.Minute
+
+	flagDescWaitFor      = `Wait for a condition before exiting`
+	flagDescPollInterval = "Poll interval for --wait-for (lower values increase API server load)"
+)
+
+// WaitCondition is a function that polls and returns (done, error).
+type WaitCondition func(ctx context.Context) (done bool, err error)
+
+// enumValue implements pflag.Value for a string constrained to a fixed set.
+type enumValue struct {
+	allowed []string
+	value   *string
+}
+
+func newEnumValue(allowed []string, target *string) *enumValue {
+	return &enumValue{allowed: allowed, value: target}
+}
+
+func (e *enumValue) String() string { return *e.value }
+
+func (e *enumValue) Set(s string) error {
+	if !slices.Contains(e.allowed, s) {
+		return fmt.Errorf("must be one of: %s", strings.Join(e.allowed, ", "))
+	}
+
+	*e.value = s
+
+	return nil
+}
+
+func (e *enumValue) Type() string {
+	return strings.Join(e.allowed, "|")
+}
+
+// WaitOptions provides reusable --wait-for and --poll-interval flag
+// support. Commands embed this struct and call its methods from their
+// own AddFlags, Validate, and Run implementations.
+type WaitOptions struct {
+	WaitFor      string
+	PollInterval time.Duration
+}
+
+// AddWaitFlags registers --wait-for and --poll-interval flags.
+// validConditions lists the values accepted by --wait-for; invalid
+// values are rejected at parse time by the enum flag type.
+func (w *WaitOptions) AddWaitFlags(fs *pflag.FlagSet, validConditions []string) {
+	fs.Var(newEnumValue(validConditions, &w.WaitFor), "wait-for", flagDescWaitFor)
+	_ = fs.SetAnnotation("wait-for", api.AnnotationValidValues, validConditions)
+	fs.DurationVar(&w.PollInterval, "poll-interval", w.PollInterval, flagDescPollInterval)
+}
+
+// HasWaitMode returns true if --wait-for is active.
+func (w *WaitOptions) HasWaitMode() bool {
+	return w.WaitFor != ""
+}
+
+// ValidateWait checks that --poll-interval and timeout are within bounds.
+// Condition validation is handled at parse time by the enum flag type.
+// timeout is the caller's --timeout value (0 means no timeout in wait mode).
+func (w *WaitOptions) ValidateWait(timeout time.Duration) error {
+	if w.WaitFor == "" {
+		return nil
+	}
+
+	if w.PollInterval < time.Second || w.PollInterval > MaxPollInterval {
+		return ErrInvalidPollInterval()
+	}
+
+	if timeout < 0 || timeout > MaxWaitTimeout {
+		return ErrInvalidWaitTimeout()
+	}
+
+	return nil
+}
+
+// RunWait polls cond at the configured interval until it returns true,
+// the timeout expires, or the context is cancelled. Pass timeout=0 for
+// no timeout (poll until condition or cancellation).
+func (w *WaitOptions) RunWait(ctx context.Context, timeout time.Duration, cond WaitCondition) error {
+	if w.PollInterval < time.Second || w.PollInterval > MaxPollInterval {
+		return ErrInvalidPollInterval()
+	}
+
+	if timeout < 0 {
+		return ErrInvalidWaitTimeout()
+	}
+
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+
+		defer cancel()
+	}
+
+	pollErr := wait.PollUntilContextCancel(ctx, w.PollInterval, true, wait.ConditionWithContextFunc(cond))
+
+	if pollErr != nil {
+		if errors.Is(pollErr, context.DeadlineExceeded) {
+			return ErrWaitTimeout(w.WaitFor)
+		}
+
+		return fmt.Errorf("waiting for condition %q: %w", w.WaitFor, pollErr)
+	}
+
+	return nil
+}

--- a/pkg/cmd/wait_errors.go
+++ b/pkg/cmd/wait_errors.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	errCodeInvalidPollInterval = "INVALID_POLL_INTERVAL"
+	errCodeInvalidWaitTimeout  = "INVALID_TIMEOUT"
+	errCodeWaitTimeout         = "WAIT_TIMEOUT"
+
+	msgInvalidPollInterval = "poll interval must be between 1s and 5m"
+	msgInvalidWaitTimeout  = "timeout must be between 0 and 30m (0 means no timeout)"
+	msgWaitTimeout         = "timed out waiting for condition %q"
+
+	suggestValidPollInterval = "Use --poll-interval with a duration between 1s and 5m (e.g., 5s, 10s, 30s)"
+	suggestValidWaitTimeout  = "Use --timeout=0 for no timeout, or a duration up to 30m (e.g., 30s, 5m)"
+	suggestWaitTimeout       = "Increase --timeout or check platform health with: kubectl odh status"
+)
+
+// ErrInvalidPollInterval creates a structured error for invalid poll interval values.
+func ErrInvalidPollInterval() *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeInvalidPollInterval,
+		Message:    msgInvalidPollInterval,
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: suggestValidPollInterval,
+	}
+}
+
+// ErrInvalidWaitTimeout creates a structured error for negative timeout in wait mode.
+func ErrInvalidWaitTimeout() *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeInvalidWaitTimeout,
+		Message:    msgInvalidWaitTimeout,
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: suggestValidWaitTimeout,
+	}
+}
+
+// ErrWaitTimeout creates a structured error when --wait-for times out.
+func ErrWaitTimeout(condition string) *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeWaitTimeout,
+		Message:    fmt.Sprintf(msgWaitTimeout, condition),
+		Category:   clierrors.CategoryTimeout,
+		Retriable:  true,
+		Suggestion: suggestWaitTimeout,
+	}
+}

--- a/pkg/cmd/wait_test.go
+++ b/pkg/cmd/wait_test.go
@@ -1,0 +1,186 @@
+package cmd_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateWait(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		opts     cmd.WaitOptions
+		timeout  time.Duration
+		wantErr  bool
+		wantCode string
+	}{
+		{
+			name:    "empty wait-for passes",
+			opts:    cmd.WaitOptions{},
+			timeout: 30 * time.Second,
+		},
+		{
+			name:    "valid condition passes",
+			opts:    cmd.WaitOptions{WaitFor: "healthy", PollInterval: 10 * time.Second},
+			timeout: 30 * time.Second,
+		},
+		{
+			name:    "second valid condition passes",
+			opts:    cmd.WaitOptions{WaitFor: "ready", PollInterval: 5 * time.Second},
+			timeout: 60 * time.Second,
+		},
+		{
+			name:    "zero timeout valid in wait mode",
+			opts:    cmd.WaitOptions{WaitFor: "healthy", PollInterval: 10 * time.Second},
+			timeout: 0,
+		},
+		{
+			name:     "zero poll interval rejected",
+			opts:     cmd.WaitOptions{WaitFor: "healthy", PollInterval: 0},
+			timeout:  30 * time.Second,
+			wantErr:  true,
+			wantCode: "INVALID_POLL_INTERVAL",
+		},
+		{
+			name:     "negative poll interval rejected",
+			opts:     cmd.WaitOptions{WaitFor: "healthy", PollInterval: -1 * time.Second},
+			timeout:  30 * time.Second,
+			wantErr:  true,
+			wantCode: "INVALID_POLL_INTERVAL",
+		},
+		{
+			name:     "negative timeout rejected",
+			opts:     cmd.WaitOptions{WaitFor: "healthy", PollInterval: 10 * time.Second},
+			timeout:  -1 * time.Second,
+			wantErr:  true,
+			wantCode: "INVALID_TIMEOUT",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			err := tt.opts.ValidateWait(tt.timeout)
+
+			if !tt.wantErr {
+				g.Expect(err).ToNot(HaveOccurred())
+
+				return
+			}
+
+			g.Expect(err).To(HaveOccurred())
+
+			var structured *clierrors.StructuredError
+			g.Expect(errors.As(err, &structured)).To(BeTrue())
+			g.Expect(structured).To(HaveField("Code", tt.wantCode))
+		})
+	}
+}
+
+func TestHasWaitMode(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	g.Expect((&cmd.WaitOptions{}).HasWaitMode()).To(BeFalse())
+	g.Expect((&cmd.WaitOptions{WaitFor: "healthy"}).HasWaitMode()).To(BeTrue())
+}
+
+const testPollInterval = 1 * time.Second
+
+func TestRunWait(t *testing.T) {
+	t.Parallel()
+
+	t.Run("condition met immediately", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		opts := cmd.WaitOptions{WaitFor: "healthy", PollInterval: testPollInterval}
+		err := opts.RunWait(t.Context(), 5*time.Second, func(_ context.Context) (bool, error) {
+			return true, nil
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("condition met after polls", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		var calls atomic.Int32
+		opts := cmd.WaitOptions{WaitFor: "healthy", PollInterval: testPollInterval}
+
+		err := opts.RunWait(t.Context(), 5*time.Second, func(_ context.Context) (bool, error) {
+			return calls.Add(1) >= 3, nil
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(calls.Load()).To(BeNumerically(">=", 3))
+	})
+
+	t.Run("timeout returns structured WAIT_TIMEOUT error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		opts := cmd.WaitOptions{WaitFor: "healthy", PollInterval: testPollInterval}
+		err := opts.RunWait(t.Context(), 50*time.Millisecond, func(_ context.Context) (bool, error) {
+			return false, nil
+		})
+		g.Expect(err).To(HaveOccurred())
+
+		var structured *clierrors.StructuredError
+		g.Expect(errors.As(err, &structured)).To(BeTrue())
+		g.Expect(structured).To(HaveField("Code", "WAIT_TIMEOUT"))
+		g.Expect(structured).To(HaveField("Category", clierrors.CategoryTimeout))
+	})
+
+	t.Run("condition error stops polling", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		condErr := errors.New("fatal")
+		opts := cmd.WaitOptions{WaitFor: "healthy", PollInterval: testPollInterval}
+
+		err := opts.RunWait(t.Context(), 5*time.Second, func(_ context.Context) (bool, error) {
+			return false, condErr
+		})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(ContainSubstring("fatal")))
+	})
+
+	t.Run("timeout zero polls until condition", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		var calls atomic.Int32
+		opts := cmd.WaitOptions{WaitFor: "healthy", PollInterval: testPollInterval}
+
+		err := opts.RunWait(t.Context(), 0, func(_ context.Context) (bool, error) {
+			return calls.Add(1) >= 5, nil
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(calls.Load()).To(BeNumerically(">=", 5))
+	})
+
+	t.Run("cancelled context returns error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		opts := cmd.WaitOptions{WaitFor: "healthy", PollInterval: testPollInterval}
+		err := opts.RunWait(ctx, 0, func(_ context.Context) (bool, error) {
+			return false, nil
+		})
+		g.Expect(err).To(HaveOccurred())
+	})
+}

--- a/pkg/status/config.go
+++ b/pkg/status/config.go
@@ -1,0 +1,103 @@
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+	"golang.org/x/sync/errgroup"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// resolveHealthConfig returns healthConfig if pre-set (testing), otherwise
+// builds one from the live cluster.
+func (c *Command) resolveHealthConfig(ctx context.Context) (*clusterhealth.Config, error) {
+	if c.healthConfig != nil {
+		return c.healthConfig, nil
+	}
+
+	return c.buildHealthConfig(ctx)
+}
+
+// buildHealthConfig performs one-time setup: DSCI fetch, namespace discovery,
+// CR name discovery, and clusterhealth config construction.
+func (c *Command) buildHealthConfig(ctx context.Context) (*clusterhealth.Config, error) {
+	dsci, err := client.GetDSCInitialization(ctx, c.client)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("getting DSCInitialization: %w", err)
+	}
+
+	nsCfg, opInfo, err := discoverNamespaces(ctx, c.client, dsci, c.AppsNamespace, c.OperatorNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("discovering namespaces: %w", err)
+	}
+
+	dsciName, dscName, err := discoverCRNames(ctx, c.client, dsci)
+	if err != nil {
+		return nil, err
+	}
+
+	crClient, err := client.NewControllerRuntimeClient(c.restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating controller-runtime client: %w", err)
+	}
+
+	operatorName := discoverOperatorName(opInfo, c.OperatorName)
+
+	nsCfgHealth := clusterhealth.NamespaceConfig{
+		Apps:       nsCfg.Apps,
+		Monitoring: nsCfg.Monitoring,
+	}
+
+	if c.IncludeInfra {
+		nsCfgHealth.Extra = []string{"kube-system"}
+	}
+
+	cfg := clusterhealth.Config{
+		Client: crClient,
+		Operator: clusterhealth.OperatorConfig{
+			Namespace: nsCfg.Operator,
+			Name:      operatorName,
+		},
+		Namespaces:   nsCfgHealth,
+		DSCI:         dsciName,
+		DSC:          dscName,
+		OnlySections: c.Sections,
+		Layers:       c.Layers,
+	}
+
+	return &cfg, nil
+}
+
+// runHealthCheck executes a single health check pass and optionally checks dependencies.
+func (c *Command) runHealthCheck(ctx context.Context, hc *clusterhealth.Config) (*clusterhealth.Report, []deps.DependencyStatus, error) {
+	var report *clusterhealth.Report
+	var depStatuses []deps.DependencyStatus
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		report, err = clusterhealth.Run(gctx, *hc)
+
+		return err //nolint:wrapcheck // only one goroutine can error; wrapping adds noise
+	})
+
+	if c.IncludeDeps {
+		g.Go(func() error {
+			depStatuses = c.checkDependencies(gctx)
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err //nolint:wrapcheck // single error source; pass through as-is
+	}
+
+	return report, depStatuses, nil
+}

--- a/pkg/status/errors.go
+++ b/pkg/status/errors.go
@@ -18,6 +18,8 @@ const (
 	msgInvalidOutputFormat = "invalid output format %q"
 	msgInvalidTimeout      = "timeout must be greater than 0"
 	msgDSCINotFound        = "no DSCInitialization found"
+	msgHealthCheckRetry    = "Warning: health check failed (retrying): %v\n"
+	msgWaitProgress        = "Waiting for %s status... (%s elapsed)\n"
 
 	suggestValidSections   = "Valid sections: nodes, deployments, pods, events, quotas, operator, dsci, dsc"
 	suggestValidLayers     = "Valid layers: infrastructure, workload, operator"

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -40,6 +40,8 @@ const (
 
 	DefaultTimeout = 30 * time.Second
 
+	WaitConditionHealthy = "healthy"
+
 	// Default operator deployment name for RHOAI.
 	defaultRHOAIOperatorName = "rhods-operator"
 
@@ -68,6 +70,8 @@ const (
 
 // Command contains the status command configuration.
 type Command struct {
+	cmd.WaitOptions
+
 	IO          iostreams.Interface
 	ConfigFlags *genericclioptions.ConfigFlags
 
@@ -90,6 +94,10 @@ type Command struct {
 	// Populated during Complete
 	restConfig *rest.Config
 	client     client.Client
+
+	// healthConfig, when non-nil, skips buildHealthConfig and uses this
+	// config directly. Allows tests to inject a fake controller-runtime client.
+	healthConfig *clusterhealth.Config
 }
 
 // NewCommand creates a new status Command with defaults.
@@ -102,9 +110,12 @@ func NewCommand(
 		ConfigFlags:  configFlags,
 		OutputFormat: OutputFormatTable,
 		Timeout:      DefaultTimeout,
-		IncludeDeps:  true,
-		QPS:          client.DefaultQPS,
-		Burst:        client.DefaultBurst,
+		WaitOptions: cmd.WaitOptions{
+			PollInterval: cmd.DefaultPollInterval,
+		},
+		IncludeDeps: true,
+		QPS:         client.DefaultQPS,
+		Burst:       client.DefaultBurst,
 	}
 }
 
@@ -122,6 +133,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.OperatorName, "operator-name", "", flagDescOperName)
 	fs.BoolVar(&c.IncludeInfra, "include-infra", false, flagDescInfra)
 	fs.BoolVar(&c.IncludeDeps, "include-deps", c.IncludeDeps, flagDescIncludeDeps)
+	c.AddWaitFlags(fs, []string{WaitConditionHealthy})
 	fs.Float32Var(&c.QPS, "qps", c.QPS, flagDescQPS)
 	fs.IntVar(&c.Burst, "burst", c.Burst, flagDescBurst)
 }
@@ -165,7 +177,11 @@ func (c *Command) Validate() error {
 		return err
 	}
 
-	if c.Timeout <= 0 {
+	if err := c.ValidateWait(c.Timeout); err != nil {
+		return err //nolint:wrapcheck // structured validation errors propagate as-is
+	}
+
+	if !c.HasWaitMode() && c.Timeout <= 0 {
 		return ErrInvalidTimeout()
 	}
 
@@ -174,80 +190,21 @@ func (c *Command) Validate() error {
 
 // Run executes the status command.
 func (c *Command) Run(ctx context.Context) error {
+	if c.HasWaitMode() {
+		return c.runWaitFor(ctx)
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
 	defer cancel()
 
-	// Fetch DSCI once and reuse across namespace discovery and CR name extraction.
-	// NotFound is non-fatal (handled by discoverNamespaces), but other errors propagate.
-	dsci, err := client.GetDSCInitialization(ctx, c.client)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("getting DSCInitialization: %w", err)
-	}
-
-	nsCfg, opInfo, err := discoverNamespaces(ctx, c.client, dsci, c.AppsNamespace, c.OperatorNamespace)
-	if err != nil {
-		return fmt.Errorf("discovering namespaces: %w", err)
-	}
-
-	dsciName, dscName, err := discoverCRNames(ctx, c.client, dsci)
+	hc, err := c.resolveHealthConfig(ctx)
 	if err != nil {
 		return err
 	}
 
-	crClient, err := client.NewControllerRuntimeClient(c.restConfig)
+	report, depStatuses, err := c.runHealthCheck(ctx, hc)
 	if err != nil {
-		return fmt.Errorf("creating controller-runtime client: %w", err)
-	}
-
-	operatorName := discoverOperatorName(opInfo, c.OperatorName)
-
-	nsCfgHealth := clusterhealth.NamespaceConfig{
-		Apps:       nsCfg.Apps,
-		Monitoring: nsCfg.Monitoring,
-	}
-
-	if c.IncludeInfra {
-		nsCfgHealth.Extra = []string{"kube-system"}
-	}
-
-	cfg := clusterhealth.Config{
-		Client: crClient,
-		Operator: clusterhealth.OperatorConfig{
-			Namespace: nsCfg.Operator,
-			Name:      operatorName,
-		},
-		Namespaces:   nsCfgHealth,
-		DSCI:         dsciName,
-		DSC:          dscName,
-		OnlySections: c.Sections,
-		Layers:       c.Layers,
-	}
-
-	var report *clusterhealth.Report
-	var depStatuses []deps.DependencyStatus
-
-	g, gctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		var err error
-		report, err = clusterhealth.Run(gctx, cfg)
-		if err != nil {
-			return fmt.Errorf("health checks: %w", err)
-		}
-
-		return nil
-	})
-
-	if c.IncludeDeps {
-		g.Go(func() error {
-			depStatuses = c.checkDependencies(gctx)
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("running status checks: %w", err)
+		return err
 	}
 
 	return c.output(ctx, report, depStatuses)

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	cmdpkg "github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/status"
 )
 
@@ -68,11 +69,15 @@ func TestCommandValidate_Timeout(t *testing.T) {
 	tests := []struct {
 		name    string
 		timeout time.Duration
+		waitFor string
 		wantErr bool
 	}{
-		{"positive timeout", 30 * time.Second, false},
-		{"zero timeout", 0, true},
-		{"negative timeout", -1 * time.Second, true},
+		{"positive timeout", 30 * time.Second, "", false},
+		{"zero timeout without wait-for", 0, "", true},
+		{"negative timeout without wait-for", -1 * time.Second, "", true},
+		{"zero timeout with wait-for (means no timeout)", 0, "healthy", false},
+		{"positive timeout with wait-for", 300 * time.Second, "healthy", false},
+		{"negative timeout with wait-for", -1 * time.Second, "healthy", true},
 	}
 
 	for _, tt := range tests {
@@ -80,10 +85,64 @@ func TestCommandValidate_Timeout(t *testing.T) {
 			cmd := &status.Command{
 				OutputFormat: status.OutputFormatTable,
 				Timeout:      tt.timeout,
+				WaitOptions:  cmdpkg.WaitOptions{WaitFor: tt.waitFor, PollInterval: cmdpkg.DefaultPollInterval},
 			}
 			err := cmd.Validate()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Command.Validate() with timeout %v error = %v, wantErr %v", tt.timeout, err, tt.wantErr)
+				t.Errorf("Command.Validate() with timeout %v, waitFor %q error = %v, wantErr %v", tt.timeout, tt.waitFor, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_WaitFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		waitFor string
+		wantErr bool
+	}{
+		{"empty (no wait)", "", false},
+		{"valid healthy", "healthy", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &status.Command{
+				OutputFormat: status.OutputFormatTable,
+				Timeout:      30 * time.Second,
+				WaitOptions:  cmdpkg.WaitOptions{WaitFor: tt.waitFor, PollInterval: cmdpkg.DefaultPollInterval},
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() with waitFor %q error = %v, wantErr %v", tt.waitFor, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_PollInterval(t *testing.T) {
+	tests := []struct {
+		name         string
+		pollInterval time.Duration
+		waitFor      string
+		wantErr      bool
+	}{
+		{"positive interval with wait-for", 5 * time.Second, "healthy", false},
+		{"zero interval with wait-for", 0, "healthy", true},
+		{"negative interval with wait-for", -1 * time.Second, "healthy", true},
+		{"zero interval without wait-for (ignored)", 0, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &status.Command{
+				OutputFormat: status.OutputFormatTable,
+				Timeout:      30 * time.Second,
+				WaitOptions:  cmdpkg.WaitOptions{WaitFor: tt.waitFor, PollInterval: tt.pollInterval},
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() with pollInterval %v, waitFor %q error = %v, wantErr %v", tt.pollInterval, tt.waitFor, err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/status/wait.go
+++ b/pkg/status/wait.go
@@ -1,0 +1,60 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// runWaitFor polls clusterhealth.Run() until the specified condition is met.
+func (c *Command) runWaitFor(ctx context.Context) error {
+	hc, err := c.resolveHealthConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	var lastReport *clusterhealth.Report
+	var lastDepStatuses []deps.DependencyStatus
+
+	start := time.Now()
+
+	err = c.RunWait(ctx, c.Timeout, func(ctx context.Context) (bool, error) {
+		report, depStatuses, err := c.runHealthCheck(ctx, hc)
+		if err != nil {
+			if client.IsUnrecoverableError(err) {
+				return false, err
+			}
+
+			_, _ = fmt.Fprintf(c.IO.ErrOut(), msgHealthCheckRetry, err)
+
+			return false, nil
+		}
+
+		lastReport = report
+		lastDepStatuses = depStatuses
+
+		if report == nil {
+			return false, nil
+		}
+
+		healthy := report.Healthy()
+
+		if !healthy {
+			elapsed := time.Since(start).Truncate(time.Second)
+			_, _ = fmt.Fprintf(c.IO.ErrOut(), msgWaitProgress, c.WaitFor, elapsed)
+		}
+
+		return healthy, nil
+	})
+
+	if err != nil {
+		return err //nolint:wrapcheck // structured wait errors propagate as-is
+	}
+
+	return c.output(context.WithoutCancel(ctx), lastReport, lastDepStatuses)
+}

--- a/pkg/status/wait_internal_test.go
+++ b/pkg/status/wait_internal_test.go
@@ -1,0 +1,227 @@
+package status
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	cmdpkg "github.com/opendatahub-io/odh-cli/pkg/cmd"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+// Test timing constants.
+const (
+	testPollInterval = 1 * time.Second
+	testTimeout      = 10 * time.Second
+	testShortTimeout = 3 * time.Second
+
+	testAppNS      = "test-apps"
+	testOperatorNS = "test-operator-ns"
+	testOperator   = "test-operator"
+)
+
+//nolint:gochecknoglobals // Test data constants
+var (
+	testDSCIGVK = schema.GroupVersionKind{
+		Group: "dscinitialization.opendatahub.io", Version: "v2", Kind: "DSCInitialization",
+	}
+	testDSCGVK = schema.GroupVersionKind{
+		Group: "datasciencecluster.opendatahub.io", Version: "v2", Kind: "DataScienceCluster",
+	}
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+
+	for _, gvk := range []schema.GroupVersionKind{testDSCIGVK, testDSCGVK} {
+		s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		s.AddKnownTypeWithName(schema.GroupVersionKind{
+			Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List",
+		}, &unstructured.UnstructuredList{})
+	}
+
+	return s
+}
+
+func newCRObject(gvk schema.GroupVersionKind, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetName(name)
+	_ = unstructured.SetNestedField(obj.Object, []any{
+		map[string]any{"type": "ReconcileComplete", "status": "True"},
+	}, "status", "conditions")
+
+	return obj
+}
+
+func testOperatorDeployment() *appsv1.Deployment {
+	replicas := int32(1)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: testOperator, Namespace: testOperatorNS},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+		},
+		Status: appsv1.DeploymentStatus{ReadyReplicas: 1, Replicas: 1, AvailableReplicas: 1},
+	}
+}
+
+func baseObjects() []crclient.Object {
+	return []crclient.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testAppNS}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testOperatorNS}},
+		newCRObject(testDSCIGVK, "default-dsci"),
+		newCRObject(testDSCGVK, "default-dsc"),
+	}
+}
+
+func newTestConfig(fc crclient.Client) *clusterhealth.Config {
+	return &clusterhealth.Config{
+		Client:     fc,
+		Operator:   clusterhealth.OperatorConfig{Namespace: testOperatorNS, Name: testOperator},
+		Namespaces: clusterhealth.NamespaceConfig{Apps: testAppNS},
+		DSCI:       types.NamespacedName{Name: "default-dsci"},
+		DSC:        types.NamespacedName{Name: "default-dsc"},
+	}
+}
+
+func healthyConfig(scheme *runtime.Scheme) *clusterhealth.Config {
+	dep := testOperatorDeployment()
+	objs := append(baseObjects(), dep)
+
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(dep).
+		Build()
+
+	return newTestConfig(fc)
+}
+
+func unhealthyConfig(scheme *runtime.Scheme) *clusterhealth.Config {
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(baseObjects()...).
+		Build()
+
+	return newTestConfig(fc)
+}
+
+func newTestWaitCommand(cfg *clusterhealth.Config) (*Command, *bytes.Buffer, *bytes.Buffer) {
+	var stdout, stderr bytes.Buffer
+
+	cmd := &Command{
+		IO:           iostreams.NewIOStreams(nil, &stdout, &stderr),
+		OutputFormat: OutputFormatJSON,
+		WaitOptions: cmdpkg.WaitOptions{
+			WaitFor:      WaitConditionHealthy,
+			PollInterval: testPollInterval,
+		},
+		Timeout:      testTimeout,
+		healthConfig: cfg,
+	}
+
+	return cmd, &stdout, &stderr
+}
+
+func TestRunWaitFor(t *testing.T) {
+	scheme := testScheme()
+
+	t.Run("healthy on first poll exits immediately", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _, _ := newTestWaitCommand(healthyConfig(scheme))
+
+		err := cmd.runWaitFor(t.Context())
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("timeout returns structured error with WAIT_TIMEOUT code", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _, _ := newTestWaitCommand(unhealthyConfig(scheme))
+		cmd.Timeout = testShortTimeout
+
+		err := cmd.runWaitFor(t.Context())
+		g.Expect(err).To(HaveOccurred())
+
+		var structured *clierrors.StructuredError
+		g.Expect(errors.As(err, &structured)).To(BeTrue())
+		g.Expect(structured).To(HaveField("Code", "WAIT_TIMEOUT"))
+		g.Expect(structured).To(HaveField("Category", clierrors.CategoryTimeout))
+	})
+
+	t.Run("unhealthy logs waiting message to stderr", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cmd, _, stderr := newTestWaitCommand(unhealthyConfig(scheme))
+		cmd.Timeout = testShortTimeout
+
+		_ = cmd.runWaitFor(t.Context())
+		g.Expect(stderr.String()).To(ContainSubstring("Waiting for healthy status"))
+	})
+
+	t.Run("cancelled context returns error", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		cmd, _, _ := newTestWaitCommand(unhealthyConfig(scheme))
+		cmd.Timeout = 0
+
+		err := cmd.runWaitFor(ctx)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("becomes healthy after operator deployment is created", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := unhealthyConfig(scheme)
+		cmd, _, _ := newTestWaitCommand(cfg)
+		cmd.Timeout = 0
+
+		dep := testOperatorDeployment()
+
+		setupErr := make(chan error, 1)
+
+		go func() {
+			time.Sleep(1500 * time.Millisecond)
+
+			if err := cfg.Client.Create(context.Background(), dep); err != nil {
+				setupErr <- err
+
+				return
+			}
+
+			dep.Status.ReadyReplicas = 1
+			dep.Status.Replicas = 1
+			dep.Status.AvailableReplicas = 1
+			setupErr <- cfg.Client.Status().Update(context.Background(), dep)
+		}()
+
+		err := cmd.runWaitFor(t.Context())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(<-setupErr).ToNot(HaveOccurred())
+	})
+}


### PR DESCRIPTION
## Description

Adds `--wait-for=healthy` polling to `kubectl odh status`, allowing users and automation to block until the platform reaches a desired state.

**Jira:** [RHOAIENG-66868](https://redhat.atlassian.net/browse/RHOAIENG-66868)

### What this PR does

- Introduces a centralized `WaitOptions`  in `pkg/cmd/` that any command can embed to get `--wait-for` and `--poll-interval` support
- Wires `--wait-for=healthy` into the status command with configurable `--timeout` and `--poll-interval`


### Usage

```bash
# Wait until healthy (5 min timeout)
kubectl odh status --wait-for=healthy --timeout=300s

# Custom poll interval
kubectl odh status --wait-for=healthy --timeout=300s --poll-interval=5s

# Wait indefinitely
kubectl odh status --wait-for=healthy --timeout=0
```

### Follow-up PR

`--watch`: stream newline-delimited JSON per state change with informer-style reconnection on network interruption (tracked in the same Jira).

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests
- [x] Validated against live ODH Cluster
## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Centralized `WaitOptions` in `pkg/cmd/` for reuse by future commands
- [x] Structured errors for all validation and timeout cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wait-mode support to the status command with `--wait-for=healthy`, configurable `--poll-interval`, and timeout behavior.
* **Documentation**
  * Expanded `status` command help/examples for healthy waiting, including default `--timeout=30s`, `--timeout=0` (no timeout), and timeout exit code `5`.
* **Bug Fixes**
  * Strengthened wait validation (poll interval and timeout bounds) and improved waiting progress/retry messaging, including structured timeout errors.
* **Tests**
  * Added/expanded test coverage for wait validation, wait execution, and end-to-end healthy-wait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->