### PR TITLE
feat(migrate): enhance RHBOK migration actions with new functionalities

### DIFF
--- a/pkg/migrate/actions/kueue/rhbok/export_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/export_test.go
@@ -2,6 +2,7 @@ package rhbok
 
 import (
 	"context"
+	"time"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube/rbac"
@@ -13,10 +14,21 @@ var (
 	ExportCheckNoRHBOKConflicts  = (*RHBOKMigrationAction).checkNoRHBOKConflicts
 	ExportVerifyKueueResources   = (*RHBOKMigrationAction).verifyKueueResources
 	ExportCheckKueueManaged      = (*RHBOKMigrationAction).checkKueueManaged
+	ExportCheckCertManager       = (*RHBOKMigrationAction).checkCertManager
+	ExportCheckOperatorChannel   = (*RHBOKMigrationAction).checkOperatorChannel
+	ExportReportLabelingPlan     = (*RHBOKMigrationAction).reportLabelingPlan
 	ExportPreserveKueueConfig    = (*RHBOKMigrationAction).preserveKueueConfig
+	ExportRemoveEmbeddedKueue    = (*RHBOKMigrationAction).removeEmbeddedKueue
+	ExportActivateRHBOK          = (*RHBOKMigrationAction).activateRHBOK
 	ExportInstallRHBOKOperator   = (*RHBOKMigrationAction).installRHBOKOperator
-	ExportUpdateDSC              = (*RHBOKMigrationAction).updateDataScienceCluster
+	ExportDeleteLegacyCRDs       = (*RHBOKMigrationAction).deleteLegacyCRDs
+	ExportLabelKueueNamespaces   = (*RHBOKMigrationAction).labelKueueNamespaces
+	ExportLabelKueueWorkloads    = (*RHBOKMigrationAction).labelKueueWorkloads
+	ExportVerifyMigration        = (*RHBOKMigrationAction).verifyMigrationComplete
 	ExportVerifyResources        = (*RHBOKMigrationAction).verifyResourcesPreserved
+	ExportWaitEmbeddedRemoval    = (*RHBOKMigrationAction).waitForEmbeddedRemoval
+	ExportWaitKueueReady         = (*RHBOKMigrationAction).waitForKueueReady
+	ExportDiscoverLabelingPlan   = (*RHBOKMigrationAction).discoverLabelingPlan
 	ExportPreparePermissions     = preparePermissions
 	ExportRunPermissions         = runPermissions
 
@@ -25,8 +37,28 @@ var (
 	ExportOperatorNamespace     = operatorNamespace
 	ExportSubscriptionName      = subscriptionName
 	ExportCSVNamePrefix         = csvNamePrefix
+	ExportEmbeddedDeployment    = embeddedKueueDeployment
+
+	ExportIsMigrationComplete = (*RHBOKMigrationAction).isMigrationComplete
 )
+
+func ExportPlanNamespaces(p labelingPlan) []string {
+	return p.namespaces
+}
+
+func ExportPlanWorkloads(p labelingPlan) []workloadRef {
+	return p.workloads
+}
+
+func ExportWorkloadQueueName(w workloadRef) string {
+	return w.queueName
+}
 
 func ExportVerifyRBAC(a *RHBOKMigrationAction, ctx context.Context, target action.Target, checks []rbac.PermissionCheck) {
 	a.verifyRBAC(ctx, target, checks)
+}
+
+func SetTestPollConfig(period, timeout time.Duration) {
+	testComponentPollPeriod = period
+	testComponentTimeout = timeout
 }

--- a/pkg/migrate/actions/kueue/rhbok/helpers_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/helpers_test.go
@@ -3,24 +3,31 @@ package rhbok_test
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
 )
 
 //nolint:gochecknoglobals // test-only GVR→ListKind mapping for fake dynamic client
@@ -29,7 +36,17 @@ var testListKinds = map[schema.GroupVersionResource]string{
 	resources.ClusterQueue.GVR():         resources.ClusterQueue.ListKind(),
 	resources.LocalQueue.GVR():           resources.LocalQueue.ListKind(),
 	resources.Subscription.GVR():         resources.Subscription.ListKind(),
+	resources.OperatorGroup.GVR():        resources.OperatorGroup.ListKind(),
 	resources.ConfigMap.GVR():            resources.ConfigMap.ListKind(),
+	resources.PackageManifest.GVR():      resources.PackageManifest.ListKind(),
+	resources.Deployment.GVR():           resources.Deployment.ListKind(),
+	resources.Namespace.GVR():            resources.Namespace.ListKind(),
+	resources.Notebook.GVR():             resources.Notebook.ListKind(),
+	resources.InferenceService.GVR():     resources.InferenceService.ListKind(),
+	resources.LLMInferenceService.GVR():  resources.LLMInferenceService.ListKind(),
+	resources.RayCluster.GVR():           resources.RayCluster.ListKind(),
+	resources.RayJob.GVR():               resources.RayJob.ListKind(),
+	resources.PyTorchJob.GVR():           resources.PyTorchJob.ListKind(),
 }
 
 type targetOpts struct {
@@ -37,20 +54,26 @@ type targetOpts struct {
 	skipConfirm    bool
 	outputDir      string
 	olmObjects     []runtime.Object
+	kubeObjects    []runtime.Object
 	rbacAllowed    bool
 	dynamicReactor func(k8stesting.Action) (bool, runtime.Object, error)
+	olmReactor     func(k8stesting.Action) (bool, runtime.Object, error)
 }
 
 func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOpts) action.Target {
 	t.Helper()
 
+	rhbok.SetTestPollConfig(5*time.Millisecond, 50*time.Millisecond)
+
 	scheme := runtime.NewScheme()
 	_ = metav1.AddMetaToScheme(scheme)
 
-	dynamicObjs := make([]runtime.Object, len(objects))
-	for i, obj := range objects {
-		dynamicObjs[i] = obj
+	dynamicObjs := make([]runtime.Object, 0, len(objects)+1)
+	for _, obj := range objects {
+		dynamicObjs = append(dynamicObjs, obj)
 	}
+
+	dynamicObjs = append(dynamicObjs, makeKueuePackageManifest())
 
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
 		scheme,
@@ -58,13 +81,41 @@ func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOp
 		dynamicObjs...,
 	)
 
+	dynamicClient.PrependReactor("update", "datascienceclusters", dscUpdateReactor)
+
 	if opts.dynamicReactor != nil {
 		dynamicClient.PrependReactor("*", "*", opts.dynamicReactor)
 	}
 
 	olmClient := operatorfake.NewSimpleClientset(opts.olmObjects...) //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 
-	kubeClient := kubefake.NewSimpleClientset() //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
+	if opts.olmReactor != nil {
+		olmClient.PrependReactor("*", "*", opts.olmReactor)
+	}
+
+	kubeObjs := make([]runtime.Object, 0, 3+len(opts.kubeObjects))
+	kubeObjs = append(kubeObjs,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rhbok.ExportOperatorNamespace}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-controller-manager",
+				Namespace: rhbok.ExportOperatorNamespace,
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	)
+	kubeObjs = append(kubeObjs, opts.kubeObjects...)
+
+	kubeClient := kubefake.NewSimpleClientset(kubeObjs...) //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
 	kubeClient.PrependReactor("create", "selfsubjectaccessreviews",
 		func(_ k8stesting.Action) (bool, runtime.Object, error) {
 			return true, &authorizationv1.SelfSubjectAccessReview{
@@ -73,10 +124,17 @@ func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOp
 		},
 	)
 
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(append(objects, makeKueuePackageManifest())...)...,
+	)
+
 	testClient := client.NewForTesting(client.TestClientConfig{
-		Dynamic:    dynamicClient,
-		OLM:        olmClient,
-		Kubernetes: kubeClient,
+		Dynamic:       dynamicClient,
+		OLM:           olmClient,
+		Kubernetes:    kubeClient,
+		APIExtensions: apiextensionsfake.NewSimpleClientset(certManagerCRD()), //nolint:staticcheck // apply configs not available for apiextensions fake
+		Metadata:      metadataClient,
 	})
 
 	outputDir := opts.outputDir
@@ -117,6 +175,60 @@ func inNamespace(ns string) objOption {
 	return func(obj *unstructured.Unstructured) {
 		obj.SetNamespace(ns)
 	}
+}
+
+func withLabel(key, value string) objOption {
+	return func(obj *unstructured.Unstructured) {
+		labels := obj.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+
+		labels[key] = value
+		obj.SetLabels(labels)
+	}
+}
+
+func withDSCCondition(condType, status, reason string) objOption {
+	return func(obj *unstructured.Unstructured) {
+		_ = unstructured.SetNestedSlice(obj.Object, []any{
+			map[string]any{
+				"type":   condType,
+				"status": status,
+				"reason": reason,
+			},
+		}, "status", "conditions")
+	}
+}
+
+func makeNamespace(name string, labels map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+	if len(labels) > 0 {
+		_ = unstructured.SetNestedStringMap(obj.Object, labels, "metadata", "labels")
+	}
+
+	return obj
+}
+
+func makeKubeNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+func makeNotebook(name string, opts ...objOption) *unstructured.Unstructured {
+	return makeObj(resources.Notebook, name, opts...)
 }
 
 func withAnnotation(key, value string) objOption {
@@ -174,6 +286,10 @@ func makeSubscription(name string, opts ...objOption) *unstructured.Unstructured
 	return makeObj(resources.Subscription, name, opts...)
 }
 
+func makeDeployment(name string, opts ...objOption) *unstructured.Unstructured {
+	return makeObj(resources.Deployment, name, opts...)
+}
+
 func newOLMSubscription(name, namespace string) *operatorsv1alpha1.Subscription {
 	return &operatorsv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
@@ -193,4 +309,69 @@ func newOLMCSV(name, namespace string) *operatorsv1alpha1.ClusterServiceVersion 
 			Phase: operatorsv1alpha1.CSVPhaseSucceeded,
 		},
 	}
+}
+
+func makeKueuePackageManifest() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": resources.PackageManifest.APIVersion(),
+		"kind":       resources.PackageManifest.Kind,
+		"metadata": map[string]any{
+			"name":      "kueue-operator",
+			"namespace": "openshift-marketplace",
+		},
+		"status": map[string]any{
+			"catalogSource": "redhat-operators",
+			"channels": []any{
+				map[string]any{
+					"name": "stable-v1.2",
+					"entries": []any{
+						map[string]any{"name": "kueue-operator.v1.2.0"},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func certManagerCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "certificates.cert-manager.io"},
+	}
+}
+
+func dscUpdateReactor(action k8stesting.Action) (bool, runtime.Object, error) {
+	updateAction, ok := action.(k8stesting.UpdateAction)
+	if !ok {
+		return false, nil, nil
+	}
+
+	obj, ok := updateAction.GetObject().(*unstructured.Unstructured)
+	if !ok {
+		return false, nil, nil
+	}
+
+	state, _, _ := unstructured.NestedString(obj.Object, "spec", "components", "kueue", "managementState")
+
+	var cond map[string]any
+
+	switch state {
+	case "Removed":
+		cond = map[string]any{
+			"type":   "KueueReady",
+			"status": "False",
+			"reason": "Removed",
+		}
+	case "Unmanaged":
+		cond = map[string]any{
+			"type":   "KueueReady",
+			"status": "True",
+			"reason": "Ready",
+		}
+	}
+
+	if cond != nil {
+		_ = unstructured.SetNestedSlice(obj.Object, []any{cond}, "status", "conditions")
+	}
+
+	return false, nil, nil
 }

--- a/pkg/migrate/actions/kueue/rhbok/prepare_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/prepare_task.go
@@ -23,8 +23,10 @@ func (t *prepareTask) Validate(
 	target action.Target,
 ) (*result.ActionResult, error) {
 	t.action.verifyRBAC(ctx, target, preparePermissions())
+	t.action.checkCertManager(ctx, target)
 	t.action.checkCurrentKueueState(ctx, target)
 	t.action.verifyKueueResources(ctx, target)
+	t.action.reportLabelingPlan(ctx, target)
 
 	rootRecorder, ok := target.Recorder.(action.RootRecorder)
 	if !ok {
@@ -38,6 +40,15 @@ func (t *prepareTask) Execute(
 	ctx context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
+	validationResult, err := t.Validate(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasFailedStep(validationResult.Status.Steps) {
+		return validationResult, errPreflightFailed
+	}
+
 	kueueManaged := t.action.checkKueueManaged(ctx, target)
 
 	if kueueManaged {

--- a/pkg/migrate/actions/kueue/rhbok/prepare_task_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/prepare_task_test.go
@@ -33,7 +33,7 @@ func TestPrepareTask_Validate(t *testing.T) {
 		res, err := task.Validate(ctx, target)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res).ToNot(BeNil())
-		g.Expect(res.Status.Steps).To(HaveLen(3))
+		g.Expect(len(res.Status.Steps)).To(BeNumerically(">=", 5))
 	})
 
 	t.Run("reports failure when DSC not found", func(t *testing.T) {
@@ -51,6 +51,26 @@ func TestPrepareTask_Validate(t *testing.T) {
 		dscStep := findStep(res.Status.Steps, "check-kueue-state")
 		g.Expect(dscStep).ToNot(BeNil())
 		g.Expect(dscStep.Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("fails execute when validation fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Prepare()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).To(MatchError("preflight checks failed"))
+		g.Expect(res).ToNot(BeNil())
+
+		dscStep := findStep(res.Status.Steps, "check-kueue-state")
+		g.Expect(dscStep).ToNot(BeNil())
+		g.Expect(dscStep.Status).To(Equal(result.StepFailed))
+		g.Expect(findStep(res.Status.Steps, "backup-kueue-resources")).To(BeNil())
+		g.Expect(findStep(res.Status.Steps, "backup-skipped")).To(BeNil())
 	})
 }
 
@@ -251,7 +271,7 @@ func TestPrepareTask_Execute_BackupNotFound(t *testing.T) {
 }
 
 func TestPrepareTask_Execute_BackupErrors(t *testing.T) {
-	t.Run("ClusterQueue list error fails backup", func(t *testing.T) {
+	t.Run("ClusterQueue list error fails validation", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
@@ -271,11 +291,12 @@ func TestPrepareTask_Execute_BackupErrors(t *testing.T) {
 		task := a.Prepare()
 
 		res, err := task.Execute(ctx, target)
-		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).To(MatchError("preflight checks failed"))
 
-		backupStep := findStepRecursive(res.Status.Steps, "backup-clusterqueues")
-		g.Expect(backupStep).ToNot(BeNil())
-		g.Expect(backupStep.Status).To(Equal(result.StepFailed))
+		verifyStep := findStep(res.Status.Steps, "verify-kueue-resources")
+		g.Expect(verifyStep).ToNot(BeNil())
+		g.Expect(verifyStep.Status).To(Equal(result.StepFailed))
+		g.Expect(findStep(res.Status.Steps, "backup-kueue-resources")).To(BeNil())
 	})
 
 	t.Run("ConfigMap get error fails backup", func(t *testing.T) {

--- a/pkg/migrate/actions/kueue/rhbok/rhbok.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok.go
@@ -3,13 +3,17 @@ package rhbok
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
@@ -28,52 +32,57 @@ const (
 	operatorNamespace   = "openshift-kueue-operator"
 	subscriptionName    = "kueue-operator"
 	subscriptionPackage = "kueue-operator"
+	subscriptionSource  = "redhat-operators"
+	sourceNamespace     = "openshift-marketplace"
+	csvNamePrefix       = "kueue-operator"
 
 	// Retry configuration for conflict resolution.
 	retryInitialDuration = 500 * time.Millisecond
 	retryFactor          = 2.0
 	retryJitter          = 0.1
 	retryMaxSteps        = 5
-	subscriptionChannel  = "stable-v1.1"
-	subscriptionSource   = "redhat-operators"
-	sourceNamespace      = "openshift-marketplace"
-	csvNamePrefix        = "kueue-operator"
 	operatorTimeout      = 5 * time.Minute
 	operatorPollPeriod   = 10 * time.Second
+	componentPollPeriod  = 10 * time.Second
+	componentTimeout     = 5 * time.Minute
 
 	// DataScienceCluster constants.
-	managementStateManaged   = "Managed"
-	managementStateUnmanaged = "Unmanaged"
-	kueueComponentPath       = ".spec.components.kueue.managementState"
+	kueueComponentPath = ".spec.components.kueue.managementState"
+	kueueReadyType     = "KueueReady"
+
+	// Embedded Kueue deployment.
+	embeddedKueueDeployment = "kueue-controller-manager"
 
 	// ConfigMap constants.
 	configMapName            = "kueue-manager-config"
 	applicationsNamespace    = "redhat-ods-applications"
 	configMapAnnotationKey   = "opendatahub.io/managed"
 	configMapAnnotationValue = "false"
+
+	defaultQueueName = "default"
 )
 
-type RHBOKMigrationAction struct{}
+// RHBOKMigrationAction migrates embedded Kueue to the Red Hat build of Kueue operator.
+type RHBOKMigrationAction struct {
+	ClusterQueueName      string
+	LocalQueueName        string
+	QueueName             string
+	Channel               string
+	SkipRemoveEmbedded    bool
+	ForceDeleteLegacyCRDs bool
 
-func (a *RHBOKMigrationAction) ID() string {
-	return actionID
+	executeLabelingPlan *labelingPlan
 }
 
-func (a *RHBOKMigrationAction) Name() string {
-	return actionName
-}
+func (a *RHBOKMigrationAction) ID() string { return actionID }
 
-func (a *RHBOKMigrationAction) Description() string {
-	return actionDescription
-}
+func (a *RHBOKMigrationAction) Name() string { return actionName }
 
-func (a *RHBOKMigrationAction) Group() action.ActionGroup {
-	return action.GroupMigration
-}
+func (a *RHBOKMigrationAction) Description() string { return actionDescription }
 
-func (a *RHBOKMigrationAction) Phase() action.ActionPhase {
-	return action.PhasePreUpgrade
-}
+func (a *RHBOKMigrationAction) Group() action.ActionGroup { return action.GroupMigration }
+
+func (a *RHBOKMigrationAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
 
 func (a *RHBOKMigrationAction) CanApply(target action.Target) bool {
 	if target.CurrentVersion == nil {
@@ -83,12 +92,79 @@ func (a *RHBOKMigrationAction) CanApply(target action.Target) bool {
 	return target.CurrentVersion.Major == 2 && target.CurrentVersion.Minor >= 25
 }
 
+func (a *RHBOKMigrationAction) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&a.ClusterQueueName, "cluster-queue-name", "",
+		"Custom default ClusterQueue name for DataScienceCluster (optional)")
+	fs.StringVar(&a.LocalQueueName, "local-queue-name", "",
+		"Custom default LocalQueue name for DataScienceCluster (optional)")
+	fs.StringVar(&a.QueueName, "workload-queue-name", defaultQueueName,
+		"Queue name value for the kueue.x-k8s.io/queue-name workload label")
+	fs.StringVar(&a.Channel, "channel", "",
+		"OLM channel for the Red Hat build of Kueue operator (default: resolved from catalog)")
+	fs.BoolVar(&a.SkipRemoveEmbedded, "skip-remove-embedded", false,
+		"Skip setting Kueue managementState to Removed before installing RHBOK (not recommended)")
+	fs.BoolVar(&a.ForceDeleteLegacyCRDs, "force-delete-legacy-crds", false,
+		"Delete legacy cohorts/topologies CRDs even when instances still exist")
+}
+
 func (a *RHBOKMigrationAction) Prepare() action.Task {
 	return &prepareTask{action: a}
 }
 
 func (a *RHBOKMigrationAction) Run() action.Task {
 	return &runTask{action: a}
+}
+
+func (a *RHBOKMigrationAction) workloadQueueName() string {
+	if a.QueueName == "" {
+		return defaultQueueName
+	}
+
+	return a.QueueName
+}
+
+func (a *RHBOKMigrationAction) getKueueManagementState(
+	ctx context.Context,
+	c client.Client,
+) (string, error) {
+	dsc, err := client.GetSingleton(ctx, c, resources.DataScienceClusterV1)
+	if err != nil {
+		return "", fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	state, err := jq.Query[string](dsc, kueueComponentPath)
+	if err != nil {
+		return "", fmt.Errorf("querying kueue managementState: %w", err)
+	}
+
+	if state == "" {
+		return "", errors.New("kueue managementState is not configured")
+	}
+
+	switch state {
+	case constants.ManagementStateManaged, constants.ManagementStateUnmanaged, constants.ManagementStateRemoved:
+		return state, nil
+	default:
+		return "", fmt.Errorf("unsupported kueue managementState %q", state)
+	}
+}
+
+func (a *RHBOKMigrationAction) isMigrationComplete(ctx context.Context, target action.Target) bool {
+	state, err := a.getKueueManagementState(ctx, target.Client)
+	if err != nil {
+		return false
+	}
+
+	if state != constants.ManagementStateUnmanaged {
+		return false
+	}
+
+	ready, err := olm.CSVReady(ctx, target.Client, operatorNamespace, csvNamePrefix)
+	if err != nil {
+		return false
+	}
+
+	return ready
 }
 
 func (a *RHBOKMigrationAction) checkKueueManaged(
@@ -100,29 +176,20 @@ func (a *RHBOKMigrationAction) checkKueueManaged(
 		"Check if Kueue is managed by DataScienceCluster",
 	)
 
-	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
-
+	state, err := a.getKueueManagementState(ctx, target.Client)
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
 
 		return false
 	}
 
-	managementState, err := jq.Query[string](dsc, kueueComponentPath)
-	if err != nil {
-		step.Completef(result.StepCompleted,
-			"Kueue component not found in DataScienceCluster (not managed)")
-
-		return false
-	}
-
-	if managementState == managementStateManaged {
-		step.Completef(result.StepCompleted, "Kueue is managed (managementState=%s)", managementState)
+	if state == constants.ManagementStateManaged {
+		step.Completef(result.StepCompleted, "Kueue is managed (managementState=%s)", state)
 
 		return true
 	}
 
-	step.Completef(result.StepCompleted, "Kueue is not managed (managementState=%s)", managementState)
+	step.Completef(result.StepCompleted, "Kueue is not managed (managementState=%s)", state)
 
 	return false
 }
@@ -136,7 +203,6 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 		"Preserve Kueue ConfigMap for reference",
 	)
 
-	// Check if ConfigMap exists (read-only, safe to run in dry-run)
 	checkStep := step.Child(
 		"check-configmap",
 		fmt.Sprintf("Checking if ConfigMap '%s' exists in namespace '%s'", configMapName, applicationsNamespace),
@@ -155,7 +221,6 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 
 	checkStep.Completef(result.StepCompleted, "ConfigMap exists")
 
-	// Apply annotation
 	annotateStep := step.Child(
 		"apply-annotation",
 		fmt.Sprintf("Apply annotation %s=%s", configMapAnnotationKey, configMapAnnotationValue),
@@ -205,6 +270,41 @@ func (a *RHBOKMigrationAction) preserveKueueConfig(
 	step.Completef(result.StepCompleted, "ConfigMap %s annotated for preservation", configMapName)
 }
 
+func (a *RHBOKMigrationAction) resolveSubscriptionChannel(
+	ctx context.Context,
+	target action.Target,
+) (string, error) {
+	if a.Channel != "" {
+		return a.Channel, nil
+	}
+
+	if !target.DryRun {
+		existing, err := target.Client.OLMClient().OperatorsV1alpha1().
+			Subscriptions(operatorNamespace).
+			Get(ctx, subscriptionName, metav1.GetOptions{})
+		if err == nil && existing.Spec != nil && existing.Spec.Channel != "" {
+			return existing.Spec.Channel, nil
+		}
+
+		if err != nil && !apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("checking existing subscription: %w", err)
+		}
+	}
+
+	channel, err := olm.ResolveOperatorChannel(ctx, target.Client, olm.PackageQuery{
+		PackageName:     subscriptionPackage,
+		CatalogSource:   subscriptionSource,
+		SourceNamespace: sourceNamespace,
+	})
+	if err != nil {
+		target.IO.Errorf("Warning: could not resolve operator channel from catalog: %v; using fallback %s", err, olm.FallbackKueueOperatorChannel)
+
+		return olm.FallbackKueueOperatorChannel, nil
+	}
+
+	return channel, nil
+}
+
 func (a *RHBOKMigrationAction) installRHBOKOperator(
 	ctx context.Context,
 	target action.Target,
@@ -214,17 +314,25 @@ func (a *RHBOKMigrationAction) installRHBOKOperator(
 		"Install Red Hat Build of Kueue Operator",
 	)
 
-	// Check if subscription exists first
+	channel, err := a.resolveSubscriptionChannel(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to resolve operator channel: %v", err)
+
+		return
+	}
+
+	step.AddDetail("channel", channel)
+
 	subscriptionExists := false
 	if !target.DryRun {
-		_, err := target.Client.OLMClient().OperatorsV1alpha1().Subscriptions(operatorNamespace).Get(ctx, subscriptionName, metav1.GetOptions{})
+		_, err := target.Client.OLMClient().OperatorsV1alpha1().Subscriptions(operatorNamespace).
+			Get(ctx, subscriptionName, metav1.GetOptions{})
 		subscriptionExists = err == nil
 	}
 
-	// Only prompt if subscription doesn't exist and we're not in dry-run mode
 	if !target.DryRun && !target.SkipConfirm && !subscriptionExists {
 		target.IO.Fprintln()
-		target.IO.Errorf("About to install Red Hat Build of Kueue Operator")
+		target.IO.Errorf("About to install Red Hat Build of Kueue Operator (channel: %s)", channel)
 		if !confirmation.Prompt(target.IO, "Proceed with operator installation?") {
 			step.Completef(result.StepSkipped, "User cancelled installation")
 
@@ -232,11 +340,11 @@ func (a *RHBOKMigrationAction) installRHBOKOperator(
 		}
 	}
 
-	err := olm.EnsureOperatorInstalled(ctx, target.Client, olm.InstallConfig{
+	err = olm.EnsureOperatorInstalled(ctx, target.Client, olm.InstallConfig{
 		Name:            subscriptionName,
 		Namespace:       operatorNamespace,
 		Package:         subscriptionPackage,
-		Channel:         subscriptionChannel,
+		Channel:         channel,
 		Source:          subscriptionSource,
 		SourceNamespace: sourceNamespace,
 		CSVNamePrefix:   csvNamePrefix,
@@ -262,133 +370,17 @@ func (a *RHBOKMigrationAction) installRHBOKOperator(
 	}
 }
 
-func (a *RHBOKMigrationAction) updateDataScienceCluster(
-	ctx context.Context,
-	target action.Target,
-) {
-	step := target.Recorder.Child(
-		"update-datasciencecluster",
-		"Update DataScienceCluster Kueue managementState",
-	)
-
-	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
+func getDSCCondition(dsc *unstructured.Unstructured, conditionType string) (*metav1.Condition, error) {
+	conds, err := jq.Query[[]metav1.Condition](dsc, ".status.conditions // []")
 	if err != nil {
-		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
-
-		return
+		return nil, err
 	}
 
-	// Check if already set to Unmanaged
-	currentState, err := jq.Query[string](dsc, ".spec.components.kueue.managementState")
-	if err == nil && currentState == managementStateUnmanaged {
-		step.Completef(result.StepSkipped, "DataScienceCluster Kueue already set to Unmanaged")
-
-		return
-	}
-
-	if target.DryRun {
-		step.Completef(result.StepSkipped, "Would set %s=%s", kueueComponentPath, managementStateUnmanaged)
-
-		return
-	}
-
-	if !target.SkipConfirm {
-		target.IO.Fprintln()
-		target.IO.Errorf("About to update DataScienceCluster Kueue managementState to %s", managementStateUnmanaged)
-		if !confirmation.Prompt(target.IO, "Proceed with configuration update?") {
-			step.Completef(result.StepSkipped, "User cancelled update")
-
-			return
+	for i := range conds {
+		if conds[i].Type == conditionType {
+			return &conds[i], nil
 		}
-		target.IO.Fprintln()
 	}
 
-	// Retry update with exponential backoff in case of conflicts
-	err = wait.ExponentialBackoff(wait.Backoff{
-		Duration: retryInitialDuration,
-		Factor:   retryFactor,
-		Jitter:   retryJitter,
-		Steps:    retryMaxSteps,
-	}, func() (bool, error) {
-		// Get latest version
-		latestDSC, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
-		if err != nil {
-			return false, fmt.Errorf("failed to get DataScienceCluster: %w", err)
-		}
-
-		// Apply the change
-		if err := jq.Transform(latestDSC, ".spec.components.kueue.managementState = %q", managementStateUnmanaged); err != nil {
-			return false, fmt.Errorf("failed to set managementState: %w", err)
-		}
-
-		// Attempt update
-		_, err = target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
-			Update(ctx, latestDSC, metav1.UpdateOptions{})
-		if err != nil {
-			// Retry on conflict errors
-			if apierrors.IsConflict(err) {
-				return false, nil // Retry
-			}
-
-			return false, fmt.Errorf("failed to update DataScienceCluster: %w", err)
-		}
-
-		return true, nil // Success
-	})
-
-	if err != nil {
-		step.Completef(result.StepFailed, "Failed to update DataScienceCluster: %v", err)
-
-		return
-	}
-
-	step.Completef(result.StepCompleted, "DataScienceCluster updated successfully")
-}
-
-func (a *RHBOKMigrationAction) verifyResourcesPreserved(
-	ctx context.Context,
-	target action.Target,
-) {
-	step := target.Recorder.Child(
-		"verify-resources-preserved",
-		"Verify ClusterQueue and LocalQueue resources preserved",
-	)
-
-	if target.DryRun {
-		step.Completef(result.StepSkipped, "Would verify ClusterQueue and LocalQueue resources are preserved")
-
-		return
-	}
-
-	clusterQueues, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
-	if err != nil {
-		// If the CRD doesn't exist, that's fine - it means there are no Kueue resources
-		if apierrors.IsNotFound(err) {
-			step.Completef(result.StepCompleted, "No ClusterQueue CRD found (no resources to preserve)")
-
-			return
-		}
-
-		step.Completef(result.StepFailed, "Failed to list ClusterQueues: %v", err)
-
-		return
-	}
-
-	localQueues, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR())
-	if err != nil {
-		// If the CRD doesn't exist, that's fine - it means there are no Kueue resources
-		if apierrors.IsNotFound(err) {
-			step.Completef(result.StepCompleted, "No LocalQueue CRD found (%d ClusterQueues preserved)", len(clusterQueues))
-
-			return
-		}
-
-		step.Completef(result.StepFailed, "Failed to list LocalQueues: %v", err)
-
-		return
-	}
-
-	step.Completef(result.StepCompleted,
-		"All %d ClusterQueues and %d LocalQueues preserved",
-		len(clusterQueues), len(localQueues))
+	return nil, nil
 }

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_crds.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_crds.go
@@ -1,0 +1,136 @@
+package rhbok
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	legacyCohortCRD     = "cohorts.kueue.x-k8s.io"
+	legacyTopologyCRD   = "topologies.kueue.x-k8s.io"
+	legacyCohortGroup   = "kueue.x-k8s.io"
+	legacyCohortVersion = "v1alpha1"
+	legacyCohortKind    = "Cohort"
+	legacyTopologyKind  = "Topology"
+)
+
+//nolint:gochecknoglobals // static legacy CRD names for migration
+var legacyCRDNames = []string{legacyCohortCRD, legacyTopologyCRD}
+
+func (a *RHBOKMigrationAction) deleteLegacyCRDs(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"delete-legacy-crds",
+		"Delete legacy v1alpha1 Kueue CRDs",
+	)
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would delete legacy CRDs: %v", legacyCRDNames)
+
+		return
+	}
+
+	failed := 0
+
+	for _, crdName := range legacyCRDNames {
+		crdStep := step.Child("delete-"+crdName, "Delete CRD "+crdName)
+
+		_, err := target.Client.APIExtensions().ApiextensionsV1().
+			CustomResourceDefinitions().
+			Get(ctx, crdName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			crdStep.Completef(result.StepSkipped, "CRD not found")
+
+			continue
+		}
+
+		if err != nil {
+			crdStep.Completef(result.StepFailed, "Failed to get CRD: %v", err)
+
+			failed++
+
+			continue
+		}
+
+		if !a.ForceDeleteLegacyCRDs {
+			if hasInstances, msg := a.legacyCRDHasInstances(ctx, target, crdName); hasInstances {
+				crdStep.Completef(result.StepFailed, "%s", msg)
+
+				failed++
+
+				continue
+			}
+		}
+
+		err = target.Client.APIExtensions().ApiextensionsV1().
+			CustomResourceDefinitions().
+			Delete(ctx, crdName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			crdStep.Completef(result.StepFailed, "Failed to delete CRD: %v", err)
+
+			failed++
+
+			continue
+		}
+
+		crdStep.Completef(result.StepCompleted, "Deleted CRD %s", crdName)
+	}
+
+	if failed > 0 {
+		step.Completef(result.StepFailed, "One or more legacy CRD deletions failed")
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Legacy CRD deletion complete")
+}
+
+func (a *RHBOKMigrationAction) legacyCRDHasInstances(
+	ctx context.Context,
+	target action.Target,
+	crdName string,
+) (bool, string) {
+	var gvr resources.ResourceType
+
+	switch crdName {
+	case legacyCohortCRD:
+		gvr = resources.ResourceType{
+			Group: legacyCohortGroup, Version: legacyCohortVersion,
+			Kind: legacyCohortKind, Resource: "cohorts",
+		}
+	case legacyTopologyCRD:
+		gvr = resources.ResourceType{
+			Group: legacyCohortGroup, Version: legacyCohortVersion,
+			Kind: legacyTopologyKind, Resource: "topologies",
+		}
+	default:
+		return false, ""
+	}
+
+	items, err := target.Client.ListResources(ctx, gvr.GVR())
+	if err != nil {
+		if apierrors.IsNotFound(err) || client.IsResourceTypeNotFound(err) {
+			return false, ""
+		}
+
+		return true, fmt.Sprintf("Could not list %s instances: %v", crdName, err)
+	}
+
+	if len(items) > 0 {
+		return true, fmt.Sprintf(
+			"CRD %s has %d instance(s); convert or delete them first, or use --force-delete-legacy-crds",
+			crdName, len(items))
+	}
+
+	return false, ""
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_dsc.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_dsc.go
@@ -1,0 +1,190 @@
+package rhbok
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+func (a *RHBOKMigrationAction) removeEmbeddedKueue(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"remove-embedded-kueue",
+		"Uninstall embedded Kueue by setting managementState to Removed",
+	)
+
+	if a.SkipRemoveEmbedded {
+		step.Completef(result.StepSkipped,
+			"Skipping embedded Kueue removal (--skip-remove-embedded); this may cause configuration conflicts")
+
+		return
+	}
+
+	state, err := a.getKueueManagementState(ctx, target.Client)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
+
+		return
+	}
+
+	if state == constants.ManagementStateRemoved || state == constants.ManagementStateUnmanaged {
+		step.Completef(result.StepSkipped, "Embedded Kueue already removed (managementState=%s)", state)
+
+		return
+	}
+
+	if state != constants.ManagementStateManaged {
+		step.Completef(result.StepSkipped, "Kueue managementState is %s; removal not required", state)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would set %s=%s", kueueComponentPath, constants.ManagementStateRemoved)
+
+		return
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to set DataScienceCluster Kueue managementState to %s", constants.ManagementStateRemoved)
+		if !confirmation.Prompt(target.IO, "Proceed with embedded Kueue removal?") {
+			step.Completef(result.StepSkipped, "User cancelled removal")
+
+			return
+		}
+		target.IO.Fprintln()
+	}
+
+	if err := a.patchKueueManagementState(ctx, target, constants.ManagementStateRemoved, nil); err != nil {
+		step.Completef(result.StepFailed, "Failed to remove embedded Kueue: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "DataScienceCluster Kueue set to Removed")
+}
+
+func (a *RHBOKMigrationAction) activateRHBOK(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"activate-rhbok",
+		"Activate Red Hat build of Kueue in DataScienceCluster",
+	)
+
+	state, err := a.getKueueManagementState(ctx, target.Client)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
+
+		return
+	}
+
+	if state == constants.ManagementStateUnmanaged {
+		step.Completef(result.StepSkipped, "DataScienceCluster Kueue already set to Unmanaged")
+
+		return
+	}
+
+	queueNames := map[string]string{}
+	if a.ClusterQueueName != "" {
+		queueNames["defaultClusterQueueName"] = a.ClusterQueueName
+	}
+
+	if a.LocalQueueName != "" {
+		queueNames["defaultLocalQueueName"] = a.LocalQueueName
+	}
+
+	if target.DryRun {
+		msg := fmt.Sprintf("Would set %s=%s", kueueComponentPath, constants.ManagementStateUnmanaged)
+		if len(queueNames) > 0 {
+			msg += fmt.Sprintf(" with queue names %v", queueNames)
+		}
+
+		step.Completef(result.StepSkipped, "%s", msg)
+
+		return
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to set DataScienceCluster Kueue managementState to %s", constants.ManagementStateUnmanaged)
+		if !confirmation.Prompt(target.IO, "Proceed with RHBOK activation?") {
+			step.Completef(result.StepSkipped, "User cancelled activation")
+
+			return
+		}
+		target.IO.Fprintln()
+	}
+
+	if err := a.patchKueueManagementState(ctx, target, constants.ManagementStateUnmanaged, queueNames); err != nil {
+		step.Completef(result.StepFailed, "Failed to activate RHBOK: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "DataScienceCluster updated to Unmanaged")
+}
+
+type kueueQueueNames map[string]string
+
+func (a *RHBOKMigrationAction) patchKueueManagementState(
+	ctx context.Context,
+	target action.Target,
+	state string,
+	queueNames kueueQueueNames,
+) error {
+	err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: retryInitialDuration,
+		Factor:   retryFactor,
+		Jitter:   retryJitter,
+		Steps:    retryMaxSteps,
+	}, func() (bool, error) {
+		latestDSC, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
+		if err != nil {
+			return false, fmt.Errorf("failed to get DataScienceCluster: %w", err)
+		}
+
+		if err := jq.Transform(latestDSC, ".spec.components.kueue.managementState = %q", state); err != nil {
+			return false, fmt.Errorf("failed to set managementState: %w", err)
+		}
+
+		for field, value := range queueNames {
+			if err := unstructured.SetNestedField(latestDSC.Object, value, "spec", "components", "kueue", field); err != nil {
+				return false, fmt.Errorf("failed to set %s: %w", field, err)
+			}
+		}
+
+		_, err = target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
+			Update(ctx, latestDSC, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to update DataScienceCluster: %w", err)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("updating kueue management state: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_labeling.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_labeling.go
@@ -1,0 +1,390 @@
+package rhbok
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+type labelingPlan struct {
+	namespaces []string
+	workloads  []workloadRef
+}
+
+type workloadRef struct {
+	resourceType resources.ResourceType
+	object       *unstructured.Unstructured
+	queueName    string
+}
+
+func (a *RHBOKMigrationAction) discoverLabelingPlan(
+	ctx context.Context,
+	target action.Target,
+) (labelingPlan, error) {
+	plan := labelingPlan{}
+
+	enabled, err := kueuediscovery.KueueEnabledNamespaces(ctx, target.Client)
+	if err != nil {
+		return plan, fmt.Errorf("listing kueue-enabled namespaces: %w", err)
+	}
+
+	workloadNS, err := kueuediscovery.WorkloadLabeledNamespaces(ctx, target.Client)
+	if err != nil {
+		return plan, fmt.Errorf("listing workload-labeled namespaces: %w", err)
+	}
+
+	localQueueNS, err := a.namespacesWithLocalQueues(ctx, target)
+	if err != nil {
+		return plan, err
+	}
+
+	candidates := enabled.Union(workloadNS).Union(localQueueNS)
+
+	for ns := range candidates {
+		labeled, err := a.namespaceHasOpenshiftManagedLabel(ctx, target, ns)
+		if err != nil {
+			return plan, fmt.Errorf("checking namespace %s: %w", ns, err)
+		}
+
+		if labeled {
+			continue
+		}
+
+		plan.namespaces = append(plan.namespaces, ns)
+	}
+
+	managedNS := enabled.Union(workloadNS)
+	for _, ns := range plan.namespaces {
+		managedNS.Insert(ns)
+	}
+
+	for ns := range managedNS {
+		queueName, err := a.queueNameForNamespace(ctx, target, ns)
+		if err != nil {
+			return plan, err
+		}
+
+		for _, rt := range kueuediscovery.MonitoredWorkloadTypes {
+			items, err := target.Client.ListResources(ctx, rt.GVR(), client.WithNamespace(ns))
+			if err != nil {
+				if client.IsResourceTypeNotFound(err) {
+					continue
+				}
+
+				return plan, fmt.Errorf("listing %s in %s: %w", rt.Kind, ns, err)
+			}
+
+			for _, item := range items {
+				if hasQueueNameLabel(item) {
+					continue
+				}
+
+				plan.workloads = append(plan.workloads, workloadRef{
+					resourceType: rt,
+					object:       item,
+					queueName:    queueName,
+				})
+			}
+		}
+	}
+
+	return plan, nil
+}
+
+func (a *RHBOKMigrationAction) clearExecuteLabelingPlan() {
+	a.executeLabelingPlan = nil
+}
+
+func (a *RHBOKMigrationAction) discoverExecuteLabelingPlan(
+	ctx context.Context,
+	target action.Target,
+) (labelingPlan, error) {
+	if a.executeLabelingPlan != nil {
+		return *a.executeLabelingPlan, nil
+	}
+
+	plan, err := a.discoverLabelingPlan(ctx, target)
+	if err != nil {
+		return plan, err
+	}
+
+	a.executeLabelingPlan = &plan
+
+	return plan, nil
+}
+
+func (a *RHBOKMigrationAction) reportLabelingPlan(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"report-labeling-plan",
+		"Report namespaces and workloads requiring labels",
+	)
+
+	plan, err := a.discoverLabelingPlan(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover labeling targets: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted,
+		"Will label %d namespace(s) and %d workload(s)",
+		len(plan.namespaces), len(plan.workloads))
+}
+
+func (a *RHBOKMigrationAction) labelKueueNamespaces(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"label-kueue-namespaces",
+		"Apply kueue.openshift.io/managed=true to namespaces",
+	)
+
+	plan, err := a.discoverExecuteLabelingPlan(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover namespaces: %v", err)
+
+		return
+	}
+
+	if len(plan.namespaces) == 0 {
+		step.Completef(result.StepCompleted, "No namespaces require labeling")
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would label %d namespace(s)", len(plan.namespaces))
+
+		return
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to label %d namespace(s) with %s=true", len(plan.namespaces), constants.LabelKueueOpenshiftManaged)
+		if !confirmation.Prompt(target.IO, "Proceed with namespace labeling?") {
+			step.Completef(result.StepSkipped, "User cancelled namespace labeling")
+
+			return
+		}
+	}
+
+	success := 0
+
+	for _, ns := range plan.namespaces {
+		if err := a.patchNamespaceLabel(ctx, target, ns); err != nil {
+			step.Child("label-"+ns, "Label namespace "+ns).
+				Completef(result.StepFailed, "Failed: %v", err)
+
+			continue
+		}
+
+		success++
+	}
+
+	step.Completef(result.StepCompleted, "Labeled %d/%d namespace(s)", success, len(plan.namespaces))
+}
+
+func (a *RHBOKMigrationAction) labelKueueWorkloads(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"label-kueue-workloads",
+		"Apply kueue.x-k8s.io/queue-name to workloads",
+	)
+
+	plan, err := a.discoverExecuteLabelingPlan(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to discover workloads: %v", err)
+
+		return
+	}
+
+	if len(plan.workloads) == 0 {
+		step.Completef(result.StepCompleted, "No workloads require queue-name labels")
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would label %d workload(s)", len(plan.workloads))
+
+		return
+	}
+
+	if !target.SkipConfirm {
+		target.IO.Fprintln()
+		target.IO.Errorf("About to add queue-name labels to %d workload(s)", len(plan.workloads))
+		if !confirmation.Prompt(target.IO, "Proceed with workload labeling?") {
+			step.Completef(result.StepSkipped, "User cancelled workload labeling")
+
+			return
+		}
+	}
+
+	success := 0
+
+	for _, wl := range plan.workloads {
+		if err := a.patchWorkloadQueueLabel(ctx, target, wl); err != nil {
+			step.Child(
+				fmt.Sprintf("label-%s-%s", wl.object.GetNamespace(), wl.object.GetName()),
+				fmt.Sprintf("Label %s %s/%s", wl.resourceType.Kind, wl.object.GetNamespace(), wl.object.GetName()),
+			).Completef(result.StepFailed, "Failed: %v", err)
+
+			continue
+		}
+
+		success++
+	}
+
+	step.Completef(result.StepCompleted, "Labeled %d/%d workload(s)", success, len(plan.workloads))
+}
+
+func (a *RHBOKMigrationAction) namespacesWithLocalQueues(
+	ctx context.Context,
+	target action.Target,
+) (sets.Set[string], error) {
+	namespaces := sets.New[string]()
+
+	items, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR())
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			return namespaces, nil
+		}
+
+		return nil, fmt.Errorf("listing LocalQueues: %w", err)
+	}
+
+	for _, item := range items {
+		if ns := item.GetNamespace(); ns != "" {
+			namespaces.Insert(ns)
+		}
+	}
+
+	return namespaces, nil
+}
+
+func (a *RHBOKMigrationAction) namespaceHasOpenshiftManagedLabel(
+	ctx context.Context,
+	target action.Target,
+	name string,
+) (bool, error) {
+	ns, err := target.Client.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("getting namespace %s: %w", name, err)
+	}
+
+	return ns.Labels[constants.LabelKueueOpenshiftManaged] == "true", nil
+}
+
+func (a *RHBOKMigrationAction) queueNameForNamespace(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+) (string, error) {
+	if a.QueueName != "" && a.QueueName != defaultQueueName {
+		return a.workloadQueueName(), nil
+	}
+
+	items, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR(), client.WithNamespace(namespace))
+	if err != nil {
+		if client.IsResourceTypeNotFound(err) {
+			return a.workloadQueueName(), nil
+		}
+
+		return "", fmt.Errorf("listing LocalQueues in %s: %w", namespace, err)
+	}
+
+	if len(items) == 1 {
+		return items[0].GetName(), nil
+	}
+
+	return a.workloadQueueName(), nil
+}
+
+func hasQueueNameLabel(obj *unstructured.Unstructured) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+
+	_, exists := labels[constants.LabelKueueQueueName]
+
+	return exists
+}
+
+func (a *RHBOKMigrationAction) patchNamespaceLabel(
+	ctx context.Context,
+	target action.Target,
+	name string,
+) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				constants.LabelKueueOpenshiftManaged: "true",
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	_, err = target.Client.CoreV1().Namespaces().Patch(ctx, name, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patching namespace %s: %w", name, err)
+	}
+
+	return nil
+}
+
+func (a *RHBOKMigrationAction) patchWorkloadQueueLabel(
+	ctx context.Context,
+	target action.Target,
+	wl workloadRef,
+) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				constants.LabelKueueQueueName: wl.queueName,
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	_, err = target.Client.Dynamic().Resource(wl.resourceType.GVR()).
+		Namespace(wl.object.GetNamespace()).
+		Patch(ctx, wl.object.GetName(), types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patching %s/%s: %w", wl.object.GetNamespace(), wl.object.GetName(), err)
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_labeling_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_labeling_test.go
@@ -1,0 +1,138 @@
+package rhbok_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDiscoverLabelingPlan(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("union of kueue-enabled and local queue namespaces", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		teamA := makeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+		teamB := makeNamespace("team-b", nil)
+		lq := makeLocalQueue("team-lq", inNamespace("team-b"))
+		objects := []*unstructured.Unstructured{teamA, teamB, lq}
+
+		target := newTarget(t, objects, targetOpts{
+			rbacAllowed: true,
+			kubeObjects: []runtime.Object{
+				makeKubeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"}),
+				makeKubeNamespace("team-b", nil),
+			},
+		})
+
+		plan, err := rhbok.ExportDiscoverLabelingPlan(a, ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rhbok.ExportPlanNamespaces(plan)).To(ConsistOf("team-a", "team-b"))
+	})
+
+	t.Run("excludes namespaces already openshift-managed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		managed := makeNamespace("team-managed", map[string]string{
+			constants.LabelKueueManaged:          "true",
+			constants.LabelKueueOpenshiftManaged: "true",
+		})
+		target := newTarget(t, []*unstructured.Unstructured{managed}, targetOpts{
+			rbacAllowed: true,
+			kubeObjects: []runtime.Object{
+				makeKubeNamespace("team-managed", map[string]string{
+					constants.LabelKueueManaged:          "true",
+					constants.LabelKueueOpenshiftManaged: "true",
+				}),
+			},
+		})
+
+		plan, err := rhbok.ExportDiscoverLabelingPlan(a, ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rhbok.ExportPlanNamespaces(plan)).To(BeEmpty())
+	})
+
+	t.Run("selects workloads missing queue-name label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		ns := makeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+		nb := makeNotebook("nb-1", inNamespace("team-a"))
+		labeled := makeNotebook("nb-2", inNamespace("team-a"),
+			withLabel(constants.LabelKueueQueueName, "existing"))
+
+		target := newTarget(t, []*unstructured.Unstructured{ns, nb, labeled}, targetOpts{
+			rbacAllowed: true,
+			kubeObjects: []runtime.Object{
+				makeKubeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"}),
+			},
+		})
+
+		plan, err := rhbok.ExportDiscoverLabelingPlan(a, ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rhbok.ExportPlanWorkloads(plan)).To(HaveLen(1))
+		g.Expect(rhbok.ExportWorkloadQueueName(rhbok.ExportPlanWorkloads(plan)[0])).To(Equal("default"))
+	})
+
+	t.Run("uses single local queue name when unambiguous", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		ns := makeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+		lq := makeLocalQueue("my-queue", inNamespace("team-a"))
+		nb := makeNotebook("nb-1", inNamespace("team-a"))
+
+		target := newTarget(t, []*unstructured.Unstructured{ns, lq, nb}, targetOpts{
+			rbacAllowed: true,
+			kubeObjects: []runtime.Object{
+				makeKubeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"}),
+			},
+		})
+
+		plan, err := rhbok.ExportDiscoverLabelingPlan(a, ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(rhbok.ExportPlanWorkloads(plan)).To(HaveLen(1))
+		g.Expect(rhbok.ExportWorkloadQueueName(rhbok.ExportPlanWorkloads(plan)[0])).To(Equal("my-queue"))
+	})
+}
+
+func TestLabelKueueNamespaces(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("applies openshift managed label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		ns := makeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+		target := newTarget(t, []*unstructured.Unstructured{ns}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			kubeObjects: []runtime.Object{
+				makeKubeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"}),
+			},
+		})
+
+		rhbok.ExportLabelKueueNamespaces(a, ctx, target)
+
+		updated, err := target.Client.CoreV1().Namespaces().Get(ctx, "team-a", metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated.Labels[constants.LabelKueueOpenshiftManaged]).To(Equal("true"))
+		g.Expect(updated.Labels[constants.LabelKueueManaged]).To(Equal("true"))
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := res.Status.Steps[0]
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("Labeled 1/1"))
+	})
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight.go
@@ -7,11 +7,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
 	"github.com/opendatahub-io/odh-cli/pkg/util/kube/rbac"
 )
 
@@ -22,21 +23,48 @@ func preparePermissions() []rbac.PermissionCheck {
 		{Verb: "list", Group: resources.ClusterQueue.Group, Resource: resources.ClusterQueue.Resource},
 		{Verb: "list", Group: resources.LocalQueue.Group, Resource: resources.LocalQueue.Resource},
 		{Verb: "get", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
+		{Verb: "list", Group: resources.PackageManifest.Group, Resource: resources.PackageManifest.Resource},
 	}
 }
 
 func runPermissions() []rbac.PermissionCheck {
-	return []rbac.PermissionCheck{
-		{Verb: "get", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
-		{Verb: "list", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
-		{Verb: "update", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
-		{Verb: "get", Group: resources.Subscription.Group, Resource: resources.Subscription.Resource, Namespace: operatorNamespace},
-		{Verb: "create", Group: resources.Subscription.Group, Resource: resources.Subscription.Resource, Namespace: operatorNamespace},
-		{Verb: "list", Group: resources.ClusterServiceVersion.Group, Resource: resources.ClusterServiceVersion.Resource, Namespace: operatorNamespace},
-		{Verb: "list", Group: resources.ClusterQueue.Group, Resource: resources.ClusterQueue.Resource},
-		{Verb: "list", Group: resources.LocalQueue.Group, Resource: resources.LocalQueue.Resource},
-		{Verb: "get", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
-		{Verb: "update", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
+	checks := append([]rbac.PermissionCheck{}, preparePermissions()...)
+	checks = append(checks,
+		rbac.PermissionCheck{Verb: "update", Group: resources.DataScienceClusterV1.Group, Resource: resources.DataScienceClusterV1.Resource},
+		rbac.PermissionCheck{Verb: "get", Group: resources.Subscription.Group, Resource: resources.Subscription.Resource, Namespace: operatorNamespace},
+		rbac.PermissionCheck{Verb: "create", Group: resources.Subscription.Group, Resource: resources.Subscription.Resource, Namespace: operatorNamespace},
+		rbac.PermissionCheck{Verb: "list", Group: resources.OperatorGroup.Group, Resource: resources.OperatorGroup.Resource, Namespace: operatorNamespace},
+		rbac.PermissionCheck{Verb: "create", Group: resources.OperatorGroup.Group, Resource: resources.OperatorGroup.Resource, Namespace: operatorNamespace},
+		rbac.PermissionCheck{Verb: "list", Group: resources.ClusterServiceVersion.Group, Resource: resources.ClusterServiceVersion.Resource, Namespace: operatorNamespace},
+		rbac.PermissionCheck{Verb: "create", Group: resources.Namespace.Group, Resource: resources.Namespace.Resource},
+		rbac.PermissionCheck{Verb: "get", Group: resources.Namespace.Group, Resource: resources.Namespace.Resource},
+		rbac.PermissionCheck{Verb: "patch", Group: resources.Namespace.Group, Resource: resources.Namespace.Resource},
+		rbac.PermissionCheck{Verb: "update", Group: resources.ConfigMap.Group, Resource: resources.ConfigMap.Resource, Namespace: applicationsNamespace},
+		rbac.PermissionCheck{Verb: "get", Group: resources.Deployment.Group, Resource: resources.Deployment.Resource, Namespace: applicationsNamespace},
+		rbac.PermissionCheck{Verb: "list", Group: resources.Deployment.Group, Resource: resources.Deployment.Resource, Namespace: applicationsNamespace},
+		rbac.PermissionCheck{Verb: "get", Group: resources.CustomResourceDefinition.Group, Resource: resources.CustomResourceDefinition.Resource},
+		rbac.PermissionCheck{Verb: "delete", Group: resources.CustomResourceDefinition.Group, Resource: resources.CustomResourceDefinition.Resource},
+		rbac.PermissionCheck{Verb: "list", Group: resources.Pod.Group, Resource: resources.Pod.Resource, Namespace: operatorNamespace},
+	)
+
+	for _, rt := range monitoredWorkloadResourceTypes() {
+		checks = append(checks,
+			rbac.PermissionCheck{Verb: "list", Group: rt.Group, Resource: rt.Resource},
+			rbac.PermissionCheck{Verb: "patch", Group: rt.Group, Resource: rt.Resource},
+		)
+	}
+
+	return checks
+}
+
+func monitoredWorkloadResourceTypes() []resources.ResourceType {
+	return []resources.ResourceType{
+		resources.Notebook,
+		resources.InferenceService,
+		resources.LLMInferenceService,
+		resources.RayCluster,
+		resources.RayJob,
+		resources.PyTorchJob,
 	}
 }
 
@@ -73,6 +101,59 @@ func (a *RHBOKMigrationAction) verifyRBAC(
 	step.Completef(result.StepCompleted, "All %d required permissions verified", len(checks))
 }
 
+func (a *RHBOKMigrationAction) checkCertManager(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"check-cert-manager",
+		"Verify cert-manager is installed",
+	)
+
+	_, err := target.Client.APIExtensions().ApiextensionsV1().
+		CustomResourceDefinitions().
+		Get(ctx, "certificates.cert-manager.io", metav1.GetOptions{})
+	if err == nil {
+		step.Completef(result.StepCompleted, "cert-manager CRD found")
+
+		return
+	}
+
+	if !apierrors.IsNotFound(err) && !apierrors.IsForbidden(err) {
+		step.Completef(result.StepFailed, "Could not check cert-manager CRD: %v", err)
+
+		return
+	}
+
+	_, err = target.Client.Get(ctx, resources.Namespace.GVR(), "cert-manager")
+	if err == nil {
+		step.Completef(result.StepCompleted, "cert-manager namespace found")
+
+		return
+	}
+
+	if !apierrors.IsNotFound(err) {
+		step.Completef(result.StepFailed, "Could not check cert-manager namespace: %v", err)
+
+		return
+	}
+
+	_, err = target.Client.Get(ctx, resources.Namespace.GVR(), "openshift-cert-manager")
+	if err == nil {
+		step.Completef(result.StepCompleted, "openshift-cert-manager namespace found")
+
+		return
+	}
+
+	if !apierrors.IsNotFound(err) {
+		step.Completef(result.StepFailed, "Could not check openshift-cert-manager namespace: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepFailed, "cert-manager not detected (required for RHBOK)")
+}
+
 func (a *RHBOKMigrationAction) checkCurrentKueueState(
 	ctx context.Context,
 	target action.Target,
@@ -82,7 +163,7 @@ func (a *RHBOKMigrationAction) checkCurrentKueueState(
 		"Verify current Kueue state",
 	)
 
-	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
+	state, err := a.getKueueManagementState(ctx, target.Client)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			step.Completef(result.StepFailed, "DataScienceCluster not found - OpenShift AI may not be installed")
@@ -90,25 +171,19 @@ func (a *RHBOKMigrationAction) checkCurrentKueueState(
 			return
 		}
 
-		step.Completef(result.StepFailed, "Failed to get DataScienceCluster: %v", err)
+		step.Completef(result.StepFailed, "Failed to get Kueue management state: %v", err)
 
 		return
 	}
 
-	managementState, err := jq.Query[string](dsc, ".spec.components.kueue.managementState")
-	if err != nil {
-		step.Completef(result.StepFailed, "Failed to query Kueue managementState: %v", err)
-
-		return
+	switch state {
+	case constants.ManagementStateRemoved:
+		step.Completef(result.StepCompleted, "Kueue state is Removed; will resume migration")
+	case constants.ManagementStateUnmanaged:
+		step.Completef(result.StepCompleted, "Kueue state is Unmanaged")
+	case constants.ManagementStateManaged:
+		step.Completef(result.StepCompleted, "Kueue state is Managed; full migration required")
 	}
-
-	if managementState == "" {
-		step.Completef(result.StepFailed, "Kueue component not configured in DataScienceCluster")
-
-		return
-	}
-
-	step.Completef(result.StepCompleted, "Current Kueue state verified (managementState: %s)", managementState)
 }
 
 func (a *RHBOKMigrationAction) checkNoRHBOKConflicts(
@@ -120,23 +195,55 @@ func (a *RHBOKMigrationAction) checkNoRHBOKConflicts(
 		"Check for Red Hat build of Kueue operator conflicts",
 	)
 
-	subscription, err := target.Client.Dynamic().Resource(resources.Subscription.GVR()).
-		Namespace("openshift-kueue-operator").
-		Get(ctx, "kueue-operator", metav1.GetOptions{})
-
-	if err == nil && subscription != nil {
-		step.Completef(result.StepCompleted, "Red Hat build of Kueue operator already installed - migration may be partially complete")
+	state, err := a.getKueueManagementState(ctx, target.Client)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to get Kueue state: %v", err)
 
 		return
 	}
 
-	if !apierrors.IsNotFound(err) {
+	info, err := olm.FindOperator(ctx, target.Client, func(sub *olm.SubscriptionInfo) bool {
+		return sub.Name == subscriptionName
+	})
+	if err != nil {
 		step.Completef(result.StepFailed, "Failed to check Red Hat build of Kueue subscription: %v", err)
 
 		return
 	}
 
+	if state == constants.ManagementStateManaged && info.Found() {
+		step.Completef(result.StepFailed,
+			"Conflict: embedded Kueue is Managed but RHBOK operator is already installed")
+
+		return
+	}
+
+	if info.Found() {
+		step.Completef(result.StepCompleted, "Red Hat build of Kueue operator already installed")
+
+		return
+	}
+
 	step.Completef(result.StepCompleted, "No Red Hat build of Kueue conflicts detected")
+}
+
+func (a *RHBOKMigrationAction) checkOperatorChannel(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"check-operator-channel",
+		"Resolve Red Hat build of Kueue operator channel",
+	)
+
+	channel, err := a.resolveSubscriptionChannel(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to resolve operator channel: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Will install from channel %s", channel)
 }
 
 func (a *RHBOKMigrationAction) verifyKueueResources(
@@ -150,6 +257,12 @@ func (a *RHBOKMigrationAction) verifyKueueResources(
 
 	clusterQueues, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
 	if err != nil {
+		if apierrors.IsNotFound(err) || client.IsResourceTypeNotFound(err) {
+			step.Completef(result.StepCompleted, "No ClusterQueue CRD found")
+
+			return
+		}
+
 		step.Completef(result.StepFailed, "Failed to list ClusterQueues: %v", err)
 
 		return
@@ -157,7 +270,7 @@ func (a *RHBOKMigrationAction) verifyKueueResources(
 
 	localQueues, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR())
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || client.IsResourceTypeNotFound(err) {
 			step.Completef(result.StepCompleted,
 				"Kueue resources found: %d ClusterQueues (LocalQueue CRD not found)",
 				len(clusterQueues))

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_preflight_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_preflight_test.go
@@ -94,7 +94,8 @@ func TestCheckNoRHBOKConflicts(t *testing.T) {
 	t.Run("no subscription exists", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
-		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: true})
 
 		rhbok.ExportCheckNoRHBOKConflicts(a, ctx, target)
 
@@ -107,8 +108,14 @@ func TestCheckNoRHBOKConflicts(t *testing.T) {
 	t.Run("subscription already exists", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Removed"))
 		sub := makeSubscription("kueue-operator", inNamespace("openshift-kueue-operator"))
-		target := newTarget(t, []*unstructured.Unstructured{sub}, targetOpts{rbacAllowed: true})
+		target := newTarget(t, []*unstructured.Unstructured{dsc, sub}, targetOpts{
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription("kueue-operator", "openshift-kueue-operator"),
+			},
+		})
 
 		rhbok.ExportCheckNoRHBOKConflicts(a, ctx, target)
 
@@ -116,6 +123,26 @@ func TestCheckNoRHBOKConflicts(t *testing.T) {
 		g.Expect(res.Status.Steps).To(HaveLen(1))
 		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
 		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("already installed"))
+	})
+
+	t.Run("conflict when managed and operator installed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		sub := makeSubscription("kueue-operator", inNamespace("openshift-kueue-operator"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, sub}, targetOpts{
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription("kueue-operator", "openshift-kueue-operator"),
+			},
+		})
+
+		rhbok.ExportCheckNoRHBOKConflicts(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepFailed))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Conflict"))
 	})
 }
 
@@ -223,11 +250,12 @@ func TestCheckNoRHBOKConflicts_APIError(t *testing.T) {
 	t.Run("non-NotFound error", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
 
-		target := newTarget(t, nil, targetOpts{
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
 			rbacAllowed: true,
-			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
-				if act.GetResource().Resource == "subscriptions" && act.GetVerb() == "get" {
+			olmReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "subscriptions" && act.GetVerb() == "list" {
 					return true, nil, errors.New("server unavailable")
 				}
 

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_verify.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_verify.go
@@ -1,0 +1,254 @@
+package rhbok
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
+)
+
+func (a *RHBOKMigrationAction) verifyMigrationComplete(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"verify-migration-complete",
+		"Verify RHBOK migration completed successfully",
+	)
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would verify migration completion")
+
+		return
+	}
+
+	var failures []string
+
+	if msg := a.verifyEmbeddedRemoved(ctx, target); msg != "" {
+		failures = append(failures, msg)
+	}
+
+	if msg := a.verifyKueueReadyStatus(ctx, target); msg != "" {
+		failures = append(failures, msg)
+	}
+
+	if msg := a.verifyOperatorReady(ctx, target); msg != "" {
+		failures = append(failures, msg)
+	}
+
+	if msg := a.verifyQueuesPreserved(ctx, target); msg != "" {
+		failures = append(failures, msg)
+	}
+
+	if msg := a.verifyNamespaceLabels(ctx, target); msg != "" {
+		failures = append(failures, msg)
+	}
+
+	if msg := a.verifyWorkloadLabels(ctx, target); msg != "" {
+		failures = append(failures, msg)
+	}
+
+	if len(failures) > 0 {
+		step.Completef(result.StepFailed, "Verification failed: %s", strings.Join(failures, "; "))
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Migration verification passed")
+}
+
+func (a *RHBOKMigrationAction) verifyEmbeddedRemoved(ctx context.Context, target action.Target) string {
+	_, err := target.Client.Dynamic().Resource(resources.Deployment.GVR()).
+		Namespace(applicationsNamespace).
+		Get(ctx, embeddedKueueDeployment, metav1.GetOptions{})
+	if err == nil {
+		return fmt.Sprintf("embedded deployment %s still exists in %s", embeddedKueueDeployment, applicationsNamespace)
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return fmt.Sprintf("checking embedded deployment: %v", err)
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyKueueReadyStatus(ctx context.Context, target action.Target) string {
+	dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
+	if err != nil {
+		return fmt.Sprintf("getting DataScienceCluster: %v", err)
+	}
+
+	cond, err := getDSCCondition(dsc, kueueReadyType)
+	if err != nil {
+		return fmt.Sprintf("querying KueueReady: %v", err)
+	}
+
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		return "KueueReady condition is not True"
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyOperatorReady(ctx context.Context, target action.Target) string {
+	info, err := olm.FindOperator(ctx, target.Client, func(sub *olm.SubscriptionInfo) bool {
+		return sub.Name == subscriptionName
+	})
+	if err != nil {
+		return fmt.Sprintf("checking RHBOK operator: %v", err)
+	}
+
+	if !info.Found() {
+		return "Red Hat build of Kueue operator subscription not found"
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyQueuesPreserved(ctx context.Context, target action.Target) string {
+	if msg := a.verifyQueueCRDListable(ctx, target, resources.ClusterQueue, "ClusterQueue"); msg != "" {
+		return msg
+	}
+
+	if msg := a.verifyQueueCRDListable(ctx, target, resources.LocalQueue, "LocalQueue"); msg != "" {
+		return msg
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyQueueCRDListable(
+	ctx context.Context,
+	target action.Target,
+	resource resources.ResourceType,
+	kind string,
+) string {
+	_, err := target.Client.ListResources(ctx, resource.GVR())
+	if err == nil {
+		return ""
+	}
+
+	if apierrors.IsNotFound(err) || client.IsResourceTypeNotFound(err) {
+		if target.IO != nil {
+			target.IO.Fprintf(
+				"Warning: %s CRD not found during migration verification; queue preservation could not be verified\n",
+				kind,
+			)
+		}
+
+		return ""
+	}
+
+	return fmt.Sprintf("listing %ss: %v", kind, err)
+}
+
+func (a *RHBOKMigrationAction) verifyNamespaceLabels(ctx context.Context, target action.Target) string {
+	plan, err := a.discoverLabelingPlan(ctx, target)
+	if err != nil {
+		return fmt.Sprintf("discovering namespace labels: %v", err)
+	}
+
+	if len(plan.namespaces) > 0 {
+		return fmt.Sprintf("%d namespace(s) still missing %s label", len(plan.namespaces), constants.LabelKueueOpenshiftManaged)
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyWorkloadLabels(ctx context.Context, target action.Target) string {
+	managed, err := kueuediscovery.KueueEnabledNamespaces(ctx, target.Client)
+	if err != nil {
+		return fmt.Sprintf("listing managed namespaces: %v", err)
+	}
+
+	var missing []string
+
+	for ns := range managed {
+		for _, rt := range kueuediscovery.MonitoredWorkloadTypes {
+			items, err := target.Client.ListResources(ctx, rt.GVR(), client.WithNamespace(ns))
+			if err != nil {
+				if client.IsResourceTypeNotFound(err) {
+					continue
+				}
+
+				return fmt.Sprintf("listing %s: %v", rt.Kind, err)
+			}
+
+			for _, item := range items {
+				if !hasQueueNameLabel(item) {
+					missing = append(missing, fmt.Sprintf("%s %s/%s", rt.Kind, ns, item.GetName()))
+				}
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		const maxShow = 5
+		shown := missing
+		if len(shown) > maxShow {
+			shown = shown[:maxShow]
+		}
+
+		return fmt.Sprintf("%d workload(s) missing queue-name label (e.g. %s)",
+			len(missing), strings.Join(shown, ", "))
+	}
+
+	return ""
+}
+
+// verifyQueuesPreserved is kept for backward-compatible test exports.
+func (a *RHBOKMigrationAction) verifyResourcesPreserved(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"verify-resources-preserved",
+		"Verify ClusterQueue and LocalQueue resources preserved",
+	)
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would verify ClusterQueue and LocalQueue resources are preserved")
+
+		return
+	}
+
+	clusterQueues, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			step.Completef(result.StepCompleted, "No ClusterQueue CRD found (no resources to preserve)")
+
+			return
+		}
+
+		step.Completef(result.StepFailed, "Failed to list ClusterQueues: %v", err)
+
+		return
+	}
+
+	localQueues, err := target.Client.ListResources(ctx, resources.LocalQueue.GVR())
+	if err != nil {
+		if apierrors.IsNotFound(err) || client.IsResourceTypeNotFound(err) {
+			step.Completef(result.StepCompleted, "No LocalQueue CRD found (%d ClusterQueues preserved)", len(clusterQueues))
+
+			return
+		}
+
+		step.Completef(result.StepFailed, "Failed to list LocalQueues: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted,
+		"All %d ClusterQueues and %d LocalQueues preserved",
+		len(clusterQueues), len(localQueues))
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_verify_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_verify_test.go
@@ -1,0 +1,245 @@
+package rhbok_test
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+
+	. "github.com/onsi/gomega"
+)
+
+type verifiedMigrationFixture struct {
+	objects []*unstructured.Unstructured
+	opts    targetOpts
+	dsc     *unstructured.Unstructured
+	ns      *unstructured.Unstructured
+	nb      *unstructured.Unstructured
+}
+
+func verifiedMigrationSetup() verifiedMigrationFixture {
+	dsc := makeDSCV1("default-dsc",
+		withComponent("kueue", "Unmanaged"),
+		withDSCCondition("KueueReady", "True", "Ready"),
+	)
+	ns := makeNamespace("team-a", map[string]string{
+		constants.LabelKueueManaged:          "true",
+		constants.LabelKueueOpenshiftManaged: "true",
+	})
+	nb := makeNotebook("nb-1", inNamespace("team-a"),
+		withLabel(constants.LabelKueueQueueName, "default"))
+
+	opts := targetOpts{
+		skipConfirm: true,
+		rbacAllowed: true,
+		olmObjects: []runtime.Object{
+			newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+		},
+		kubeObjects: []runtime.Object{
+			makeKubeNamespace("team-a", map[string]string{
+				constants.LabelKueueManaged:          "true",
+				constants.LabelKueueOpenshiftManaged: "true",
+			}),
+		},
+	}
+
+	return verifiedMigrationFixture{
+		objects: []*unstructured.Unstructured{dsc, ns, nb},
+		opts:    opts,
+		dsc:     dsc,
+		ns:      ns,
+		nb:      nb,
+	}
+}
+
+func TestVerifyMigrationComplete(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("dry-run skips", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{dryRun: true, rbacAllowed: true})
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("passes when all criteria are met", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("passed"))
+	})
+
+	t.Run("fails when embedded deployment still exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		embedded := makeDeployment(rhbok.ExportEmbeddedDeployment,
+			inNamespace(rhbok.ExportApplicationsNamespace))
+		objects := append(fixture.objects, embedded)
+		target := newTarget(t, objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("embedded deployment"))
+	})
+
+	t.Run("fails when KueueReady is not True", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.dsc = makeDSCV1("default-dsc",
+			withComponent("kueue", "Unmanaged"),
+			withDSCCondition("KueueReady", "False", "Removed"),
+		)
+		fixture.objects[0] = fixture.dsc
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("KueueReady"))
+	})
+
+	t.Run("fails when operator subscription is missing", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.opts.olmObjects = nil
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("subscription not found"))
+	})
+
+	t.Run("fails when namespaces are missing openshift managed label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.ns = makeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+		fixture.objects[1] = fixture.ns
+		fixture.opts.kubeObjects = []runtime.Object{
+			makeKubeNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"}),
+		}
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("missing"))
+		g.Expect(step.Message).To(ContainSubstring(constants.LabelKueueOpenshiftManaged))
+	})
+
+	t.Run("fails when workloads are missing queue-name label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.nb = makeNotebook("nb-1", inNamespace("team-a"))
+		fixture.objects[2] = fixture.nb
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("missing queue-name label"))
+	})
+}
+
+func TestVerifyResourcesPreserved(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("reports preserved queue counts", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq1 := makeClusterQueue("cq-1")
+		cq2 := makeClusterQueue("cq-2")
+		lq := makeLocalQueue("lq-1", inNamespace("default"))
+		target := newTarget(t, []*unstructured.Unstructured{cq1, cq2, lq}, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step).ToNot(BeNil())
+		g.Expect(step.Status).To(Equal(result.StepCompleted))
+		g.Expect(step.Message).To(ContainSubstring("2 ClusterQueues"))
+		g.Expect(step.Message).To(ContainSubstring("1 LocalQueues"))
+	})
+
+	t.Run("dry-run skips", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{dryRun: true, rbacAllowed: true})
+
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step.Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("ClusterQueue list error fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		target := newTarget(t, nil, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "clusterqueues" && act.GetVerb() == "list" {
+					return true, nil, errors.New("forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("Failed to list ClusterQueues"))
+	})
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_wait.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_wait.go
@@ -1,0 +1,183 @@
+package rhbok
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+//nolint:gochecknoglobals // test-only poll overrides set via SetTestPollConfig in export_test.go
+var (
+	testComponentPollPeriod time.Duration
+	testComponentTimeout    time.Duration
+)
+
+func podReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodSucceeded {
+		return true
+	}
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func pollPeriod() time.Duration {
+	if testComponentPollPeriod > 0 {
+		return testComponentPollPeriod
+	}
+
+	return componentPollPeriod
+}
+
+func pollTimeout() time.Duration {
+	if testComponentTimeout > 0 {
+		return testComponentTimeout
+	}
+
+	return componentTimeout
+}
+
+func (a *RHBOKMigrationAction) waitForEmbeddedRemoval(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"wait-embedded-removal",
+		"Wait for embedded Kueue to be removed",
+	)
+
+	if a.SkipRemoveEmbedded {
+		step.Completef(result.StepSkipped, "Skipped (--skip-remove-embedded)")
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would wait for embedded Kueue removal")
+
+		return
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, pollPeriod(), pollTimeout(), true,
+		func(ctx context.Context) (bool, error) {
+			state, err := a.getKueueManagementState(ctx, target.Client)
+			if err != nil {
+				return false, err
+			}
+
+			if state != constants.ManagementStateRemoved {
+				return false, nil
+			}
+
+			dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
+			if err != nil {
+				return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+			}
+
+			cond, err := getDSCCondition(dsc, kueueReadyType)
+			if err != nil {
+				return false, err
+			}
+
+			if cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == constants.ManagementStateRemoved {
+				return true, nil
+			}
+
+			_, err = target.Client.Dynamic().Resource(resources.Deployment.GVR()).
+				Namespace(applicationsNamespace).
+				Get(ctx, embeddedKueueDeployment, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+
+			if err != nil {
+				return false, fmt.Errorf("getting embedded Kueue deployment: %w", err)
+			}
+
+			return false, nil
+		})
+	if err != nil {
+		step.Completef(result.StepFailed, "Timed out waiting for embedded Kueue removal: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "Embedded Kueue removed")
+}
+
+func (a *RHBOKMigrationAction) waitForKueueReady(
+	ctx context.Context,
+	target action.Target,
+) {
+	step := target.Recorder.Child(
+		"wait-kueue-ready",
+		"Wait for KueueReady condition",
+	)
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, "Would wait for KueueReady=True")
+
+		return
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, pollPeriod(), pollTimeout(), true,
+		func(ctx context.Context) (bool, error) {
+			dsc, err := client.GetSingleton(ctx, target.Client, resources.DataScienceClusterV1)
+			if err != nil {
+				return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+			}
+
+			cond, err := getDSCCondition(dsc, kueueReadyType)
+			if err != nil {
+				return false, err
+			}
+
+			if cond == nil || cond.Status != metav1.ConditionTrue {
+				return false, nil
+			}
+
+			pods, err := target.Client.CoreV1().Pods(operatorNamespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return false, fmt.Errorf("listing RHBOK pods: %w", err)
+			}
+
+			if len(pods.Items) == 0 {
+				return false, nil
+			}
+
+			for i := range pods.Items {
+				if !podReady(&pods.Items[i]) {
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
+	if err != nil {
+		step.Completef(result.StepFailed, "Timed out waiting for KueueReady: %v", err)
+
+		return
+	}
+
+	step.Completef(result.StepCompleted, "KueueReady=True and RHBOK pods ready")
+}

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_wait_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_wait_test.go
@@ -1,0 +1,77 @@
+package rhbok_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/kueue/rhbok"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWaitForEmbeddedRemoval(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("completes when KueueReady is Removed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc",
+			withComponent("kueue", "Removed"),
+			withDSCCondition("KueueReady", "False", "Removed"),
+		)
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		rhbok.ExportWaitEmbeddedRemoval(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("Embedded Kueue removed"))
+	})
+
+	t.Run("skips when skip-remove-embedded is set", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		a := &rhbok.RHBOKMigrationAction{SkipRemoveEmbedded: true}
+		target := newTarget(t, nil, targetOpts{rbacAllowed: true})
+
+		rhbok.ExportWaitEmbeddedRemoval(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepSkipped))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("skip-remove-embedded"))
+	})
+}
+
+func TestWaitForKueueReady(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("completes when KueueReady is True and pods are running", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc",
+			withComponent("kueue", "Unmanaged"),
+			withDSCCondition("KueueReady", "True", "Ready"),
+		)
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+		})
+
+		rhbok.ExportWaitKueueReady(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		g.Expect(res.Status.Steps).To(HaveLen(1))
+		g.Expect(res.Status.Steps[0].Status).To(Equal(result.StepCompleted))
+		g.Expect(res.Status.Steps[0].Message).To(ContainSubstring("KueueReady=True"))
+	})
+}

--- a/pkg/migrate/actions/kueue/rhbok/run_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/run_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 )
@@ -17,9 +18,12 @@ func (t *runTask) Validate(
 	target action.Target,
 ) (*result.ActionResult, error) {
 	t.action.verifyRBAC(ctx, target, runPermissions())
+	t.action.checkCertManager(ctx, target)
 	t.action.checkCurrentKueueState(ctx, target)
 	t.action.checkNoRHBOKConflicts(ctx, target)
+	t.action.checkOperatorChannel(ctx, target)
 	t.action.verifyKueueResources(ctx, target)
+	t.action.reportLabelingPlan(ctx, target)
 
 	rootRecorder, ok := target.Recorder.(action.RootRecorder)
 	if !ok {
@@ -33,20 +37,153 @@ func (t *runTask) Execute(
 	ctx context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	kueueManaged := t.action.checkKueueManaged(ctx, target)
-
-	if kueueManaged {
-		t.action.preserveKueueConfig(ctx, target)
+	validationResult, err := t.Validate(ctx, target)
+	if err != nil {
+		return nil, err
 	}
 
-	t.action.installRHBOKOperator(ctx, target)
-	t.action.updateDataScienceCluster(ctx, target)
-	t.action.verifyResourcesPreserved(ctx, target)
+	if hasFailedStep(validationResult.Status.Steps) {
+		return validationResult, errPreflightFailed
+	}
 
 	rootRecorder, ok := target.Recorder.(action.RootRecorder)
 	if !ok {
 		return nil, errors.New("recorder is not a RootRecorder")
 	}
 
+	if t.action.isMigrationComplete(ctx, target) {
+		step := target.Recorder.Child(
+			"migration-complete",
+			"Check if migration already complete",
+		)
+		step.Completef(result.StepSkipped, "RHBOK migration already complete (Unmanaged + operator installed)")
+	} else {
+		t.executeMigration(ctx, target)
+	}
+
 	return rootRecorder.Build(), nil
+}
+
+var errPreflightFailed = errors.New("preflight checks failed")
+
+func (t *runTask) executeMigration(ctx context.Context, target action.Target) {
+	t.action.clearExecuteLabelingPlan()
+
+	state, err := t.action.getKueueManagementState(ctx, target.Client)
+	if err != nil {
+		target.Recorder.Child("get-kueue-state", "Get Kueue managementState").
+			Completef(result.StepFailed, "Failed: %v", err)
+
+		return
+	}
+
+	if state == constants.ManagementStateManaged {
+		t.action.preserveKueueConfig(ctx, target)
+		if haltIfStepFailed(target, "preserve-kueue-config") {
+			return
+		}
+	}
+
+	if state == constants.ManagementStateManaged && !t.action.SkipRemoveEmbedded {
+		t.action.removeEmbeddedKueue(ctx, target)
+		if haltIfStepFailed(target, "remove-embedded-kueue") {
+			return
+		}
+
+		t.action.waitForEmbeddedRemoval(ctx, target)
+		if haltIfStepFailed(target, "wait-embedded-removal") {
+			return
+		}
+	}
+
+	t.action.deleteLegacyCRDs(ctx, target)
+	if haltIfStepFailed(target, "delete-legacy-crds") {
+		return
+	}
+
+	t.action.installRHBOKOperator(ctx, target)
+	if haltIfStepFailed(target, "install-rhbok-operator") {
+		return
+	}
+
+	if state != constants.ManagementStateUnmanaged {
+		t.action.activateRHBOK(ctx, target)
+		if haltIfStepFailed(target, "activate-rhbok") {
+			return
+		}
+	}
+
+	t.action.waitForKueueReady(ctx, target)
+	if haltIfStepFailed(target, "wait-kueue-ready") {
+		return
+	}
+
+	t.action.labelKueueNamespaces(ctx, target)
+	if haltIfStepFailed(target, "label-kueue-namespaces") {
+		return
+	}
+
+	t.action.labelKueueWorkloads(ctx, target)
+	if haltIfStepFailed(target, "label-kueue-workloads") {
+		return
+	}
+
+	t.action.verifyMigrationComplete(ctx, target)
+}
+
+func haltIfStepFailed(target action.Target, stepName string) bool {
+	root, ok := target.Recorder.(action.RootRecorder)
+	if !ok {
+		return false
+	}
+
+	if !stepTreeFailed(root.Build().Status.Steps, stepName) {
+		return false
+	}
+
+	target.Recorder.Child("migration-halted", "Halt migration after step failure").
+		Completef(result.StepFailed, "Migration halted: step %q failed", stepName)
+
+	return true
+}
+
+func stepTreeFailed(steps []result.ActionStep, stepName string) bool {
+	step := findActionStep(steps, stepName)
+	if step == nil {
+		return false
+	}
+
+	if step.Status == result.StepFailed {
+		return true
+	}
+
+	return hasFailedStep(step.Children)
+}
+
+func hasFailedStep(steps []result.ActionStep) bool {
+	for _, step := range steps {
+		if step.Status == result.StepFailed {
+			return true
+		}
+
+		if hasFailedStep(step.Children) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func findActionStep(steps []result.ActionStep, name string) *result.ActionStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+
+		if found := findActionStep(steps[i].Children, name); found != nil {
+			return found
+		}
+	}
+
+	return nil
 }

--- a/pkg/migrate/actions/kueue/rhbok/run_task_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/run_task_test.go
@@ -36,8 +36,21 @@ func TestRunTask_Validate(t *testing.T) {
 		res, err := task.Validate(ctx, target)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res).ToNot(BeNil())
-		// checkCurrentKueueState + checkNoRHBOKConflicts + verifyKueueResources + verifyRBAC
-		g.Expect(res.Status.Steps).To(HaveLen(4))
+
+		expectedSteps := []string{
+			"verify-rbac",
+			"check-cert-manager",
+			"check-kueue-state",
+			"check-rhbok-conflicts",
+			"check-operator-channel",
+			"verify-kueue-resources",
+			"report-labeling-plan",
+		}
+		stepNames := make([]string, len(res.Status.Steps))
+		for i := range res.Status.Steps {
+			stepNames[i] = res.Status.Steps[i].Name
+		}
+		g.Expect(stepNames).To(Equal(expectedSteps))
 	})
 
 	t.Run("reports RBAC failure", func(t *testing.T) {
@@ -56,6 +69,52 @@ func TestRunTask_Validate(t *testing.T) {
 		rbacStep := findStep(res.Status.Steps, "verify-rbac")
 		g.Expect(rbacStep).ToNot(BeNil())
 		g.Expect(rbacStep.Status).To(Equal(result.StepFailed))
+	})
+
+	t.Run("fails execute when validation fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{rbacAllowed: false})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).To(MatchError("preflight checks failed"))
+		g.Expect(res).ToNot(BeNil())
+
+		rbacStep := findStep(res.Status.Steps, "verify-rbac")
+		g.Expect(rbacStep).ToNot(BeNil())
+		g.Expect(rbacStep.Status).To(Equal(result.StepFailed))
+		g.Expect(findStep(res.Status.Steps, "preserve-kueue-config")).To(BeNil())
+	})
+
+	t.Run("fails execute when managed Kueue conflicts with installed operator", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		sub := makeSubscription(rhbok.ExportSubscriptionName, inNamespace(rhbok.ExportOperatorNamespace))
+		target := newTarget(t, []*unstructured.Unstructured{dsc, sub}, targetOpts{
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		task := a.Run()
+
+		res, err := task.Execute(ctx, target)
+		g.Expect(err).To(MatchError("preflight checks failed"))
+		g.Expect(res).ToNot(BeNil())
+
+		conflictStep := findStep(res.Status.Steps, "check-rhbok-conflicts")
+		g.Expect(conflictStep).ToNot(BeNil())
+		g.Expect(conflictStep.Status).To(Equal(result.StepFailed))
+		g.Expect(findStep(res.Status.Steps, "preserve-kueue-config")).To(BeNil())
 	})
 }
 
@@ -88,11 +147,11 @@ func TestRunTask_Execute(t *testing.T) {
 		g.Expect(installStep).ToNot(BeNil())
 		g.Expect(installStep.Status).To(Equal(result.StepSkipped))
 
-		updateStep := findStep(res.Status.Steps, "update-datasciencecluster")
+		updateStep := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(updateStep).ToNot(BeNil())
 		g.Expect(updateStep.Status).To(Equal(result.StepSkipped))
 
-		verifyStep := findStep(res.Status.Steps, "verify-resources-preserved")
+		verifyStep := findStep(res.Status.Steps, "verify-migration-complete")
 		g.Expect(verifyStep).ToNot(BeNil())
 		g.Expect(verifyStep.Status).To(Equal(result.StepSkipped))
 	})
@@ -139,10 +198,10 @@ func TestRunTask_Execute(t *testing.T) {
 		res, err := task.Execute(ctx, target)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		updateStep := findStep(res.Status.Steps, "update-datasciencecluster")
-		g.Expect(updateStep).ToNot(BeNil())
-		g.Expect(updateStep.Status).To(Equal(result.StepSkipped))
-		g.Expect(updateStep.Message).To(ContainSubstring("already set to Unmanaged"))
+		completeStep := findStep(res.Status.Steps, "migration-complete")
+		g.Expect(completeStep).ToNot(BeNil())
+		g.Expect(completeStep.Status).To(Equal(result.StepSkipped))
+		g.Expect(completeStep.Message).To(ContainSubstring("already complete"))
 	})
 
 	t.Run("preserveKueueConfig annotates ConfigMap", func(t *testing.T) {
@@ -239,13 +298,13 @@ func TestRunTask_Execute(t *testing.T) {
 		})
 
 		a := &rhbok.RHBOKMigrationAction{}
-		rhbok.ExportUpdateDSC(a, ctx, target)
+		rhbok.ExportActivateRHBOK(a, ctx, target)
 
 		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
-		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		step := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(step).ToNot(BeNil())
 		g.Expect(step.Status).To(Equal(result.StepCompleted))
-		g.Expect(step.Message).To(ContainSubstring("updated successfully"))
+		g.Expect(step.Message).To(ContainSubstring("updated to Unmanaged"))
 	})
 
 	t.Run("updateDataScienceCluster dry-run skips", func(t *testing.T) {
@@ -259,10 +318,10 @@ func TestRunTask_Execute(t *testing.T) {
 		})
 
 		a := &rhbok.RHBOKMigrationAction{}
-		rhbok.ExportUpdateDSC(a, ctx, target)
+		rhbok.ExportActivateRHBOK(a, ctx, target)
 
 		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
-		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		step := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(step).ToNot(BeNil())
 		g.Expect(step.Status).To(Equal(result.StepSkipped))
 		g.Expect(step.Message).To(ContainSubstring("Would set"))
@@ -278,10 +337,10 @@ func TestRunTask_Execute(t *testing.T) {
 		})
 
 		a := &rhbok.RHBOKMigrationAction{}
-		rhbok.ExportUpdateDSC(a, ctx, target)
+		rhbok.ExportActivateRHBOK(a, ctx, target)
 
 		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
-		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		step := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(step).ToNot(BeNil())
 		g.Expect(step.Status).To(Equal(result.StepFailed))
 	})
@@ -519,10 +578,10 @@ func TestRunTask_Execute(t *testing.T) {
 		})
 
 		a := &rhbok.RHBOKMigrationAction{}
-		rhbok.ExportUpdateDSC(a, ctx, target)
+		rhbok.ExportActivateRHBOK(a, ctx, target)
 
 		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
-		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		step := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(step).ToNot(BeNil())
 		g.Expect(step.Status).To(Equal(result.StepFailed))
 	})
@@ -559,10 +618,10 @@ func TestRunTask_Execute(t *testing.T) {
 		target.IO = iostreams.NewIOStreams(inBuf, &bytes.Buffer{}, &bytes.Buffer{})
 
 		a := &rhbok.RHBOKMigrationAction{}
-		rhbok.ExportUpdateDSC(a, ctx, target)
+		rhbok.ExportActivateRHBOK(a, ctx, target)
 
 		res := target.Recorder.(interface{ Build() *result.ActionResult }).Build()
-		step := findStep(res.Status.Steps, "update-datasciencecluster")
+		step := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(step).ToNot(BeNil())
 		g.Expect(step.Status).To(Equal(result.StepSkipped))
 		g.Expect(step.Message).To(ContainSubstring("cancelled"))
@@ -572,7 +631,7 @@ func TestRunTask_Execute(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Removed"))
 		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
 		cq := makeClusterQueue("cq-1")
 		lq := makeLocalQueue("lq-1", inNamespace("default"))
@@ -593,18 +652,17 @@ func TestRunTask_Execute(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
-		g.Expect(configStep).ToNot(BeNil())
-		g.Expect(configStep.Status).To(Equal(result.StepCompleted))
+		g.Expect(configStep).To(BeNil())
 
 		installStep := findStep(res.Status.Steps, "install-rhbok-operator")
 		g.Expect(installStep).ToNot(BeNil())
 		g.Expect(installStep.Status).To(Equal(result.StepCompleted))
 
-		updateStep := findStep(res.Status.Steps, "update-datasciencecluster")
+		updateStep := findStep(res.Status.Steps, "activate-rhbok")
 		g.Expect(updateStep).ToNot(BeNil())
 		g.Expect(updateStep.Status).To(Equal(result.StepCompleted))
 
-		verifyStep := findStep(res.Status.Steps, "verify-resources-preserved")
+		verifyStep := findStep(res.Status.Steps, "verify-migration-complete")
 		g.Expect(verifyStep).ToNot(BeNil())
 		g.Expect(verifyStep.Status).To(Equal(result.StepCompleted))
 	})
@@ -700,7 +758,7 @@ func TestRunTask_Execute(t *testing.T) {
 		})
 
 		a := &rhbok.RHBOKMigrationAction{}
-		rhbok.ExportUpdateDSC(a, ctx, target)
+		rhbok.ExportActivateRHBOK(a, ctx, target)
 
 		fetched, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
 			Get(ctx, "default-dsc", metav1.GetOptions{})
@@ -795,7 +853,7 @@ func TestRunTask_Execute(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Removed"))
 		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
 		cq := makeClusterQueue("cq-1")
 		lq := makeLocalQueue("lq-1", inNamespace("default"))
@@ -824,13 +882,13 @@ func TestRunTask_Execute(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(state).To(Equal("Unmanaged"))
 
-		// ConfigMap should have the preservation annotation
+		// ConfigMap preservation only runs when Kueue starts Managed
 		fetchedCM, err := target.Client.Dynamic().Resource(resources.ConfigMap.GVR()).
 			Namespace(rhbok.ExportApplicationsNamespace).
 			Get(ctx, rhbok.ExportConfigMapName, metav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
 
-		g.Expect(fetchedCM.GetAnnotations()).To(HaveKeyWithValue("opendatahub.io/managed", "false"))
+		g.Expect(fetchedCM.GetAnnotations()).ToNot(HaveKey("opendatahub.io/managed"))
 
 		// Kueue resources should still exist
 		cqs, err := target.Client.ListResources(ctx, resources.ClusterQueue.GVR())
@@ -846,7 +904,7 @@ func TestRunTask_Execute(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Removed"))
 		cm := makeConfigMap(rhbok.ExportConfigMapName, inNamespace(rhbok.ExportApplicationsNamespace))
 		cq := makeClusterQueue("cq-1")
 		sub := makeSubscription(rhbok.ExportSubscriptionName, inNamespace(rhbok.ExportOperatorNamespace))
@@ -866,11 +924,11 @@ func TestRunTask_Execute(t *testing.T) {
 		res1, err := task.Execute(ctx, target)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		updateStep1 := findStep(res1.Status.Steps, "update-datasciencecluster")
+		updateStep1 := findStep(res1.Status.Steps, "activate-rhbok")
 		g.Expect(updateStep1).ToNot(BeNil())
 		g.Expect(updateStep1.Status).To(Equal(result.StepCompleted))
 
-		// Second run on the same target — DSC is already Unmanaged, operator already installed
+		// Second run on the same target — migration already complete
 		target2 := newTarget(t, nil, targetOpts{
 			skipConfirm: true,
 			rbacAllowed: true,
@@ -879,7 +937,6 @@ func TestRunTask_Execute(t *testing.T) {
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
-		// Re-use the same dynamic client so we see the mutated state from run 1
 		target2.Client = target.Client
 		target2.IO = target.IO
 
@@ -887,22 +944,10 @@ func TestRunTask_Execute(t *testing.T) {
 		res2, err := task2.Execute(ctx, target2)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		// DSC update should be skipped — already Unmanaged
-		updateStep2 := findStep(res2.Status.Steps, "update-datasciencecluster")
-		g.Expect(updateStep2).ToNot(BeNil())
-		g.Expect(updateStep2.Status).To(Equal(result.StepSkipped))
-		g.Expect(updateStep2.Message).To(ContainSubstring("already set to Unmanaged"))
-
-		// Operator install should report already installed
-		installStep2 := findStep(res2.Status.Steps, "install-rhbok-operator")
-		g.Expect(installStep2).ToNot(BeNil())
-		g.Expect(installStep2.Status).To(Equal(result.StepCompleted))
-		g.Expect(installStep2.Message).To(ContainSubstring("already installed"))
-
-		// Resources should still be preserved
-		verifyStep2 := findStep(res2.Status.Steps, "verify-resources-preserved")
-		g.Expect(verifyStep2).ToNot(BeNil())
-		g.Expect(verifyStep2.Status).To(Equal(result.StepCompleted))
+		completeStep := findStep(res2.Status.Steps, "migration-complete")
+		g.Expect(completeStep).ToNot(BeNil())
+		g.Expect(completeStep.Status).To(Equal(result.StepSkipped))
+		g.Expect(completeStep.Message).To(ContainSubstring("already complete"))
 
 		// Verify final k8s state is unchanged from first run
 		fetchedDSC, err := target.Client.Dynamic().Resource(resources.DataScienceClusterV1.GVR()).
@@ -937,5 +982,73 @@ func TestRunTask_Execute(t *testing.T) {
 		configStep := findStep(res.Status.Steps, "preserve-kueue-config")
 		g.Expect(configStep).ToNot(BeNil())
 		g.Expect(configStep.Status).To(Equal(result.StepSkipped))
+	})
+}
+
+func TestIsMigrationComplete(t *testing.T) {
+	a := &rhbok.RHBOKMigrationAction{}
+
+	t.Run("requires succeeded CSV not just subscription", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		g.Expect(rhbok.ExportIsMigrationComplete(a, ctx, target)).To(BeFalse())
+	})
+
+	t.Run("true when unmanaged and operator CSV succeeded", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		g.Expect(rhbok.ExportIsMigrationComplete(a, ctx, target)).To(BeTrue())
+	})
+}
+
+func TestRunTask_HaltsOnStepFailure(t *testing.T) {
+	t.Run("halts when remove embedded fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Managed"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			skipConfirm: true,
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "datascienceclusters" && act.GetVerb() == "update" {
+					return true, nil, errors.New("update forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		a := &rhbok.RHBOKMigrationAction{}
+		res, err := a.Run().Execute(ctx, target)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		haltStep := findStep(res.Status.Steps, "migration-halted")
+		g.Expect(haltStep).ToNot(BeNil())
+		g.Expect(haltStep.Status).To(Equal(result.StepFailed))
+		g.Expect(haltStep.Message).To(ContainSubstring("remove-embedded-kueue"))
+
+		g.Expect(findStep(res.Status.Steps, "delete-legacy-crds")).To(BeNil())
+		g.Expect(findStep(res.Status.Steps, "install-rhbok-operator")).To(BeNil())
+		g.Expect(findStep(res.Status.Steps, "activate-rhbok")).To(BeNil())
 	})
 }

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -274,6 +274,13 @@ var (
 		Resource: "installplans",
 	}
 
+	OperatorGroup = ResourceType{
+		Group:    "operators.coreos.com",
+		Version:  "v1",
+		Kind:     "OperatorGroup",
+		Resource: "operatorgroups",
+	}
+
 	// ClusterQueue is the Kueue ClusterQueue resource.
 	ClusterQueue = ResourceType{
 		Group:    "kueue.x-k8s.io",

--- a/pkg/util/kube/olm/channel.go
+++ b/pkg/util/kube/olm/channel.go
@@ -1,0 +1,126 @@
+package olm
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver/v4"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	// FallbackKueueOperatorChannel is used when PackageManifest lookup fails.
+	FallbackKueueOperatorChannel = "stable-v1.2"
+)
+
+var stableChannelPattern = regexp.MustCompile(`^stable-v(\d+(?:\.\d+)*)$`)
+
+// PackageQuery identifies an operator package in a catalog source.
+type PackageQuery struct {
+	PackageName     string
+	CatalogSource   string
+	SourceNamespace string
+}
+
+// ResolveOperatorChannel returns the highest stable-v* channel from the operator's PackageManifest.
+// If no stable-v* channel exists, it falls back to status.defaultChannel.
+func ResolveOperatorChannel(
+	ctx context.Context,
+	r client.Reader,
+	query PackageQuery,
+) (string, error) {
+	manifests, err := client.List[*unstructured.Unstructured](ctx, r, resources.PackageManifest,
+		func(pm *unstructured.Unstructured) (bool, error) {
+			if pm.GetName() != query.PackageName {
+				return false, nil
+			}
+
+			if query.SourceNamespace != "" && pm.GetNamespace() != query.SourceNamespace {
+				return false, nil
+			}
+
+			if query.CatalogSource == "" {
+				return true, nil
+			}
+
+			catalogSource, err := jq.Query[string](pm, ".status.catalogSource")
+			if err != nil {
+				return false, nil
+			}
+
+			return catalogSource == query.CatalogSource, nil
+		})
+	if err != nil {
+		return "", fmt.Errorf("listing PackageManifests for %s: %w", query.PackageName, err)
+	}
+
+	if len(manifests) == 0 {
+		return "", fmt.Errorf("PackageManifest %q not found in catalog %q", query.PackageName, query.CatalogSource)
+	}
+
+	return resolveChannelFromManifest(manifests[0])
+}
+
+func resolveChannelFromManifest(pm *unstructured.Unstructured) (string, error) {
+	channels, err := jq.Query[[]any](pm, ".status.channels")
+	if err != nil {
+		return "", fmt.Errorf("querying channels: %w", err)
+	}
+
+	bestChannel := ""
+	bestVersion := semver.Version{}
+
+	for _, ch := range channels {
+		chMap, ok := ch.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := chMap["name"].(string)
+		if name == "" {
+			continue
+		}
+
+		matches := stableChannelPattern.FindStringSubmatch(name)
+		if len(matches) != 2 {
+			continue
+		}
+
+		v, err := parseChannelVersion(matches[1])
+		if err != nil {
+			continue
+		}
+
+		if bestChannel == "" || v.GT(bestVersion) {
+			bestChannel = name
+			bestVersion = v
+		}
+	}
+
+	if bestChannel != "" {
+		return bestChannel, nil
+	}
+
+	defaultChannel, err := jq.Query[string](pm, ".status.defaultChannel")
+	if err != nil || strings.TrimSpace(defaultChannel) == "" {
+		return "", fmt.Errorf("no stable-v* or defaultChannel found in PackageManifest %s", pm.GetName())
+	}
+
+	return defaultChannel, nil
+}
+
+func parseChannelVersion(version string) (semver.Version, error) {
+	parts := strings.Split(version, ".")
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+
+	return semver.Parse(strings.Join(parts[:3], ".")) //nolint:wrapcheck // version padding is local; parse error is self-descriptive
+}

--- a/pkg/util/kube/olm/channel_test.go
+++ b/pkg/util/kube/olm/channel_test.go
@@ -1,0 +1,71 @@
+package olm_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
+
+	. "github.com/onsi/gomega"
+)
+
+func newKueuePackageManifest(channels []string, defaultChannel string) *unstructured.Unstructured {
+	channelObjs := make([]any, 0, len(channels))
+	for _, ch := range channels {
+		channelObjs = append(channelObjs, map[string]any{
+			"name": ch,
+			"entries": []any{
+				map[string]any{"name": "kueue-operator.v1.0.0"},
+			},
+		})
+	}
+
+	status := map[string]any{
+		"catalogSource": "redhat-operators",
+		"channels":      channelObjs,
+	}
+	if defaultChannel != "" {
+		status["defaultChannel"] = defaultChannel
+	}
+
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": resources.PackageManifest.APIVersion(),
+		"kind":       resources.PackageManifest.Kind,
+		"metadata": map[string]any{
+			"name":      "kueue-operator",
+			"namespace": "openshift-marketplace",
+		},
+		"status": status,
+	}}
+}
+
+func TestResolveChannelFromManifest_HighestStableV(t *testing.T) {
+	g := NewWithT(t)
+
+	pm := newKueuePackageManifest([]string{"stable-v1.0", "stable-v1.2", "stable-v1.1", "candidate"}, "")
+
+	channel, err := olm.ExportResolveChannelFromManifest(pm)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(channel).To(Equal("stable-v1.2"))
+}
+
+func TestResolveChannelFromManifest_FallbackDefaultChannel(t *testing.T) {
+	g := NewWithT(t)
+
+	pm := newKueuePackageManifest([]string{"candidate"}, "stable")
+
+	channel, err := olm.ExportResolveChannelFromManifest(pm)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(channel).To(Equal("stable"))
+}
+
+func TestResolveChannelFromManifest_NoChannels(t *testing.T) {
+	g := NewWithT(t)
+
+	pm := newKueuePackageManifest(nil, "")
+
+	_, err := olm.ExportResolveChannelFromManifest(pm)
+	g.Expect(err).To(HaveOccurred())
+}

--- a/pkg/util/kube/olm/export_test.go
+++ b/pkg/util/kube/olm/export_test.go
@@ -1,0 +1,8 @@
+package olm
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// ExportResolveChannelFromManifest exposes resolveChannelFromManifest for external tests.
+func ExportResolveChannelFromManifest(pm *unstructured.Unstructured) (string, error) {
+	return resolveChannelFromManifest(pm)
+}

--- a/pkg/util/kube/olm/install.go
+++ b/pkg/util/kube/olm/install.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"time"
 
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,6 +37,8 @@ type InstallConfig struct {
 	Source              string
 	SourceNamespace     string
 	CSVNamePrefix       string
+	OperatorGroupName   string
+	TargetNamespaces    []string
 	PollInterval        time.Duration
 	Timeout             time.Duration
 	StartingCSV         string
@@ -64,6 +68,19 @@ func EnsureOperatorInstalled(
 
 	if config.DryRun {
 		return dryRunOperatorInstall(ctx, k8sClient, config)
+	}
+
+	if err := ensureNamespace(ctx, k8sClient, config.Namespace); err != nil {
+		return fmt.Errorf("failed to ensure namespace: %w", err)
+	}
+
+	operatorGroupName := config.OperatorGroupName
+	if operatorGroupName == "" {
+		operatorGroupName = defaultOperatorGroupName(config.Namespace)
+	}
+
+	if err := ensureOperatorGroup(ctx, k8sClient, config.Namespace, operatorGroupName, config.TargetNamespaces); err != nil {
+		return fmt.Errorf("failed to ensure operator group: %w", err)
 	}
 
 	// Check if subscription exists
@@ -98,6 +115,8 @@ func dryRunOperatorInstall(
 	if config.Recorder == nil {
 		return errors.New("recorder required for dry-run mode")
 	}
+
+	recordDryRunPrerequisiteSteps(config)
 
 	checkStep := config.Recorder.Child("check-subscription",
 		fmt.Sprintf("Checking if subscription '%s' exists in namespace '%s'", config.Name, config.Namespace))
@@ -149,6 +168,139 @@ func dryRunOperatorInstall(
 	return nil
 }
 
+func recordDryRunPrerequisiteSteps(config InstallConfig) {
+	nsStep := config.Recorder.Child("ensure-namespace",
+		fmt.Sprintf("Would ensure namespace '%s' exists", config.Namespace))
+	nsStep.Completef(result.StepSkipped, "Would create namespace if missing")
+
+	ogStep := config.Recorder.Child("ensure-operatorgroup",
+		fmt.Sprintf("Would ensure OperatorGroup exists in namespace '%s'", config.Namespace))
+	ogStep.AddDetail("name", operatorGroupName(config))
+	ogStep.Completef(result.StepSkipped, "Would create OperatorGroup if missing")
+}
+
+func operatorGroupName(config InstallConfig) string {
+	if config.OperatorGroupName != "" {
+		return config.OperatorGroupName
+	}
+
+	return defaultOperatorGroupName(config.Namespace)
+}
+
+func defaultOperatorGroupName(namespace string) string {
+	return namespace + "-og"
+}
+
+func ensureOperatorGroup(
+	ctx context.Context,
+	k8sClient client.Client,
+	namespace string,
+	name string,
+	targetNamespaces []string,
+) error {
+	list, err := k8sClient.OLMClient().OperatorsV1().OperatorGroups(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("list operatorgroups in %s: %w", namespace, err)
+	}
+
+	if len(list.Items) > 0 {
+		return validateExistingOperatorGroups(list.Items, namespace, targetNamespaces)
+	}
+
+	og := &operatorsv1.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	if len(targetNamespaces) > 0 {
+		og.Spec.TargetNamespaces = append([]string(nil), targetNamespaces...)
+	}
+
+	_, err = k8sClient.OLMClient().OperatorsV1().OperatorGroups(namespace).Create(ctx, og, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if apierrors.IsAlreadyExists(err) {
+		list, listErr := k8sClient.OLMClient().OperatorsV1().OperatorGroups(namespace).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			return fmt.Errorf("list operatorgroups in %s after already exists: %w", namespace, listErr)
+		}
+
+		return validateExistingOperatorGroups(list.Items, namespace, targetNamespaces)
+	}
+
+	return fmt.Errorf("create operatorgroup %s/%s: %w", namespace, name, err)
+}
+
+func validateExistingOperatorGroups(
+	items []operatorsv1.OperatorGroup,
+	namespace string,
+	requested []string,
+) error {
+	if len(items) > 1 {
+		return fmt.Errorf("expected at most one OperatorGroup in %s, found %d", namespace, len(items))
+	}
+
+	if len(items) == 0 {
+		return fmt.Errorf("no OperatorGroup found in %s after create conflict", namespace)
+	}
+
+	existingTargets := items[0].Spec.TargetNamespaces
+	if !slicesEqualUnordered(existingTargets, requested) {
+		return fmt.Errorf(
+			"operatorgroup %s/%s exists with targetNamespaces %v, but requested %v",
+			namespace, items[0].Name, existingTargets, requested,
+		)
+	}
+
+	return nil
+}
+
+func slicesEqualUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	counts := make(map[string]int, len(a))
+	for _, value := range a {
+		counts[value]++
+	}
+
+	for _, value := range b {
+		counts[value]--
+		if counts[value] < 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func ensureNamespace(ctx context.Context, k8sClient client.Client, name string) error {
+	_, err := k8sClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get namespace %s: %w", name, err)
+	}
+
+	_, err = k8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create namespace %s: %w", name, err)
+	}
+
+	return nil
+}
+
 func createSubscription(
 	ctx context.Context,
 	k8sClient client.Client,
@@ -180,6 +332,31 @@ func createSubscription(
 	return nil
 }
 
+// CSVReady reports whether a ClusterServiceVersion with the given name prefix has reached Succeeded phase.
+func CSVReady(
+	ctx context.Context,
+	k8sClient client.Reader,
+	namespace string,
+	csvNamePrefix string,
+) (bool, error) {
+	if csvNamePrefix == "" {
+		return false, errors.New("csv name prefix must not be empty")
+	}
+
+	csvList, err := k8sClient.OLM().ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("listing CSVs in %s: %w", namespace, err)
+	}
+
+	for _, csv := range csvList.Items {
+		if strings.HasPrefix(csv.Name, csvNamePrefix) && csv.Status.Phase == csvPhaseSucceeded {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // WaitForCSV waits for a ClusterServiceVersion with the given name prefix to reach Succeeded phase.
 func WaitForCSV(
 	ctx context.Context,
@@ -189,6 +366,10 @@ func WaitForCSV(
 	pollInterval time.Duration,
 	timeout time.Duration,
 ) error {
+	if csvNamePrefix == "" {
+		return errors.New("csv name prefix must not be empty")
+	}
+
 	if pollInterval == 0 {
 		pollInterval = defaultPollInterval
 	}

--- a/pkg/util/kube/olm/install_internal_test.go
+++ b/pkg/util/kube/olm/install_internal_test.go
@@ -1,0 +1,266 @@
+package olm
+
+import (
+	"errors"
+	"testing"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testOperatorNamespace = "openshift-kueue-operator"
+)
+
+func TestEnsureNamespace(t *testing.T) {
+	t.Run("creates namespace when missing", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		kubeClient := kubefake.NewSimpleClientset() //nolint:staticcheck // fake client without apply configs
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			Kubernetes: kubeClient,
+		})
+
+		err := ensureNamespace(ctx, k8sClient, testOperatorNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		ns, err := kubeClient.CoreV1().Namespaces().Get(ctx, testOperatorNamespace, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ns.Name).To(Equal(testOperatorNamespace))
+	})
+
+	t.Run("succeeds when namespace already exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		kubeClient := kubefake.NewSimpleClientset(&corev1.Namespace{ //nolint:staticcheck // fake client without apply configs
+			ObjectMeta: metav1.ObjectMeta{Name: testOperatorNamespace},
+		})
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			Kubernetes: kubeClient,
+		})
+
+		err := ensureNamespace(ctx, k8sClient, testOperatorNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("returns error when namespace get fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		kubeClient := kubefake.NewSimpleClientset() //nolint:staticcheck // fake client without apply configs
+		kubeClient.PrependReactor("get", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("connection refused")
+		})
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			Kubernetes: kubeClient,
+		})
+
+		err := ensureNamespace(ctx, k8sClient, testOperatorNamespace)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("get namespace"))
+	})
+}
+
+func TestEnsureOperatorGroup(t *testing.T) {
+	t.Run("creates operator group when missing", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		olmClient := operatorfake.NewSimpleClientset() //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			OLM: olmClient,
+		})
+
+		err := ensureOperatorGroup(ctx, k8sClient, testOperatorNamespace, "openshift-kueue-operator-og", nil)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		list, err := olmClient.OperatorsV1().OperatorGroups(testOperatorNamespace).List(ctx, metav1.ListOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(list.Items).To(HaveLen(1))
+		g.Expect(list.Items[0].Name).To(Equal("openshift-kueue-operator-og"))
+	})
+
+	t.Run("succeeds when operator group already exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		existing := &operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-operators",
+				Namespace: testOperatorNamespace,
+			},
+		}
+
+		olmClient := operatorfake.NewSimpleClientset(existing) //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			OLM: olmClient,
+		})
+
+		err := ensureOperatorGroup(ctx, k8sClient, testOperatorNamespace, "openshift-kueue-operator-og", nil)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("succeeds when existing target namespaces match requested", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		existing := &operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-operators",
+				Namespace: testOperatorNamespace,
+			},
+			Spec: operatorsv1.OperatorGroupSpec{
+				TargetNamespaces: []string{"team-a", "team-b"},
+			},
+		}
+
+		olmClient := operatorfake.NewSimpleClientset(existing) //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			OLM: olmClient,
+		})
+
+		err := ensureOperatorGroup(ctx, k8sClient, testOperatorNamespace, "openshift-kueue-operator-og",
+			[]string{"team-b", "team-a"})
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("returns error when target namespaces conflict", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		existing := &operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-operators",
+				Namespace: testOperatorNamespace,
+			},
+			Spec: operatorsv1.OperatorGroupSpec{
+				TargetNamespaces: []string{"other-ns"},
+			},
+		}
+
+		olmClient := operatorfake.NewSimpleClientset(existing) //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			OLM: olmClient,
+		})
+
+		err := ensureOperatorGroup(ctx, k8sClient, testOperatorNamespace, "openshift-kueue-operator-og", nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("targetNamespaces"))
+	})
+
+	t.Run("treats AlreadyExists as success when operator group exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		existing := &operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "openshift-kueue-operator-og",
+				Namespace: testOperatorNamespace,
+			},
+		}
+
+		olmClient := operatorfake.NewSimpleClientset(existing) //nolint:staticcheck // apply configs not available in OLM fake
+		olmClient.PrependReactor("create", "operatorgroups", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewAlreadyExists(
+				schema.GroupResource{Group: "operators.coreos.com", Resource: "operatorgroups"},
+				"openshift-kueue-operator-og",
+			)
+		})
+
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			OLM: olmClient,
+		})
+
+		err := ensureOperatorGroup(ctx, k8sClient, testOperatorNamespace, "openshift-kueue-operator-og", nil)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("returns error when multiple operator groups exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		og1 := &operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "og-1",
+				Namespace: testOperatorNamespace,
+			},
+		}
+		og2 := &operatorsv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "og-2",
+				Namespace: testOperatorNamespace,
+			},
+		}
+
+		olmClient := operatorfake.NewSimpleClientset(og1, og2) //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{
+			OLM: olmClient,
+		})
+
+		err := ensureOperatorGroup(ctx, k8sClient, testOperatorNamespace, "openshift-kueue-operator-og", nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("expected at most one OperatorGroup"))
+	})
+}
+
+func TestCSVReady(t *testing.T) {
+	t.Run("false when no succeeded CSV", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		olmClient := operatorfake.NewSimpleClientset() //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{OLM: olmClient})
+
+		ready, err := CSVReady(ctx, k8sClient, testOperatorNamespace, "kueue-operator")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ready).To(BeFalse())
+	})
+
+	t.Run("true when succeeded CSV exists", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		olmClient := operatorfake.NewSimpleClientset(&operatorsv1alpha1.ClusterServiceVersion{ //nolint:staticcheck // apply configs not available in OLM fake
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kueue-operator.v1.0.0",
+				Namespace: testOperatorNamespace,
+			},
+			Status: operatorsv1alpha1.ClusterServiceVersionStatus{
+				Phase: operatorsv1alpha1.CSVPhaseSucceeded,
+			},
+		})
+		k8sClient := client.NewForTesting(client.TestClientConfig{OLM: olmClient})
+
+		ready, err := CSVReady(ctx, k8sClient, testOperatorNamespace, "kueue-operator")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ready).To(BeTrue())
+	})
+
+	t.Run("error when csv name prefix is empty", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		olmClient := operatorfake.NewSimpleClientset() //nolint:staticcheck // apply configs not available in OLM fake
+		k8sClient := client.NewForTesting(client.TestClientConfig{OLM: olmClient})
+
+		ready, err := CSVReady(ctx, k8sClient, testOperatorNamespace, "")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("csv name prefix must not be empty"))
+		g.Expect(ready).To(BeFalse())
+	})
+}


### PR DESCRIPTION
## Description
- Introduced new methods for handling Kueue management, including `activateRHBOK`, `removeEmbeddedKueue`, and `deleteLegacyCRDs`.
- Added functions to discover and report labeling plans for namespaces and workloads.
- Enhanced validation checks in `prepare_task` to include cert-manager verification and reporting of labeling plans.
- Updated tests to cover new functionalities and ensure robust validation of migration actions.
- Refactored existing code for improved clarity and maintainability.

This commit lays the groundwork for a more comprehensive migration process, ensuring that legacy resources are properly managed and new configurations are correctly applied.

https://redhat.atlassian.net/browse/RHOAIENG-63118

the old migration implementation vastly drifted from the current rhbok migration steps (see https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.25/html/managing_openshift_ai/managing-workloads-with-kueue#migrating-to-the-rhbok-operator_kueue) so enhanced it before implementing https://docs.google.com/document/d/1ON66oE8MuKhHsT_YaG5hxTdAjhcHbYOvd5pskj9uPyg/edit?tab=t.0#heading=h.7pgm4jr9szr0


## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator installation now also ensures an OperatorGroup exists and supports dry-run visibility for both the namespace and OperatorGroup steps.
  * Added operator CSV readiness detection and automatic channel resolution for operator installs.
  * Enhanced RHBOK migration with configurable flags, improved labeling discovery/application, and a full “migration verification” workflow.

* **Bug Fixes**
  * Expanded preflight checks (including cert-manager detection) and improved conflict detection logic.
  * More robust handling of missing Kueue CRDs during resource verification, treating absent CRDs as successful completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->