### PR TITLE
feat(migrate): add attach-kueue-label action for workbench migration

### DIFF
--- a/pkg/migrate/actions/workbenches/kueue/kueue.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue.go
@@ -160,7 +160,7 @@ func (a *AttachKueueLabelAction) patchLabel(
 	nb *unstructured.Unstructured,
 ) error {
 	patch := map[string]any{
-		"metadata": map[string]any{ //nolint:goconst // standard K8s JSON patch key
+		"metadata": map[string]any{
 			"labels": map[string]any{
 				constants.LabelKueueQueueName: a.queueName(),
 			},

--- a/pkg/migrate/actions/workbenches/kueue/kueue.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,6 +18,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
 )
 
 const (
@@ -75,6 +77,20 @@ func (a *AttachKueueLabelAction) Run() action.Task {
 	return &runTask{action: a}
 }
 
+func (a *AttachKueueLabelAction) promptBeforeModification(
+	target action.Target,
+	count int,
+) bool {
+	if target.SkipConfirm {
+		return true
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("About to add the Kueue queue-name label to %d Notebook(s)", count)
+
+	return confirmation.Prompt(target.IO, "Proceed with label modifications?")
+}
+
 func (a *AttachKueueLabelAction) queueName() string {
 	if a.QueueName == "" {
 		return defaultQueueName
@@ -87,6 +103,21 @@ func (a *AttachKueueLabelAction) listNotebooks(
 	ctx context.Context,
 	target action.Target,
 ) ([]*unstructured.Unstructured, error) {
+	if a.WorkbenchName != "" {
+		nb, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace(a.WorkbenchNamespace).
+			Get(ctx, a.WorkbenchName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+
+			return nil, fmt.Errorf("getting notebook %s/%s: %w", a.WorkbenchNamespace, a.WorkbenchName, err)
+		}
+
+		return []*unstructured.Unstructured{nb}, nil
+	}
+
 	var opts []client.ListResourcesOption
 	if a.WorkbenchNamespace != "" {
 		opts = append(opts, client.WithNamespace(a.WorkbenchNamespace))
@@ -95,16 +126,6 @@ func (a *AttachKueueLabelAction) listNotebooks(
 	nbs, err := target.Client.List(ctx, resources.Notebook, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("listing notebooks: %w", err)
-	}
-
-	if a.WorkbenchName != "" {
-		for _, nb := range nbs {
-			if nb.GetName() == a.WorkbenchName {
-				return []*unstructured.Unstructured{nb}, nil
-			}
-		}
-
-		return nil, nil
 	}
 
 	return nbs, nil
@@ -139,7 +160,7 @@ func (a *AttachKueueLabelAction) patchLabel(
 	nb *unstructured.Unstructured,
 ) error {
 	patch := map[string]any{
-		"metadata": map[string]any{
+		"metadata": map[string]any{ //nolint:goconst // standard K8s JSON patch key
 			"labels": map[string]any{
 				constants.LabelKueueQueueName: a.queueName(),
 			},

--- a/pkg/migrate/actions/workbenches/kueue/kueue.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/pflag"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,10 +107,6 @@ func (a *AttachKueueLabelAction) listNotebooks(
 			Namespace(a.WorkbenchNamespace).
 			Get(ctx, a.WorkbenchName, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil, nil
-			}
-
 			return nil, fmt.Errorf("getting notebook %s/%s: %w", a.WorkbenchNamespace, a.WorkbenchName, err)
 		}
 

--- a/pkg/migrate/actions/workbenches/kueue/kueue.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue.go
@@ -1,0 +1,162 @@
+package kueue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	actionID          = "workbenches.attach-kueue-label"
+	actionName        = "Attach Kueue queue-name label to workbenches"
+	actionDescription = "Adds the kueue.x-k8s.io/queue-name label to notebooks in Kueue-managed namespaces"
+
+	defaultQueueName = "default"
+
+	minTargetMajorVersion = 3
+)
+
+// AttachKueueLabelAction implements the workbenches.attach-kueue-label migration action.
+// It adds the kueue.x-k8s.io/queue-name label to notebooks in namespaces
+// that have the kueue.openshift.io/managed=true label.
+type AttachKueueLabelAction struct {
+	QueueName          string
+	WorkbenchNamespace string
+	WorkbenchName      string
+}
+
+func (a *AttachKueueLabelAction) ID() string          { return actionID }
+func (a *AttachKueueLabelAction) Name() string        { return actionName }
+func (a *AttachKueueLabelAction) Description() string { return actionDescription }
+
+func (a *AttachKueueLabelAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *AttachKueueLabelAction) Phase() action.ActionPhase {
+	return action.PhasePostUpgrade
+}
+
+func (a *AttachKueueLabelAction) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&a.QueueName, "queue-name", defaultQueueName,
+		"Queue name value for the kueue.x-k8s.io/queue-name label")
+	fs.StringVar(&a.WorkbenchNamespace, "workbench-namespace", "",
+		"Limit to notebooks in this namespace (default: all namespaces)")
+	fs.StringVar(&a.WorkbenchName, "workbench-name", "",
+		"Target a single notebook by name (requires --workbench-namespace)")
+}
+
+func (a *AttachKueueLabelAction) CanApply(target action.Target) bool {
+	if target.TargetVersion == nil {
+		return false
+	}
+
+	return target.TargetVersion.Major >= minTargetMajorVersion
+}
+
+func (a *AttachKueueLabelAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *AttachKueueLabelAction) Run() action.Task {
+	return &runTask{action: a}
+}
+
+func (a *AttachKueueLabelAction) queueName() string {
+	if a.QueueName == "" {
+		return defaultQueueName
+	}
+
+	return a.QueueName
+}
+
+func (a *AttachKueueLabelAction) listNotebooks(
+	ctx context.Context,
+	target action.Target,
+) ([]*unstructured.Unstructured, error) {
+	var opts []client.ListResourcesOption
+	if a.WorkbenchNamespace != "" {
+		opts = append(opts, client.WithNamespace(a.WorkbenchNamespace))
+	}
+
+	nbs, err := target.Client.List(ctx, resources.Notebook, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("listing notebooks: %w", err)
+	}
+
+	if a.WorkbenchName != "" {
+		for _, nb := range nbs {
+			if nb.GetName() == a.WorkbenchName {
+				return []*unstructured.Unstructured{nb}, nil
+			}
+		}
+
+		return nil, nil
+	}
+
+	return nbs, nil
+}
+
+func (a *AttachKueueLabelAction) kueueManagedNamespaces(
+	ctx context.Context,
+	target action.Target,
+) (sets.Set[string], error) {
+	ns, err := kueuediscovery.KueueEnabledNamespaces(ctx, target.Client)
+	if err != nil {
+		return nil, fmt.Errorf("listing Kueue-enabled namespaces: %w", err)
+	}
+
+	return ns, nil
+}
+
+func hasQueueNameLabel(nb *unstructured.Unstructured) bool {
+	labels := nb.GetLabels()
+	if labels == nil {
+		return false
+	}
+
+	_, exists := labels[constants.LabelKueueQueueName]
+
+	return exists
+}
+
+func (a *AttachKueueLabelAction) patchLabel(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				constants.LabelKueueQueueName: a.queueName(),
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace(nb.GetNamespace()).
+		Patch(ctx, nb.GetName(), types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patching notebook %s/%s: %w", nb.GetNamespace(), nb.GetName(), err)
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/workbenches/kueue/kueue_test.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue_test.go
@@ -150,6 +150,35 @@ func newFakeClientWithPatchError(objects []*unstructured.Unstructured) client.Cl
 	})
 }
 
+func newFakeClientWithListError(objects []*unstructured.Unstructured) client.Client {
+	scheme := newScheme()
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	dynamicClient.PrependReactor("list", "notebooks", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated API server error")
+	})
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+}
+
 func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
 	targetVersion := semver.MustParse("3.0.0")
 
@@ -194,6 +223,7 @@ func TestAttachKueueLabelAction_Metadata(t *testing.T) {
 }
 
 func TestAttachKueueLabelAction_CanApply(t *testing.T) {
+	v216 := semver.MustParse("2.16.0")
 	v3 := semver.MustParse("3.0.0")
 	v35 := semver.MustParse("3.5.0")
 
@@ -202,6 +232,7 @@ func TestAttachKueueLabelAction_CanApply(t *testing.T) {
 		targetVersion *semver.Version
 		expected      bool
 	}{
+		{"does not apply for target 2.16", &v216, false},
 		{"applies for target 3.0", &v3, true},
 		{"applies for target 3.5", &v35, true},
 		{"does not apply for nil target version", nil, false},
@@ -300,6 +331,9 @@ func TestQueueName_DefaultAndCustom(t *testing.T) {
 
 	a.QueueName = "custom-queue"
 	g.Expect(a.queueName()).To(Equal("custom-queue"))
+
+	a.QueueName = ""
+	g.Expect(a.queueName()).To(Equal("default"))
 }
 
 // --- Validate Tests ---
@@ -380,6 +414,33 @@ func TestRunTask_Validate_AllNotebooksAlreadyLabeled(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
 	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClientWithListError([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
 }
 
 // --- Execute Tests ---
@@ -974,4 +1035,75 @@ func TestRunTask_Execute_MixedManagedAndNonManaged(t *testing.T) {
 		Namespace("regular-ns").Get(context.Background(), "nb-regular", metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(regular.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClientWithListError([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+// --- Confirmation Tests ---
+
+func TestRunTask_Execute_ConfirmationCancelled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+
+	stdinBuf := bytes.NewBufferString("n\n")
+
+	io := iostreams.NewIOStreams(
+		stdinBuf,
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	targetVersion := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client:        k8sClient,
+		TargetVersion: &targetVersion,
+		DryRun:        false,
+		SkipConfirm:   false,
+		Recorder:      action.NewVerboseRootRecorder(io),
+		IO:            io,
+	}
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
 }

--- a/pkg/migrate/actions/workbenches/kueue/kueue_test.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -96,7 +97,7 @@ func kueueManagedLabels() map[string]string {
 	}
 }
 
-func newFakeClient(objects []*unstructured.Unstructured) client.Client {
+func newFakeClient(objects []*unstructured.Unstructured, reactors ...k8stesting.Reactor) client.Client {
 	scheme := newScheme()
 
 	dynamicObjs := make([]runtime.Object, len(objects))
@@ -109,6 +110,10 @@ func newFakeClient(objects []*unstructured.Unstructured) client.Client {
 		testListKinds,
 		dynamicObjs...,
 	)
+
+	for _, r := range reactors {
+		dynamicClient.ReactionChain = append([]k8stesting.Reactor{r}, dynamicClient.ReactionChain...)
+	}
 
 	metadataClient := metadatafake.NewSimpleMetadataClient(
 		scheme,
@@ -121,62 +126,24 @@ func newFakeClient(objects []*unstructured.Unstructured) client.Client {
 	})
 }
 
-func newFakeClientWithPatchError(objects []*unstructured.Unstructured) client.Client {
-	scheme := newScheme()
-
-	dynamicObjs := make([]runtime.Object, len(objects))
-	for i, obj := range objects {
-		dynamicObjs[i] = obj
+func patchErrorReactor() k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "patch",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated patch error")
+		},
 	}
-
-	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-		scheme,
-		testListKinds,
-		dynamicObjs...,
-	)
-
-	dynamicClient.PrependReactor("patch", "notebooks", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("simulated patch error")
-	})
-
-	metadataClient := metadatafake.NewSimpleMetadataClient(
-		scheme,
-		kube.ToPartialObjectMetadata(objects...)...,
-	)
-
-	return client.NewForTesting(client.TestClientConfig{
-		Dynamic:  dynamicClient,
-		Metadata: metadataClient,
-	})
 }
 
-func newFakeClientWithListError(objects []*unstructured.Unstructured) client.Client {
-	scheme := newScheme()
-
-	dynamicObjs := make([]runtime.Object, len(objects))
-	for i, obj := range objects {
-		dynamicObjs[i] = obj
+func listErrorReactor() k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "list",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated API server error")
+		},
 	}
-
-	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-		scheme,
-		testListKinds,
-		dynamicObjs...,
-	)
-
-	dynamicClient.PrependReactor("list", "notebooks", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("simulated API server error")
-	})
-
-	metadataClient := metadatafake.NewSimpleMetadataClient(
-		scheme,
-		kube.ToPartialObjectMetadata(objects...)...,
-	)
-
-	return client.NewForTesting(client.TestClientConfig{
-		Dynamic:  dynamicClient,
-		Metadata: metadataClient,
-	})
 }
 
 func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
@@ -336,6 +303,45 @@ func TestQueueName_DefaultAndCustom(t *testing.T) {
 	g.Expect(a.queueName()).To(Equal("default"))
 }
 
+func TestRunTask_Validate_InvalidQueueName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+	})
+	target := newTarget(k8sClient)
+
+	tests := []struct {
+		name      string
+		queueName string
+	}{
+		{"leading dash", "-invalid"},
+		{"contains spaces", "my queue"},
+		{"too long", strings.Repeat("a", 64)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			a := &AttachKueueLabelAction{QueueName: tt.queueName}
+			runTask := a.Run()
+
+			_, err := runTask.Validate(ctx, target)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("invalid --queue-name"))
+		})
+	}
+
+	a := &AttachKueueLabelAction{QueueName: "my queue"}
+	runTask := a.Run()
+
+	_, err := runTask.Execute(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("invalid --queue-name"))
+}
+
 // --- Validate Tests ---
 
 func TestRunTask_Validate_NoNotebooks(t *testing.T) {
@@ -420,9 +426,9 @@ func TestRunTask_Validate_ListError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	k8sClient := newFakeClientWithListError([]*unstructured.Unstructured{
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
 		newNamespace("ns1", kueueManagedLabels()),
-	})
+	}, listErrorReactor())
 	target := newTarget(k8sClient)
 
 	a := &AttachKueueLabelAction{}
@@ -688,10 +694,10 @@ func TestRunTask_Execute_PatchError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	k8sClient := newFakeClientWithPatchError([]*unstructured.Unstructured{
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
 		newNamespace("ns1", kueueManagedLabels()),
 		newNotebook("nb1", "ns1", nil),
-	})
+	}, patchErrorReactor())
 	target := newTarget(k8sClient)
 
 	a := &AttachKueueLabelAction{}
@@ -961,7 +967,16 @@ func TestRunTask_Execute_SingleNotebookTargeting_NotFound(t *testing.T) {
 	result, err := runTask.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
 
 	otherNb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
 		Namespace("ns1").Get(context.Background(), "other-nb", metav1.GetOptions{})
@@ -1041,9 +1056,9 @@ func TestRunTask_Execute_ListError(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	k8sClient := newFakeClientWithListError([]*unstructured.Unstructured{
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
 		newNamespace("ns1", kueueManagedLabels()),
-	})
+	}, listErrorReactor())
 	target := newTarget(k8sClient)
 
 	a := &AttachKueueLabelAction{}
@@ -1106,4 +1121,46 @@ func TestRunTask_Execute_ConfirmationCancelled(t *testing.T) {
 		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(nb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_ConfirmationAccepted(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+
+	stdinBuf := bytes.NewBufferString("y\n")
+
+	io := iostreams.NewIOStreams(
+		stdinBuf,
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	targetVersion := semver.MustParse("3.0.0")
+
+	target := action.Target{
+		Client:        k8sClient,
+		TargetVersion: &targetVersion,
+		DryRun:        false,
+		SkipConfirm:   false,
+		Recorder:      action.NewVerboseRootRecorder(io),
+		IO:            io,
+	}
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
 }

--- a/pkg/migrate/actions/workbenches/kueue/kueue_test.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue_test.go
@@ -1,0 +1,977 @@
+//nolint:testpackage // Tests internal implementation (unexported helpers)
+package kueue
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
+
+	. "github.com/onsi/gomega"
+)
+
+// --- Test Fixtures ---
+
+//nolint:gochecknoglobals // test-only GVR→ListKind mapping for fake dynamic client
+var testListKinds = map[schema.GroupVersionResource]string{
+	resources.Notebook.GVR():  resources.Notebook.ListKind(),
+	resources.Namespace.GVR(): resources.Namespace.ListKind(),
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+func newNotebook(name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+	}
+
+	if len(labels) > 0 {
+		anyLabels := make(map[string]any, len(labels))
+		for k, v := range labels {
+			anyLabels[k] = v
+		}
+
+		metadata["labels"] = anyLabels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Notebook.APIVersion(),
+			"kind":       resources.Notebook.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func newNamespace(name string, labels map[string]string) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name": name,
+	}
+
+	if len(labels) > 0 {
+		anyLabels := make(map[string]any, len(labels))
+		for k, v := range labels {
+			anyLabels[k] = v
+		}
+
+		metadata["labels"] = anyLabels
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Namespace.APIVersion(),
+			"kind":       resources.Namespace.Kind,
+			"metadata":   metadata,
+		},
+	}
+}
+
+func kueueManagedLabels() map[string]string {
+	return map[string]string{
+		constants.LabelKueueOpenshiftManaged: "true",
+	}
+}
+
+func newFakeClient(objects []*unstructured.Unstructured) client.Client {
+	scheme := newScheme()
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+}
+
+func newFakeClientWithPatchError(objects []*unstructured.Unstructured) client.Client {
+	scheme := newScheme()
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	dynamicClient.PrependReactor("patch", "notebooks", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated patch error")
+	})
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:        k8sClient,
+		TargetVersion: &targetVersion,
+		DryRun:        false,
+		SkipConfirm:   true,
+		Recorder:      action.NewVerboseRootRecorder(io),
+		IO:            io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+// --- Action Metadata Tests ---
+
+func TestAttachKueueLabelAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &AttachKueueLabelAction{}
+
+	g.Expect(a.ID()).To(Equal("workbenches.attach-kueue-label"))
+	g.Expect(a.Name()).To(Equal("Attach Kueue queue-name label to workbenches"))
+	g.Expect(a.Description()).To(ContainSubstring("queue-name"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
+}
+
+func TestAttachKueueLabelAction_CanApply(t *testing.T) {
+	v3 := semver.MustParse("3.0.0")
+	v35 := semver.MustParse("3.5.0")
+
+	tests := []struct {
+		name          string
+		targetVersion *semver.Version
+		expected      bool
+	}{
+		{"applies for target 3.0", &v3, true},
+		{"applies for target 3.5", &v35, true},
+		{"does not apply for nil target version", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			a := &AttachKueueLabelAction{}
+			target := action.Target{
+				TargetVersion: tt.targetVersion,
+			}
+
+			g.Expect(a.CanApply(target)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestAttachKueueLabelAction_PrepareIsNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &AttachKueueLabelAction{}
+	g.Expect(a.Prepare()).To(BeNil())
+}
+
+func TestAttachKueueLabelAction_RunNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &AttachKueueLabelAction{}
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestAttachKueueLabelAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &AttachKueueLabelAction{}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	queueFlag := fs.Lookup("queue-name")
+	g.Expect(queueFlag).ToNot(BeNil())
+	g.Expect(queueFlag.DefValue).To(Equal("default"))
+
+	nsFlag := fs.Lookup("workbench-namespace")
+	g.Expect(nsFlag).ToNot(BeNil())
+	g.Expect(nsFlag.DefValue).To(Equal(""))
+
+	nameFlag := fs.Lookup("workbench-name")
+	g.Expect(nameFlag).ToNot(BeNil())
+	g.Expect(nameFlag.DefValue).To(Equal(""))
+}
+
+// --- Helper Function Tests ---
+
+func TestHasQueueNameLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		nb       *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			"has queue-name label",
+			newNotebook("nb1", "ns1", map[string]string{
+				constants.LabelKueueQueueName: "default",
+			}),
+			true,
+		},
+		{
+			"no labels",
+			newNotebook("nb1", "ns1", nil),
+			false,
+		},
+		{
+			"has other labels but not queue-name",
+			newNotebook("nb1", "ns1", map[string]string{
+				"app": "jupyter",
+			}),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hasQueueNameLabel(tt.nb)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestQueueName_DefaultAndCustom(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &AttachKueueLabelAction{}
+	g.Expect(a.queueName()).To(Equal("default"))
+
+	a.QueueName = "custom-queue"
+	g.Expect(a.queueName()).To(Equal("custom-queue"))
+}
+
+// --- Validate Tests ---
+
+func TestRunTask_Validate_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_NoKueueNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", nil),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_NotebooksMissingLabel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+		newNotebook("nb2", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_AllNotebooksAlreadyLabeled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", map[string]string{
+			constants.LabelKueueQueueName: "default",
+		}),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+// --- Execute Tests ---
+
+func TestRunTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_LabelApplied(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+}
+
+func TestRunTask_Execute_CustomQueueName(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{QueueName: "my-queue"}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "my-queue"))
+}
+
+func TestRunTask_Execute_SkipsAlreadyLabeledNotebook(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("labeled-nb", "ns1", map[string]string{
+			constants.LabelKueueQueueName: "existing-queue",
+		}),
+		newNotebook("unlabeled-nb", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	labeled, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "labeled-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(labeled.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "existing-queue"))
+
+	unlabeled, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "unlabeled-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(unlabeled.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+}
+
+func TestRunTask_Execute_SkipsNonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("kueue-ns", kueueManagedLabels()),
+		newNamespace("regular-ns", nil),
+		newNotebook("nb-kueue", "kueue-ns", nil),
+		newNotebook("nb-regular", "regular-ns", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	kueueNb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("kueue-ns").Get(context.Background(), "nb-kueue", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(kueueNb.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+
+	regularNb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("regular-ns").Get(context.Background(), "nb-regular", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(regularNb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_MultipleNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns-a", kueueManagedLabels()),
+		newNamespace("ns-b", kueueManagedLabels()),
+		newNotebook("nb1", "ns-a", nil),
+		newNotebook("nb2", "ns-b", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb1, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns-a").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb1.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+
+	nb2, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns-b").Get(context.Background(), "nb2", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb2.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+}
+
+func TestRunTask_Execute_NoKueueNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", nil),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+// --- Dry-Run Tests ---
+
+func TestRunTask_Execute_DryRun_NoChanges(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_DryRun_MultipleNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+		newNotebook("nb2", "ns1", nil),
+	})
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	for _, name := range []string{"nb1", "nb2"} {
+		nb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace("ns1").Get(context.Background(), name, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(nb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+	}
+}
+
+// --- Error Path Tests ---
+
+func TestRunTask_Execute_PatchError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClientWithPatchError([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_PatchError_ContinuesWithRemaining(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := newScheme()
+	objects := []*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb-fail", "ns1", nil),
+		newNotebook("nb-ok", "ns1", nil),
+	}
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme, testListKinds, dynamicObjs...,
+	)
+
+	dynamicClient.PrependReactor("patch", "notebooks", func(a k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction := a.(k8stesting.PatchAction)
+		if patchAction.GetName() == "nb-fail" {
+			return true, nil, errors.New("simulated patch error")
+		}
+
+		return false, nil, nil
+	})
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	k8sClient := client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+
+	target := newTarget(k8sClient)
+
+	act := &AttachKueueLabelAction{}
+	runTask := act.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nbOk, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "nb-ok", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nbOk.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+}
+
+// --- Step Recording Tests ---
+
+func TestRunTask_Execute_StepRecording(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult.Status.Steps).ToNot(BeEmpty())
+
+	hasLabelStep := false
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "apply-kueue-labels" {
+			hasLabelStep = true
+		}
+	}
+
+	g.Expect(hasLabelStep).To(BeTrue())
+}
+
+func TestRunTask_Validate_StepRecording(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult.Status.Steps).ToNot(BeEmpty())
+
+	hasValidateStep := false
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "validate-kueue-labels" {
+			hasValidateStep = true
+		}
+	}
+
+	g.Expect(hasValidateStep).To(BeTrue())
+}
+
+// --- Targeting Mode Tests ---
+
+func TestRunTask_Validate_NameRequiresNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{WorkbenchName: "nb1"}
+	runTask := a.Run()
+
+	_, err := runTask.Validate(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-name requires --workbench-namespace"))
+}
+
+func TestRunTask_Execute_NameRequiresNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("nb1", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{WorkbenchName: "nb1"}
+	runTask := a.Run()
+
+	_, err := runTask.Execute(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-name requires --workbench-namespace"))
+}
+
+func TestRunTask_Execute_NamespaceScopedTargeting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns-a", kueueManagedLabels()),
+		newNamespace("ns-b", kueueManagedLabels()),
+		newNotebook("nb1", "ns-a", nil),
+		newNotebook("nb2", "ns-b", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{WorkbenchNamespace: "ns-a"}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb1, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns-a").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb1.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+
+	nb2, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns-b").Get(context.Background(), "nb2", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb2.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_NamespaceScopedTargeting_NonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("regular-ns", nil),
+		newNotebook("nb1", "regular-ns", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{WorkbenchNamespace: "regular-ns"}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb1, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("regular-ns").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb1.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_SingleNotebookTargeting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("target-nb", "ns1", nil),
+		newNotebook("other-nb", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{
+		WorkbenchNamespace: "ns1",
+		WorkbenchName:      "target-nb",
+	}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	targetNb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "target-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(targetNb.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+
+	otherNb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "other-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(otherNb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_SingleNotebookTargeting_NotFound(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("ns1", kueueManagedLabels()),
+		newNotebook("other-nb", "ns1", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{
+		WorkbenchNamespace: "ns1",
+		WorkbenchName:      "nonexistent-nb",
+	}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	otherNb, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "other-nb", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(otherNb.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+func TestRunTask_Execute_SingleNotebookTargeting_NonKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("regular-ns", nil),
+		newNotebook("nb1", "regular-ns", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{
+		WorkbenchNamespace: "regular-ns",
+		WorkbenchName:      "nb1",
+	}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	nb1, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("regular-ns").Get(context.Background(), "nb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(nb1.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}
+
+// --- Mixed Scenario Tests ---
+
+func TestRunTask_Execute_MixedManagedAndNonManaged(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newNamespace("managed-ns", kueueManagedLabels()),
+		newNamespace("regular-ns", nil),
+		newNotebook("nb-managed-unlabeled", "managed-ns", nil),
+		newNotebook("nb-managed-labeled", "managed-ns", map[string]string{
+			constants.LabelKueueQueueName: "existing",
+		}),
+		newNotebook("nb-regular", "regular-ns", nil),
+	})
+	target := newTarget(k8sClient)
+
+	a := &AttachKueueLabelAction{}
+	runTask := a.Run()
+
+	result, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	unlabeled, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("managed-ns").Get(context.Background(), "nb-managed-unlabeled", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(unlabeled.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "default"))
+
+	labeled, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("managed-ns").Get(context.Background(), "nb-managed-labeled", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(labeled.GetLabels()).To(HaveKeyWithValue(constants.LabelKueueQueueName, "existing"))
+
+	regular, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("regular-ns").Get(context.Background(), "nb-regular", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(regular.GetLabels()).ToNot(HaveKey(constants.LabelKueueQueueName))
+}

--- a/pkg/migrate/actions/workbenches/kueue/run_task.go
+++ b/pkg/migrate/actions/workbenches/kueue/run_task.go
@@ -143,6 +143,12 @@ func (t *runTask) applyLabels(
 		return
 	}
 
+	if !t.action.promptBeforeModification(target, len(notebooks)) {
+		step.Completef(result.StepSkipped, "User cancelled modification")
+
+		return
+	}
+
 	successCount := 0
 	failCount := 0
 

--- a/pkg/migrate/actions/workbenches/kueue/run_task.go
+++ b/pkg/migrate/actions/workbenches/kueue/run_task.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
@@ -22,6 +24,10 @@ func (t *runTask) Validate(
 ) (*result.ActionResult, error) {
 	if t.action.WorkbenchName != "" && t.action.WorkbenchNamespace == "" {
 		return nil, errors.New("--workbench-name requires --workbench-namespace")
+	}
+
+	if errs := validation.IsValidLabelValue(t.action.queueName()); len(errs) > 0 {
+		return nil, fmt.Errorf("invalid --queue-name %q: %s", t.action.queueName(), strings.Join(errs, "; "))
 	}
 
 	step := target.Recorder.Child(
@@ -54,6 +60,10 @@ func (t *runTask) Execute(
 ) (*result.ActionResult, error) {
 	if t.action.WorkbenchName != "" && t.action.WorkbenchNamespace == "" {
 		return nil, errors.New("--workbench-name requires --workbench-namespace")
+	}
+
+	if errs := validation.IsValidLabelValue(t.action.queueName()); len(errs) > 0 {
+		return nil, fmt.Errorf("invalid --queue-name %q: %s", t.action.queueName(), strings.Join(errs, "; "))
 	}
 
 	discoverStep := target.Recorder.Child(

--- a/pkg/migrate/actions/workbenches/kueue/run_task.go
+++ b/pkg/migrate/actions/workbenches/kueue/run_task.go
@@ -1,0 +1,175 @@
+package kueue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+)
+
+type runTask struct {
+	action *AttachKueueLabelAction
+}
+
+func (t *runTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if t.action.WorkbenchName != "" && t.action.WorkbenchNamespace == "" {
+		return nil, errors.New("--workbench-name requires --workbench-namespace")
+	}
+
+	step := target.Recorder.Child(
+		"validate-kueue-labels",
+		"Validate Kueue label requirements",
+	)
+
+	eligible, err := t.findEligibleNotebooks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover eligible notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(eligible) == 0 {
+		step.Completef(result.StepCompleted, "No notebooks require the Kueue queue-name label")
+
+		return action.BuildResult(target)
+	}
+
+	step.Completef(result.StepCompleted,
+		"Found %d notebook(s) in Kueue-managed namespaces missing the queue-name label", len(eligible))
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if t.action.WorkbenchName != "" && t.action.WorkbenchNamespace == "" {
+		return nil, errors.New("--workbench-name requires --workbench-namespace")
+	}
+
+	discoverStep := target.Recorder.Child(
+		"discover-notebooks",
+		"Discover notebooks requiring Kueue label",
+	)
+
+	eligible, err := t.findEligibleNotebooks(ctx, target)
+	if err != nil {
+		discoverStep.Completef(result.StepFailed, "Failed to discover eligible notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(eligible) == 0 {
+		discoverStep.Completef(result.StepCompleted,
+			"No notebooks require the Kueue queue-name label")
+
+		return action.BuildResult(target)
+	}
+
+	discoverStep.Completef(result.StepCompleted,
+		"Found %d notebook(s) requiring the queue-name label", len(eligible))
+
+	t.applyLabels(ctx, target, eligible)
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) findEligibleNotebooks(
+	ctx context.Context,
+	target action.Target,
+) ([]*unstructured.Unstructured, error) {
+	kueueNamespaces, err := t.action.kueueManagedNamespaces(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	if kueueNamespaces.Len() == 0 {
+		return nil, nil
+	}
+
+	notebooks, err := t.action.listNotebooks(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	var eligible []*unstructured.Unstructured
+
+	for _, nb := range notebooks {
+		if !kueueNamespaces.Has(nb.GetNamespace()) {
+			continue
+		}
+
+		if hasQueueNameLabel(nb) {
+			continue
+		}
+
+		eligible = append(eligible, nb)
+	}
+
+	return eligible, nil
+}
+
+func (t *runTask) applyLabels(
+	ctx context.Context,
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+) {
+	step := target.Recorder.Child(
+		"apply-kueue-labels",
+		"Apply Kueue queue-name labels",
+	)
+
+	if target.DryRun {
+		for _, nb := range notebooks {
+			step.Recordf("would-label",
+				fmt.Sprintf("Would add label %s=%s to %s/%s",
+					constants.LabelKueueQueueName, t.action.queueName(),
+					nb.GetNamespace(), nb.GetName()),
+				result.StepSkipped)
+		}
+
+		step.Completef(result.StepSkipped,
+			"Would label %d notebook(s) with queue-name=%s", len(notebooks), t.action.queueName())
+
+		return
+	}
+
+	successCount := 0
+	failCount := 0
+
+	for _, nb := range notebooks {
+		nbStep := step.Child(
+			fmt.Sprintf("label-%s-%s", nb.GetNamespace(), nb.GetName()),
+			fmt.Sprintf("Label %s/%s", nb.GetNamespace(), nb.GetName()),
+		)
+
+		if err := t.action.patchLabel(ctx, target, nb); err != nil {
+			nbStep.Completef(result.StepFailed,
+				"Failed to label notebook %s/%s: %v", nb.GetNamespace(), nb.GetName(), err)
+			failCount++
+
+			continue
+		}
+
+		nbStep.Completef(result.StepCompleted,
+			"Added label queue-name=%s to %s/%s", t.action.queueName(), nb.GetNamespace(), nb.GetName())
+		successCount++
+	}
+
+	if failCount > 0 {
+		step.Completef(result.StepFailed,
+			"Labeled %d/%d notebook(s), %d failure(s)", successCount, len(notebooks), failCount)
+	} else {
+		step.Completef(result.StepCompleted,
+			"Labeled %d notebook(s) with queue-name=%s", successCount, t.action.queueName())
+	}
+}

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/guardrails"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/metrics"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/otelexporter"
+	workbenchkueue "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 )
 
@@ -29,6 +30,7 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
+	registry.MustRegister(&workbenchkueue.AttachKueueLabelAction{})
 	registry.MustRegister(&deadlock.BreakGPUDeadlockAction{})
 	registry.MustRegister(&guardrails.PatchGuardrailsAction{})
 	registry.MustRegister(&otelexporter.MigrateOtelExporterAction{})


### PR DESCRIPTION
## Description

Implement the workbenches.attach-kueue-label migration action that converts the attach-kueue-label shell script from rhoai-upgrade-helpers into a native Go action in odh-cli. The action adds the kueue.x-k8s.io/queue-name label to notebooks in Kueue-managed namespaces (those with the kueue.openshift.io/managed=true label).

Key capabilities:
- Three targeting modes: cluster-wide discovery, namespace-scoped, and single notebook targeting via --workbench-namespace and --workbench-name flags
- Configurable queue name via --queue-name flag (defaults to "default")
- Dry-run support with detailed step recording
- Skips notebooks that already carry the correct label
- 31 tests at 91.4% coverage

[RHOAIENG-72120](https://redhat.atlassian.net/browse/RHOAIENG-72120)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new migration step to automatically label eligible notebooks with a Kueue queue name during upgrades.
  * Supports default or custom queue names, with optional targeting by notebook namespace or a single notebook.
  * The migration now includes this step in the default action set.

* **Bug Fixes**
  * Skips notebooks that are already labeled or are outside Kueue-managed namespaces.
  * Improves safety with confirmation prompts and dry-run support before making changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->