### PR TITLE
feat(mcp): add tool definitions and tests for all CLI commands

### DIFF
--- a/pkg/mcp/adapter.go
+++ b/pkg/mcp/adapter.go
@@ -14,7 +14,7 @@ import (
 )
 
 // toolDefinition pairs an MCP tool schema with a handler.
-type toolDefinition struct { //nolint:unused // used by tools.go in a follow-up PR
+type toolDefinition struct {
 	tool    mcp.Tool
 	handler server.ToolHandlerFunc
 }
@@ -35,7 +35,6 @@ type toolAdapter struct {
 	applier     argumentApplier
 }
 
-//nolint:unparam // error return required by server.ToolHandlerFunc signature
 func (a *toolAdapter) handle(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	var outBuf, errBuf bytes.Buffer
 

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -1,0 +1,643 @@
+package mcp
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	pkgcmd "github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	"github.com/opendatahub-io/odh-cli/pkg/events"
+	"github.com/opendatahub-io/odh-cli/pkg/get"
+	"github.com/opendatahub-io/odh-cli/pkg/lint"
+	"github.com/opendatahub-io/odh-cli/pkg/logs"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/status"
+)
+
+const outputJSON = "json"
+
+func parseDuration(request mcp.CallToolRequest, key, fallback string) (time.Duration, error) {
+	raw := request.GetString(key, fallback)
+	if raw == "" {
+		return 0, nil
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s duration %q: %w", key, raw, err)
+	}
+
+	return d, nil
+}
+
+// allTools returns all MCP tool definitions wired to the given ConfigFlags.
+func allTools(configFlags *genericclioptions.ConfigFlags) []toolDefinition {
+	return []toolDefinition{
+		statusTool(configFlags),
+		lintTool(configFlags),
+		getTool(configFlags),
+		depsTool(configFlags),
+		depsInstallTool(configFlags),
+		backupTool(configFlags),
+		logsTool(configFlags),
+		eventsTool(configFlags),
+		componentsListTool(configFlags),
+		componentsDescribeTool(configFlags),
+		migrateListTool(configFlags),
+		migrateRunTool(configFlags),
+	}
+}
+
+// --- odh_status ---
+
+func statusTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_status",
+		mcp.WithDescription("Show platform health and version information for OpenShift AI / RHOAI"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithBoolean("verbose", mcp.Description("Show per-item details for each section")),
+		mcp.WithArray("sections", mcp.Description("Limit output to specific sections"),
+			mcp.WithStringEnumItems([]string{"nodes", "deployments", "pods", "events", "quotas", "operator", "dsci", "dsc"})),
+		mcp.WithArray("layers", mcp.Description("Limit output to specific layers"),
+			mcp.WithStringEnumItems([]string{"infrastructure", "workload", "operator"})),
+		mcp.WithString("timeout", mcp.Description("Maximum time to wait (Go duration, e.g. '30s')"), mcp.DefaultString("30s")),
+		mcp.WithString("apps_namespace", mcp.Description("Override the applications namespace")),
+		mcp.WithString("operator_namespace", mcp.Description("Override the operator namespace")),
+		mcp.WithBoolean("include_deps", mcp.Description("Include dependency operator status"), mcp.DefaultBool(true)),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return status.NewCommand(streams, flags)
+		},
+		applier: applyStatusArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyStatusArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*status.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = status.OutputFormatJSON
+	cmd.NoColor = true
+	cmd.Verbose = request.GetBool("verbose", false)
+	cmd.Sections = request.GetStringSlice("sections", nil)
+	cmd.Layers = request.GetStringSlice("layers", nil)
+	cmd.AppsNamespace = request.GetString("apps_namespace", "")
+	cmd.OperatorNamespace = request.GetString("operator_namespace", "")
+	cmd.IncludeDeps = request.GetBool("include_deps", true)
+
+	d, err := parseDuration(request, "timeout", "30s")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Timeout = d
+	}
+
+	return nil
+}
+
+// --- odh_lint ---
+
+func lintTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_lint",
+		mcp.WithDescription("Validate current OpenShift AI installation or assess upgrade readiness"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("target_version", mcp.Description("Target version for upgrade assessment (e.g. '3.0')")),
+		mcp.WithString("severity", mcp.Description("Minimum severity threshold"),
+			mcp.Enum("prohibited", "critical", "warning", "info"), mcp.DefaultString("info")),
+		mcp.WithArray("checks", mcp.Description("Check selector patterns (glob)"), mcp.WithStringItems()),
+		mcp.WithString("isvc_deployment_mode", mcp.Description("Filter InferenceService by deployment mode"),
+			mcp.Enum("all", "serverless", "modelmesh"), mcp.DefaultString("all")),
+		mcp.WithString("timeout", mcp.Description("Maximum execution time"), mcp.DefaultString("5m")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return lint.NewCommand(streams, flags)
+		},
+		applier: applyLintArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyLintArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*lint.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = lint.OutputFormatJSON
+	cmd.Quiet = false
+	cmd.NoColor = true
+	cmd.TargetVersion = request.GetString("target_version", "")
+	cmd.ISVCDeploymentMode = request.GetString("isvc_deployment_mode", "all")
+
+	if severity := request.GetString("severity", ""); severity != "" {
+		cmd.SeverityLevel = lint.SeverityLevel(severity)
+	}
+
+	if checks := request.GetStringSlice("checks", nil); len(checks) > 0 {
+		cmd.CheckSelectors = checks
+	}
+
+	d, err := parseDuration(request, "timeout", "5m")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Timeout = d
+	}
+
+	return nil
+}
+
+// --- odh_get ---
+
+func getTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_get",
+		mcp.WithDescription("Get ODH/RHOAI resources (notebooks, inference services, serving runtimes, pipelines)"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("resource", mcp.Required(),
+			mcp.Description("Resource type"),
+			mcp.Enum("notebooks", "nb", "inferenceservices", "isvc", "servingruntimes", "sr", "datasciencepipelinesapplications", "pipeline")),
+		mcp.WithString("name", mcp.Description("Specific resource name")),
+		mcp.WithString("namespace", mcp.Description("Target namespace")),
+		mcp.WithBoolean("all_namespaces", mcp.Description("List across all namespaces")),
+		mcp.WithString("selector", mcp.Description("Label selector to filter resources")),
+		mcp.WithBoolean("verbose", mcp.Description("Show additional details")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return get.NewCommand(streams, flags)
+		},
+		applier: applyGetArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyGetArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*get.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = outputJSON
+	cmd.ResourceName = request.GetString("resource", "")
+	cmd.ItemName = request.GetString("name", "")
+	cmd.AllNamespaces = request.GetBool("all_namespaces", false)
+	cmd.LabelSelector = request.GetString("selector", "")
+	cmd.Verbose = request.GetBool("verbose", false)
+
+	if ns := request.GetString("namespace", ""); ns != "" {
+		cmd.Namespace = ns
+	}
+
+	return nil
+}
+
+// --- odh_deps ---
+
+func depsTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_deps",
+		mcp.WithDescription("Show operator dependency status for OpenShift AI / RHOAI"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithBoolean("dry_run", mcp.Description("Show manifest data without querying cluster")),
+		mcp.WithString("version", mcp.Description("ODH/RHOAI version to show dependencies for")),
+		mcp.WithBoolean("refresh", mcp.Description("Fetch latest manifest from odh-gitops")),
+		mcp.WithBoolean("verbose", mcp.Description("Enable verbose output")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return deps.NewCommand(streams, flags)
+		},
+		applier: applyDepsArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyDepsArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*deps.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.Output = outputJSON
+	cmd.DryRun = request.GetBool("dry_run", false)
+	cmd.Version = request.GetString("version", "")
+	cmd.Refresh = request.GetBool("refresh", false)
+	cmd.Verbose = request.GetBool("verbose", false)
+
+	return nil
+}
+
+// --- odh_deps_install ---
+
+func depsInstallTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_deps_install",
+		mcp.WithDescription("Install missing operator dependencies for OpenShift AI / RHOAI via OLM"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithString("target", mcp.Description("Specific dependency name to install (empty = all missing required)")),
+		mcp.WithBoolean("dry_run", mcp.Description("Show what would be installed without executing"), mcp.DefaultBool(true)),
+		mcp.WithBoolean("include_optional", mcp.Description("Install optional dependencies in addition to required")),
+		mcp.WithString("version", mcp.Description("ODH/RHOAI version to install dependencies for")),
+		mcp.WithBoolean("refresh", mcp.Description("Fetch latest manifest from odh-gitops")),
+		mcp.WithString("timeout", mcp.Description("Timeout for waiting on each operator CSV"), mcp.DefaultString("5m")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return deps.NewInstallCommand(streams, flags)
+		},
+		applier: applyDepsInstallArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyDepsInstallArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*deps.InstallCommand)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.TargetDep = request.GetString("target", "")
+	cmd.DryRun = request.GetBool("dry_run", true)
+	cmd.IncludeOptional = request.GetBool("include_optional", false)
+	cmd.Version = request.GetString("version", "")
+	cmd.Refresh = request.GetBool("refresh", false)
+
+	d, err := parseDuration(request, "timeout", "5m")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Timeout = d
+	}
+
+	return nil
+}
+
+// --- odh_backup ---
+
+func backupTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_backup",
+		mcp.WithDescription("Backup OpenShift AI workloads and dependencies as YAML"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("output_dir", mcp.Description("Output directory for backups (empty = return YAML in response)")),
+		mcp.WithArray("includes", mcp.Description("Workload types to include (e.g. notebooks.kubeflow.org)"), mcp.WithStringItems()),
+		mcp.WithArray("excludes", mcp.Description("Workload types to exclude"), mcp.WithStringItems()),
+		mcp.WithBoolean("dependencies", mcp.Description("Resolve and backup workload dependencies"), mcp.DefaultBool(true)),
+		mcp.WithBoolean("dry_run", mcp.Description("Preview backup without writing files")),
+		mcp.WithString("timeout", mcp.Description("Timeout for backup operation"), mcp.DefaultString("10m")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			cmd := backup.NewCommand(streams)
+			cmd.ConfigFlags = flags
+
+			return cmd
+		},
+		applier: applyBackupArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyBackupArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*backup.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	outputDir := request.GetString("output_dir", "")
+	if outputDir != "" {
+		outputDir = filepath.Clean(outputDir)
+		if filepath.IsAbs(outputDir) {
+			return fmt.Errorf("output_dir %q must be a relative path", outputDir)
+		}
+		if strings.HasPrefix(outputDir, "..") {
+			return fmt.Errorf("output_dir %q must not traverse above working directory", outputDir)
+		}
+	}
+
+	cmd.OutputDir = outputDir
+	cmd.Includes = request.GetStringSlice("includes", nil)
+	cmd.Excludes = request.GetStringSlice("excludes", nil)
+	cmd.Dependencies = request.GetBool("dependencies", true)
+	cmd.DryRun = request.GetBool("dry_run", false)
+
+	d, err := parseDuration(request, "timeout", "10m")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Timeout = d
+	}
+
+	return nil
+}
+
+// --- odh_logs ---
+
+func logsTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_logs",
+		mcp.WithDescription("Get logs from OpenShift AI operator or component pods"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("target", mcp.Required(),
+			mcp.Description("Log target: 'operator' or a component name (e.g. dashboard, kserve, ray)"),
+			mcp.Enum(append([]string{"operator"}, resources.ComponentNames()...)...)),
+		mcp.WithInteger("tail", mcp.Description("Number of recent log lines to display (default: all)"), mcp.DefaultNumber(-1)),
+		mcp.WithString("since", mcp.Description("Only return logs newer than a relative duration (e.g. 5s, 2m, 3h)")),
+		mcp.WithBoolean("previous", mcp.Description("Show logs from previous terminated container")),
+		mcp.WithString("container", mcp.Description("Container name to get logs from")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return logs.NewCommand(streams, flags)
+		},
+		applier: applyLogsArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyLogsArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*logs.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.Follow = false // MCP cannot stream
+	cmd.Target = request.GetString("target", "")
+	cmd.Tail = int64(request.GetInt("tail", -1))
+	cmd.Previous = request.GetBool("previous", false)
+	cmd.Container = request.GetString("container", "")
+
+	d, err := parseDuration(request, "since", "")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Since = d
+	}
+
+	return nil
+}
+
+// --- odh_events ---
+
+func eventsTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_events",
+		mcp.WithDescription("List Kubernetes events for OpenShift AI components"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("type", mcp.Description("Filter events by type: Warning or Normal"), mcp.Enum("Warning", "Normal")),
+		mcp.WithString("since", mcp.Description("Only show events newer than this duration (e.g. 5m, 1h)"), mcp.DefaultString("1h")),
+		mcp.WithBoolean("all_namespaces", mcp.Description("List events across all ODH namespaces")),
+		mcp.WithString("component", mcp.Description("Filter events by ODH component (dashboard, kserve, ray, etc.)"),
+			mcp.Enum(resources.ComponentNames()...)),
+		mcp.WithString("operator_namespace", mcp.Description("Override the operator namespace")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return events.NewCommand(streams, flags)
+		},
+		applier: applyEventsArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyEventsArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*events.Command)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = outputJSON
+	cmd.Follow = false // MCP cannot stream
+	cmd.EventType = request.GetString("type", "")
+	cmd.AllNamespaces = request.GetBool("all_namespaces", false)
+	cmd.Component = request.GetString("component", "")
+	cmd.OperatorNSOverride = request.GetString("operator_namespace", "")
+
+	d, err := parseDuration(request, "since", "1h")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Since = d
+	}
+
+	return nil
+}
+
+// --- odh_components_list ---
+
+func componentsListTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_components_list",
+		mcp.WithDescription("List all OpenShift AI components and their status"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithBoolean("verbose", mcp.Description("Enable verbose output")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return components.NewListCommand(streams, flags)
+		},
+		applier: applyComponentsListArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyComponentsListArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*components.ListCommand)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = outputJSON
+	cmd.Verbose = request.GetBool("verbose", false)
+
+	return nil
+}
+
+// --- odh_components_describe ---
+
+func componentsDescribeTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_components_describe",
+		mcp.WithDescription("Show detailed information about a specific OpenShift AI component"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("component", mcp.Required(),
+			mcp.Description("Component name (e.g. dashboard, kserve, ray)"),
+			mcp.Enum(resources.ComponentNames()...)),
+		mcp.WithBoolean("verbose", mcp.Description("Enable verbose output")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			return components.NewDescribeCommand(streams, flags)
+		},
+		applier: applyComponentsDescribeArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyComponentsDescribeArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*components.DescribeCommand)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = outputJSON
+	cmd.ComponentName = request.GetString("component", "")
+	cmd.Verbose = request.GetBool("verbose", false)
+
+	return nil
+}
+
+// --- odh_migrate_list ---
+
+func migrateListTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_migrate_list",
+		mcp.WithDescription("List available migrations for OpenShift AI"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithString("target_version", mcp.Description("Target version to filter migrations")),
+		mcp.WithBoolean("all", mcp.Description("Show all migrations regardless of applicability")),
+		mcp.WithString("phase", mcp.Description("Filter by lifecycle phase"),
+			mcp.Enum("pre-upgrade", "post-upgrade", "pre-enablement")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			cmd := migrate.NewListCommand(streams)
+			cmd.ConfigFlags = flags
+
+			return cmd
+		},
+		applier: applyMigrateListArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyMigrateListArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*migrate.ListCommand)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.OutputFormat = migrate.OutputFormatJSON
+	cmd.TargetVersion = request.GetString("target_version", "")
+	cmd.ShowAll = request.GetBool("all", false)
+	cmd.Phase = request.GetString("phase", "")
+
+	return nil
+}
+
+// --- odh_migrate_run ---
+
+func migrateRunTool(configFlags *genericclioptions.ConfigFlags) toolDefinition {
+	tool := mcp.NewTool("odh_migrate_run",
+		mcp.WithDescription("Execute OpenShift AI migrations (destructive — changes cluster state)"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithArray("migrations", mcp.Required(),
+			mcp.Description("Migration IDs to execute"), mcp.WithStringItems()),
+		mcp.WithString("target_version", mcp.Required(),
+			mcp.Description("Target version")),
+		mcp.WithBoolean("dry_run", mcp.Description("Preview changes without applying"), mcp.DefaultBool(true)),
+		mcp.WithString("phase", mcp.Description("Lifecycle phase"),
+			mcp.Enum("pre-upgrade", "post-upgrade", "pre-enablement")),
+		mcp.WithString("timeout", mcp.Description("Maximum execution time"), mcp.DefaultString("10m")),
+	)
+
+	adapter := &toolAdapter{
+		configFlags: configFlags,
+		factory: func(streams genericiooptions.IOStreams, flags *genericclioptions.ConfigFlags) pkgcmd.Command {
+			cmd := migrate.NewRunCommand(streams)
+			cmd.ConfigFlags = flags
+
+			return cmd
+		},
+		applier: applyMigrateRunArgs,
+	}
+
+	return toolDefinition{tool: tool, handler: adapter.handle}
+}
+
+func applyMigrateRunArgs(command pkgcmd.Command, request mcp.CallToolRequest) error {
+	cmd, ok := command.(*migrate.RunCommand)
+	if !ok {
+		return fmt.Errorf("unexpected command type: %T", command)
+	}
+
+	cmd.Yes = true // MCP cannot prompt interactively
+	cmd.MigrationIDs = request.GetStringSlice("migrations", nil)
+	cmd.TargetVersion = request.GetString("target_version", "")
+	cmd.DryRun = request.GetBool("dry_run", true)
+	cmd.Phase = request.GetString("phase", "")
+
+	d, err := parseDuration(request, "timeout", "10m")
+	if err != nil {
+		return err
+	}
+
+	if d > 0 {
+		cmd.Timeout = d
+	}
+
+	return nil
+}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -1,0 +1,601 @@
+//nolint:testpackage // Tests internal tool definitions and applier functions
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/components"
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+	"github.com/opendatahub-io/odh-cli/pkg/events"
+	"github.com/opendatahub-io/odh-cli/pkg/get"
+	"github.com/opendatahub-io/odh-cli/pkg/lint"
+	"github.com/opendatahub-io/odh-cli/pkg/logs"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate"
+	"github.com/opendatahub-io/odh-cli/pkg/status"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAllTools(t *testing.T) {
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should return exactly 12 tools", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tools := allTools(flags)
+
+		g.Expect(tools).To(HaveLen(12))
+	})
+
+	t.Run("should have expected tool names", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tools := allTools(flags)
+		names := make([]string, len(tools))
+		for i, def := range tools {
+			names[i] = def.tool.Name
+		}
+
+		g.Expect(names).To(ConsistOf(
+			"odh_status",
+			"odh_lint",
+			"odh_get",
+			"odh_deps",
+			"odh_deps_install",
+			"odh_backup",
+			"odh_logs",
+			"odh_events",
+			"odh_components_list",
+			"odh_components_describe",
+			"odh_migrate_list",
+			"odh_migrate_run",
+		))
+	})
+
+	t.Run("should mark read-only tools correctly", func(t *testing.T) {
+		g := NewWithT(t)
+
+		readOnlyTools := []string{"odh_status", "odh_lint", "odh_get", "odh_deps", "odh_logs", "odh_events", "odh_components_list", "odh_components_describe", "odh_migrate_list"}
+		tools := allTools(flags)
+
+		for _, def := range tools {
+			for _, name := range readOnlyTools {
+				if def.tool.Name == name {
+					g.Expect(*def.tool.Annotations.ReadOnlyHint).To(BeTrue(), "%s should be read-only", name)
+					g.Expect(*def.tool.Annotations.DestructiveHint).To(BeFalse(), "%s should not be destructive", name)
+				}
+			}
+		}
+	})
+
+	t.Run("should mark destructive tools correctly", func(t *testing.T) {
+		g := NewWithT(t)
+
+		destructiveTools := []string{"odh_migrate_run", "odh_deps_install"}
+		tools := allTools(flags)
+
+		for _, def := range tools {
+			for _, name := range destructiveTools {
+				if def.tool.Name == name {
+					g.Expect(*def.tool.Annotations.DestructiveHint).To(BeTrue(), "%s should be destructive", name)
+					g.Expect(*def.tool.Annotations.ReadOnlyHint).To(BeFalse(), "%s should not be read-only", name)
+				}
+			}
+		}
+	})
+
+	t.Run("should require resource for odh_get", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tools := allTools(flags)
+
+		for _, def := range tools {
+			if def.tool.Name == "odh_get" {
+				g.Expect(def.tool.InputSchema.Required).To(ContainElement("resource"))
+			}
+		}
+	})
+
+	t.Run("should require migrations and target_version for odh_migrate_run", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tools := allTools(flags)
+
+		for _, def := range tools {
+			if def.tool.Name == "odh_migrate_run" {
+				g.Expect(def.tool.InputSchema.Required).To(ContainElement("migrations"))
+				g.Expect(def.tool.InputSchema.Required).To(ContainElement("target_version"))
+			}
+		}
+	})
+
+	t.Run("should have non-nil handlers for all tools", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tools := allTools(flags)
+
+		for _, def := range tools {
+			g.Expect(def.handler).ToNot(BeNil(), "handler for %s should not be nil", def.tool.Name)
+		}
+	})
+}
+
+func newRequest(args map[string]any) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: args,
+		},
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	t.Run("should return zero for empty string with no fallback", func(t *testing.T) {
+		g := NewWithT(t)
+
+		d, err := parseDuration(newRequest(nil), "timeout", "")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(d).To(BeZero())
+	})
+
+	t.Run("should use fallback when key is missing", func(t *testing.T) {
+		g := NewWithT(t)
+
+		d, err := parseDuration(newRequest(nil), "timeout", "30s")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(d).To(Equal(30 * time.Second))
+	})
+
+	t.Run("should parse valid duration", func(t *testing.T) {
+		g := NewWithT(t)
+
+		d, err := parseDuration(newRequest(map[string]any{"timeout": "45s"}), "timeout", "30s")
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(d).To(Equal(45 * time.Second))
+	})
+
+	t.Run("should return error for invalid duration", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := parseDuration(newRequest(map[string]any{"timeout": "bad"}), "timeout", "30s")
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid timeout duration"))
+		g.Expect(err.Error()).To(ContainSubstring("bad"))
+	})
+
+	t.Run("should return error for duration missing unit", func(t *testing.T) {
+		g := NewWithT(t)
+
+		_, err := parseDuration(newRequest(map[string]any{"since": "30"}), "since", "1h")
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid since duration"))
+	})
+}
+
+func TestApplyStatusArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON output and no color", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := status.NewCommand(streams, flags)
+
+		err := applyStatusArgs(cmd, newRequest(nil))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal(status.OutputFormatJSON))
+		g.Expect(cmd.NoColor).To(BeTrue())
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := status.NewCommand(streams, flags)
+
+		err := applyStatusArgs(cmd, newRequest(map[string]any{
+			"verbose":            true,
+			"sections":           []any{"nodes", "pods"},
+			"layers":             []any{"operator"},
+			"timeout":            "45s",
+			"apps_namespace":     "my-apps",
+			"operator_namespace": "my-operator",
+			"include_deps":       false,
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.Verbose).To(BeTrue())
+		g.Expect(cmd.Sections).To(Equal([]string{"nodes", "pods"}))
+		g.Expect(cmd.Layers).To(Equal([]string{"operator"}))
+		g.Expect(cmd.Timeout).To(Equal(45 * time.Second))
+		g.Expect(cmd.AppsNamespace).To(Equal("my-apps"))
+		g.Expect(cmd.OperatorNamespace).To(Equal("my-operator"))
+		g.Expect(cmd.IncludeDeps).To(BeFalse())
+	})
+}
+
+func TestApplyLintArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON output", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := lint.NewCommand(streams, flags)
+
+		err := applyLintArgs(cmd, newRequest(nil))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal(lint.OutputFormatJSON))
+		g.Expect(cmd.NoColor).To(BeTrue())
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := lint.NewCommand(streams, flags)
+
+		err := applyLintArgs(cmd, newRequest(map[string]any{
+			"target_version":       "3.0",
+			"severity":             "warning",
+			"checks":               []any{"*notebook*"},
+			"isvc_deployment_mode": "serverless",
+			"timeout":              "2m",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.TargetVersion).To(Equal("3.0"))
+		g.Expect(cmd.SeverityLevel).To(Equal(lint.SeverityLevel("warning")))
+		g.Expect(cmd.CheckSelectors).To(Equal([]string{"*notebook*"}))
+		g.Expect(cmd.ISVCDeploymentMode).To(Equal("serverless"))
+		g.Expect(cmd.Timeout).To(Equal(2 * time.Minute))
+	})
+}
+
+func TestApplyGetArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON output and map resource", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := get.NewCommand(streams, flags)
+
+		err := applyGetArgs(cmd, newRequest(map[string]any{
+			"resource": "nb",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal("json"))
+		g.Expect(cmd.ResourceName).To(Equal("nb"))
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := get.NewCommand(streams, flags)
+
+		err := applyGetArgs(cmd, newRequest(map[string]any{
+			"resource":       "isvc",
+			"name":           "my-model",
+			"namespace":      "prod",
+			"all_namespaces": true,
+			"selector":       "app=serving",
+			"verbose":        true,
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.ResourceName).To(Equal("isvc"))
+		g.Expect(cmd.ItemName).To(Equal("my-model"))
+		g.Expect(cmd.Namespace).To(Equal("prod"))
+		g.Expect(cmd.AllNamespaces).To(BeTrue())
+		g.Expect(cmd.LabelSelector).To(Equal("app=serving"))
+		g.Expect(cmd.Verbose).To(BeTrue())
+	})
+}
+
+func TestApplyDepsArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON output", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := deps.NewCommand(streams, flags)
+
+		err := applyDepsArgs(cmd, newRequest(nil))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.Output).To(Equal("json"))
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := deps.NewCommand(streams, flags)
+
+		err := applyDepsArgs(cmd, newRequest(map[string]any{
+			"dry_run": true,
+			"version": "2.17.0",
+			"refresh": true,
+			"verbose": true,
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.DryRun).To(BeTrue())
+		g.Expect(cmd.Version).To(Equal("2.17.0"))
+		g.Expect(cmd.Refresh).To(BeTrue())
+		g.Expect(cmd.Verbose).To(BeTrue())
+	})
+}
+
+func TestApplyDepsInstallArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should default dry_run to true", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := deps.NewInstallCommand(streams, flags)
+
+		err := applyDepsInstallArgs(cmd, newRequest(nil))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.DryRun).To(BeTrue())
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := deps.NewInstallCommand(streams, flags)
+
+		err := applyDepsInstallArgs(cmd, newRequest(map[string]any{
+			"target":           "servicemeshoperator",
+			"dry_run":          true,
+			"include_optional": true,
+			"version":          "2.17.0",
+			"refresh":          true,
+			"timeout":          "8m",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.TargetDep).To(Equal("servicemeshoperator"))
+		g.Expect(cmd.DryRun).To(BeTrue())
+		g.Expect(cmd.IncludeOptional).To(BeTrue())
+		g.Expect(cmd.Version).To(Equal("2.17.0"))
+		g.Expect(cmd.Refresh).To(BeTrue())
+		g.Expect(cmd.Timeout).To(Equal(8 * time.Minute))
+	})
+}
+
+func TestApplyLogsArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should disable Follow and map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := logs.NewCommand(streams, flags)
+
+		err := applyLogsArgs(cmd, newRequest(map[string]any{
+			"target":    "dashboard",
+			"tail":      100,
+			"since":     "5m",
+			"previous":  true,
+			"container": "oauth-proxy",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.Follow).To(BeFalse())
+		g.Expect(cmd.Target).To(Equal("dashboard"))
+		g.Expect(cmd.Tail).To(Equal(int64(100)))
+		g.Expect(cmd.Since).To(Equal(5 * time.Minute))
+		g.Expect(cmd.Previous).To(BeTrue())
+		g.Expect(cmd.Container).To(Equal("oauth-proxy"))
+	})
+}
+
+func TestApplyEventsArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON, disable Follow, and map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := events.NewCommand(streams, flags)
+
+		err := applyEventsArgs(cmd, newRequest(map[string]any{
+			"type":               "Warning",
+			"since":              "30m",
+			"all_namespaces":     true,
+			"component":          "kserve",
+			"operator_namespace": "redhat-ods-operator",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal("json"))
+		g.Expect(cmd.Follow).To(BeFalse())
+		g.Expect(cmd.EventType).To(Equal("Warning"))
+		g.Expect(cmd.Since).To(Equal(30 * time.Minute))
+		g.Expect(cmd.AllNamespaces).To(BeTrue())
+		g.Expect(cmd.Component).To(Equal("kserve"))
+		g.Expect(cmd.OperatorNSOverride).To(Equal("redhat-ods-operator"))
+	})
+}
+
+func TestApplyComponentsListArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON output and map arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := components.NewListCommand(streams, flags)
+
+		err := applyComponentsListArgs(cmd, newRequest(map[string]any{
+			"verbose": true,
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal("json"))
+		g.Expect(cmd.Verbose).To(BeTrue())
+	})
+}
+
+func TestApplyComponentsDescribeArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+	flags := genericclioptions.NewConfigFlags(true)
+
+	t.Run("should force JSON output and map arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := components.NewDescribeCommand(streams, flags)
+
+		err := applyComponentsDescribeArgs(cmd, newRequest(map[string]any{
+			"component": "kserve",
+			"verbose":   true,
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal("json"))
+		g.Expect(cmd.ComponentName).To(Equal("kserve"))
+		g.Expect(cmd.Verbose).To(BeTrue())
+	})
+}
+
+func TestApplyBackupArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+
+	t.Run("should reject path traversal in output_dir", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := backup.NewCommand(streams)
+
+		err := applyBackupArgs(cmd, newRequest(map[string]any{
+			"output_dir": "../../etc/evil",
+		}))
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("must not traverse"))
+	})
+
+	t.Run("should reject intermediate path traversal in output_dir", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := backup.NewCommand(streams)
+
+		err := applyBackupArgs(cmd, newRequest(map[string]any{
+			"output_dir": "foo/../../bar",
+		}))
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("must not traverse"))
+	})
+
+	t.Run("should reject absolute paths in output_dir", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := backup.NewCommand(streams)
+
+		err := applyBackupArgs(cmd, newRequest(map[string]any{
+			"output_dir": "/tmp/backup",
+		}))
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("must be a relative path"))
+	})
+
+	t.Run("should allow relative paths in output_dir", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := backup.NewCommand(streams)
+
+		err := applyBackupArgs(cmd, newRequest(map[string]any{
+			"output_dir": "backups/my-backup",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputDir).To(Equal("backups/my-backup"))
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := backup.NewCommand(streams)
+
+		err := applyBackupArgs(cmd, newRequest(map[string]any{
+			"output_dir":   "backups/cluster-1",
+			"includes":     []any{"notebooks.kubeflow.org"},
+			"excludes":     []any{"pipelines"},
+			"dependencies": false,
+			"dry_run":      true,
+			"timeout":      "15m",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputDir).To(Equal("backups/cluster-1"))
+		g.Expect(cmd.Includes).To(Equal([]string{"notebooks.kubeflow.org"}))
+		g.Expect(cmd.Excludes).To(Equal([]string{"pipelines"}))
+		g.Expect(cmd.Dependencies).To(BeFalse())
+		g.Expect(cmd.DryRun).To(BeTrue())
+		g.Expect(cmd.Timeout).To(Equal(15 * time.Minute))
+	})
+}
+
+func TestApplyMigrateListArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+
+	t.Run("should force JSON output", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := migrate.NewListCommand(streams)
+
+		err := applyMigrateListArgs(cmd, newRequest(nil))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.OutputFormat).To(Equal(migrate.OutputFormatJSON))
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := migrate.NewListCommand(streams)
+
+		err := applyMigrateListArgs(cmd, newRequest(map[string]any{
+			"target_version": "3.0",
+			"all":            true,
+			"phase":          "pre-upgrade",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.TargetVersion).To(Equal("3.0"))
+		g.Expect(cmd.ShowAll).To(BeTrue())
+		g.Expect(cmd.Phase).To(Equal("pre-upgrade"))
+	})
+}
+
+func TestApplyMigrateRunArgs(t *testing.T) {
+	streams := genericiooptions.IOStreams{}
+
+	t.Run("should auto-set Yes and default dry_run to true", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := migrate.NewRunCommand(streams)
+
+		err := applyMigrateRunArgs(cmd, newRequest(nil))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.Yes).To(BeTrue())
+		g.Expect(cmd.DryRun).To(BeTrue())
+	})
+
+	t.Run("should map all arguments", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd := migrate.NewRunCommand(streams)
+
+		err := applyMigrateRunArgs(cmd, newRequest(map[string]any{
+			"migrations":     []any{"dspa-v2", "kserve-v3"},
+			"target_version": "3.0",
+			"dry_run":        true,
+			"phase":          "post-upgrade",
+			"timeout":        "20m",
+		}))
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(cmd.MigrationIDs).To(Equal([]string{"dspa-v2", "kserve-v3"}))
+		g.Expect(cmd.TargetVersion).To(Equal("3.0"))
+		g.Expect(cmd.DryRun).To(BeTrue())
+		g.Expect(cmd.Phase).To(Equal("post-upgrade"))
+		g.Expect(cmd.Timeout).To(Equal(20 * time.Minute))
+		g.Expect(cmd.Yes).To(BeTrue())
+	})
+}


### PR DESCRIPTION
## Description

Add MCP tool definitions and tests for all 12 CLI commands.

Each tool defines a typed MCP schema with argument mapping to the underlying command struct:

| Tool | Command | Read-Only |
|------|---------|-----------|
| `odh_status` | `odh status` | Yes |
| `odh_lint` | `odh lint` | Yes |
| `odh_get` | `odh get` | Yes |
| `odh_deps` | `odh deps` | Yes |
| `odh_deps_install` | `odh deps install` | No (destructive) |
| `odh_backup` | `odh backup` | No |
| `odh_logs` | `odh logs` | Yes |
| `odh_events` | `odh events` | Yes |
| `odh_components_list` | `odh components list` | Yes |
| `odh_components_describe` | `odh components describe` | Yes |
| `odh_migrate_list` | `odh migrate list` | Yes |
| `odh_migrate_run` | `odh migrate run` | No (destructive) |

Key design decisions:
- `parseDuration` helper returns errors instead of silently swallowing invalid inputs
- Destructive tools (`deps_install`, `migrate_run`) default `dry_run=true`
- Schema defaults match handler fallbacks for duration parameters
- `Follow=false` hardcoded for logs/events (MCP cannot stream)
- All tools force JSON output and disable color

This PR adds the tool definitions only. Server wiring and CLI command will follow in a separate PR.

## Testing

- [X] Unit tests pass (`make test`)
- [X] Linter passes (`make lint`)
- [X] New functionality includes tests

## Review checklist

- [X] Code follows project conventions (see docs/coding/)
- [X] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCP tool registry for 12 commands (status, lint, get, deps, backup, logs, events, components, and migrations) with structured input schemas and consistent defaults (including standardized JSON output for selected commands).
  * Improved handling of time-based options and made migration runs non-interactive by default.
* **Bug Fixes**
  * Hardened backup `output_dir` to allow only safe relative paths and reject traversal/absolute paths.
  * Enforced correct argument mapping for all tool requests, including disabling follow behavior for log/event tools.
* **Tests**
  * Added automated coverage for tool definitions, argument mapping, and duration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->