### PR TITLE
[RHOAIENG-61440] Update lint message to reflect Go actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LINT_TIMEOUT := 10m
 
 # Container registry configuration
 CONTAINER_REGISTRY ?= quay.io
-CONTAINER_REPO ?= $(CONTAINER_REGISTRY)/rhoai/rhoai-upgrade-helpers-rhel9
+CONTAINER_REPO ?= $(CONTAINER_REGISTRY)/rhoai/odh-cli-rhel9
 CONTAINER_PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le
 CONTAINER_TAGS ?= $(VERSION)
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Run the CLI using the pre-built container image:
 ```bash
 podman run --rm -ti \
   -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
+  quay.io/rhoai/rhai-cli-rhel9:dev lint --target-version 3.3.0
 ```
 
 **Docker:**
 ```bash
 docker run --rm -ti \
   -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
+  quay.io/rhoai/rhai-cli-rhel9:dev lint --target-version 3.3.0
 ```
 
 The container has `KUBECONFIG=/kubeconfig` set by default, so you just need to mount your kubeconfig to that path.
@@ -29,12 +29,12 @@ The container has `KUBECONFIG=/kubeconfig` set by default, so you just need to m
 > # Podman
 > podman run --rm -ti \
 >   -v $KUBECONFIG:/kubeconfig:Z \
->   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
+>   quay.io/rhoai/rhai-cli-rhel9:dev lint --target-version 3.3.0
 >
 > # Docker
 > docker run --rm -ti \
 >   -v $KUBECONFIG:/kubeconfig:Z \
->   quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev lint --target-version 3.3.0
+>   quay.io/rhoai/rhai-cli-rhel9:dev lint --target-version 3.3.0
 > ```
 
 **Available Tags:**
@@ -53,7 +53,7 @@ The container also bundles migration tools and CLI utilities that can be used di
 podman run -it --rm \
   -v $KUBECONFIG:/kubeconfig \
   --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
+  quay.io/rhoai/rhai-cli-rhel9:dev
 ```
 
 **Docker:**
@@ -61,7 +61,7 @@ podman run -it --rm \
 docker run -it --rm \
   -v $KUBECONFIG:/kubeconfig \
   --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev
+  quay.io/rhoai/rhai-cli-rhel9:dev
 ```
 
 Available tools:
@@ -92,7 +92,7 @@ For environments where you have a token and server URL instead of a kubeconfig f
 **Podman:**
 ```bash
 podman run --rm -ti \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev \
+  quay.io/rhoai/rhai-cli-rhel9:dev \
   lint \
   --target-version 3.3.0 \
   --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
@@ -102,7 +102,7 @@ podman run --rm -ti \
 **Docker:**
 ```bash
 docker run --rm -ti \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:dev \
+  quay.io/rhoai/rhai-cli-rhel9:dev \
   lint \
   --target-version 3.3.0 \
   --token=sha256~xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \

--- a/docs/design.md
+++ b/docs/design.md
@@ -20,7 +20,7 @@ The container sets `KUBECONFIG=/kubeconfig` by default. Mount your local kubecon
 ```bash
 docker run --rm -ti \
   -v $KUBECONFIG:/kubeconfig \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest lint --target-version 3.3.0
+  quay.io/rhoai/rhai-cli-rhel9:latest lint --target-version 3.3.0
 ```
 
 **Custom Path:**
@@ -30,7 +30,7 @@ Override the KUBECONFIG environment variable if needed:
 docker run --rm -ti \
   -v $KUBECONFIG:/custom/path \
   -e KUBECONFIG=/custom/path \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest lint --target-version 3.3.0
+  quay.io/rhoai/rhai-cli-rhel9:latest lint --target-version 3.3.0
 ```
 
 **Interactive Debugging:**
@@ -41,7 +41,7 @@ The container includes kubectl, oc, and common utilities (wget, curl, tar, gzip,
 docker run -it --rm \
   -v $KUBECONFIG:/kubeconfig \
   --entrypoint /bin/bash \
-  quay.io/rhoai/rhoai-upgrade-helpers-rhel9:latest
+  quay.io/rhoai/rhai-cli-rhel9:latest
 
 # Inside container, use kubectl/oc for troubleshooting
 kubectl get pods -n opendatahub

--- a/pkg/lint/checks/workloads/llamastack/llamastack.go
+++ b/pkg/lint/checks/workloads/llamastack/llamastack.go
@@ -25,7 +25,7 @@ const (
 	numConditions = 1 // Number of conditions in buildConditions
 )
 
-// ConfigCheck validates LlamaStackDistribution resources for 3.3 upgrade compatibility.
+// ConfigCheck validates LlamaStackDistribution resources for 3.3+ upgrade compatibility.
 type ConfigCheck struct {
 	check.BaseCheck
 }
@@ -37,9 +37,9 @@ func NewConfigCheck() *ConfigCheck {
 			Kind:             kind,
 			Type:             "config",
 			CheckID:          "workloads.llamastack.config",
-			CheckName:        "Workloads :: LlamaStack :: Upgrade Preparation (2.x to 3.3)",
-			CheckDescription: "Identifies LlamaStackDistribution resources that require deletion and recreation for RHOAI 3.3 upgrade",
-			CheckRemediation: "Back up configurations using the backup script from rhoai-upgrade-helpers repository, coordinate with owners, then delete and recreate LlamaStackDistributions in RHOAI 3.3.0 following the migration guide",
+			CheckName:        "Workloads :: LlamaStack :: Upgrade Preparation (2.x to 3.3+)",
+			CheckDescription: "Identifies LlamaStackDistribution resources that require deletion and recreation for RHOAI 3.3+ upgrade",
+			CheckRemediation: "Run 'kubectl odh migrate prepare' to back up LlamaStack resources, coordinate with owners about data loss, then delete and recreate LlamaStackDistributions after upgrade following RHOAI 3.3+ documentation",
 		},
 	}
 }
@@ -127,9 +127,9 @@ func (c *ConfigCheck) buildConditions(totalCount int) []result.Condition {
 		ConditionTypeRequiresRecreation,
 		metav1.ConditionFalse,
 		check.WithReason("ArchitecturalIncompatibility"),
-		check.WithMessage("Found %d LlamaStackDistribution(s) that must be deleted and recreated after RHOAI 3.3 upgrade. In-place upgrade is not supported. ALL DATA WILL BE LOST - Archive data before upgrade.", totalCount),
+		check.WithMessage("Found %d LlamaStackDistribution(s) that must be deleted and recreated after RHOAI 3.3+ upgrade. In-place upgrade is not supported. ALL DATA WILL BE LOST - Archive data before upgrade.", totalCount),
 		check.WithImpact(result.ImpactBlocking),
-		check.WithRemediation("1. Run backup script: llamastack/backup-all-llamastack.sh from rhoai-upgrade-helpers repo to archive existing configurations. 2. Coordinate with LLSD owners about data loss and recreation requirements. 3. After RHOAI 3.3 upgrade, delete old LLSDs and create new ones following RHOAI 3.3 documentation."),
+		check.WithRemediation("1. Run 'kubectl odh migrate prepare' to back up existing LlamaStack configurations and pod data. 2. Coordinate with LLSD owners about data loss and recreation requirements. 3. After RHOAI 3.3+ upgrade, delete old LLSDs and create new ones following RHOAI 3.3+ documentation."),
 	))
 
 	return conditions

--- a/pkg/lint/checks/workloads/llamastack/llamastack_test.go
+++ b/pkg/lint/checks/workloads/llamastack/llamastack_test.go
@@ -176,7 +176,7 @@ func TestLlamaStackConfigCheck_WorkloadsFound(t *testing.T) {
 	g.Expect(res.Status.Conditions[0].Condition.Message).To(ContainSubstring("must be deleted and recreated"))
 	g.Expect(res.Status.Conditions[0].Condition.Message).To(ContainSubstring("ALL DATA WILL BE LOST"))
 	g.Expect(res.Status.Conditions[0].Impact).To(Equal(result.ImpactBlocking))
-	g.Expect(res.Status.Conditions[0].Remediation).To(ContainSubstring("backup script"))
+	g.Expect(res.Status.Conditions[0].Remediation).To(ContainSubstring("kubectl odh migrate prepare"))
 
 	// Verify impacted objects
 	g.Expect(res.ImpactedObjects).To(HaveLen(2))
@@ -193,7 +193,7 @@ func TestLlamaStackConfigCheck_Metadata(t *testing.T) {
 	chk := llamastack.NewConfigCheck()
 
 	g.Expect(chk.ID()).To(Equal("workloads.llamastack.config"))
-	g.Expect(chk.Name()).To(Equal("Workloads :: LlamaStack :: Upgrade Preparation (2.x to 3.3)"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: LlamaStack :: Upgrade Preparation (2.x to 3.3+)"))
 	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
 	g.Expect(chk.Description()).ToNot(BeEmpty())
 	g.Expect(chk.CheckKind()).To(Equal("llamastackdistribution"))


### PR DESCRIPTION
## Description
chore: update llamastack lint checks to reflect go actions instead of bash scripts

<!-- What does this PR do? -->

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade-preparation guidance and wording to target **RHOAI 3.3+**, including the `kubectl odh migrate prepare` step and recommended post-upgrade LLSD delete/recreate actions.
  * Refreshed Podman/Docker example images to use `quay.io/rhoai/odh-cli-rhel9` and `quay.io/rhoai/rhai-cli-rhel9` for lint and shell/token-auth usage.
* **Chores**
  * Updated the default image publish repository for the `publish` target to `quay.io/rhoai/odh-cli-rhel9`.
* **Tests**
  * Updated expected check name and remediation text to match the **3.3+** flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->