### PR TITLE
feat(migrate): add cleanup-oauth action for workbench migration

### DIFF
--- a/pkg/migrate/actions/workbenches/cleanup/cleanup.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup.go
@@ -194,24 +194,6 @@ func deleteResourceIfPresent(
 
 	var err error
 	if namespace != "" {
-		_, err = ri.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
-	} else {
-		_, err = ri.Get(ctx, name, metav1.GetOptions{})
-	}
-
-	if apierrors.IsNotFound(err) {
-		step.Recordf(stepID, "Already absent: %s", result.StepCompleted, label)
-
-		return true
-	}
-
-	if err != nil {
-		step.Recordf(stepID, "Failed to check %s: %v", result.StepFailed, label, err)
-
-		return false
-	}
-
-	if namespace != "" {
 		err = ri.Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	} else {
 		err = ri.Delete(ctx, name, metav1.DeleteOptions{})

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup.go
@@ -1,0 +1,278 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	actionID          = "workbenches.cleanup-oauth"
+	actionName        = "Clean up legacy OAuth resources from workbenches"
+	actionDescription = "Removes stale OAuth-proxy resources (Route, Service, Secrets, OAuthClient) " +
+		"left behind after migrating workbenches from 2.x to 3.x"
+
+	annotationInjectAuth  = "notebooks.opendatahub.io/inject-auth"
+	annotationInjectOAuth = "notebooks.opendatahub.io/inject-oauth"
+
+	containerKubeRBACProxy = "kube-rbac-proxy"
+	containerOAuthProxy    = "oauth-proxy"
+
+	envNotebookArgs       = "NOTEBOOK_ARGS"
+	tornadoSettingsPrefix = "--ServerApp.tornado_settings="
+
+	minTargetMajorVersion = 3
+)
+
+// CleanupOAuthAction implements the workbenches.cleanup-oauth migration action.
+// It removes legacy OAuth-proxy resources (Route, Service, Secrets, OAuthClient)
+// for notebooks that have been migrated to kube-rbac-proxy.
+type CleanupOAuthAction struct {
+	Scope *workbenches.SharedScopeOptions
+}
+
+func (a *CleanupOAuthAction) ID() string          { return actionID }
+func (a *CleanupOAuthAction) Name() string        { return actionName }
+func (a *CleanupOAuthAction) Description() string { return actionDescription }
+
+func (a *CleanupOAuthAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *CleanupOAuthAction) Phase() action.ActionPhase {
+	return action.PhasePostUpgrade
+}
+
+func (a *CleanupOAuthAction) AddFlags(fs *pflag.FlagSet) {
+	workbenches.AddScopeFlags(a.Scope, fs)
+}
+
+func (a *CleanupOAuthAction) CanApply(target action.Target) bool {
+	if target.TargetVersion == nil {
+		return false
+	}
+
+	return target.TargetVersion.Major >= minTargetMajorVersion
+}
+
+func (a *CleanupOAuthAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *CleanupOAuthAction) Run() action.Task {
+	return &runTask{action: a}
+}
+
+// checkMigrationState verifies that a notebook has been successfully migrated
+// from OAuth-proxy to kube-rbac-proxy. Returns true if all checks pass, along
+// with a list of failure messages for any checks that did not pass.
+func checkMigrationState(nb *unstructured.Unstructured) (bool, []string) {
+	var failures []string
+
+	annotations := nb.GetAnnotations()
+
+	if annotations[annotationInjectAuth] != "true" {
+		failures = append(failures,
+			fmt.Sprintf("inject-auth annotation missing or not 'true' (found: %q)",
+				annotations[annotationInjectAuth]))
+	}
+
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		failures = append(failures, fmt.Sprintf("could not read containers: %v", err))
+
+		return false, failures
+	}
+
+	hasKubeRBACProxy := false
+	hasOAuthProxy := false
+
+	for _, raw := range containers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := containerMap["name"].(string)
+
+		switch name {
+		case containerKubeRBACProxy:
+			hasKubeRBACProxy = true
+		case containerOAuthProxy:
+			hasOAuthProxy = true
+		}
+	}
+
+	if !hasKubeRBACProxy {
+		failures = append(failures, "kube-rbac-proxy sidecar container missing")
+	}
+
+	if hasOAuthProxy {
+		failures = append(failures, "legacy oauth-proxy sidecar still present")
+	}
+
+	if injectOAuth, exists := annotations[annotationInjectOAuth]; exists {
+		if !hasKubeRBACProxy || hasOAuthProxy {
+			failures = append(failures,
+				fmt.Sprintf("legacy inject-oauth annotation still exists: %q", injectOAuth))
+		}
+	}
+
+	if hasTornadoSettings(containers) {
+		failures = append(failures,
+			"--ServerApp.tornado_settings still present in NOTEBOOK_ARGS")
+	}
+
+	return len(failures) == 0, failures
+}
+
+func hasTornadoSettings(containers []any) bool {
+	for _, raw := range containers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		envVars, ok := containerMap["env"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, envRaw := range envVars {
+			envMap, ok := envRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name, _ := envMap["name"].(string)
+			value, _ := envMap["value"].(string)
+
+			if name == envNotebookArgs && strings.Contains(value, tornadoSettingsPrefix) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// deleteResourceIfPresent performs an idempotent deletion: if the resource
+// exists it is deleted; if it is already absent, no error is raised.
+// For cluster-scoped resources, pass an empty namespace.
+// Returns true if the resource was deleted or already absent; false on error.
+func deleteResourceIfPresent(
+	ctx context.Context,
+	target action.Target,
+	gvr schema.GroupVersionResource,
+	name string,
+	namespace string,
+	step action.StepRecorder,
+) bool {
+	label := resourceLabel(gvr, name, namespace)
+	stepID := fmt.Sprintf("delete-%s-%s", gvr.Resource, name)
+
+	if target.DryRun {
+		step.Recordf(stepID, "Would delete %s", result.StepSkipped, label)
+
+		return true
+	}
+
+	ri := target.Client.Dynamic().Resource(gvr)
+
+	var err error
+	if namespace != "" {
+		_, err = ri.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	} else {
+		_, err = ri.Get(ctx, name, metav1.GetOptions{})
+	}
+
+	if apierrors.IsNotFound(err) {
+		step.Recordf(stepID, "Already absent: %s", result.StepCompleted, label)
+
+		return true
+	}
+
+	if err != nil {
+		step.Recordf(stepID, "Failed to check %s: %v", result.StepFailed, label, err)
+
+		return false
+	}
+
+	if namespace != "" {
+		err = ri.Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	} else {
+		err = ri.Delete(ctx, name, metav1.DeleteOptions{})
+	}
+
+	if apierrors.IsNotFound(err) {
+		step.Recordf(stepID, "Already absent: %s", result.StepCompleted, label)
+
+		return true
+	}
+
+	if err != nil {
+		step.Recordf(stepID, "Failed to delete %s: %v", result.StepFailed, label, err)
+
+		return false
+	}
+
+	step.Recordf(stepID, "Deleted %s", result.StepCompleted, label)
+
+	return true
+}
+
+func resourceLabel(gvr schema.GroupVersionResource, name, namespace string) string {
+	if namespace != "" {
+		return fmt.Sprintf("%s/%s in namespace %q", gvr.Resource, name, namespace)
+	}
+
+	return fmt.Sprintf("%s/%s (cluster-scoped)", gvr.Resource, name)
+}
+
+func (a *CleanupOAuthAction) promptCleanupContinueOrSkip(
+	target action.Target,
+	name string,
+	namespace string,
+	failures []string,
+) bool {
+	if target.SkipConfirm {
+		return true
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("Pre-checks failed for %s/%s:", namespace, name)
+
+	for _, f := range failures {
+		target.IO.Errorf("  - %s", f)
+	}
+
+	return confirmation.Prompt(target.IO,
+		fmt.Sprintf("Continue cleanup for %s/%s despite failed pre-checks?", namespace, name))
+}
+
+func (a *CleanupOAuthAction) promptBeforeCleanup(
+	target action.Target,
+	count int,
+) bool {
+	if target.SkipConfirm {
+		return true
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("About to delete legacy OAuth resources for %d Notebook(s)", count)
+
+	return confirmation.Prompt(target.IO, "Proceed with OAuth resource cleanup?")
+}

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
@@ -1,0 +1,1058 @@
+//nolint:testpackage // Tests internal implementation (unexported helpers)
+package cleanup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
+
+	. "github.com/onsi/gomega"
+)
+
+// --- Test Fixtures ---
+
+//nolint:gochecknoglobals // test-only GVR→ListKind mapping for fake dynamic client
+var testListKinds = map[schema.GroupVersionResource]string{
+	resources.Notebook.GVR():    resources.Notebook.ListKind(),
+	resources.Route.GVR():       resources.Route.ListKind(),
+	resources.Service.GVR():     resources.Service.ListKind(),
+	resources.Secret.GVR():      resources.Secret.ListKind(),
+	resources.OAuthClient.GVR(): resources.OAuthClient.ListKind(),
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+type notebookOption func(map[string]any)
+
+func withAnnotations(annotations map[string]string) notebookOption {
+	return func(obj map[string]any) {
+		metadata := obj["metadata"].(map[string]any)
+		anyAnnotations := make(map[string]any, len(annotations))
+
+		for k, v := range annotations {
+			anyAnnotations[k] = v
+		}
+
+		metadata["annotations"] = anyAnnotations
+	}
+}
+
+func withContainers(containers ...map[string]any) notebookOption {
+	return func(obj map[string]any) {
+		obj["spec"] = map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": toAnySlice(containers),
+				},
+			},
+		}
+	}
+}
+
+func toAnySlice(items []map[string]any) []any {
+	result := make([]any, len(items))
+	for i, item := range items {
+		result[i] = item
+	}
+
+	return result
+}
+
+func container(name string) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"image": "registry.example.com/" + name + ":latest",
+	}
+}
+
+func containerWithEnv(name string, envVars ...map[string]any) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"image": "registry.example.com/" + name + ":latest",
+		"env":   toAnySlice(envVars),
+	}
+}
+
+func envVar(name, value string) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"value": value,
+	}
+}
+
+func migratedAnnotations() map[string]string {
+	return map[string]string{
+		annotationInjectAuth: "true",
+	}
+}
+
+func migratedContainers() []map[string]any {
+	return []map[string]any{
+		container("my-notebook"),
+		container(containerKubeRBACProxy),
+	}
+}
+
+func newNotebook(name, namespace string, opts ...notebookOption) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": resources.Notebook.APIVersion(),
+		"kind":       resources.Notebook.Kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newMigratedNotebook(name, namespace string) *unstructured.Unstructured {
+	return newNotebook(name, namespace,
+		withAnnotations(migratedAnnotations()),
+		withContainers(migratedContainers()...))
+}
+
+func newRoute(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Route.APIVersion(),
+			"kind":       resources.Route.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newService(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Service.APIVersion(),
+			"kind":       resources.Service.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newSecret(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Secret.APIVersion(),
+			"kind":       resources.Secret.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newOAuthClient(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.OAuthClient.APIVersion(),
+			"kind":       resources.OAuthClient.Kind,
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+}
+
+func allOAuthResources(nbName, namespace string) []*unstructured.Unstructured {
+	return []*unstructured.Unstructured{
+		newRoute(nbName, namespace),
+		newService(nbName+"-tls", namespace),
+		newSecret(nbName+"-oauth-client", namespace),
+		newSecret(nbName+"-oauth-config", namespace),
+		newSecret(nbName+"-tls", namespace),
+		newOAuthClient(nbName + "-" + namespace + "-oauth-client"),
+	}
+}
+
+func newFakeClient(objects []*unstructured.Unstructured, reactors ...k8stesting.Reactor) client.Client {
+	scheme := newScheme()
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	for _, r := range reactors {
+		dynamicClient.ReactionChain = append([]k8stesting.Reactor{r}, dynamicClient.ReactionChain...)
+	}
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+}
+
+func deleteErrorReactor(resource string) k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "delete",
+		Resource: resource,
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated delete error")
+		},
+	}
+}
+
+func listErrorReactor() k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "list",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated API server error")
+		},
+	}
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:        k8sClient,
+		TargetVersion: &targetVersion,
+		DryRun:        false,
+		SkipConfirm:   true,
+		Recorder:      action.NewVerboseRootRecorder(io),
+		IO:            io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func withInteractiveConfirm(input string) func(*action.Target) {
+	return func(t *action.Target) {
+		t.SkipConfirm = false
+		t.IO = iostreams.NewIOStreams(
+			strings.NewReader(input),
+			&bytes.Buffer{},
+			&bytes.Buffer{},
+		)
+		t.Recorder = action.NewVerboseRootRecorder(t.IO)
+	}
+}
+
+// --- Action Metadata Tests ---
+
+func TestCleanupOAuthAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+
+	g.Expect(a.ID()).To(Equal("workbenches.cleanup-oauth"))
+	g.Expect(a.Name()).To(Equal("Clean up legacy OAuth resources from workbenches"))
+	g.Expect(a.Description()).To(ContainSubstring("OAuth-proxy"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
+}
+
+func TestCleanupOAuthAction_CanApply(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+
+	g.Expect(a.CanApply(action.Target{})).To(BeFalse(), "nil target version")
+
+	v2 := semver.MustParse("2.16.0")
+	g.Expect(a.CanApply(action.Target{TargetVersion: &v2})).To(BeFalse(), "target 2.x")
+
+	v3 := semver.MustParse("3.0.0")
+	g.Expect(a.CanApply(action.Target{TargetVersion: &v3})).To(BeTrue(), "target 3.0")
+
+	v35 := semver.MustParse("3.5.0")
+	g.Expect(a.CanApply(action.Target{TargetVersion: &v35})).To(BeTrue(), "target 3.5")
+}
+
+func TestCleanupOAuthAction_PrepareIsNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	g.Expect(a.Prepare()).To(BeNil())
+}
+
+func TestCleanupOAuthAction_RunNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestCleanupOAuthAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	g.Expect(fs.Lookup("workbench-namespace")).ToNot(BeNil())
+	g.Expect(fs.Lookup("workbench-name")).ToNot(BeNil())
+}
+
+// --- Pre-check Tests ---
+
+func TestCheckMigrationState_AllPassed(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newMigratedNotebook("wb1", "ns1")
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeTrue())
+	g.Expect(failures).To(BeEmpty())
+}
+
+func TestCheckMigrationState_InjectAuthMissing(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(migratedContainers()...))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(ContainElement(ContainSubstring("inject-auth")))
+}
+
+func TestCheckMigrationState_KubeRBACProxyMissing(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(migratedAnnotations()),
+		withContainers(container("my-notebook")))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(ContainElement(ContainSubstring("kube-rbac-proxy")))
+}
+
+func TestCheckMigrationState_OAuthProxyStillPresent(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(migratedAnnotations()),
+		withContainers(
+			container("my-notebook"),
+			container(containerKubeRBACProxy),
+			container(containerOAuthProxy)))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(ContainElement(ContainSubstring("oauth-proxy")))
+}
+
+func TestCheckMigrationState_InjectOAuthTolerated(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationInjectAuth:  "true",
+			annotationInjectOAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(containerKubeRBACProxy)))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeTrue(), "inject-oauth tolerated when kube-rbac-proxy present and oauth-proxy absent")
+	g.Expect(failures).To(BeEmpty())
+}
+
+func TestCheckMigrationState_InjectOAuthFails(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationInjectAuth:  "true",
+			annotationInjectOAuth: "true",
+		}),
+		withContainers(container("my-notebook")))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(ContainElement(ContainSubstring("inject-oauth")))
+}
+
+func TestCheckMigrationState_TornadoSettingsPresent(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(migratedAnnotations()),
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar("NOTEBOOK_ARGS", "--ServerApp.tornado_settings={\"xsrf_cookies\": false}")),
+			container(containerKubeRBACProxy)))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(ContainElement(ContainSubstring("tornado_settings")))
+}
+
+func TestCheckMigrationState_NoContainers(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(migratedAnnotations()))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(ContainElement(ContainSubstring("could not read containers")))
+}
+
+func TestCheckMigrationState_TornadoSettingsInDifferentEnvVar(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(migratedAnnotations()),
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar("OTHER_VAR", "--ServerApp.tornado_settings={\"xsrf_cookies\": false}")),
+			container(containerKubeRBACProxy)))
+
+	passed, failures := checkMigrationState(nb)
+
+	g.Expect(passed).To(BeTrue(), "tornado_settings in a non-NOTEBOOK_ARGS env var should be ignored")
+	g.Expect(failures).To(BeEmpty())
+}
+
+// --- Validate Tests ---
+
+func TestRunTask_Validate_MixedPassFail(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb-good", "ns1"),
+		newNotebook("wb-bad", "ns1", withContainers(container("my-notebook"))),
+	})
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+
+			g.Expect(step.Message).To(ContainSubstring("1/2"))
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+func TestRunTask_Validate_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_PassingChecks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Validate_FailingChecks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")))
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+func TestRunTask_Validate_NameRequiresNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{WorkbenchName: "wb1"}}
+	task := a.Run()
+
+	_, err := task.Validate(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-name requires --workbench-namespace"))
+}
+
+func TestRunTask_Validate_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+// --- Execute Tests ---
+
+func TestRunTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_CleanupSuccess(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// Verify resources are deleted
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "route should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Service.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-tls", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "service should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Secret.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-oauth-client", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "secret oauth-client should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Secret.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-oauth-config", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "secret oauth-config should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Secret.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-tls", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "secret tls should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.OAuthClient.GVR()).
+		Get(context.Background(), "wb1-ns1-oauth-client", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "oauthclient should be deleted")
+}
+
+func TestRunTask_Execute_ResourcesAlreadyAbsent(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_DeleteError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects, deleteErrorReactor("routes"))
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+
+		for _, child := range step.Children {
+			if child.Status == "Failed" {
+				hasFailedStep = true
+			}
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+func TestRunTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient, withDryRun)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify resources are NOT deleted in dry-run
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "route should still exist in dry-run")
+
+	_, err = k8sClient.Dynamic().Resource(resources.OAuthClient.GVR()).
+		Get(context.Background(), "wb1-ns1-oauth-client", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "oauthclient should still exist in dry-run")
+}
+
+func TestRunTask_Execute_PreCheckFails_SkipConfirm(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")))
+
+	objects := append(
+		[]*unstructured.Unstructured{nb},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// SkipConfirm=true means pre-check failure is overridden and cleanup proceeds
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "route should be deleted even with failed pre-check (SkipConfirm)")
+}
+
+func TestRunTask_Execute_PreCheckFails_UserSkips(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")))
+
+	objects := append(
+		[]*unstructured.Unstructured{nb},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient, withInteractiveConfirm("n\ny\n"))
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// User said "n" to per-notebook pre-check prompt, so resources should still exist
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "route should still exist when user skips")
+}
+
+func TestRunTask_Execute_MultipleNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := make([]*unstructured.Unstructured, 0, 14)
+	objects = append(objects, newMigratedNotebook("wb1", "ns1"))
+	objects = append(objects, allOAuthResources("wb1", "ns1")...)
+	objects = append(objects, newMigratedNotebook("wb2", "ns2"))
+	objects = append(objects, allOAuthResources("wb2", "ns2")...)
+
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// Both notebooks' resources should be deleted
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "wb1 route should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns2").Get(context.Background(), "wb2", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "wb2 route should be deleted")
+}
+
+func TestRunTask_Execute_SingleNotebookTargeting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := make([]*unstructured.Unstructured, 0, 14)
+	objects = append(objects, newMigratedNotebook("wb1", "ns1"))
+	objects = append(objects, allOAuthResources("wb1", "ns1")...)
+	objects = append(objects, newMigratedNotebook("wb2", "ns1"))
+	objects = append(objects, allOAuthResources("wb2", "ns1")...)
+
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{
+		WorkbenchNamespace: "ns1",
+		WorkbenchName:      "wb1",
+	}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// wb1 resources should be deleted
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "wb1 route should be deleted")
+
+	// wb2 resources should still exist (not targeted)
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb2", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "wb2 route should still exist")
+}
+
+func TestRunTask_Execute_NamespaceScopedTargeting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := make([]*unstructured.Unstructured, 0, 14)
+	objects = append(objects, newMigratedNotebook("wb1", "ns1"))
+	objects = append(objects, allOAuthResources("wb1", "ns1")...)
+	objects = append(objects, newMigratedNotebook("wb2", "ns2"))
+	objects = append(objects, allOAuthResources("wb2", "ns2")...)
+
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{
+		WorkbenchNamespace: "ns1",
+	}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// ns1 resources should be deleted
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "ns1 route should be deleted")
+
+	// ns2 resources should still exist
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns2").Get(context.Background(), "wb2", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "ns2 route should still exist")
+}
+
+func TestRunTask_Execute_OAuthClientClusterScoped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		newOAuthClient("wb1-ns1-oauth-client"),
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// Cluster-scoped OAuthClient should be deleted (no namespace in Get)
+	_, err = k8sClient.Dynamic().Resource(resources.OAuthClient.GVR()).
+		Get(context.Background(), "wb1-ns1-oauth-client", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "oauthclient should be deleted")
+}
+
+func TestRunTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range result.Status.Steps {
+		if step.Status == "Failed" {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+func TestRunTask_Execute_NameRequiresNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{WorkbenchName: "wb1"}}
+	task := a.Run()
+
+	_, err := task.Execute(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-name requires --workbench-namespace"))
+}
+
+func TestRunTask_Execute_ConfirmationAccepted(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient, withInteractiveConfirm("y\n"))
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "route should be deleted after confirmation")
+}
+
+func TestRunTask_Execute_ConfirmationCancelled(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient, withInteractiveConfirm("n\n"))
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Resources should still exist since user cancelled
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "route should still exist after cancellation")
+}
+
+func TestRunTask_Execute_MixedPresent(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	// Only route and one secret present; others absent
+	objects := []*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+		newRoute("wb1", "ns1"),
+		newSecret("wb1-oauth-client", "ns1"),
+	}
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	result, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Status.Completed).To(BeTrue())
+
+	// Present resources should be deleted
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "route should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Secret.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-oauth-client", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "secret should be deleted")
+}

--- a/pkg/migrate/actions/workbenches/cleanup/run_task.go
+++ b/pkg/migrate/actions/workbenches/cleanup/run_task.go
@@ -1,0 +1,235 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+type runTask struct {
+	action *CleanupOAuthAction
+}
+
+func (t *runTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
+	}
+
+	step := target.Recorder.Child(
+		"validate-cleanup-readiness",
+		"Validate notebooks are ready for OAuth cleanup",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(notebooks) == 0 {
+		step.Completef(result.StepCompleted, "No Notebook instances found, nothing to clean up")
+
+		return action.BuildResult(target)
+	}
+
+	passCount := 0
+	failCount := 0
+
+	for _, nb := range notebooks {
+		passed, failures := checkMigrationState(nb)
+		if passed {
+			passCount++
+		} else {
+			failCount++
+			step.Recordf(
+				fmt.Sprintf("precheck-%s-%s", nb.GetNamespace(), nb.GetName()),
+				"Pre-check failed for %s/%s: %s",
+				result.StepFailed,
+				nb.GetNamespace(), nb.GetName(), joinFailures(failures))
+		}
+	}
+
+	if failCount > 0 {
+		step.Completef(result.StepFailed,
+			"%d/%d Notebook(s) failed migration pre-checks; resolve before cleanup",
+			failCount, len(notebooks))
+	} else {
+		step.Completef(result.StepCompleted,
+			"All %d Notebook(s) passed migration pre-checks and are ready for cleanup",
+			passCount)
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
+	}
+
+	discoverStep := target.Recorder.Child(
+		"discover-notebooks",
+		"Discover notebooks for OAuth cleanup",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		discoverStep.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(notebooks) == 0 {
+		discoverStep.Completef(result.StepCompleted,
+			"No Notebook instances found, nothing to clean up")
+
+		return action.BuildResult(target)
+	}
+
+	discoverStep.Completef(result.StepCompleted,
+		"Found %d Notebook(s) for cleanup", len(notebooks))
+
+	if !target.DryRun && !t.action.promptBeforeCleanup(target, len(notebooks)) {
+		target.Recorder.Recordf("cleanup-cancelled",
+			"User cancelled cleanup", result.StepSkipped)
+
+		return action.BuildResult(target)
+	}
+
+	cleanedCount := 0
+	skippedCount := 0
+	failedCount := 0
+
+	for _, nb := range notebooks {
+		r := t.cleanupWorkbench(ctx, target, nb)
+
+		switch r {
+		case cleanupResultCleaned:
+			cleanedCount++
+		case cleanupResultSkipped:
+			skippedCount++
+		case cleanupResultFailed:
+			failedCount++
+		}
+	}
+
+	summaryStep := target.Recorder.Child("cleanup-summary", "Cleanup summary")
+
+	if failedCount > 0 {
+		summaryStep.Completef(result.StepFailed,
+			"Cleaned %d, skipped %d, failed %d out of %d Notebook(s)",
+			cleanedCount, skippedCount, failedCount, len(notebooks))
+	} else if target.DryRun {
+		summaryStep.Completef(result.StepSkipped,
+			"Would clean up OAuth resources for %d Notebook(s)", len(notebooks)-skippedCount)
+	} else {
+		summaryStep.Completef(result.StepCompleted,
+			"Cleaned %d, skipped %d out of %d Notebook(s)",
+			cleanedCount, skippedCount, len(notebooks))
+	}
+
+	return action.BuildResult(target)
+}
+
+type cleanupResult int
+
+const (
+	cleanupResultCleaned cleanupResult = iota
+	cleanupResultSkipped
+	cleanupResultFailed
+)
+
+func (t *runTask) cleanupWorkbench(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+) cleanupResult {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	step := target.Recorder.Child(
+		fmt.Sprintf("cleanup-%s-%s", namespace, name),
+		fmt.Sprintf("Clean up OAuth resources for %s/%s", namespace, name),
+	)
+
+	passed, failures := checkMigrationState(nb)
+	if !passed {
+		step.Recordf("precheck",
+			"Pre-check failed: %s",
+			result.StepFailed,
+			joinFailures(failures))
+
+		if !t.action.promptCleanupContinueOrSkip(target, name, namespace, failures) {
+			step.Completef(result.StepSkipped,
+				"Skipped cleanup for %s/%s (pre-check failed)", namespace, name)
+
+			return cleanupResultSkipped
+		}
+
+		step.Recordf("precheck-override",
+			"Continuing cleanup despite failed pre-checks", result.StepCompleted)
+	}
+
+	hasFailed := !deleteResourceIfPresent(ctx, target,
+		resources.Route.GVR(), name, namespace, step)
+
+	if !deleteResourceIfPresent(ctx, target,
+		resources.Service.GVR(), name+"-tls", namespace, step) {
+		hasFailed = true
+	}
+
+	if !deleteResourceIfPresent(ctx, target,
+		resources.Secret.GVR(), name+"-oauth-client", namespace, step) {
+		hasFailed = true
+	}
+
+	if !deleteResourceIfPresent(ctx, target,
+		resources.Secret.GVR(), name+"-oauth-config", namespace, step) {
+		hasFailed = true
+	}
+
+	if !deleteResourceIfPresent(ctx, target,
+		resources.Secret.GVR(), name+"-tls", namespace, step) {
+		hasFailed = true
+	}
+
+	oauthClientName := fmt.Sprintf("%s-%s-oauth-client", name, namespace)
+	if !deleteResourceIfPresent(ctx, target,
+		resources.OAuthClient.GVR(), oauthClientName, "", step) {
+		hasFailed = true
+	}
+
+	if hasFailed {
+		step.Completef(result.StepFailed,
+			"Cleanup partially failed for %s/%s", namespace, name)
+
+		return cleanupResultFailed
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped,
+			"Would clean up OAuth resources for %s/%s", namespace, name)
+	} else {
+		step.Completef(result.StepCompleted,
+			"Cleaned up OAuth resources for %s/%s", namespace, name)
+	}
+
+	return cleanupResultCleaned
+}
+
+func joinFailures(failures []string) string {
+	return strings.Join(failures, "; ")
+}

--- a/pkg/migrate/actions/workbenches/kueue/kueue.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue.go
@@ -15,8 +15,8 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
 )
 
@@ -34,9 +34,8 @@ const (
 // It adds the kueue.x-k8s.io/queue-name label to notebooks in namespaces
 // that have the kueue.openshift.io/managed=true label.
 type AttachKueueLabelAction struct {
-	QueueName          string
-	WorkbenchNamespace string
-	WorkbenchName      string
+	QueueName string
+	Scope     *workbenches.SharedScopeOptions
 }
 
 func (a *AttachKueueLabelAction) ID() string          { return actionID }
@@ -54,10 +53,7 @@ func (a *AttachKueueLabelAction) Phase() action.ActionPhase {
 func (a *AttachKueueLabelAction) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.QueueName, "queue-name", defaultQueueName,
 		"Queue name value for the kueue.x-k8s.io/queue-name label")
-	fs.StringVar(&a.WorkbenchNamespace, "workbench-namespace", "",
-		"Limit to notebooks in this namespace (default: all namespaces)")
-	fs.StringVar(&a.WorkbenchName, "workbench-name", "",
-		"Target a single notebook by name (requires --workbench-namespace)")
+	workbenches.AddScopeFlags(a.Scope, fs)
 }
 
 func (a *AttachKueueLabelAction) CanApply(target action.Target) bool {
@@ -96,34 +92,6 @@ func (a *AttachKueueLabelAction) queueName() string {
 	}
 
 	return a.QueueName
-}
-
-func (a *AttachKueueLabelAction) listNotebooks(
-	ctx context.Context,
-	target action.Target,
-) ([]*unstructured.Unstructured, error) {
-	if a.WorkbenchName != "" {
-		nb, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
-			Namespace(a.WorkbenchNamespace).
-			Get(ctx, a.WorkbenchName, metav1.GetOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("getting notebook %s/%s: %w", a.WorkbenchNamespace, a.WorkbenchName, err)
-		}
-
-		return []*unstructured.Unstructured{nb}, nil
-	}
-
-	var opts []client.ListResourcesOption
-	if a.WorkbenchNamespace != "" {
-		opts = append(opts, client.WithNamespace(a.WorkbenchNamespace))
-	}
-
-	nbs, err := target.Client.List(ctx, resources.Notebook, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("listing notebooks: %w", err)
-	}
-
-	return nbs, nil
 }
 
 func (a *AttachKueueLabelAction) kueueManagedNamespaces(

--- a/pkg/migrate/actions/workbenches/kueue/kueue_test.go
+++ b/pkg/migrate/actions/workbenches/kueue/kueue_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
@@ -180,7 +181,7 @@ func withDryRun(t *action.Target) {
 func TestAttachKueueLabelAction_Metadata(t *testing.T) {
 	g := NewWithT(t)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 
 	g.Expect(a.ID()).To(Equal("workbenches.attach-kueue-label"))
 	g.Expect(a.Name()).To(Equal("Attach Kueue queue-name label to workbenches"))
@@ -209,7 +210,7 @@ func TestAttachKueueLabelAction_CanApply(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			a := &AttachKueueLabelAction{}
+			a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 			target := action.Target{
 				TargetVersion: tt.targetVersion,
 			}
@@ -222,21 +223,21 @@ func TestAttachKueueLabelAction_CanApply(t *testing.T) {
 func TestAttachKueueLabelAction_PrepareIsNil(t *testing.T) {
 	g := NewWithT(t)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	g.Expect(a.Prepare()).To(BeNil())
 }
 
 func TestAttachKueueLabelAction_RunNotNil(t *testing.T) {
 	g := NewWithT(t)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	g.Expect(a.Run()).ToNot(BeNil())
 }
 
 func TestAttachKueueLabelAction_AddFlags(t *testing.T) {
 	g := NewWithT(t)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	a.AddFlags(fs)
 
@@ -293,7 +294,7 @@ func TestHasQueueNameLabel(t *testing.T) {
 func TestQueueName_DefaultAndCustom(t *testing.T) {
 	g := NewWithT(t)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	g.Expect(a.queueName()).To(Equal("default"))
 
 	a.QueueName = "custom-queue"
@@ -325,7 +326,7 @@ func TestRunTask_Validate_InvalidQueueName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			a := &AttachKueueLabelAction{QueueName: tt.queueName}
+			a := &AttachKueueLabelAction{QueueName: tt.queueName, Scope: &workbenches.SharedScopeOptions{}}
 			runTask := a.Run()
 
 			_, err := runTask.Validate(ctx, target)
@@ -334,7 +335,7 @@ func TestRunTask_Validate_InvalidQueueName(t *testing.T) {
 		})
 	}
 
-	a := &AttachKueueLabelAction{QueueName: "my queue"}
+	a := &AttachKueueLabelAction{QueueName: "my queue", Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	_, err := runTask.Execute(ctx, target)
@@ -353,7 +354,7 @@ func TestRunTask_Validate_NoNotebooks(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Validate(ctx, target)
@@ -372,7 +373,7 @@ func TestRunTask_Validate_NoKueueNamespaces(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Validate(ctx, target)
@@ -392,7 +393,7 @@ func TestRunTask_Validate_NotebooksMissingLabel(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Validate(ctx, target)
@@ -413,7 +414,7 @@ func TestRunTask_Validate_AllNotebooksAlreadyLabeled(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Validate(ctx, target)
@@ -431,7 +432,7 @@ func TestRunTask_Validate_ListError(t *testing.T) {
 	}, listErrorReactor())
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Validate(ctx, target)
@@ -460,7 +461,7 @@ func TestRunTask_Execute_NoNotebooks(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -479,7 +480,7 @@ func TestRunTask_Execute_LabelApplied(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -503,7 +504,7 @@ func TestRunTask_Execute_CustomQueueName(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{QueueName: "my-queue"}
+	a := &AttachKueueLabelAction{QueueName: "my-queue", Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -530,7 +531,7 @@ func TestRunTask_Execute_SkipsAlreadyLabeledNotebook(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -561,7 +562,7 @@ func TestRunTask_Execute_SkipsNonKueueNamespace(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -592,7 +593,7 @@ func TestRunTask_Execute_MultipleNamespaces(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -621,7 +622,7 @@ func TestRunTask_Execute_NoKueueNamespaces(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -647,7 +648,7 @@ func TestRunTask_Execute_DryRun_NoChanges(t *testing.T) {
 	})
 	target := newTarget(k8sClient, withDryRun)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -672,7 +673,7 @@ func TestRunTask_Execute_DryRun_MultipleNotebooks(t *testing.T) {
 	})
 	target := newTarget(k8sClient, withDryRun)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -700,7 +701,7 @@ func TestRunTask_Execute_PatchError(t *testing.T) {
 	}, patchErrorReactor())
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -750,7 +751,7 @@ func TestRunTask_Execute_PatchError_ContinuesWithRemaining(t *testing.T) {
 
 	target := newTarget(k8sClient)
 
-	act := &AttachKueueLabelAction{}
+	act := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := act.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -776,7 +777,7 @@ func TestRunTask_Execute_StepRecording(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	actionResult, err := runTask.Execute(ctx, target)
@@ -804,7 +805,7 @@ func TestRunTask_Validate_StepRecording(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	actionResult, err := runTask.Validate(ctx, target)
@@ -834,7 +835,7 @@ func TestRunTask_Validate_NameRequiresNamespace(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{WorkbenchName: "nb1"}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{WorkbenchName: "nb1"}}
 	runTask := a.Run()
 
 	_, err := runTask.Validate(ctx, target)
@@ -852,7 +853,7 @@ func TestRunTask_Execute_NameRequiresNamespace(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{WorkbenchName: "nb1"}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{WorkbenchName: "nb1"}}
 	runTask := a.Run()
 
 	_, err := runTask.Execute(ctx, target)
@@ -872,7 +873,7 @@ func TestRunTask_Execute_NamespaceScopedTargeting(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{WorkbenchNamespace: "ns-a"}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{WorkbenchNamespace: "ns-a"}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -901,7 +902,7 @@ func TestRunTask_Execute_NamespaceScopedTargeting_NonKueueNamespace(t *testing.T
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{WorkbenchNamespace: "regular-ns"}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{WorkbenchNamespace: "regular-ns"}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -926,10 +927,10 @@ func TestRunTask_Execute_SingleNotebookTargeting(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{
 		WorkbenchNamespace: "ns1",
 		WorkbenchName:      "target-nb",
-	}
+	}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -958,10 +959,10 @@ func TestRunTask_Execute_SingleNotebookTargeting_NotFound(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{
 		WorkbenchNamespace: "ns1",
 		WorkbenchName:      "nonexistent-nb",
-	}
+	}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -994,10 +995,10 @@ func TestRunTask_Execute_SingleNotebookTargeting_NonKueueNamespace(t *testing.T)
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{
 		WorkbenchNamespace: "regular-ns",
 		WorkbenchName:      "nb1",
-	}
+	}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -1028,7 +1029,7 @@ func TestRunTask_Execute_MixedManagedAndNonManaged(t *testing.T) {
 	})
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -1061,7 +1062,7 @@ func TestRunTask_Execute_ListError(t *testing.T) {
 	}, listErrorReactor())
 	target := newTarget(k8sClient)
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -1109,7 +1110,7 @@ func TestRunTask_Execute_ConfirmationCancelled(t *testing.T) {
 		IO:            io,
 	}
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)
@@ -1151,7 +1152,7 @@ func TestRunTask_Execute_ConfirmationAccepted(t *testing.T) {
 		IO:            io,
 	}
 
-	a := &AttachKueueLabelAction{}
+	a := &AttachKueueLabelAction{Scope: &workbenches.SharedScopeOptions{}}
 	runTask := a.Run()
 
 	result, err := runTask.Execute(ctx, target)

--- a/pkg/migrate/actions/workbenches/kueue/run_task.go
+++ b/pkg/migrate/actions/workbenches/kueue/run_task.go
@@ -2,7 +2,6 @@ package kueue
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -22,8 +21,8 @@ func (t *runTask) Validate(
 	ctx context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	if t.action.WorkbenchName != "" && t.action.WorkbenchNamespace == "" {
-		return nil, errors.New("--workbench-name requires --workbench-namespace")
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
 	}
 
 	if errs := validation.IsValidLabelValue(t.action.queueName()); len(errs) > 0 {
@@ -58,8 +57,8 @@ func (t *runTask) Execute(
 	ctx context.Context,
 	target action.Target,
 ) (*result.ActionResult, error) {
-	if t.action.WorkbenchName != "" && t.action.WorkbenchNamespace == "" {
-		return nil, errors.New("--workbench-name requires --workbench-namespace")
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
 	}
 
 	if errs := validation.IsValidLabelValue(t.action.queueName()); len(errs) > 0 {
@@ -106,9 +105,9 @@ func (t *runTask) findEligibleNotebooks(
 		return nil, nil
 	}
 
-	notebooks, err := t.action.listNotebooks(ctx, target)
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing notebooks: %w", err)
 	}
 
 	var eligible []*unstructured.Unstructured

--- a/pkg/migrate/actions/workbenches/options.go
+++ b/pkg/migrate/actions/workbenches/options.go
@@ -64,6 +64,8 @@ func (o *SharedScopeOptions) ListNotebooks(
 // AddScopeFlags registers the shared workbench targeting flags into fs.
 // Guards with fs.Lookup so paired actions that share the same backing
 // struct do not trigger flag-collision panics in RegisterActionFlags.
+// All actions using these flags must share a single SharedScopeOptions
+// instance (see registry.go) so the flag values are visible to every action.
 func AddScopeFlags(opts *SharedScopeOptions, fs *pflag.FlagSet) {
 	if fs.Lookup("workbench-namespace") == nil {
 		fs.StringVar(&opts.WorkbenchNamespace, "workbench-namespace", "",

--- a/pkg/migrate/actions/workbenches/options.go
+++ b/pkg/migrate/actions/workbenches/options.go
@@ -1,0 +1,77 @@
+package workbenches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// SharedScopeOptions holds the workbench targeting flags shared by multiple
+// workbench actions (e.g., kueue label attach, OAuth cleanup).
+type SharedScopeOptions struct {
+	WorkbenchNamespace string
+	WorkbenchName      string
+}
+
+// Validate checks that flag combinations are valid.
+func (o *SharedScopeOptions) Validate() error {
+	if o.WorkbenchName != "" && o.WorkbenchNamespace == "" {
+		return errors.New("--workbench-name requires --workbench-namespace")
+	}
+
+	return nil
+}
+
+// ListNotebooks returns the notebooks matching the scope filters.
+func (o *SharedScopeOptions) ListNotebooks(
+	ctx context.Context,
+	target action.Target,
+) ([]*unstructured.Unstructured, error) {
+	if o.WorkbenchName != "" {
+		nb, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace(o.WorkbenchNamespace).
+			Get(ctx, o.WorkbenchName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("getting notebook %s/%s: %w",
+				o.WorkbenchNamespace, o.WorkbenchName, err)
+		}
+
+		return []*unstructured.Unstructured{nb}, nil
+	}
+
+	var opts []client.ListResourcesOption
+	if o.WorkbenchNamespace != "" {
+		opts = append(opts, client.WithNamespace(o.WorkbenchNamespace))
+	}
+
+	nbs, err := target.Client.List(ctx, resources.Notebook, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("listing notebooks: %w", err)
+	}
+
+	return nbs, nil
+}
+
+// AddScopeFlags registers the shared workbench targeting flags into fs.
+// Guards with fs.Lookup so paired actions that share the same backing
+// struct do not trigger flag-collision panics in RegisterActionFlags.
+func AddScopeFlags(opts *SharedScopeOptions, fs *pflag.FlagSet) {
+	if fs.Lookup("workbench-namespace") == nil {
+		fs.StringVar(&opts.WorkbenchNamespace, "workbench-namespace", "",
+			"Limit to notebooks in this namespace (default: all namespaces)")
+	}
+
+	if fs.Lookup("workbench-name") == nil {
+		fs.StringVar(&opts.WorkbenchName, "workbench-name", "",
+			"Target a single notebook by name (requires --workbench-namespace)")
+	}
+}

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/guardrails"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/metrics"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/otelexporter"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	workbenchcleanup "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/cleanup"
 	workbenchkueue "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
 )
@@ -30,7 +32,9 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&modelserving.AddOwnerReferencesAction{})
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
-	registry.MustRegister(&workbenchkueue.AttachKueueLabelAction{})
+	wbScope := &workbenches.SharedScopeOptions{}
+	registry.MustRegister(&workbenchkueue.AttachKueueLabelAction{Scope: wbScope})
+	registry.MustRegister(&workbenchcleanup.CleanupOAuthAction{Scope: wbScope})
 	registry.MustRegister(&deadlock.BreakGPUDeadlockAction{})
 	registry.MustRegister(&guardrails.PatchGuardrailsAction{})
 	registry.MustRegister(&otelexporter.MigrateOtelExporterAction{})

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -484,6 +484,14 @@ var (
 		Resource: "gateways",
 	}
 
+	// OAuthClient is the OpenShift OAuthClient resource (cluster-scoped).
+	OAuthClient = ResourceType{
+		Group:    "oauth.openshift.io",
+		Version:  "v1",
+		Kind:     "OAuthClient",
+		Resource: "oauthclients",
+	}
+
 	// Route is the OpenShift Route resource for external service access.
 	Route = ResourceType{
 		Group:    "route.openshift.io",


### PR DESCRIPTION
## Description
Implement the cleanup-oauth action that removes legacy OAuth-proxy resources (Route, Service, Secrets, OAuthClient) left behind after migrating workbenches from RHOAI 2.x to 3.x.

- Add cleanup action in pkg/migrate/actions/workbenches/cleanup/ with support for dry-run mode and per-resource error handling
- Extract SharedScopeOptions from the kueue action into pkg/migrate/actions/workbenches/options.go to eliminate duplicate notebook listing and validation logic between actions
- Refactor kueue action to use the shared scope options
- Add OAuthClient resource type to pkg/resources/types.go
- Register cleanup-oauth action in the migrate registry
- Add comprehensive test suite with 36 test cases covering all code paths including error scenarios and edge cases

Relates-to: [RHOAIENG-72119](https://redhat.atlassian.net/browse/RHOAIENG-72119)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cleanup action to remove legacy OAuth-related resources after notebook migration.
  * Added shared workbench selection options, including filtering by notebook name or namespace.
  * Updated existing migration actions to use the same selection behavior.

* **Bug Fixes**
  * Improved handling of already-migrated or missing resources so cleanup runs safely and idempotently.
  * Added clearer confirmation and dry-run behavior during migration cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->