### PR TITLE
feat(watch): add --watch flag with centralized WatchOptions

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -59,6 +59,10 @@ the platform to stabilize after changes. The --timeout flag controls
 how long to wait (default 30s; use --timeout=0 for no timeout).
 Exit code 5 indicates a timeout.
 
+Use --watch with -o json or -o yaml to stream status changes. Each state
+change emits one JSON line (NDJSON) or YAML document. Only changes are
+emitted; duplicate states are suppressed. Agents consume this as a stream.
+
 Examples:
   # Show platform health summary
   kubectl odh status
@@ -108,6 +112,15 @@ const cmdExample = `
 
   # Wait indefinitely (no timeout)
   kubectl odh status --wait-for=healthy --timeout=0
+
+  # Watch status changes as streaming JSON (NDJSON)
+  kubectl odh status --watch -o json
+
+  # Watch with custom poll interval
+  kubectl odh status --watch -o json --poll-interval=30s
+
+  # Watch as YAML stream
+  kubectl odh status --watch -o yaml
 `
 
 // AddCommand adds the status command to the root command.
@@ -130,6 +143,7 @@ func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			errOut := cmd.ErrOrStderr()
 			outputFormat := string(command.OutputFormat)
+			command.TimeoutExplicit = cmd.Flags().Changed("timeout")
 
 			if err := command.Complete(); err != nil {
 				return handleErr(errOut, err, outputFormat)

--- a/pkg/cmd/watch.go
+++ b/pkg/cmd/watch.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+const (
+	MaxWatchErrors      = 5
+	InitialWatchBackoff = time.Second
+	MaxWatchBackoff     = 30 * time.Second
+	WatchBackoffFactor  = 2
+
+	flagDescWatch = "Watch for changes (streaming JSON or YAML output)"
+
+	msgWatchRetry = "Warning: poll failed (retrying): %v\n"
+)
+
+// WatchPoller polls for new data.
+// Returns the data to emit and a snapshot for state-change comparison.
+type WatchPoller func(ctx context.Context) (data any, snapshot []byte, err error)
+
+// WatchEmitter writes one streaming output item.
+type WatchEmitter func(data any) error
+
+// WatchRunConfig configures a RunWatch invocation.
+type WatchRunConfig struct {
+	Timeout      time.Duration
+	PollInterval time.Duration
+	Poller       WatchPoller
+	Emitter      WatchEmitter
+	ErrOut       io.Writer
+}
+
+// WatchOptions provides a reusable --watch flag.
+// Commands embed this struct and call its methods from their
+// own AddFlags, Validate, and Run implementations.
+type WatchOptions struct {
+	Watch bool
+}
+
+// AddWatchFlag registers the --watch flag.
+func (w *WatchOptions) AddWatchFlag(fs *pflag.FlagSet) {
+	fs.BoolVar(&w.Watch, "watch", false, flagDescWatch)
+}
+
+// ValidateWatch checks that --watch is consistent with other flags.
+// waitActive is true if --wait-for is set (mutually exclusive).
+// outputFormat is the current -o value; structuredFormats lists the
+// formats that support streaming (e.g., ["json", "yaml"]).
+func (w *WatchOptions) ValidateWatch(
+	waitActive bool,
+	outputFormat string,
+	structuredFormats []string,
+	timeout, pollInterval time.Duration,
+) error {
+	if !w.Watch {
+		return nil
+	}
+
+	if waitActive {
+		return ErrWatchWaitExclusive()
+	}
+
+	if !slices.Contains(structuredFormats, outputFormat) {
+		return ErrWatchRequiresStructuredOutput()
+	}
+
+	if pollInterval < time.Second || pollInterval > MaxPollInterval {
+		return ErrInvalidPollInterval()
+	}
+
+	if timeout < 0 || timeout > MaxWaitTimeout {
+		return ErrInvalidWaitTimeout()
+	}
+
+	return nil
+}
+
+// RunWatch polls via cfg.Poller and emits via cfg.Emitter on each state change.
+// It runs until the context is cancelled, the timeout expires, or an
+// unrecoverable error occurs. Transient errors are retried with exponential
+// backoff up to MaxWatchErrors consecutive failures.
+func (w *WatchOptions) RunWatch(ctx context.Context, cfg WatchRunConfig) error {
+	if cfg.PollInterval < time.Second || cfg.PollInterval > MaxPollInterval {
+		return ErrInvalidPollInterval()
+	}
+
+	if cfg.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.Timeout)
+
+		defer cancel()
+	}
+
+	data, snapshot, err := cfg.Poller(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := cfg.Emitter(data); err != nil {
+		return err
+	}
+
+	prevSnapshot := snapshot
+
+	ticker := time.NewTicker(cfg.PollInterval)
+	defer ticker.Stop()
+
+	ws := &watchState{backoff: InitialWatchBackoff}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			data, snapshot, err = cfg.Poller(ctx)
+			if err != nil {
+				if done, retErr := ws.handleError(ctx, err, cfg.ErrOut); done {
+					return retErr
+				}
+
+				continue
+			}
+
+			ws.reset()
+
+			if bytes.Equal(prevSnapshot, snapshot) {
+				continue
+			}
+
+			prevSnapshot = snapshot
+
+			if err := cfg.Emitter(data); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+type watchState struct {
+	consecutiveErrors int
+	backoff           time.Duration
+}
+
+// handleError processes a transient poll error with backoff.
+// Returns (true, err) to stop the loop, (false, nil) to continue.
+func (s *watchState) handleError(ctx context.Context, err error, errOut io.Writer) (bool, error) {
+	if client.IsUnrecoverableError(err) {
+		return true, err
+	}
+
+	s.consecutiveErrors++
+	if s.consecutiveErrors >= MaxWatchErrors {
+		return true, ErrWatchMaxErrors(err)
+	}
+
+	if errOut != nil {
+		_, _ = fmt.Fprintf(errOut, msgWatchRetry, err)
+	}
+
+	select {
+	case <-time.After(s.backoff):
+	case <-ctx.Done():
+		return true, nil
+	}
+
+	s.backoff = min(s.backoff*WatchBackoffFactor, MaxWatchBackoff)
+
+	return false, nil
+}
+
+func (s *watchState) reset() {
+	s.consecutiveErrors = 0
+	s.backoff = InitialWatchBackoff
+}

--- a/pkg/cmd/watch_errors.go
+++ b/pkg/cmd/watch_errors.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+)
+
+const (
+	errCodeWatchWaitExclusive      = "WATCH_WAIT_EXCLUSIVE"
+	errCodeWatchRequiresStructured = "WATCH_OUTPUT_FORMAT"
+	errCodeWatchMaxErrors          = "WATCH_MAX_ERRORS"
+
+	msgWatchWaitExclusive      = "cannot use --watch and --wait-for together"
+	msgWatchRequiresStructured = "--watch requires structured output (-o json or -o yaml)"
+	msgWatchMaxErrors          = "watch stopped after %d consecutive errors: %v"
+
+	suggestWatchWaitExclusive  = "Use --watch for streaming output or --wait-for to block until a condition is met, not both"
+	suggestWatchRequiresFormat = "Use --watch with -o json or -o yaml for machine-readable streaming output"
+	suggestWatchMaxErrors      = "Check cluster connectivity and credentials, then retry"
+)
+
+// ErrWatchWaitExclusive creates a structured error when --watch and --wait-for are both set.
+func ErrWatchWaitExclusive() *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeWatchWaitExclusive,
+		Message:    msgWatchWaitExclusive,
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: suggestWatchWaitExclusive,
+	}
+}
+
+// ErrWatchRequiresStructuredOutput creates a structured error when --watch is used with unsupported output.
+func ErrWatchRequiresStructuredOutput() *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeWatchRequiresStructured,
+		Message:    msgWatchRequiresStructured,
+		Category:   clierrors.CategoryValidation,
+		Retriable:  false,
+		Suggestion: suggestWatchRequiresFormat,
+	}
+}
+
+// ErrWatchMaxErrors creates a structured error when watch exceeds max consecutive errors.
+func ErrWatchMaxErrors(lastErr error) *clierrors.StructuredError {
+	return &clierrors.StructuredError{
+		Code:       errCodeWatchMaxErrors,
+		Message:    fmt.Sprintf(msgWatchMaxErrors, MaxWatchErrors, lastErr),
+		Category:   clierrors.CategoryConnection,
+		Retriable:  true,
+		Suggestion: suggestWatchMaxErrors,
+	}
+}

--- a/pkg/cmd/watch_test.go
+++ b/pkg/cmd/watch_test.go
@@ -1,0 +1,221 @@
+package cmd_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+
+	. "github.com/onsi/gomega"
+)
+
+const watchTestPollInterval = 1 * time.Second
+
+func TestValidateWatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		watch    bool
+		wait     bool
+		format   string
+		wantErr  bool
+		wantCode string
+	}{
+		{
+			name:   "watch off passes",
+			watch:  false,
+			format: "table",
+		},
+		{
+			name:   "watch with json passes",
+			watch:  true,
+			format: "json",
+		},
+		{
+			name:   "watch with yaml passes",
+			watch:  true,
+			format: "yaml",
+		},
+		{
+			name:     "watch with table rejected",
+			watch:    true,
+			format:   "table",
+			wantErr:  true,
+			wantCode: "WATCH_OUTPUT_FORMAT",
+		},
+		{
+			name:     "watch with wait-for rejected",
+			watch:    true,
+			wait:     true,
+			format:   "json",
+			wantErr:  true,
+			wantCode: "WATCH_WAIT_EXCLUSIVE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			opts := cmd.WatchOptions{Watch: tt.watch}
+			err := opts.ValidateWatch(tt.wait, tt.format, []string{"json", "yaml"}, 30*time.Second, cmd.DefaultPollInterval)
+
+			if !tt.wantErr {
+				g.Expect(err).ToNot(HaveOccurred())
+
+				return
+			}
+
+			g.Expect(err).To(HaveOccurred())
+
+			var structured *clierrors.StructuredError
+			g.Expect(errors.As(err, &structured)).To(BeTrue())
+			g.Expect(structured).To(HaveField("Code", tt.wantCode))
+		})
+	}
+}
+
+func TestRunWatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("emits initial data immediately", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		var emitted atomic.Int32
+
+		opts := cmd.WatchOptions{Watch: true}
+		err := opts.RunWatch(ctx, cmd.WatchRunConfig{
+			PollInterval: watchTestPollInterval,
+			Poller: func(_ context.Context) (any, []byte, error) {
+				return "data", []byte("snap"), nil
+			},
+			Emitter: func(data any) error {
+				emitted.Add(1)
+				cancel()
+
+				return nil
+			},
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(emitted.Load()).To(Equal(int32(1)))
+	})
+
+	t.Run("suppresses duplicate snapshots", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		var emitted atomic.Int32
+		var polls atomic.Int32
+
+		opts := cmd.WatchOptions{Watch: true}
+		err := opts.RunWatch(ctx, cmd.WatchRunConfig{
+			PollInterval: watchTestPollInterval,
+			Poller: func(_ context.Context) (any, []byte, error) {
+				if polls.Add(1) >= 3 {
+					cancel()
+				}
+
+				return "data", []byte("same-snap"), nil
+			},
+			Emitter: func(data any) error {
+				emitted.Add(1)
+
+				return nil
+			},
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(emitted.Load()).To(Equal(int32(1)))
+	})
+
+	t.Run("emits on state change", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		var polls atomic.Int32
+		var emitted atomic.Int32
+
+		opts := cmd.WatchOptions{Watch: true}
+		err := opts.RunWatch(ctx, cmd.WatchRunConfig{
+			PollInterval: watchTestPollInterval,
+			Poller: func(_ context.Context) (any, []byte, error) {
+				n := polls.Add(1)
+				snap := []byte("snap-" + string('0'+n))
+
+				if n >= 3 {
+					cancel()
+				}
+
+				return "data", snap, nil
+			},
+			Emitter: func(data any) error {
+				emitted.Add(1)
+
+				return nil
+			},
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(emitted.Load()).To(BeNumerically(">=", 3))
+	})
+
+	t.Run("transient error retried with warning", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		var polls atomic.Int32
+		var stderr bytes.Buffer
+
+		opts := cmd.WatchOptions{Watch: true}
+		err := opts.RunWatch(ctx, cmd.WatchRunConfig{
+			PollInterval: watchTestPollInterval,
+			ErrOut:       &stderr,
+			Poller: func(_ context.Context) (any, []byte, error) {
+				n := polls.Add(1)
+				if n == 2 {
+					return nil, nil, errors.New("transient")
+				}
+				if n >= 3 {
+					cancel()
+				}
+
+				return "data", []byte("snap"), nil
+			},
+			Emitter: func(data any) error {
+				return nil
+			},
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stderr.String()).To(ContainSubstring("Warning: poll failed"))
+	})
+
+	t.Run("cancelled context exits cleanly", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		opts := cmd.WatchOptions{Watch: true}
+		err := opts.RunWatch(ctx, cmd.WatchRunConfig{
+			PollInterval: watchTestPollInterval,
+			Poller: func(_ context.Context) (any, []byte, error) {
+				return "data", []byte("snap"), nil
+			},
+			Emitter: func(data any) error {
+				return nil
+			},
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}

--- a/pkg/status/errors.go
+++ b/pkg/status/errors.go
@@ -20,6 +20,7 @@ const (
 	msgDSCINotFound        = "no DSCInitialization found"
 	msgHealthCheckRetry    = "Warning: health check failed (retrying): %v\n"
 	msgWaitProgress        = "Waiting for %s status... (%s elapsed)\n"
+	msgUnexpectedWatchData = "unexpected watch data type: %T"
 
 	suggestValidSections   = "Valid sections: nodes, deployments, pods, events, quotas, operator, dsci, dsc"
 	suggestValidLayers     = "Valid layers: infrastructure, workload, operator"

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -71,6 +71,7 @@ const (
 // Command contains the status command configuration.
 type Command struct {
 	cmd.WaitOptions
+	cmd.WatchOptions
 
 	IO          iostreams.Interface
 	ConfigFlags *genericclioptions.ConfigFlags
@@ -90,6 +91,10 @@ type Command struct {
 
 	QPS   float32
 	Burst int
+
+	// TimeoutExplicit is true when --timeout was explicitly passed by the user.
+	// When false and --watch is active, timeout defaults to 0 (indefinite).
+	TimeoutExplicit bool
 
 	// Populated during Complete
 	restConfig *rest.Config
@@ -134,6 +139,7 @@ func (c *Command) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.IncludeInfra, "include-infra", false, flagDescInfra)
 	fs.BoolVar(&c.IncludeDeps, "include-deps", c.IncludeDeps, flagDescIncludeDeps)
 	c.AddWaitFlags(fs, []string{WaitConditionHealthy})
+	c.AddWatchFlag(fs)
 	fs.Float32Var(&c.QPS, "qps", c.QPS, flagDescQPS)
 	fs.IntVar(&c.Burst, "burst", c.Burst, flagDescBurst)
 }
@@ -177,11 +183,15 @@ func (c *Command) Validate() error {
 		return err
 	}
 
+	if err := c.ValidateWatch(c.HasWaitMode(), string(c.OutputFormat), []string{"json", "yaml"}, c.Timeout, c.PollInterval); err != nil {
+		return err //nolint:wrapcheck // structured validation errors propagate as-is
+	}
+
 	if err := c.ValidateWait(c.Timeout); err != nil {
 		return err //nolint:wrapcheck // structured validation errors propagate as-is
 	}
 
-	if !c.HasWaitMode() && c.Timeout <= 0 {
+	if !c.HasWaitMode() && !c.Watch && c.Timeout <= 0 {
 		return ErrInvalidTimeout()
 	}
 
@@ -190,6 +200,10 @@ func (c *Command) Validate() error {
 
 // Run executes the status command.
 func (c *Command) Run(ctx context.Context) error {
+	if c.Watch {
+		return c.runWatch(ctx)
+	}
+
 	if c.HasWaitMode() {
 		return c.runWaitFor(ctx)
 	}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -178,3 +178,46 @@ func TestCommandValidate_Layers(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandValidate_Watch(t *testing.T) {
+	tests := []struct {
+		name    string
+		watch   bool
+		format  status.OutputFormat
+		wantErr bool
+	}{
+		{"watch with json", true, status.OutputFormatJSON, false},
+		{"watch with yaml", true, status.OutputFormatYAML, false},
+		{"watch with table rejected", true, status.OutputFormatTable, true},
+		{"no watch with table", false, status.OutputFormatTable, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &status.Command{
+				OutputFormat: tt.format,
+				Timeout:      30 * time.Second,
+				WatchOptions: cmdpkg.WatchOptions{Watch: tt.watch},
+				WaitOptions:  cmdpkg.WaitOptions{PollInterval: cmdpkg.DefaultPollInterval},
+			}
+			err := cmd.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Command.Validate() watch=%v format=%q error = %v, wantErr %v", tt.watch, tt.format, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandValidate_WatchWaitExclusive(t *testing.T) {
+	cmd := &status.Command{
+		OutputFormat: status.OutputFormatJSON,
+		Timeout:      30 * time.Second,
+		WatchOptions: cmdpkg.WatchOptions{Watch: true},
+		WaitOptions:  cmdpkg.WaitOptions{WaitFor: "healthy", PollInterval: cmdpkg.DefaultPollInterval},
+	}
+
+	err := cmd.Validate()
+	if err == nil {
+		t.Error("Command.Validate() expected error for --watch + --wait-for, got nil")
+	}
+}

--- a/pkg/status/stream_internal_test.go
+++ b/pkg/status/stream_internal_test.go
@@ -1,0 +1,76 @@
+package status
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStreamJSON(t *testing.T) {
+	g := NewWithT(t)
+
+	var buf bytes.Buffer
+	report := &clusterhealth.Report{}
+
+	err := streamJSON(&buf, report, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+	g.Expect(output).To(HaveSuffix("\n"))
+	g.Expect(strings.Count(output, "\n")).To(Equal(1))
+
+	var parsed map[string]any
+	g.Expect(json.Unmarshal(buf.Bytes(), &parsed)).To(Succeed())
+	g.Expect(parsed).To(HaveKey("apiVersion"))
+	g.Expect(parsed).To(HaveKey("report"))
+}
+
+func TestStreamJSON_MultipleCallsProduceNDJSON(t *testing.T) {
+	g := NewWithT(t)
+
+	var buf bytes.Buffer
+	report := &clusterhealth.Report{}
+
+	g.Expect(streamJSON(&buf, report, nil)).To(Succeed())
+	g.Expect(streamJSON(&buf, report, nil)).To(Succeed())
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	g.Expect(lines).To(HaveLen(2))
+
+	for _, line := range lines {
+		var parsed map[string]any
+		g.Expect(json.Unmarshal([]byte(line), &parsed)).To(Succeed())
+	}
+}
+
+func TestStreamYAML(t *testing.T) {
+	g := NewWithT(t)
+
+	var buf bytes.Buffer
+	report := &clusterhealth.Report{}
+
+	err := streamYAML(&buf, report, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	output := buf.String()
+	g.Expect(output).To(HavePrefix("---\n"))
+	g.Expect(output).To(ContainSubstring("apiVersion:"))
+}
+
+func TestStreamYAML_MultipleCallsProduceMultiDoc(t *testing.T) {
+	g := NewWithT(t)
+
+	var buf bytes.Buffer
+	report := &clusterhealth.Report{}
+
+	g.Expect(streamYAML(&buf, report, nil)).To(Succeed())
+	g.Expect(streamYAML(&buf, report, nil)).To(Succeed())
+
+	output := buf.String()
+	g.Expect(strings.Count(output, "---\n")).To(Equal(2))
+}

--- a/pkg/status/watch.go
+++ b/pkg/status/watch.go
@@ -1,0 +1,112 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	"github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/deps"
+)
+
+type watchData struct {
+	report      *clusterhealth.Report
+	depStatuses []deps.DependencyStatus
+}
+
+// runWatch polls clusterhealth.Run() and emits streaming output on each state change.
+func (c *Command) runWatch(ctx context.Context) error {
+	hc, err := c.resolveHealthConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	timeout := time.Duration(0)
+	if c.TimeoutExplicit {
+		timeout = c.Timeout
+	}
+
+	return c.RunWatch(ctx, cmd.WatchRunConfig{ //nolint:wrapcheck // structured watch errors propagate as-is
+		Timeout:      timeout,
+		PollInterval: c.PollInterval,
+		ErrOut:       c.IO.ErrOut(),
+		Poller: func(ctx context.Context) (any, []byte, error) {
+			report, depStatuses, err := c.runHealthCheck(ctx, hc)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			return &watchData{report, depStatuses}, snapshotReport(report), nil
+		},
+		Emitter: func(data any) error {
+			d, ok := data.(*watchData)
+			if !ok {
+				return fmt.Errorf(msgUnexpectedWatchData, data)
+			}
+
+			return c.streamOutput(d.report, d.depStatuses)
+		},
+	})
+}
+
+// streamOutput writes a single report in the configured streaming format.
+func (c *Command) streamOutput(report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	switch c.OutputFormat {
+	case OutputFormatJSON:
+		return streamJSON(c.IO.Out(), report, depStatuses)
+	case OutputFormatYAML:
+		return streamYAML(c.IO.Out(), report, depStatuses)
+	case OutputFormatTable:
+		return cmd.ErrWatchRequiresStructuredOutput()
+	}
+
+	return cmd.ErrWatchRequiresStructuredOutput()
+}
+
+// snapshotReport marshals the report to compact JSON for state-change comparison.
+// The CollectedAt timestamp is zeroed to avoid false positives.
+func snapshotReport(report *clusterhealth.Report) []byte {
+	if report == nil {
+		return nil
+	}
+
+	cpy := *report
+	cpy.CollectedAt = time.Time{}
+
+	data, err := json.Marshal(cpy)
+	if err != nil {
+		return []byte("marshal-error")
+	}
+
+	return data
+}
+
+// streamJSON writes a single StatusReport as a compact NDJSON line.
+func streamJSON(w io.Writer, report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	statusReport := NewStatusReport(report, depStatuses)
+
+	data, err := json.Marshal(statusReport)
+	if err != nil {
+		return fmt.Errorf("streaming JSON report: %w", err)
+	}
+
+	_, err = fmt.Fprintf(w, "%s\n", data)
+	if err != nil {
+		return fmt.Errorf("writing JSON line: %w", err)
+	}
+
+	return nil
+}
+
+// streamYAML writes a single StatusReport as a YAML document with a --- separator.
+func streamYAML(w io.Writer, report *clusterhealth.Report, depStatuses []deps.DependencyStatus) error {
+	if _, err := fmt.Fprint(w, "---\n"); err != nil {
+		return fmt.Errorf("writing YAML separator: %w", err)
+	}
+
+	return renderYAML(w, report, depStatuses)
+}

--- a/pkg/status/watch_internal_test.go
+++ b/pkg/status/watch_internal_test.go
@@ -1,0 +1,199 @@
+package status
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opendatahub-io/opendatahub-operator/pkg/clusterhealth"
+
+	cmdpkg "github.com/opendatahub-io/odh-cli/pkg/cmd"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	watchTestPollInterval = 1 * time.Second
+	watchTestTimeout      = 10 * time.Second
+)
+
+func newTestWatchCommand(cfg *clusterhealth.Config) (*Command, *bytes.Buffer, *bytes.Buffer) {
+	var stdout, stderr bytes.Buffer
+
+	cmd := &Command{
+		IO:           iostreams.NewIOStreams(nil, &stdout, &stderr),
+		OutputFormat: OutputFormatJSON,
+		WatchOptions: cmdpkg.WatchOptions{Watch: true},
+		WaitOptions: cmdpkg.WaitOptions{
+			PollInterval: watchTestPollInterval,
+		},
+		Timeout:      watchTestTimeout,
+		healthConfig: cfg,
+	}
+
+	return cmd, &stdout, &stderr
+}
+
+func TestRunWatch(t *testing.T) {
+	scheme := testScheme()
+
+	t.Run("emits initial report immediately", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		cmd, stdout, _ := newTestWatchCommand(healthyConfig(scheme))
+		cmd.Timeout = 0
+
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			cancel()
+		}()
+
+		err := cmd.runWatch(ctx)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		lines := nonEmptyLines(stdout.String())
+		g.Expect(lines).ToNot(BeEmpty())
+
+		var parsed map[string]any
+		g.Expect(json.Unmarshal([]byte(lines[0]), &parsed)).To(Succeed())
+		g.Expect(parsed).To(HaveKey("report"))
+	})
+
+	t.Run("suppresses duplicate state", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		cmd, stdout, _ := newTestWatchCommand(healthyConfig(scheme))
+		cmd.Timeout = 0
+
+		go func() {
+			time.Sleep(3500 * time.Millisecond)
+			cancel()
+		}()
+
+		err := cmd.runWatch(ctx)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		lines := nonEmptyLines(stdout.String())
+		g.Expect(lines).To(HaveLen(1))
+	})
+
+	t.Run("emits on state change", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := unhealthyConfig(scheme)
+		cmd, stdout, _ := newTestWatchCommand(cfg)
+		cmd.Timeout = 0
+
+		dep := testOperatorDeployment()
+		setupErr := make(chan error, 1)
+		setupCtx := t.Context()
+		stateChanged := make(chan struct{}, 1)
+
+		go func() {
+			time.Sleep(1500 * time.Millisecond)
+
+			if err := cfg.Client.Create(setupCtx, dep); err != nil {
+				setupErr <- err
+
+				return
+			}
+
+			dep.Status.ReadyReplicas = 1
+			dep.Status.Replicas = 1
+			dep.Status.AvailableReplicas = 1
+			setupErr <- cfg.Client.Status().Update(setupCtx, dep)
+		}()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		// Cancel after detecting the state change emission rather than
+		// relying on wall-clock timing.
+		origOut := cmd.IO.Out()
+		cmd.IO = iostreams.NewIOStreams(nil, writerFunc(func(p []byte) (int, error) {
+			n, err := origOut.Write(p)
+			if err == nil {
+				select {
+				case stateChanged <- struct{}{}:
+				default:
+				}
+			}
+
+			return n, err //nolint:wrapcheck // test passthrough writer
+		}), cmd.IO.ErrOut())
+
+		go func() {
+			// Wait for initial emit, then wait for the state-change emit.
+			<-stateChanged // initial
+			<-stateChanged // state change
+			cancel()
+		}()
+
+		err := cmd.runWatch(ctx)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(<-setupErr).ToNot(HaveOccurred())
+
+		lines := nonEmptyLines(stdout.String())
+		g.Expect(len(lines)).To(BeNumerically(">=", 2))
+	})
+
+	t.Run("cancelled context exits cleanly", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		cmd, _, _ := newTestWatchCommand(healthyConfig(scheme))
+		cmd.Timeout = 0
+
+		err := cmd.runWatch(ctx)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("yaml output produces multi-document format", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		cmd, stdout, _ := newTestWatchCommand(healthyConfig(scheme))
+		cmd.OutputFormat = OutputFormatYAML
+		cmd.Timeout = 0
+
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			cancel()
+		}()
+
+		err := cmd.runWatch(ctx)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(stdout.String()).To(HavePrefix("---\n"))
+		g.Expect(stdout.String()).To(ContainSubstring("apiVersion:"))
+	})
+}
+
+// testOperatorDeployment is defined in wait_internal_test.go but we need it here too.
+// Since both files are in the same package, we can use it directly.
+
+// writerFunc adapts a function to io.Writer for test instrumentation.
+type writerFunc func(p []byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+func nonEmptyLines(s string) []string {
+	var lines []string
+
+	for line := range strings.SplitSeq(strings.TrimSpace(s), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return lines
+}


### PR DESCRIPTION

### Jira:  
[RHOAIENG-66868](https://redhat.atlassian.net/browse/RHOAIENG-66868)

## Description

Add `--watch` flag to `kubectl odh status` for streaming status changes as NDJSON (`-o json`) or multi-document YAML (`-o yaml`). Only state changes are emitted; duplicates are suppressed.

Watch infrastructure is centralized in `pkg/cmd/WatchOptions` — any command can add `--watch` by embedding it and providing a poller + emitter, same pattern as `WaitOptions`.


```bash
kubectl odh status --watch -o json
kubectl odh status --watch -o json --poll-interval=30s
```

- Mutually exclusive with `--wait-for`; requires `-o json` or `-o yaml`
- Exponential backoff on transient errors; unrecoverable errors stop immediately

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added reusable `--watch` streaming for JSON/YAML and integrated watch mode into the `status` command.
  * Watch emits an initial update immediately, then outputs only when the reported state changes.

* **Bug Fixes**
  * Improved CLI validation (structured formats only) with clear mutual exclusivity against wait mode.
  * Enhanced transient watch retries with backoff and warning output, and improved streaming output formatting for JSON (NDJSON) and YAML (multi-document).

* **Tests**
  * Added unit tests covering watch validation, streaming format, duplicate suppression, and retry/state-change behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-66868]: https://redhat.atlassian.net/browse/RHOAIENG-66868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ