### PR TITLE
[RHOAIENG-72117] feat: implement missing authmodel migration action from upgrade helpers

### DIFF
--- a/pkg/events/command_test.go
+++ b/pkg/events/command_test.go
@@ -141,6 +141,8 @@ func TestNewCommand(t *testing.T) {
 
 	if cmd == nil {
 		t.Fatal("NewCommand() returned nil")
+
+		return
 	}
 
 	if cmd.OutputFormat != "table" {

--- a/pkg/migrate/actions/workbenches/authmodel/authmodel.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel.go
@@ -1,0 +1,88 @@
+package authmodel
+
+import (
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/cleanup"
+)
+
+const (
+	actionID          = "workbenches.patch-auth-model"
+	actionName        = "Patch workbench auth model from OAuth-proxy to kube-rbac-proxy"
+	actionDescription = "Migrates Notebook CRs from oauth-proxy (2.x) to kube-rbac-proxy (3.x) auth " +
+		"model by removing OAuth sidecar, annotations, volumes, finalizers, and tornado_settings"
+
+	annotationKubeflowResourceStopped = "kubeflow-resource-stopped"
+
+	minCurrentMajorVersion = 2
+	minCurrentMinorVersion = 16
+	minTargetMajorVersion  = 3
+)
+
+// PatchAuthModelAction implements the workbenches.patch-auth-model migration action.
+// It patches Notebook CRs to switch from OAuth-proxy (2.x) to kube-rbac-proxy (3.x).
+type PatchAuthModelAction struct {
+	Scope       *workbenches.SharedScopeOptions
+	SkipStop    bool
+	OnlyStopped bool
+	WithCleanup bool
+
+	CleanupAction *cleanup.CleanupOAuthAction
+}
+
+func (a *PatchAuthModelAction) ID() string          { return actionID }
+func (a *PatchAuthModelAction) Name() string        { return actionName }
+func (a *PatchAuthModelAction) Description() string { return actionDescription }
+
+func (a *PatchAuthModelAction) Group() action.ActionGroup {
+	return action.GroupMigration
+}
+
+func (a *PatchAuthModelAction) Phase() action.ActionPhase {
+	return action.PhasePreUpgrade
+}
+
+func (a *PatchAuthModelAction) AddFlags(fs *pflag.FlagSet) {
+	workbenches.AddScopeFlags(a.Scope, fs)
+
+	fs.BoolVar(&a.SkipStop, "skip-stop", false,
+		"Skip auto stop/restart of running workbenches before patching")
+	fs.BoolVar(&a.OnlyStopped, "only-stopped", false,
+		"Only patch stopped workbenches, skip running ones")
+	fs.BoolVar(&a.WithCleanup, "with-cleanup", false,
+		"Delete legacy OAuth resources (Route, Service, Secrets, OAuthClient) after patching")
+}
+
+func (a *PatchAuthModelAction) CanApply(target action.Target) bool {
+	if target.CurrentVersion == nil || target.TargetVersion == nil {
+		return false
+	}
+
+	return target.CurrentVersion.Major == minCurrentMajorVersion &&
+		target.CurrentVersion.Minor >= minCurrentMinorVersion &&
+		target.TargetVersion.Major >= minTargetMajorVersion
+}
+
+func (a *PatchAuthModelAction) Prepare() action.Task {
+	return &prepareTask{action: a}
+}
+
+func (a *PatchAuthModelAction) Run() action.Task {
+	return &runTask{action: a}
+}
+
+// isStopped returns true if the notebook has the kubeflow-resource-stopped annotation.
+func isStopped(nb *unstructured.Unstructured) bool {
+	annotations := nb.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, stopped := annotations[annotationKubeflowResourceStopped]
+
+	return stopped
+}

--- a/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
@@ -1,0 +1,2561 @@
+//nolint:testpackage // Tests internal implementation (unexported helpers)
+package authmodel
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	workbenchcleanup "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/cleanup"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
+
+	. "github.com/onsi/gomega"
+)
+
+// --- Test Fixtures ---
+
+//nolint:gochecknoglobals // test-only GVR→ListKind mapping for fake dynamic client
+var testListKinds = map[schema.GroupVersionResource]string{
+	resources.Notebook.GVR():    resources.Notebook.ListKind(),
+	resources.StatefulSet.GVR(): resources.StatefulSet.ListKind(),
+	resources.Pod.GVR():         resources.Pod.ListKind(),
+	resources.Namespace.GVR():   resources.Namespace.ListKind(),
+	resources.Route.GVR():       resources.Route.ListKind(),
+	resources.Service.GVR():     resources.Service.ListKind(),
+	resources.Secret.GVR():      resources.Secret.ListKind(),
+	resources.OAuthClient.GVR(): resources.OAuthClient.ListKind(),
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+type notebookOption func(map[string]any)
+
+func withAnnotations(annotations map[string]string) notebookOption {
+	return func(obj map[string]any) {
+		metadata := obj["metadata"].(map[string]any)
+		anyAnnotations := make(map[string]any, len(annotations))
+
+		for k, v := range annotations {
+			anyAnnotations[k] = v
+		}
+
+		metadata["annotations"] = anyAnnotations
+	}
+}
+
+func withContainers(containers ...map[string]any) notebookOption {
+	return func(obj map[string]any) {
+		spec, ok := obj["spec"].(map[string]any)
+		if !ok {
+			spec = make(map[string]any)
+			obj["spec"] = spec
+		}
+
+		template, ok := spec["template"].(map[string]any)
+		if !ok {
+			template = make(map[string]any)
+			spec["template"] = template
+		}
+
+		podSpec, ok := template["spec"].(map[string]any)
+		if !ok {
+			podSpec = make(map[string]any)
+			template["spec"] = podSpec
+		}
+
+		podSpec["containers"] = toAnySlice(containers)
+	}
+}
+
+func withVolumes(volumes ...map[string]any) notebookOption {
+	return func(obj map[string]any) {
+		spec, ok := obj["spec"].(map[string]any)
+		if !ok {
+			spec = make(map[string]any)
+			obj["spec"] = spec
+		}
+
+		template, ok := spec["template"].(map[string]any)
+		if !ok {
+			template = make(map[string]any)
+			spec["template"] = template
+		}
+
+		podSpec, ok := template["spec"].(map[string]any)
+		if !ok {
+			podSpec = make(map[string]any)
+			template["spec"] = podSpec
+		}
+
+		podSpec["volumes"] = toAnySlice(volumes)
+	}
+}
+
+func withFinalizers(finalizers ...string) notebookOption {
+	return func(obj map[string]any) {
+		metadata := obj["metadata"].(map[string]any)
+		anyFinalizers := make([]any, len(finalizers))
+
+		for i, f := range finalizers {
+			anyFinalizers[i] = f
+		}
+
+		metadata["finalizers"] = anyFinalizers
+	}
+}
+
+func toAnySlice(items []map[string]any) []any {
+	result := make([]any, len(items))
+	for i, item := range items {
+		result[i] = item
+	}
+
+	return result
+}
+
+func container(name string) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"image": "registry.example.com/" + name + ":latest",
+	}
+}
+
+func containerWithEnv(name string, envVars ...map[string]any) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"image": "registry.example.com/" + name + ":latest",
+		"env":   toAnySlice(envVars),
+	}
+}
+
+func envVar(name, value string) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"value": value,
+	}
+}
+
+func volume(name string) map[string]any {
+	return map[string]any{
+		"name":     name,
+		"emptyDir": map[string]any{},
+	}
+}
+
+func newNotebook(name, namespace string, opts ...notebookOption) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": resources.Notebook.APIVersion(),
+		"kind":       resources.Notebook.Kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// oauthNotebook creates a notebook with full 2.x OAuth artifacts.
+func oauthNotebook(name, namespace string) *unstructured.Unstructured {
+	return newNotebook(name, namespace,
+		withAnnotations(map[string]string{
+			annotationInjectOAuth:    "true",
+			annotationOAuthLogoutURL: "https://example.com/logout",
+		}),
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs,
+					`--ServerApp.port=8888 --ServerApp.tornado_settings={"headers":{"Content-Security-Policy":"frame-ancestors 'self'"}}`)),
+			container(containerOAuthProxy),
+		),
+		withVolumes(
+			volume("oauth-config"),
+			volume("oauth-client"),
+			volume("tls-certificates"),
+			volume("data"),
+		),
+		withFinalizers(finalizerOAuthClient, "other-finalizer"),
+	)
+}
+
+// patchedNotebook creates a notebook that has already been patched for 3.x.
+func patchedNotebook(name, namespace string) *unstructured.Unstructured {
+	return newNotebook(name, namespace,
+		withAnnotations(map[string]string{
+			annotationInjectAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container("kube-rbac-proxy"),
+		),
+		withVolumes(volume("data")),
+	)
+}
+
+// stoppedOAuthNotebook creates a stopped notebook with OAuth artifacts.
+func stoppedOAuthNotebook(name, namespace string) *unstructured.Unstructured {
+	return newNotebook(name, namespace,
+		withAnnotations(map[string]string{
+			annotationInjectOAuth:             "true",
+			annotationKubeflowResourceStopped: "2024-01-01T00:00:00Z",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(containerOAuthProxy),
+		),
+		withVolumes(
+			volume("oauth-config"),
+			volume("oauth-client"),
+			volume("tls-certificates"),
+		),
+		withFinalizers(finalizerOAuthClient),
+	)
+}
+
+func newStatefulSet(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.StatefulSet.APIVersion(),
+			"kind":       resources.StatefulSet.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"replicas": int64(0),
+			},
+		},
+	}
+}
+
+func newRoute(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Route.APIVersion(),
+			"kind":       resources.Route.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newService(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Service.APIVersion(),
+			"kind":       resources.Service.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newSecret(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Secret.APIVersion(),
+			"kind":       resources.Secret.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newOAuthClient(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.OAuthClient.APIVersion(),
+			"kind":       resources.OAuthClient.Kind,
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+}
+
+func allOAuthResources(nbName, namespace string) []*unstructured.Unstructured {
+	return []*unstructured.Unstructured{
+		newRoute(nbName, namespace),
+		newService(nbName+"-tls", namespace),
+		newSecret(nbName+"-oauth-client", namespace),
+		newSecret(nbName+"-oauth-config", namespace),
+		newSecret(nbName+"-tls", namespace),
+		newOAuthClient(nbName + "-" + namespace + "-oauth-client"),
+	}
+}
+
+func newFakeClient(objects []*unstructured.Unstructured, reactors ...k8stesting.Reactor) client.Client {
+	scheme := newScheme()
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	for _, r := range reactors {
+		dynamicClient.ReactionChain = append([]k8stesting.Reactor{r}, dynamicClient.ReactionChain...)
+	}
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+}
+
+func updateErrorReactor() k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "update",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated update error")
+		},
+	}
+}
+
+func listErrorReactor() k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "list",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated API server error")
+		},
+	}
+}
+
+func newAction() *PatchAuthModelAction {
+	return &PatchAuthModelAction{
+		Scope:         &workbenches.SharedScopeOptions{},
+		CleanupAction: &workbenchcleanup.CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}},
+	}
+}
+
+func newTarget(k8sClient client.Client, opts ...func(*action.Target)) action.Target {
+	currentVersion := semver.MustParse("2.16.0")
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	target := action.Target{
+		Client:         k8sClient,
+		CurrentVersion: &currentVersion,
+		TargetVersion:  &targetVersion,
+		DryRun:         false,
+		SkipConfirm:    true,
+		OutputDir:      "/tmp/test-backup",
+		Recorder:       action.NewVerboseRootRecorder(io),
+		IO:             io,
+	}
+
+	for _, opt := range opts {
+		opt(&target)
+	}
+
+	return target
+}
+
+func withDryRun(t *action.Target) {
+	t.DryRun = true
+}
+
+func withInteractiveConfirm(input string) func(*action.Target) {
+	return func(t *action.Target) {
+		t.SkipConfirm = false
+		t.IO = iostreams.NewIOStreams(
+			strings.NewReader(input),
+			&bytes.Buffer{},
+			&bytes.Buffer{},
+		)
+		t.Recorder = action.NewVerboseRootRecorder(t.IO)
+	}
+}
+
+// --- Action Metadata Tests ---
+
+func TestPatchAuthModelAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+
+	g.Expect(a.ID()).To(Equal("workbenches.patch-auth-model"))
+	g.Expect(a.Name()).To(ContainSubstring("auth model"))
+	g.Expect(a.Description()).To(ContainSubstring("oauth-proxy"))
+	g.Expect(a.Group()).To(Equal(action.GroupMigration))
+	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+}
+
+func TestPatchAuthModelAction_CanApply(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+
+	g.Expect(a.CanApply(action.Target{})).To(BeFalse(), "nil versions")
+
+	v216 := semver.MustParse("2.16.0")
+	v3 := semver.MustParse("3.0.0")
+	g.Expect(a.CanApply(action.Target{CurrentVersion: &v216, TargetVersion: &v3})).To(BeTrue(), "2.16→3.0")
+
+	v220 := semver.MustParse("2.20.0")
+	g.Expect(a.CanApply(action.Target{CurrentVersion: &v220, TargetVersion: &v3})).To(BeTrue(), "2.20→3.0")
+
+	v215 := semver.MustParse("2.15.0")
+	g.Expect(a.CanApply(action.Target{CurrentVersion: &v215, TargetVersion: &v3})).To(BeFalse(), "2.15→3.0 too old")
+
+	v2 := semver.MustParse("2.16.0")
+	v25 := semver.MustParse("2.17.0")
+	g.Expect(a.CanApply(action.Target{CurrentVersion: &v2, TargetVersion: &v25})).To(BeFalse(), "2→2 no upgrade")
+
+	v1 := semver.MustParse("1.0.0")
+	g.Expect(a.CanApply(action.Target{CurrentVersion: &v1, TargetVersion: &v3})).To(BeFalse(), "1.x not applicable")
+}
+
+func TestPatchAuthModelAction_PrepareNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	g.Expect(a.Prepare()).ToNot(BeNil())
+}
+
+func TestPatchAuthModelAction_RunNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestPatchAuthModelAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	g.Expect(fs.Lookup("workbench-namespace")).ToNot(BeNil())
+	g.Expect(fs.Lookup("workbench-name")).ToNot(BeNil())
+	g.Expect(fs.Lookup("skip-stop")).ToNot(BeNil())
+	g.Expect(fs.Lookup("only-stopped")).ToNot(BeNil())
+	g.Expect(fs.Lookup("with-cleanup")).ToNot(BeNil())
+}
+
+func TestPatchAuthModelAction_FlagDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	g.Expect(a.SkipStop).To(BeFalse())
+	g.Expect(a.OnlyStopped).To(BeFalse())
+	g.Expect(a.WithCleanup).To(BeFalse())
+}
+
+// --- Patch Helper Tests ---
+
+func TestNeedsAuthModelPatch_OAuthAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationInjectOAuth: "true",
+		}),
+		withContainers(container("my-notebook")),
+	)
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeTrue())
+}
+
+func TestNeedsAuthModelPatch_OAuthProxyContainer(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook"), container(containerOAuthProxy)),
+	)
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeTrue())
+}
+
+func TestNeedsAuthModelPatch_OAuthFinalizer(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withFinalizers(finalizerOAuthClient),
+	)
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeTrue())
+}
+
+func TestNeedsAuthModelPatch_OAuthVolumes(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(volume("oauth-config")),
+	)
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeTrue())
+}
+
+func TestNeedsAuthModelPatch_TornadoSettings(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs, "--ServerApp.tornado_settings={}")),
+		),
+	)
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeTrue())
+}
+
+func TestNeedsAuthModelPatch_AlreadyPatched(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := patchedNotebook("wb1", "ns1")
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeFalse())
+}
+
+func TestNeedsAuthModelPatch_CleanNotebook(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(volume("data")),
+	)
+
+	g.Expect(needsAuthModelPatch(nb)).To(BeFalse())
+}
+
+func TestAddInjectAuthAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	addInjectAuthAnnotation(nb)
+
+	g.Expect(nb.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+}
+
+func TestAddInjectAuthAnnotation_PreservesExisting(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{"other": "value"}),
+	)
+	addInjectAuthAnnotation(nb)
+
+	g.Expect(nb.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+	g.Expect(nb.GetAnnotations()["other"]).To(Equal("value"))
+}
+
+func TestRemoveAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationInjectOAuth: "true",
+			"other":               "keep",
+		}),
+	)
+	removeAnnotation(nb, annotationInjectOAuth)
+
+	g.Expect(nb.GetAnnotations()).ToNot(HaveKey(annotationInjectOAuth))
+	g.Expect(nb.GetAnnotations()["other"]).To(Equal("keep"))
+}
+
+func TestRemoveAnnotation_NoAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	removeAnnotation(nb, annotationInjectOAuth)
+
+	g.Expect(nb.GetAnnotations()).To(BeNil())
+}
+
+func TestRemoveOAuthProxyContainer(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook"), container(containerOAuthProxy)),
+	)
+
+	err := removeOAuthProxyContainer(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(hasOAuthProxyContainer(nb)).To(BeFalse())
+
+	containers, _ := nb.Object["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)
+	g.Expect(containers).To(HaveLen(1))
+}
+
+func TestRemoveOAuthProxyContainer_NotPresent(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+	)
+
+	err := removeOAuthProxyContainer(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestRemoveOAuthFinalizer(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withFinalizers(finalizerOAuthClient, "other-finalizer"),
+	)
+
+	removeOAuthFinalizer(nb)
+
+	g.Expect(nb.GetFinalizers()).To(Equal([]string{"other-finalizer"}))
+}
+
+func TestRemoveOAuthFinalizer_NotPresent(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withFinalizers("other-finalizer"),
+	)
+
+	removeOAuthFinalizer(nb)
+
+	g.Expect(nb.GetFinalizers()).To(Equal([]string{"other-finalizer"}))
+}
+
+func TestRemoveOAuthVolumes(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(
+			volume("oauth-config"),
+			volume("oauth-client"),
+			volume("tls-certificates"),
+			volume("data"),
+		),
+	)
+
+	err := removeOAuthVolumes(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeFalse())
+
+	podSpec := nb.Object["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)
+	volumes := podSpec["volumes"].([]any)
+	g.Expect(volumes).To(HaveLen(1))
+}
+
+func TestRemoveOAuthVolumes_NonePresent(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(volume("data")),
+	)
+
+	err := removeOAuthVolumes(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestStripTornadoSettings(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs,
+					`--ServerApp.port=8888 --ServerApp.tornado_settings={"headers":{"Content-Security-Policy":"frame-ancestors 'self'"}}`)),
+		),
+	)
+
+	err := stripTornadoSettings(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+func TestStripTornadoSettings_PreservesOtherArgs(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs,
+					`--ServerApp.port=8888 --ServerApp.tornado_settings={"foo":"bar"} --ServerApp.base_url=/notebook`)),
+		),
+	)
+
+	err := stripTornadoSettings(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	containers := nb.Object["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)
+	env := containers[0].(map[string]any)["env"].([]any)
+	value := env[0].(map[string]any)["value"].(string)
+	g.Expect(value).To(ContainSubstring("--ServerApp.port=8888"))
+	g.Expect(value).To(ContainSubstring("--ServerApp.base_url=/notebook"))
+	g.Expect(value).ToNot(ContainSubstring("tornado_settings"))
+}
+
+func TestStripTornadoSettings_NoTornadoSettings(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs, "--ServerApp.port=8888")),
+		),
+	)
+
+	err := stripTornadoSettings(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestApplyAllPatches(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := oauthNotebook("wb1", "ns1")
+	modified := nb.DeepCopy()
+
+	err := applyAllPatches(modified)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(modified.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+	g.Expect(modified.GetAnnotations()).ToNot(HaveKey(annotationInjectOAuth))
+	g.Expect(modified.GetAnnotations()).ToNot(HaveKey(annotationOAuthLogoutURL))
+	g.Expect(hasOAuthProxyContainer(modified)).To(BeFalse())
+	g.Expect(hasOAuthFinalizer(modified)).To(BeFalse())
+	g.Expect(hasOAuthVolumes(modified)).To(BeFalse())
+	g.Expect(hasTornadoSettings(modified)).To(BeFalse())
+
+	g.Expect(modified.GetFinalizers()).To(Equal([]string{"other-finalizer"}))
+}
+
+// --- IsStopped Tests ---
+
+func TestIsStopped_WithAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationKubeflowResourceStopped: "2024-01-01T00:00:00Z",
+		}),
+	)
+
+	g.Expect(isStopped(nb)).To(BeTrue())
+}
+
+func TestIsStopped_WithoutAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+
+	g.Expect(isStopped(nb)).To(BeFalse())
+}
+
+// --- Validate Tests ---
+
+func TestRunTask_Validate_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Validate_OAuthNotebooksFound(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	objs := []*unstructured.Unstructured{
+		oauthNotebook("wb1", "ns1"),
+		patchedNotebook("wb2", "ns1"),
+	}
+
+	k8sClient := newFakeClient(objs)
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Validate_AllPatched(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	objs := []*unstructured.Unstructured{
+		patchedNotebook("wb1", "ns1"),
+	}
+
+	k8sClient := newFakeClient(objs)
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Validate_FlagConflict(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.SkipStop = true
+	a.OnlyStopped = true
+	task := a.Run()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	_, err := task.Validate(context.Background(), target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+}
+
+func TestRunTask_Validate_NameWithoutNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.Scope.WorkbenchName = "wb1"
+	task := a.Run()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	_, err := task.Validate(context.Background(), target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-namespace"))
+}
+
+func TestRunTask_Validate_ListError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- Execute Tests ---
+
+func TestRunTask_Execute_FullPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify the notebook was updated
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+	g.Expect(updated.GetAnnotations()).ToNot(HaveKey(annotationInjectOAuth))
+	g.Expect(hasOAuthProxyContainer(updated)).To(BeFalse())
+	g.Expect(hasOAuthFinalizer(updated)).To(BeFalse())
+	g.Expect(hasOAuthVolumes(updated)).To(BeFalse())
+}
+
+func TestRunTask_Execute_AlreadyPatchedSkipped(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := patchedNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient, withDryRun)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify notebook was NOT modified
+	current, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasOAuthProxyContainer(current)).To(BeTrue(), "dry-run should not modify notebook")
+}
+
+func TestRunTask_Execute_MultipleNamespaces(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb1 := stoppedOAuthNotebook("wb1", "ns1")
+	nb2 := stoppedOAuthNotebook("wb2", "ns2")
+	sts1 := newStatefulSet("wb1", "ns1")
+	sts2 := newStatefulSet("wb2", "ns2")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb1, nb2, sts1, sts2})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify both notebooks were updated
+	for _, ns := range []string{"ns1", "ns2"} {
+		updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace(ns).Get(context.Background(), "wb1", metav1.GetOptions{})
+		if err != nil {
+			updated, err = k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+				Namespace(ns).Get(context.Background(), "wb2", metav1.GetOptions{})
+		}
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+	}
+}
+
+func TestRunTask_Execute_UpdateError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb}, updateErrorReactor())
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Execute_StatefulSetDeleted(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify StatefulSet was deleted
+	_, err = k8sClient.Dynamic().Resource(resources.StatefulSet.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestRunTask_Execute_StatefulSetNotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- Lifecycle Tests ---
+
+func TestRunTask_Execute_OnlyStopped_FiltersRunning(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.OnlyStopped = true
+	task := a.Run()
+
+	stopped := stoppedOAuthNotebook("wb-stopped", "ns1")
+	running := oauthNotebook("wb-running", "ns1")
+	sts := newStatefulSet("wb-stopped", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{stopped, running, sts})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Stopped notebook should be patched
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb-stopped", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+
+	// Running notebook should NOT be patched
+	notPatched, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb-running", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasOAuthProxyContainer(notPatched)).To(BeTrue())
+}
+
+func TestRunTask_Execute_SkipStop(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.SkipStop = true
+	task := a.Run()
+
+	nb := oauthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Notebook should be patched despite being running
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+}
+
+// --- Targeting Tests ---
+
+func TestRunTask_Execute_SingleNotebook(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.Scope.WorkbenchNamespace = "ns1"
+	a.Scope.WorkbenchName = "wb1"
+	task := a.Run()
+
+	nb1 := stoppedOAuthNotebook("wb1", "ns1")
+	nb2 := stoppedOAuthNotebook("wb2", "ns1")
+	sts1 := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb1, nb2, sts1})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// wb1 should be patched
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+
+	// wb2 should NOT be patched (not targeted)
+	notPatched, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb2", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasOAuthProxyContainer(notPatched)).To(BeTrue())
+}
+
+func TestRunTask_Execute_NamespaceScoped(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.Scope.WorkbenchNamespace = "ns1"
+	task := a.Run()
+
+	nb1 := stoppedOAuthNotebook("wb1", "ns1")
+	nb2 := stoppedOAuthNotebook("wb2", "ns2")
+	sts1 := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb1, nb2, sts1})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// wb1 in ns1 should be patched
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+}
+
+// --- Cleanup Tests ---
+
+func TestRunTask_Execute_WithCleanup(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.WithCleanup = true
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+	oauthResources := allOAuthResources("wb1", "ns1")
+
+	objs := append([]*unstructured.Unstructured{nb, sts}, oauthResources...)
+	k8sClient := newFakeClient(objs)
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify OAuth resources were deleted
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "Route should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Service.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-tls", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "Service should be deleted")
+}
+
+func TestRunTask_Execute_WithCleanup_DryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.WithCleanup = true
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	oauthResources := allOAuthResources("wb1", "ns1")
+
+	objs := append([]*unstructured.Unstructured{nb}, oauthResources...)
+	k8sClient := newFakeClient(objs)
+	target := newTarget(k8sClient, withDryRun)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify Route still exists (dry-run)
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "Route should still exist in dry-run")
+}
+
+func TestRunTask_Execute_WithCleanup_NoPatchedNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.WithCleanup = true
+	task := a.Run()
+
+	nb := patchedNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- Confirmation Tests ---
+
+func TestRunTask_Execute_ConfirmationCancelled(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient, withInteractiveConfirm("n\n"))
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify notebook was NOT modified
+	current, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasOAuthProxyContainer(current)).To(BeTrue())
+}
+
+func TestRunTask_Execute_ConfirmationAccepted(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient, withInteractiveConfirm("y\n"))
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Verify notebook was patched
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+}
+
+func TestRunTask_Execute_AutoStopCancelledRestartsNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := oauthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient, withInteractiveConfirm("n\n"))
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	current, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Notebook should NOT be patched (user cancelled)
+	g.Expect(hasOAuthProxyContainer(current)).To(BeTrue())
+
+	// Notebook should be restarted (stop annotation removed)
+	g.Expect(isStopped(current)).To(BeFalse())
+}
+
+// --- PrepareTask Tests ---
+
+func TestPrepareTask_Validate_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestPrepareTask_Validate_MixedNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	objs := []*unstructured.Unstructured{
+		oauthNotebook("wb1", "ns1"),
+		patchedNotebook("wb2", "ns1"),
+	}
+
+	k8sClient := newFakeClient(objs)
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestPrepareTask_Execute_DryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	nb := oauthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient, withDryRun)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestPrepareTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestPrepareTask_Validate_ListError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestPrepareTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestPrepareTask_Validate_NameWithoutNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.Scope.WorkbenchName = "wb1"
+	task := a.Prepare()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	_, err := task.Validate(context.Background(), target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-namespace"))
+}
+
+// --- Edge Cases ---
+
+func TestRunTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+func TestRunTask_Execute_OnlyStopped_AllRunning(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.OnlyStopped = true
+	task := a.Run()
+
+	nb := oauthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Notebook should NOT be patched
+	current, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasOAuthProxyContainer(current)).To(BeTrue())
+}
+
+func TestRunTask_Execute_WithCleanup_CleanupConfirmationCancelled(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.WithCleanup = true
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+	oauthResources := allOAuthResources("wb1", "ns1")
+
+	objs := append([]*unstructured.Unstructured{nb, sts}, oauthResources...)
+	k8sClient := newFakeClient(objs)
+	// First "y" for patch confirmation, then "n" for cleanup confirmation
+	target := newTarget(k8sClient, withInteractiveConfirm("y\nn\n"))
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Notebook should be patched
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+
+	// Route should still exist (cleanup was cancelled)
+	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred(), "Route should still exist because cleanup was cancelled")
+}
+
+func TestHasOAuthAnnotation_LogoutURL(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationOAuthLogoutURL: "https://example.com/logout",
+		}),
+	)
+
+	g.Expect(hasOAuthAnnotation(nb)).To(BeTrue())
+}
+
+func TestHasOAuthAnnotation_Neither(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{"other": "value"}),
+	)
+
+	g.Expect(hasOAuthAnnotation(nb)).To(BeFalse())
+}
+
+func TestHasOAuthAnnotation_NilAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+
+	g.Expect(hasOAuthAnnotation(nb)).To(BeFalse())
+}
+
+// --- Lifecycle Tests (direct function calls) ---
+
+func TestStopWorkbench(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := oauthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	err := stopWorkbench(context.Background(), target, nb, step)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify stop annotation was applied
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(isStopped(updated)).To(BeTrue())
+}
+
+func TestRestartWorkbench(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	restartWorkbench(context.Background(), target, nb, step)
+
+	// Verify stop annotation was removed
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(isStopped(updated)).To(BeFalse())
+}
+
+func TestDeleteStatefulSet(t *testing.T) {
+	g := NewWithT(t)
+
+	sts := newStatefulSet("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{sts})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+
+	// Verify it was deleted
+	_, err := k8sClient.Dynamic().Resource(resources.StatefulSet.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestDeleteStatefulSet_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	// Should not panic or error
+	deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+	g.Expect(true).To(BeTrue())
+}
+
+func TestDeleteStatefulSet_Error(t *testing.T) {
+	g := NewWithT(t)
+
+	sts := newStatefulSet("wb1", "ns1")
+	reactor := &k8stesting.SimpleReactor{
+		Verb:     "delete",
+		Resource: "statefulsets",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated delete error")
+		},
+	}
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{sts}, reactor)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	// Should record the error but not panic
+	deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+	g.Expect(true).To(BeTrue())
+}
+
+func TestCheckKueueTerminatingPods_NoKueueNamespaces(t *testing.T) {
+	g := NewWithT(t)
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	// Should complete without error when no Kueue namespaces exist
+	checkKueueTerminatingPods(context.Background(), target, nil, step)
+	g.Expect(true).To(BeTrue())
+}
+
+func TestWaitForStatefulSetScaleDown_NotFound(t *testing.T) {
+	g := NewWithT(t)
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	err := waitForStatefulSetScaleDown(context.Background(), target, "wb1", "ns1")
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestWaitForStatefulSetScaleDown_AlreadyScaledDown(t *testing.T) {
+	g := NewWithT(t)
+
+	sts := newStatefulSet("wb1", "ns1") // replicas=0
+	k8sClient := newFakeClient([]*unstructured.Unstructured{sts})
+	target := newTarget(k8sClient)
+
+	err := waitForStatefulSetScaleDown(context.Background(), target, "wb1", "ns1")
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+// --- Auto-stop integration ---
+
+func TestRunTask_Execute_AutoStopRunningNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	// One running notebook + its STS
+	nb := oauthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Notebook should be patched
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+
+	// After patching and restarting, the stop annotation should be removed
+	g.Expect(isStopped(updated)).To(BeFalse())
+}
+
+func TestRunTask_Execute_AutoStopMixedStoppedRunning(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	stopped := stoppedOAuthNotebook("wb-stopped", "ns1")
+	running := oauthNotebook("wb-running", "ns1")
+	sts1 := newStatefulSet("wb-stopped", "ns1")
+	sts2 := newStatefulSet("wb-running", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{stopped, running, sts1, sts2})
+	target := newTarget(k8sClient)
+
+	_, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Both should be patched
+	for _, name := range []string{"wb-stopped", "wb-running"} {
+		updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace("ns1").Get(context.Background(), name, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated.GetAnnotations()[annotationInjectAuth]).To(Equal("true"))
+	}
+}
+
+func TestRunTask_Execute_AutoStopDryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := oauthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient, withDryRun)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	// Notebook should NOT be modified in dry-run
+	current, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasOAuthProxyContainer(current)).To(BeTrue())
+}
+
+// --- backupNotebooks Tests ---
+
+func TestBackupNotebooks_DryRun(t *testing.T) {
+	g := NewWithT(t)
+
+	target := newTarget(newFakeClient(nil), withDryRun)
+	step := target.Recorder.Child("test", "test")
+
+	nb := oauthNotebook("wb1", "ns1")
+	err := backupNotebooks(target, []*unstructured.Unstructured{nb}, step)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestBackupNotebooks_WritesToDir(t *testing.T) {
+	g := NewWithT(t)
+
+	outputDir := t.TempDir()
+	target := newTarget(newFakeClient(nil))
+	target.OutputDir = outputDir
+	step := target.Recorder.Child("test", "test")
+
+	nb := oauthNotebook("wb1", "ns1")
+	err := backupNotebooks(target, []*unstructured.Unstructured{nb}, step)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestBackupNotebooks_MultipleNamespaces(t *testing.T) {
+	g := NewWithT(t)
+
+	outputDir := t.TempDir()
+	target := newTarget(newFakeClient(nil))
+	target.OutputDir = outputDir
+	step := target.Recorder.Child("test", "test")
+
+	nbs := []*unstructured.Unstructured{
+		oauthNotebook("wb1", "ns1"),
+		oauthNotebook("wb2", "ns2"),
+	}
+
+	err := backupNotebooks(target, nbs, step)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+// --- RestartWorkbench error path ---
+
+func TestRestartWorkbench_PatchError(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	reactor := &k8stesting.SimpleReactor{
+		Verb:     "patch",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated patch error")
+		},
+	}
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb}, reactor)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	restartWorkbench(context.Background(), target, nb, step)
+	g.Expect(true).To(BeTrue()) // should not panic
+}
+
+// --- StopWorkbench error path ---
+
+func TestStopWorkbench_PatchError(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := oauthNotebook("wb1", "ns1")
+	reactor := &k8stesting.SimpleReactor{
+		Verb:     "patch",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated patch error")
+		},
+	}
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb}, reactor)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	err := stopWorkbench(context.Background(), target, nb, step)
+	g.Expect(err).To(HaveOccurred())
+}
+
+// --- hasOAuthVolumes edge cases ---
+
+func TestHasOAuthVolumes_AllThree(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(
+			volume("oauth-config"),
+			volume("oauth-client"),
+			volume("tls-certificates"),
+		),
+	)
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeTrue())
+}
+
+func TestHasOAuthVolumes_OneOAuth(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(volume("tls-certificates")),
+	)
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeTrue())
+}
+
+func TestHasOAuthVolumes_NoOAuth(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+		withVolumes(volume("data")),
+	)
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeFalse())
+}
+
+func TestHasOAuthVolumes_NoVolumes(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+	)
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeFalse())
+}
+
+func TestHasOAuthFinalizer_True(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withFinalizers(finalizerOAuthClient),
+	)
+
+	g.Expect(hasOAuthFinalizer(nb)).To(BeTrue())
+}
+
+func TestHasOAuthFinalizer_False(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+
+	g.Expect(hasOAuthFinalizer(nb)).To(BeFalse())
+}
+
+func TestHasOAuthProxyContainer_True(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook"), container(containerOAuthProxy)),
+	)
+
+	g.Expect(hasOAuthProxyContainer(nb)).To(BeTrue())
+}
+
+func TestHasOAuthProxyContainer_False(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+	)
+
+	g.Expect(hasOAuthProxyContainer(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_True(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs, "--ServerApp.tornado_settings={}")),
+		),
+	)
+
+	g.Expect(hasTornadoSettings(nb)).To(BeTrue())
+}
+
+func TestHasTornadoSettings_False(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar(envNotebookArgs, "--ServerApp.port=8888")),
+		),
+	)
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_DifferentEnvVar(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(
+			containerWithEnv("my-notebook",
+				envVar("OTHER_VAR", "--ServerApp.tornado_settings={}")),
+		),
+	)
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_NoEnvVars(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")),
+	)
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+// --- Kueue Terminating Pods Tests ---
+
+func newNamespaceWithLabel(name string, labels map[string]string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name":   name,
+				"labels": toAnyMap(labels),
+			},
+		},
+	}
+}
+
+func toAnyMap(m map[string]string) map[string]any {
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+
+	return result
+}
+
+func newTerminatingPod(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]any{
+				"name":              name,
+				"namespace":         namespace,
+				"deletionTimestamp": "2024-01-01T00:00:00Z",
+			},
+		},
+	}
+}
+
+func TestCheckKueueTerminatingPods_WithStuckPods(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := newNamespaceWithLabel("ns1", map[string]string{
+		"kueue.openshift.io/managed": "true",
+	})
+	pod := newTerminatingPod("wb1-0", "ns1")
+	nb := oauthNotebook("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{ns, pod, nb})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	checkKueueTerminatingPods(context.Background(), target,
+		[]*unstructured.Unstructured{nb}, step)
+
+	g.Expect(true).To(BeTrue()) // should record warning without error
+}
+
+func TestCheckKueueTerminatingPods_NoStuckPods(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := newNamespaceWithLabel("ns1", map[string]string{
+		"kueue.openshift.io/managed": "true",
+	})
+	nb := oauthNotebook("wb1", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{ns, nb})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	checkKueueTerminatingPods(context.Background(), target,
+		[]*unstructured.Unstructured{nb}, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestCheckKueueTerminatingPods_NotebookNotInKueueNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := newNamespaceWithLabel("ns1", map[string]string{
+		"kueue.openshift.io/managed": "true",
+	})
+	nb := oauthNotebook("wb1", "ns2") // different namespace
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{ns, nb})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	checkKueueTerminatingPods(context.Background(), target,
+		[]*unstructured.Unstructured{nb}, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+func TestCheckKueueTerminatingPods_NilNotebooks(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := newNamespaceWithLabel("ns1", map[string]string{
+		"kueue.openshift.io/managed": "true",
+	})
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{ns})
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	checkKueueTerminatingPods(context.Background(), target, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// --- Execute with SkipStop + Kueue check ---
+
+func TestRunTask_Execute_SkipStop_TriggersKueueCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.SkipStop = true
+	task := a.Run()
+
+	ns := newNamespaceWithLabel("ns1", map[string]string{
+		"kueue.openshift.io/managed": "true",
+	})
+	nb := oauthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+	pod := newTerminatingPod("wb1-0", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{ns, nb, sts, pod})
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- removeOAuthFinalizer: no finalizers ---
+
+func TestRemoveOAuthFinalizer_NoFinalizers(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	removeOAuthFinalizer(nb)
+
+	g.Expect(nb.GetFinalizers()).To(BeNil())
+}
+
+// --- PrepareTask Execute: backup with valid dir ---
+
+func TestPrepareTask_Execute_BackupWritten(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	nb := oauthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+	target.OutputDir = t.TempDir()
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- PrepareTask Validate: all patched ---
+
+func TestPrepareTask_Validate_AllPatched(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	nb := patchedNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	result, err := task.Validate(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- runCleanup refetch error ---
+
+func TestRunTask_Execute_WithCleanup_RefetchError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	a.WithCleanup = true
+	task := a.Run()
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	sts := newStatefulSet("wb1", "ns1")
+
+	// Create client with the notebook + STS but add a reactor that fails GET
+	// after the first update (patch succeeds, but cleanup re-fetch fails)
+	updateCount := 0
+	getErrorReactor := &k8stesting.SimpleReactor{
+		Verb:     "get",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			updateCount++
+			// Let the first GET through (for ListNotebooks), fail subsequent ones
+			if updateCount > 1 {
+				return true, nil, errors.New("simulated get error")
+			}
+
+			return false, nil, nil
+		},
+	}
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts}, getErrorReactor)
+	// Use scope with specific name/namespace to use Get (not List)
+	a.Scope.WorkbenchNamespace = "ns1"
+	a.Scope.WorkbenchName = "wb1"
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- predicate edge cases: non-map items in containers/volumes ---
+
+func TestHasOAuthProxyContainer_NonMapContainer(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	containers := []any{"not-a-map", "also-not-a-map"}
+	_ = unstructured.SetNestedField(nb.Object,
+		containers,
+		"spec", "template", "spec", "containers")
+
+	g.Expect(hasOAuthProxyContainer(nb)).To(BeFalse())
+}
+
+func TestHasOAuthVolumes_NonMapVolume(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	volumes := []any{"not-a-map"}
+	_ = unstructured.SetNestedField(nb.Object,
+		volumes,
+		"spec", "template", "spec", "volumes")
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_NonMapContainer(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	containers := []any{"not-a-map"}
+	_ = unstructured.SetNestedField(nb.Object,
+		containers,
+		"spec", "template", "spec", "containers")
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_NonMapEnvVar(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	containers := []any{
+		map[string]any{
+			"name": "main",
+			"env":  []any{"not-a-map"},
+		},
+	}
+	_ = unstructured.SetNestedField(nb.Object,
+		containers,
+		"spec", "template", "spec", "containers")
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_NoEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	containers := []any{
+		map[string]any{
+			"name": "main",
+		},
+	}
+	_ = unstructured.SetNestedField(nb.Object,
+		containers,
+		"spec", "template", "spec", "containers")
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+// --- remove functions with non-map items ---
+
+func TestRemoveOAuthProxyContainer_PreservesNonMapItems(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	containers := []any{
+		"not-a-map",
+		map[string]any{"name": "oauth-proxy", "image": "oauth"},
+		map[string]any{"name": "main", "image": "main"},
+	}
+	_ = unstructured.SetNestedField(nb.Object,
+		containers,
+		"spec", "template", "spec", "containers")
+
+	err := removeOAuthProxyContainer(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, _ := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	g.Expect(got).To(HaveLen(2))
+}
+
+func TestRemoveOAuthVolumes_PreservesNonMapItems(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	volumes := []any{
+		"not-a-map",
+		map[string]any{"name": "oauth-config"},
+		map[string]any{"name": "data"},
+	}
+	_ = unstructured.SetNestedField(nb.Object,
+		volumes,
+		"spec", "template", "spec", "volumes")
+
+	err := removeOAuthVolumes(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	got, _ := jq.Query[[]any](nb, ".spec.template.spec.volumes")
+	g.Expect(got).To(HaveLen(2))
+}
+
+func TestStripTornadoSettings_NonMapContainerAndEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+	containers := []any{
+		"not-a-map",
+		map[string]any{
+			"name": "main",
+			"env": []any{
+				"not-a-map",
+				map[string]any{
+					"name":  "NOTEBOOK_ARGS",
+					"value": "--NotebookApp.port=8888 --ServerApp.tornado_settings={\"headers\":{}} --arg2",
+				},
+			},
+		},
+	}
+	_ = unstructured.SetNestedField(nb.Object,
+		containers,
+		"spec", "template", "spec", "containers")
+
+	err := stripTornadoSettings(nb)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+// --- waitForStatefulSetScaleDown with Get error ---
+
+func TestWaitForStatefulSetScaleDown_GetError(t *testing.T) {
+	g := NewWithT(t)
+
+	reactor := &k8stesting.SimpleReactor{
+		Verb:     "get",
+		Resource: "statefulsets",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("server error")
+		},
+	}
+
+	k8sClient := newFakeClient(nil, reactor)
+	target := newTarget(k8sClient)
+
+	err := waitForStatefulSetScaleDown(context.Background(), target, "wb1", "ns1")
+	g.Expect(err).To(HaveOccurred())
+}
+
+// --- stopWorkbench with wait timeout ---
+
+func TestStopWorkbench_WaitTimeout(t *testing.T) {
+	g := NewWithT(t)
+
+	sts := newStatefulSet("wb1", "ns1")
+	_ = unstructured.SetNestedField(sts.Object, int64(1), "spec", "replicas")
+
+	nb := oauthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, sts})
+	target := newTarget(k8sClient)
+
+	step := target.Recorder.Child("test", "test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := stopWorkbench(ctx, target, nb, step)
+	g.Expect(err).To(HaveOccurred())
+}
+
+// --- restartWorkbench success path ---
+
+func TestRestartWorkbench_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := stoppedOAuthNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	step := target.Recorder.Child("test", "test")
+
+	restartWorkbench(context.Background(), target, nb, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// --- predicate no-spec edge cases ---
+
+func TestHasOAuthProxyContainer_NoContainers(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	g.Expect(hasOAuthProxyContainer(nb)).To(BeFalse())
+}
+
+func TestHasOAuthVolumes_NoSpec2(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	g.Expect(hasOAuthVolumes(nb)).To(BeFalse())
+}
+
+func TestHasTornadoSettings_NoSpec2(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	g.Expect(hasTornadoSettings(nb)).To(BeFalse())
+}
+
+// --- remove functions with no spec ---
+
+func TestRemoveOAuthProxyContainer_NoContainers2(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	err := removeOAuthProxyContainer(nb)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestRemoveOAuthVolumes_NoSpec2(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	err := removeOAuthVolumes(nb)
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestStripTornadoSettings_NoContainers2(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	err := stripTornadoSettings(nb)
+	g.Expect(err).To(HaveOccurred())
+}
+
+// --- applyAllPatches error propagation ---
+
+func TestApplyAllPatches_NoContainersErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata":   map[string]any{"name": "wb1", "namespace": "ns1"},
+		},
+	}
+
+	err := applyAllPatches(nb)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("removing oauth-proxy container"))
+}
+
+// --- patchNotebooks applyAllPatches error ---
+
+func TestRunTask_Execute_PatchApplyError(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Run()
+
+	nb := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubeflow.org/v1",
+			"kind":       "Notebook",
+			"metadata": map[string]any{
+				"name":      "wb1",
+				"namespace": "ns1",
+				"annotations": map[string]any{
+					"notebooks.opendatahub.io/inject-oauth": "true",
+					"kubeflow-resource-stopped":             "2024-01-01T00:00:00Z",
+				},
+			},
+		},
+	}
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	a.Scope.WorkbenchNamespace = "ns1"
+	a.Scope.WorkbenchName = "wb1"
+	target := newTarget(k8sClient)
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- prepare_task.go Execute backup ---
+
+func TestPrepareTask_Execute_BackupMultipleNamespaces(t *testing.T) {
+	g := NewWithT(t)
+
+	a := newAction()
+	task := a.Prepare()
+
+	nb1 := oauthNotebook("wb1", "ns1")
+	nb2 := oauthNotebook("wb2", "ns2")
+	nb3 := newNotebook("wb3", "ns1")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb1, nb2, nb3})
+	target := newTarget(k8sClient)
+	target.OutputDir = t.TempDir()
+
+	result, err := task.Execute(context.Background(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+}
+
+// --- checkKueueTerminatingPods error from discovery ---
+
+func TestCheckKueueTerminatingPods_DiscoveryError(t *testing.T) {
+	g := NewWithT(t)
+
+	reactor := &k8stesting.SimpleReactor{
+		Verb:     "list",
+		Resource: "namespaces",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("namespace list error")
+		},
+	}
+
+	k8sClient := newFakeClient(nil, reactor)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	checkKueueTerminatingPods(context.Background(), target, nil, step)
+
+	g.Expect(true).To(BeTrue())
+}
+
+// --- checkKueueTerminatingPods with pod Get error ---
+
+func TestCheckKueueTerminatingPods_PodGetError(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := newNamespaceWithLabel("ns1", map[string]string{"kueue.x-k8s.io/managed": "true"})
+	nb := oauthNotebook("wb1", "ns1")
+
+	reactor := &k8stesting.SimpleReactor{
+		Verb:     "get",
+		Resource: "pods",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("pod get error")
+		},
+	}
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{ns, nb}, reactor)
+	target := newTarget(k8sClient)
+	step := target.Recorder.Child("test", "test")
+
+	checkKueueTerminatingPods(context.Background(), target, []*unstructured.Unstructured{nb}, step)
+
+	g.Expect(true).To(BeTrue())
+}

--- a/pkg/migrate/actions/workbenches/authmodel/lifecycle.go
+++ b/pkg/migrate/actions/workbenches/authmodel/lifecycle.go
@@ -1,0 +1,291 @@
+package authmodel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+const (
+	stopWaitTimeout  = 120 * time.Second
+	stopWaitInterval = 2 * time.Second
+)
+
+// stopWorkbench annotates a notebook with kubeflow-resource-stopped and waits
+// for the StatefulSet to scale down. Returns an error if stopping fails.
+func stopWorkbench(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+	step action.StepRecorder,
+) error {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				annotationKubeflowResourceStopped: timestamp,
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling stop patch: %w", err)
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace(namespace).
+		Patch(ctx, name, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("annotating notebook %s/%s for stop: %w", namespace, name, err)
+	}
+
+	step.Recordf(
+		fmt.Sprintf("stop-%s-%s", namespace, name),
+		"Stopped %s/%s, waiting for scale-down",
+		result.StepCompleted,
+		namespace, name,
+	)
+
+	if err := waitForStatefulSetScaleDown(ctx, target, name, namespace); err != nil {
+		step.Recordf(
+			fmt.Sprintf("wait-%s-%s", namespace, name),
+			"Timed out waiting for StatefulSet %s/%s to scale down: %v",
+			result.StepFailed,
+			namespace, name, err,
+		)
+
+		return err
+	}
+
+	return nil
+}
+
+// waitForStatefulSetScaleDown polls until the StatefulSet has 0 replicas or is deleted.
+func waitForStatefulSetScaleDown(
+	ctx context.Context,
+	target action.Target,
+	name string,
+	namespace string,
+) error {
+	err := wait.PollUntilContextTimeout(ctx, stopWaitInterval, stopWaitTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			sts, err := target.Client.Dynamic().Resource(resources.StatefulSet.GVR()).
+				Namespace(namespace).
+				Get(ctx, name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+
+			if err != nil {
+				return false, fmt.Errorf("getting statefulset %s/%s: %w", namespace, name, err)
+			}
+
+			replicas, found, err := unstructured.NestedInt64(sts.Object, "spec", "replicas")
+			if err != nil {
+				return false, fmt.Errorf("reading spec.replicas: %w", err)
+			}
+
+			if !found || replicas == 0 {
+				return true, nil
+			}
+
+			return false, nil
+		})
+	if err != nil {
+		return fmt.Errorf("waiting for statefulset %s/%s scale-down: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// restartWorkbench removes the kubeflow-resource-stopped annotation to restart a notebook.
+func restartWorkbench(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+	step action.StepRecorder,
+) {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				annotationKubeflowResourceStopped: nil,
+			},
+		},
+	}
+
+	patchData, err := json.Marshal(patch)
+	if err != nil {
+		step.Recordf(
+			fmt.Sprintf("restart-%s-%s", namespace, name),
+			"Failed to marshal restart patch for %s/%s: %v",
+			result.StepFailed,
+			namespace, name, err,
+		)
+
+		return
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace(namespace).
+		Patch(ctx, name, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		step.Recordf(
+			fmt.Sprintf("restart-%s-%s", namespace, name),
+			"Failed to restart %s/%s: %v",
+			result.StepFailed,
+			namespace, name, err,
+		)
+
+		return
+	}
+
+	step.Recordf(
+		fmt.Sprintf("restart-%s-%s", namespace, name),
+		"Restarted %s/%s",
+		result.StepCompleted,
+		namespace, name,
+	)
+}
+
+// deleteStatefulSet deletes the StatefulSet associated with a notebook. IsNotFound is not an error.
+func deleteStatefulSet(
+	ctx context.Context,
+	target action.Target,
+	name string,
+	namespace string,
+	step action.StepRecorder,
+) {
+	err := target.Client.Dynamic().Resource(resources.StatefulSet.GVR()).
+		Namespace(namespace).
+		Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		step.Recordf(
+			fmt.Sprintf("delete-sts-%s-%s", namespace, name),
+			"StatefulSet %s/%s already absent",
+			result.StepCompleted,
+			namespace, name,
+		)
+
+		return
+	}
+
+	if err != nil {
+		step.Recordf(
+			fmt.Sprintf("delete-sts-%s-%s", namespace, name),
+			"Failed to delete StatefulSet %s/%s: %v",
+			result.StepFailed,
+			namespace, name, err,
+		)
+
+		return
+	}
+
+	step.Recordf(
+		fmt.Sprintf("delete-sts-%s-%s", namespace, name),
+		"Deleted StatefulSet %s/%s",
+		result.StepCompleted,
+		namespace, name,
+	)
+}
+
+// checkKueueTerminatingPods detects pods stuck in Terminating state in
+// Kueue-managed namespaces and reports them with remediation commands.
+func checkKueueTerminatingPods(
+	ctx context.Context,
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+	step action.StepRecorder,
+) bool {
+	kueueNamespaces, err := kueuediscovery.KueueEnabledNamespaces(ctx, target.Client)
+	if err != nil {
+		step.Recordf("kueue-check",
+			"Failed to discover Kueue-managed namespaces: %v",
+			result.StepFailed, err)
+
+		return true
+	}
+
+	if kueueNamespaces.Len() == 0 {
+		return false
+	}
+
+	var kueueNotebooks []*unstructured.Unstructured
+
+	for _, nb := range notebooks {
+		if kueueNamespaces.Has(nb.GetNamespace()) {
+			kueueNotebooks = append(kueueNotebooks, nb)
+		}
+	}
+
+	if len(kueueNotebooks) == 0 {
+		return false
+	}
+
+	var stuckPods []string
+
+	for _, nb := range kueueNotebooks {
+		podName := nb.GetName() + "-0"
+		namespace := nb.GetNamespace()
+
+		pod, err := target.Client.Dynamic().Resource(resources.Pod.GVR()).
+			Namespace(namespace).
+			Get(ctx, podName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+
+		if err != nil {
+			continue
+		}
+
+		if pod.GetDeletionTimestamp() != nil {
+			stuckPods = append(stuckPods, fmt.Sprintf("%s/%s", namespace, podName))
+		}
+	}
+
+	if len(stuckPods) == 0 {
+		step.Recordf("kueue-check",
+			"No pods stuck in Terminating state in Kueue-managed namespaces",
+			result.StepCompleted)
+
+		return false
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("WARNING: Kueue Finalizer Conflicts detected")
+	target.IO.Errorf("The following pods are stuck in Terminating state:")
+
+	for _, pod := range stuckPods {
+		target.IO.Errorf("  - %s", pod)
+	}
+
+	target.IO.Errorf("")
+	target.IO.Errorf("To resolve, remove the finalizer from the affected pod:")
+	target.IO.Errorf("  oc patch pod <pod-name> -n <namespace> -p '{\"metadata\":{\"finalizers\":null}}' --type=merge")
+
+	step.Recordf("kueue-check",
+		"Found %d pod(s) stuck in Terminating state in Kueue-managed namespaces",
+		result.StepFailed, len(stuckPods))
+
+	return true
+}

--- a/pkg/migrate/actions/workbenches/authmodel/patch.go
+++ b/pkg/migrate/actions/workbenches/authmodel/patch.go
@@ -1,0 +1,389 @@
+package authmodel
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	annotationInjectAuth     = "notebooks.opendatahub.io/inject-auth"
+	annotationInjectOAuth    = "notebooks.opendatahub.io/inject-oauth"
+	annotationOAuthLogoutURL = "notebooks.opendatahub.io/oauth-logout-url"
+
+	containerOAuthProxy = "oauth-proxy"
+
+	finalizerOAuthClient = "notebook-oauth-client-finalizer.opendatahub.io"
+
+	envNotebookArgs = "NOTEBOOK_ARGS"
+)
+
+// isOAuthVolumeName returns true if name is one of the volumes injected by the
+// 2.x OAuth-proxy sidecar.
+func isOAuthVolumeName(name string) bool {
+	switch name {
+	case "oauth-config", "oauth-client", "tls-certificates":
+		return true
+	default:
+		return false
+	}
+}
+
+const tornadoSettingsPrefix = "--ServerApp.tornado_settings="
+
+func isArgWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+func findBraceEnd(s string, start int) int {
+	depth := 0
+
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		}
+
+		if depth == 0 {
+			return i + 1
+		}
+	}
+
+	return len(s)
+}
+
+// removeTornadoArg strips all --ServerApp.tornado_settings=... arguments
+// (and their leading whitespace) from s while preserving neighbouring args.
+// If the value starts with '{', brace-depth counting is used to find the end,
+// which correctly handles JSON that contains embedded spaces.
+func removeTornadoArg(s string) string {
+	for {
+		idx := strings.Index(s, tornadoSettingsPrefix)
+		if idx < 0 {
+			return s
+		}
+
+		start := idx
+		for start > 0 && isArgWhitespace(s[start-1]) {
+			start--
+		}
+
+		end := idx + len(tornadoSettingsPrefix)
+		if end < len(s) && s[end] == '{' {
+			end = findBraceEnd(s, end)
+		} else {
+			for end < len(s) && !isArgWhitespace(s[end]) {
+				end++
+			}
+		}
+
+		s = s[:start] + s[end:]
+	}
+}
+
+// needsAuthModelPatch returns true if the notebook still has any 2.x OAuth
+// artifacts that must be removed before 3.x.
+func needsAuthModelPatch(nb *unstructured.Unstructured) bool {
+	return hasOAuthAnnotation(nb) ||
+		hasOAuthProxyContainer(nb) ||
+		hasOAuthFinalizer(nb) ||
+		hasOAuthVolumes(nb) ||
+		hasTornadoSettings(nb)
+}
+
+// hasOAuthAnnotation returns true if inject-oauth or oauth-logout-url is present.
+func hasOAuthAnnotation(nb *unstructured.Unstructured) bool {
+	annotations := nb.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	if _, ok := annotations[annotationInjectOAuth]; ok {
+		return true
+	}
+
+	_, ok := annotations[annotationOAuthLogoutURL]
+
+	return ok
+}
+
+// hasOAuthProxyContainer returns true if there is an "oauth-proxy" container.
+func hasOAuthProxyContainer(nb *unstructured.Unstructured) bool {
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return false
+	}
+
+	for _, raw := range containers {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if name, _ := m["name"].(string); name == containerOAuthProxy {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasOAuthFinalizer returns true if the OAuth client finalizer is present.
+func hasOAuthFinalizer(nb *unstructured.Unstructured) bool {
+	return slices.Contains(nb.GetFinalizers(), finalizerOAuthClient)
+}
+
+// hasOAuthVolumes returns true if any of the OAuth volumes are present.
+func hasOAuthVolumes(nb *unstructured.Unstructured) bool {
+	volumes, err := jq.Query[[]any](nb, ".spec.template.spec.volumes")
+	if err != nil {
+		return false
+	}
+
+	for _, raw := range volumes {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if name, _ := m["name"].(string); isOAuthVolumeName(name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasTornadoSettings returns true if any container has a NOTEBOOK_ARGS env var
+// that contains --ServerApp.tornado_settings=.
+func hasTornadoSettings(nb *unstructured.Unstructured) bool {
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return false
+	}
+
+	for _, raw := range containers {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		envVars, ok := m["env"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, envRaw := range envVars {
+			envMap, ok := envRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name, _ := envMap["name"].(string)
+			value, _ := envMap["value"].(string)
+
+			if name == envNotebookArgs && strings.Contains(value, "--ServerApp.tornado_settings=") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// addInjectAuthAnnotation sets the inject-auth annotation to "true".
+func addInjectAuthAnnotation(nb *unstructured.Unstructured) {
+	annotations := nb.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[annotationInjectAuth] = "true"
+	nb.SetAnnotations(annotations)
+}
+
+// removeAnnotation deletes a single annotation key.
+func removeAnnotation(nb *unstructured.Unstructured, key string) {
+	annotations := nb.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+
+	delete(annotations, key)
+	nb.SetAnnotations(annotations)
+}
+
+// removeOAuthProxyContainer filters out the oauth-proxy container.
+func removeOAuthProxyContainer(nb *unstructured.Unstructured) error {
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return fmt.Errorf("querying containers: %w", err)
+	}
+
+	filtered := make([]any, 0, len(containers))
+
+	for _, raw := range containers {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			filtered = append(filtered, raw)
+
+			continue
+		}
+
+		if name, _ := m["name"].(string); name == containerOAuthProxy {
+			continue
+		}
+
+		filtered = append(filtered, raw)
+	}
+
+	data, err := json.Marshal(filtered)
+	if err != nil {
+		return fmt.Errorf("marshaling containers: %w", err)
+	}
+
+	if err := jq.Transform(nb, ".spec.template.spec.containers = %s", data); err != nil {
+		return fmt.Errorf("setting containers: %w", err)
+	}
+
+	return nil
+}
+
+// removeOAuthFinalizer removes the notebook-oauth-client-finalizer.
+func removeOAuthFinalizer(nb *unstructured.Unstructured) {
+	finalizers := nb.GetFinalizers()
+	if len(finalizers) == 0 {
+		return
+	}
+
+	var filtered []string
+
+	for _, f := range finalizers {
+		if f != finalizerOAuthClient {
+			filtered = append(filtered, f)
+		}
+	}
+
+	nb.SetFinalizers(filtered)
+}
+
+// removeOAuthVolumes filters out the three OAuth volumes.
+func removeOAuthVolumes(nb *unstructured.Unstructured) error {
+	volumes, err := jq.Query[[]any](nb, ".spec.template.spec.volumes")
+	if err != nil {
+		return fmt.Errorf("querying volumes: %w", err)
+	}
+
+	filtered := make([]any, 0, len(volumes))
+
+	for _, raw := range volumes {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			filtered = append(filtered, raw)
+
+			continue
+		}
+
+		if name, _ := m["name"].(string); isOAuthVolumeName(name) {
+			continue
+		}
+
+		filtered = append(filtered, raw)
+	}
+
+	data, err := json.Marshal(filtered)
+	if err != nil {
+		return fmt.Errorf("marshaling volumes: %w", err)
+	}
+
+	if err := jq.Transform(nb, ".spec.template.spec.volumes = %s", data); err != nil {
+		return fmt.Errorf("setting volumes: %w", err)
+	}
+
+	return nil
+}
+
+// stripTornadoSettings removes --ServerApp.tornado_settings=... from the
+// NOTEBOOK_ARGS env var in all containers.
+func stripTornadoSettings(nb *unstructured.Unstructured) error {
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return fmt.Errorf("querying containers: %w", err)
+	}
+
+	modified := false
+
+	for _, raw := range containers {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		envVars, ok := m["env"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, envRaw := range envVars {
+			envMap, ok := envRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name, _ := envMap["name"].(string)
+			value, _ := envMap["value"].(string)
+
+			if name == envNotebookArgs && strings.Contains(value, "--ServerApp.tornado_settings=") {
+				envMap["value"] = strings.TrimSpace(removeTornadoArg(value))
+				modified = true
+			}
+		}
+	}
+
+	if !modified {
+		return nil
+	}
+
+	data, err := json.Marshal(containers)
+	if err != nil {
+		return fmt.Errorf("marshaling containers: %w", err)
+	}
+
+	if err := jq.Transform(nb, ".spec.template.spec.containers = %s", data); err != nil {
+		return fmt.Errorf("setting containers: %w", err)
+	}
+
+	return nil
+}
+
+// applyAllPatches applies all 7 patch operations to a notebook (must be a DeepCopy):
+// addInjectAuthAnnotation, removeAnnotation (×2), removeOAuthProxyContainer,
+// removeOAuthFinalizer, removeOAuthVolumes, and stripTornadoSettings.
+func applyAllPatches(nb *unstructured.Unstructured) error {
+	addInjectAuthAnnotation(nb)
+	removeAnnotation(nb, annotationInjectOAuth)
+	removeAnnotation(nb, annotationOAuthLogoutURL)
+
+	if err := removeOAuthProxyContainer(nb); err != nil {
+		return fmt.Errorf("removing oauth-proxy container: %w", err)
+	}
+
+	removeOAuthFinalizer(nb)
+
+	if err := removeOAuthVolumes(nb); err != nil {
+		return fmt.Errorf("removing OAuth volumes: %w", err)
+	}
+
+	if err := stripTornadoSettings(nb); err != nil {
+		return fmt.Errorf("stripping tornado_settings: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/workbenches/authmodel/prepare_task.go
+++ b/pkg/migrate/actions/workbenches/authmodel/prepare_task.go
@@ -1,0 +1,140 @@
+package authmodel
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/backup"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+)
+
+type prepareTask struct {
+	action *PatchAuthModelAction
+}
+
+func (t *prepareTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
+	}
+
+	step := target.Recorder.Child(
+		"validate-patch-readiness",
+		"Validate notebooks for auth model patch",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(notebooks) == 0 {
+		step.Completef(result.StepCompleted, "No Notebook instances found")
+
+		return action.BuildResult(target)
+	}
+
+	needsPatch := 0
+	alreadyPatched := 0
+
+	for _, nb := range notebooks {
+		if needsAuthModelPatch(nb) {
+			needsPatch++
+		} else {
+			alreadyPatched++
+		}
+	}
+
+	if needsPatch == 0 {
+		step.Completef(result.StepCompleted,
+			"All %d Notebook(s) already patched for 3.x auth model", alreadyPatched)
+	} else {
+		step.Completef(result.StepCompleted,
+			"Found %d Notebook(s) needing auth model patch, %d already patched",
+			needsPatch, alreadyPatched)
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *prepareTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
+	}
+
+	step := target.Recorder.Child(
+		"backup-notebooks",
+		"Backup Notebook resources before auth model patch",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(notebooks) == 0 {
+		step.Completef(result.StepCompleted, "No Notebook instances found, nothing to backup")
+
+		return action.BuildResult(target)
+	}
+
+	if err := backupNotebooks(target, notebooks, step); err != nil {
+		return nil, fmt.Errorf("notebook backup failed: %w", err)
+	}
+
+	return action.BuildResult(target)
+}
+
+func backupNotebooks(
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+	step action.StepRecorder,
+) error {
+	if target.DryRun {
+		step.Completef(result.StepSkipped,
+			"Would backup %d Notebook(s) to %s", len(notebooks), target.OutputDir)
+
+		return nil
+	}
+
+	byNamespace := make(map[string][]*unstructured.Unstructured)
+	for _, nb := range notebooks {
+		ns := nb.GetNamespace()
+		byNamespace[ns] = append(byNamespace[ns], nb)
+	}
+
+	totalBacked := 0
+
+	for ns, nbs := range byNamespace {
+		outputDir := filepath.Join(target.OutputDir, ns)
+
+		if err := backup.WriteResourcesToDir(outputDir, resources.Notebook.GVR(), nbs); err != nil {
+			step.Completef(result.StepFailed,
+				"Failed to write Notebooks in namespace %s: %v", ns, err)
+
+			return fmt.Errorf("backup failed for namespace %s: %w", ns, err)
+		}
+
+		totalBacked += len(nbs)
+	}
+
+	step.Completef(result.StepCompleted,
+		"Backed up %d Notebook(s) across %d namespace(s) to %s",
+		totalBacked, len(byNamespace), target.OutputDir)
+
+	return nil
+}

--- a/pkg/migrate/actions/workbenches/authmodel/run_task.go
+++ b/pkg/migrate/actions/workbenches/authmodel/run_task.go
@@ -1,0 +1,477 @@
+package authmodel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/cleanup"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
+)
+
+type runTask struct {
+	action *PatchAuthModelAction
+}
+
+func (t *runTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.validateFlags(); err != nil {
+		return nil, err
+	}
+
+	step := target.Recorder.Child(
+		"validate-auth-model-patch",
+		"Validate notebooks for auth model patch",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		step.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(notebooks) == 0 {
+		step.Completef(result.StepCompleted, "No Notebook instances found")
+
+		return action.BuildResult(target)
+	}
+
+	toPatch, alreadyPatched := classifyNotebooks(notebooks)
+
+	if len(toPatch) == 0 {
+		step.Completef(result.StepCompleted,
+			"All %d Notebook(s) already patched for 3.x auth model", len(alreadyPatched))
+	} else {
+		step.Completef(result.StepCompleted,
+			"Found %d Notebook(s) needing auth model patch, %d already patched",
+			len(toPatch), len(alreadyPatched))
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.validateFlags(); err != nil {
+		return nil, err
+	}
+
+	// Step 1: Discover notebooks
+	discoverStep := target.Recorder.Child(
+		"discover-notebooks",
+		"Discover notebooks for auth model patch",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		discoverStep.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return action.BuildResult(target)
+	}
+
+	if len(notebooks) == 0 {
+		discoverStep.Completef(result.StepCompleted,
+			"No Notebook instances found, nothing to patch")
+
+		return action.BuildResult(target)
+	}
+
+	// Step 2: Classify
+	toPatch, alreadyPatched := classifyNotebooks(notebooks)
+
+	discoverStep.Completef(result.StepCompleted,
+		"Found %d Notebook(s) needing patch, %d already patched",
+		len(toPatch), len(alreadyPatched))
+
+	if len(toPatch) == 0 {
+		return action.BuildResult(target)
+	}
+
+	// Step 3: Filter by stopped/running state and auto-stop
+	var stoppedByAction []*unstructured.Unstructured
+
+	toPatch, stoppedByAction = t.handleLifecycle(ctx, target, toPatch)
+
+	if len(toPatch) == 0 {
+		return action.BuildResult(target)
+	}
+
+	// Step 4: Dry-run reporting
+	if target.DryRun {
+		t.reportDryRun(target, toPatch)
+
+		return action.BuildResult(target)
+	}
+
+	// Step 5: Confirmation
+	if !t.promptBeforePatch(target, len(toPatch)) {
+		target.Recorder.Recordf("patch-cancelled",
+			"User cancelled auth model patch", result.StepSkipped)
+
+		if len(stoppedByAction) > 0 {
+			t.restartNotebooks(ctx, target, stoppedByAction)
+		}
+
+		return action.BuildResult(target)
+	}
+
+	// Step 6: Patch notebooks
+	patched := t.patchNotebooks(ctx, target, toPatch)
+
+	// Step 7: Cleanup (if requested and notebooks were patched)
+	if t.action.WithCleanup && len(patched) > 0 {
+		t.runCleanup(ctx, target, patched)
+	}
+
+	// Step 8: Restart notebooks that were stopped by this action
+	if len(stoppedByAction) > 0 {
+		t.restartNotebooks(ctx, target, stoppedByAction)
+	}
+
+	// Step 9: Check for Kueue terminating pods (when --skip-stop was used)
+	if t.action.SkipStop && len(patched) > 0 {
+		kueueStep := target.Recorder.Child(
+			"check-kueue-terminating",
+			"Check for Kueue finalizer conflicts",
+		)
+
+		if checkKueueTerminatingPods(ctx, target, patched, kueueStep) {
+			kueueStep.Completef(result.StepFailed,
+				"Kueue finalizer conflicts detected")
+		} else {
+			kueueStep.Completef(result.StepCompleted,
+				"Kueue terminating pod check complete")
+		}
+	}
+
+	return action.BuildResult(target)
+}
+
+func (t *runTask) validateFlags() error {
+	if err := t.action.Scope.Validate(); err != nil {
+		return fmt.Errorf("invalid flags: %w", err)
+	}
+
+	if t.action.SkipStop && t.action.OnlyStopped {
+		return errors.New("--skip-stop and --only-stopped are mutually exclusive")
+	}
+
+	return nil
+}
+
+func classifyNotebooks(
+	notebooks []*unstructured.Unstructured,
+) ([]*unstructured.Unstructured, []*unstructured.Unstructured) {
+	var toPatch, alreadyPatched []*unstructured.Unstructured
+
+	for _, nb := range notebooks {
+		if needsAuthModelPatch(nb) {
+			toPatch = append(toPatch, nb)
+		} else {
+			alreadyPatched = append(alreadyPatched, nb)
+		}
+	}
+
+	return toPatch, alreadyPatched
+}
+
+// handleLifecycle manages stopping/filtering running notebooks before patching.
+// Returns the filtered list of notebooks to patch and a list of notebooks
+// that were stopped by this action (for later restart).
+func (t *runTask) handleLifecycle(
+	ctx context.Context,
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+) ([]*unstructured.Unstructured, []*unstructured.Unstructured) {
+	var toPatch, stoppedByAction []*unstructured.Unstructured
+
+	if t.action.OnlyStopped {
+		step := target.Recorder.Child(
+			"filter-stopped",
+			"Filter to stopped workbenches only",
+		)
+
+		var stopped, running []*unstructured.Unstructured
+
+		for _, nb := range notebooks {
+			if isStopped(nb) {
+				stopped = append(stopped, nb)
+			} else {
+				running = append(running, nb)
+			}
+		}
+
+		if len(running) > 0 {
+			step.Completef(result.StepCompleted,
+				"Skipping %d running Notebook(s), proceeding with %d stopped",
+				len(running), len(stopped))
+		} else {
+			step.Completef(result.StepCompleted,
+				"All %d Notebook(s) are stopped", len(stopped))
+		}
+
+		return stopped, nil
+	}
+
+	if t.action.SkipStop {
+		return notebooks, nil
+	}
+
+	// Default: auto-stop running notebooks
+	step := target.Recorder.Child(
+		"auto-stop-workbenches",
+		"Stop running workbenches before patching",
+	)
+
+	for _, nb := range notebooks {
+		if isStopped(nb) {
+			toPatch = append(toPatch, nb)
+
+			continue
+		}
+
+		if target.DryRun {
+			step.Recordf(
+				fmt.Sprintf("would-stop-%s-%s", nb.GetNamespace(), nb.GetName()),
+				"Would stop %s/%s before patching",
+				result.StepSkipped,
+				nb.GetNamespace(), nb.GetName(),
+			)
+
+			toPatch = append(toPatch, nb)
+
+			continue
+		}
+
+		if err := stopWorkbench(ctx, target, nb, step); err != nil {
+			step.Recordf(
+				fmt.Sprintf("stop-failed-%s-%s", nb.GetNamespace(), nb.GetName()),
+				"Failed to stop %s/%s, skipping: %v",
+				result.StepFailed,
+				nb.GetNamespace(), nb.GetName(), err,
+			)
+
+			continue
+		}
+
+		stoppedByAction = append(stoppedByAction, nb)
+		toPatch = append(toPatch, nb)
+	}
+
+	if len(stoppedByAction) > 0 {
+		step.Completef(result.StepCompleted,
+			"Stopped %d running Notebook(s)", len(stoppedByAction))
+	} else {
+		step.Completef(result.StepCompleted,
+			"No running Notebooks required stopping")
+	}
+
+	return toPatch, stoppedByAction
+}
+
+func (t *runTask) reportDryRun(
+	target action.Target,
+	toPatch []*unstructured.Unstructured,
+) {
+	step := target.Recorder.Child(
+		"dry-run-report",
+		"Dry-run: planned operations",
+	)
+
+	for _, nb := range toPatch {
+		step.Recordf(
+			fmt.Sprintf("would-patch-%s-%s", nb.GetNamespace(), nb.GetName()),
+			"Would patch %s/%s: set inject-auth, remove oauth-proxy/volumes/finalizer/annotations/tornado_settings, delete StatefulSet",
+			result.StepSkipped,
+			nb.GetNamespace(), nb.GetName(),
+		)
+	}
+
+	step.Completef(result.StepSkipped,
+		"Would patch %d Notebook(s)", len(toPatch))
+}
+
+func (t *runTask) patchNotebooks(
+	ctx context.Context,
+	target action.Target,
+	toPatch []*unstructured.Unstructured,
+) []*unstructured.Unstructured {
+	step := target.Recorder.Child(
+		"patch-auth-model",
+		"Patch notebooks for kube-rbac-proxy auth model",
+	)
+
+	var patched []*unstructured.Unstructured
+
+	successCount := 0
+	failCount := 0
+
+	for _, nb := range toPatch {
+		name := nb.GetName()
+		namespace := nb.GetNamespace()
+
+		nbStep := step.Child(
+			fmt.Sprintf("patch-%s-%s", namespace, name),
+			fmt.Sprintf("Patch %s/%s", namespace, name),
+		)
+
+		modified := nb.DeepCopy()
+
+		if err := applyAllPatches(modified); err != nil {
+			nbStep.Completef(result.StepFailed,
+				"Failed to apply patches to %s/%s: %v", namespace, name, err)
+			failCount++
+
+			continue
+		}
+
+		_, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace(namespace).
+			Update(ctx, modified, metav1.UpdateOptions{})
+		if err != nil {
+			nbStep.Completef(result.StepFailed,
+				"Failed to update %s/%s: %v", namespace, name, err)
+			failCount++
+
+			continue
+		}
+
+		nbStep.Recordf("patch-applied",
+			"Auth model patch applied to %s/%s",
+			result.StepCompleted, namespace, name)
+
+		deleteStatefulSet(ctx, target, name, namespace, nbStep)
+
+		nbStep.Completef(result.StepCompleted,
+			"Patched %s/%s", namespace, name)
+
+		patched = append(patched, modified)
+		successCount++
+	}
+
+	if failCount > 0 {
+		step.Completef(result.StepFailed,
+			"Patched %d/%d Notebook(s), %d failure(s)",
+			successCount, len(toPatch), failCount)
+	} else {
+		step.Completef(result.StepCompleted,
+			"Patched %d Notebook(s)", successCount)
+	}
+
+	return patched
+}
+
+func (t *runTask) runCleanup(
+	ctx context.Context,
+	target action.Target,
+	patched []*unstructured.Unstructured,
+) {
+	if !target.DryRun && !t.promptBeforeCleanup(target, len(patched)) {
+		target.Recorder.Recordf("cleanup-cancelled",
+			"User cancelled OAuth cleanup", result.StepSkipped)
+
+		return
+	}
+
+	cleanupStep := target.Recorder.Child(
+		"cleanup-oauth-resources",
+		"Clean up legacy OAuth resources",
+	)
+
+	successCount := 0
+	failCount := 0
+
+	for _, nb := range patched {
+		name := nb.GetName()
+		namespace := nb.GetNamespace()
+
+		// Re-fetch the notebook to get the reconciled state
+		refreshed, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace(namespace).
+			Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			cleanupStep.Recordf(
+				fmt.Sprintf("refetch-failed-%s-%s", namespace, name),
+				"Failed to re-fetch %s/%s for cleanup: %v",
+				result.StepFailed, namespace, name, err)
+			failCount++
+
+			continue
+		}
+
+		if cleanup.CleanupNotebook(ctx, target, refreshed, cleanupStep) == cleanup.CleanupResultCleaned {
+			successCount++
+		} else {
+			failCount++
+		}
+	}
+
+	if failCount > 0 {
+		cleanupStep.Completef(result.StepFailed,
+			"Cleaned %d/%d Notebook(s), %d failure(s)",
+			successCount, len(patched), failCount)
+	} else if target.DryRun {
+		cleanupStep.Completef(result.StepSkipped,
+			"Would clean up OAuth resources for %d Notebook(s)", len(patched))
+	} else {
+		cleanupStep.Completef(result.StepCompleted,
+			"Cleaned up OAuth resources for %d Notebook(s)", successCount)
+	}
+}
+
+func (t *runTask) restartNotebooks(
+	ctx context.Context,
+	target action.Target,
+	stoppedByAction []*unstructured.Unstructured,
+) {
+	step := target.Recorder.Child(
+		"restart-workbenches",
+		"Restart workbenches stopped by this action",
+	)
+
+	for _, nb := range stoppedByAction {
+		restartWorkbench(ctx, target, nb, step)
+	}
+
+	step.Completef(result.StepCompleted,
+		"Restart complete for %d Notebook(s)", len(stoppedByAction))
+}
+
+func (t *runTask) promptBeforePatch(
+	target action.Target,
+	count int,
+) bool {
+	if target.SkipConfirm {
+		return true
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("About to patch %d Notebook(s) for kube-rbac-proxy auth model", count)
+
+	return confirmation.Prompt(target.IO, "Proceed with auth model patch?")
+}
+
+func (t *runTask) promptBeforeCleanup(
+	target action.Target,
+	count int,
+) bool {
+	if target.SkipConfirm {
+		return true
+	}
+
+	target.IO.Fprintln()
+	target.IO.Errorf("About to delete legacy OAuth resources for %d Notebook(s)", count)
+
+	return confirmation.Prompt(target.IO, "Proceed with OAuth resource cleanup?")
+}

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
@@ -76,10 +77,10 @@ func (a *CleanupOAuthAction) Run() action.Task {
 	return &runTask{action: a}
 }
 
-// checkMigrationState verifies that a notebook has been successfully migrated
+// CheckMigrationState verifies that a notebook has been successfully migrated
 // from OAuth-proxy to kube-rbac-proxy. Returns true if all checks pass, along
 // with a list of failure messages for any checks that did not pass.
-func checkMigrationState(nb *unstructured.Unstructured) (bool, []string) {
+func CheckMigrationState(nb *unstructured.Unstructured) (bool, []string) {
 	var failures []string
 
 	annotations := nb.GetAnnotations()
@@ -169,11 +170,11 @@ func hasTornadoSettings(containers []any) bool {
 	return false
 }
 
-// deleteResourceIfPresent performs an idempotent deletion: if the resource
+// DeleteResourceIfPresent performs an idempotent deletion: if the resource
 // exists it is deleted; if it is already absent, no error is raised.
 // For cluster-scoped resources, pass an empty namespace.
 // Returns true if the resource was deleted or already absent; false on error.
-func deleteResourceIfPresent(
+func DeleteResourceIfPresent(
 	ctx context.Context,
 	target action.Target,
 	gvr schema.GroupVersionResource,
@@ -224,25 +225,104 @@ func resourceLabel(gvr schema.GroupVersionResource, name, namespace string) stri
 	return fmt.Sprintf("%s/%s (cluster-scoped)", gvr.Resource, name)
 }
 
-func (a *CleanupOAuthAction) promptCleanupContinueOrSkip(
+// CleanupResult indicates the outcome of a single notebook cleanup.
+type CleanupResult int
+
+const (
+	CleanupResultCleaned CleanupResult = iota
+	CleanupResultSkipped
+	CleanupResultFailed
+)
+
+// CleanupNotebook deletes the legacy OAuth resources for a single notebook.
+// It runs the pre-check and prompts for confirmation if the check fails.
+func CleanupNotebook(
+	ctx context.Context,
 	target action.Target,
-	name string,
-	namespace string,
-	failures []string,
-) bool {
-	if target.SkipConfirm {
-		return true
+	nb *unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) CleanupResult {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	step := parentStep.Child(
+		fmt.Sprintf("cleanup-%s-%s", namespace, name),
+		fmt.Sprintf("Clean up OAuth resources for %s/%s", namespace, name),
+	)
+
+	passed, failures := CheckMigrationState(nb)
+	if !passed {
+		step.Recordf("precheck",
+			"Pre-check failed: %s",
+			result.StepFailed,
+			strings.Join(failures, "; "))
+
+		if !target.SkipConfirm {
+			target.IO.Fprintln()
+			target.IO.Errorf("Pre-checks failed for %s/%s:", namespace, name)
+
+			for _, f := range failures {
+				target.IO.Errorf("  - %s", f)
+			}
+
+			if !confirmation.Prompt(target.IO,
+				fmt.Sprintf("Continue cleanup for %s/%s despite failed pre-checks?", namespace, name)) {
+				step.Completef(result.StepSkipped,
+					"Skipped cleanup for %s/%s (pre-check failed)", namespace, name)
+
+				return CleanupResultSkipped
+			}
+		}
+
+		step.Recordf("precheck-override",
+			"Continuing cleanup despite failed pre-checks", result.StepCompleted)
 	}
 
-	target.IO.Fprintln()
-	target.IO.Errorf("Pre-checks failed for %s/%s:", namespace, name)
+	hasFailed := !DeleteResourceIfPresent(ctx, target,
+		resources.Route.GVR(), name, namespace, step)
 
-	for _, f := range failures {
-		target.IO.Errorf("  - %s", f)
+	if !DeleteResourceIfPresent(ctx, target,
+		resources.Service.GVR(), name+"-tls", namespace, step) {
+		hasFailed = true
 	}
 
-	return confirmation.Prompt(target.IO,
-		fmt.Sprintf("Continue cleanup for %s/%s despite failed pre-checks?", namespace, name))
+	if !DeleteResourceIfPresent(ctx, target,
+		resources.Secret.GVR(), name+"-oauth-client", namespace, step) {
+		hasFailed = true
+	}
+
+	if !DeleteResourceIfPresent(ctx, target,
+		resources.Secret.GVR(), name+"-oauth-config", namespace, step) {
+		hasFailed = true
+	}
+
+	if !DeleteResourceIfPresent(ctx, target,
+		resources.Secret.GVR(), name+"-tls", namespace, step) {
+		hasFailed = true
+	}
+
+	oauthClientName := fmt.Sprintf("%s-%s-oauth-client", name, namespace)
+	if !DeleteResourceIfPresent(ctx, target,
+		resources.OAuthClient.GVR(), oauthClientName, "", step) {
+		hasFailed = true
+	}
+
+	if hasFailed {
+		step.Completef(result.StepFailed,
+			"Cleanup partially failed for %s/%s", namespace, name)
+
+		return CleanupResultFailed
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped,
+			"Would clean up OAuth resources for %s/%s", namespace, name)
+	} else {
+		step.Completef(result.StepCompleted,
+			"Cleaned up OAuth resources for %s/%s", namespace, name)
+	}
+
+	return CleanupResultCleaned
 }
 
 func (a *CleanupOAuthAction) promptBeforeCleanup(

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
@@ -355,7 +355,7 @@ func TestCheckMigrationState_AllPassed(t *testing.T) {
 	g := NewWithT(t)
 
 	nb := newMigratedNotebook("wb1", "ns1")
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeTrue())
 	g.Expect(failures).To(BeEmpty())
@@ -367,7 +367,7 @@ func TestCheckMigrationState_InjectAuthMissing(t *testing.T) {
 	nb := newNotebook("wb1", "ns1",
 		withContainers(migratedContainers()...))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeFalse())
 	g.Expect(failures).To(ContainElement(ContainSubstring("inject-auth")))
@@ -380,7 +380,7 @@ func TestCheckMigrationState_KubeRBACProxyMissing(t *testing.T) {
 		withAnnotations(migratedAnnotations()),
 		withContainers(container("my-notebook")))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeFalse())
 	g.Expect(failures).To(ContainElement(ContainSubstring("kube-rbac-proxy")))
@@ -396,7 +396,7 @@ func TestCheckMigrationState_OAuthProxyStillPresent(t *testing.T) {
 			container(containerKubeRBACProxy),
 			container(containerOAuthProxy)))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeFalse())
 	g.Expect(failures).To(ContainElement(ContainSubstring("oauth-proxy")))
@@ -414,7 +414,7 @@ func TestCheckMigrationState_InjectOAuthTolerated(t *testing.T) {
 			container("my-notebook"),
 			container(containerKubeRBACProxy)))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeTrue(), "inject-oauth tolerated when kube-rbac-proxy present and oauth-proxy absent")
 	g.Expect(failures).To(BeEmpty())
@@ -430,7 +430,7 @@ func TestCheckMigrationState_InjectOAuthFails(t *testing.T) {
 		}),
 		withContainers(container("my-notebook")))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeFalse())
 	g.Expect(failures).To(ContainElement(ContainSubstring("inject-oauth")))
@@ -446,7 +446,7 @@ func TestCheckMigrationState_TornadoSettingsPresent(t *testing.T) {
 				envVar("NOTEBOOK_ARGS", "--ServerApp.tornado_settings={\"xsrf_cookies\": false}")),
 			container(containerKubeRBACProxy)))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeFalse())
 	g.Expect(failures).To(ContainElement(ContainSubstring("tornado_settings")))
@@ -458,7 +458,7 @@ func TestCheckMigrationState_NoContainers(t *testing.T) {
 	nb := newNotebook("wb1", "ns1",
 		withAnnotations(migratedAnnotations()))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeFalse())
 	g.Expect(failures).To(ContainElement(ContainSubstring("could not read containers")))
@@ -474,7 +474,7 @@ func TestCheckMigrationState_TornadoSettingsInDifferentEnvVar(t *testing.T) {
 				envVar("OTHER_VAR", "--ServerApp.tornado_settings={\"xsrf_cookies\": false}")),
 			container(containerKubeRBACProxy)))
 
-	passed, failures := checkMigrationState(nb)
+	passed, failures := CheckMigrationState(nb)
 
 	g.Expect(passed).To(BeTrue(), "tornado_settings in a non-NOTEBOOK_ARGS env var should be ignored")
 	g.Expect(failures).To(BeEmpty())

--- a/pkg/migrate/actions/workbenches/cleanup/run_task.go
+++ b/pkg/migrate/actions/workbenches/cleanup/run_task.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 )
 
 type runTask struct {
@@ -46,7 +45,7 @@ func (t *runTask) Validate(
 	failCount := 0
 
 	for _, nb := range notebooks {
-		passed, failures := checkMigrationState(nb)
+		passed, failures := CheckMigrationState(nb)
 		if passed {
 			passCount++
 		} else {
@@ -117,11 +116,11 @@ func (t *runTask) Execute(
 		r := t.cleanupWorkbench(ctx, target, nb)
 
 		switch r {
-		case cleanupResultCleaned:
+		case CleanupResultCleaned:
 			cleanedCount++
-		case cleanupResultSkipped:
+		case CleanupResultSkipped:
 			skippedCount++
-		case cleanupResultFailed:
+		case CleanupResultFailed:
 			failedCount++
 		}
 	}
@@ -144,90 +143,12 @@ func (t *runTask) Execute(
 	return action.BuildResult(target)
 }
 
-type cleanupResult int
-
-const (
-	cleanupResultCleaned cleanupResult = iota
-	cleanupResultSkipped
-	cleanupResultFailed
-)
-
 func (t *runTask) cleanupWorkbench(
 	ctx context.Context,
 	target action.Target,
 	nb *unstructured.Unstructured,
-) cleanupResult {
-	name := nb.GetName()
-	namespace := nb.GetNamespace()
-
-	step := target.Recorder.Child(
-		fmt.Sprintf("cleanup-%s-%s", namespace, name),
-		fmt.Sprintf("Clean up OAuth resources for %s/%s", namespace, name),
-	)
-
-	passed, failures := checkMigrationState(nb)
-	if !passed {
-		step.Recordf("precheck",
-			"Pre-check failed: %s",
-			result.StepFailed,
-			joinFailures(failures))
-
-		if !t.action.promptCleanupContinueOrSkip(target, name, namespace, failures) {
-			step.Completef(result.StepSkipped,
-				"Skipped cleanup for %s/%s (pre-check failed)", namespace, name)
-
-			return cleanupResultSkipped
-		}
-
-		step.Recordf("precheck-override",
-			"Continuing cleanup despite failed pre-checks", result.StepCompleted)
-	}
-
-	hasFailed := !deleteResourceIfPresent(ctx, target,
-		resources.Route.GVR(), name, namespace, step)
-
-	if !deleteResourceIfPresent(ctx, target,
-		resources.Service.GVR(), name+"-tls", namespace, step) {
-		hasFailed = true
-	}
-
-	if !deleteResourceIfPresent(ctx, target,
-		resources.Secret.GVR(), name+"-oauth-client", namespace, step) {
-		hasFailed = true
-	}
-
-	if !deleteResourceIfPresent(ctx, target,
-		resources.Secret.GVR(), name+"-oauth-config", namespace, step) {
-		hasFailed = true
-	}
-
-	if !deleteResourceIfPresent(ctx, target,
-		resources.Secret.GVR(), name+"-tls", namespace, step) {
-		hasFailed = true
-	}
-
-	oauthClientName := fmt.Sprintf("%s-%s-oauth-client", name, namespace)
-	if !deleteResourceIfPresent(ctx, target,
-		resources.OAuthClient.GVR(), oauthClientName, "", step) {
-		hasFailed = true
-	}
-
-	if hasFailed {
-		step.Completef(result.StepFailed,
-			"Cleanup partially failed for %s/%s", namespace, name)
-
-		return cleanupResultFailed
-	}
-
-	if target.DryRun {
-		step.Completef(result.StepSkipped,
-			"Would clean up OAuth resources for %s/%s", namespace, name)
-	} else {
-		step.Completef(result.StepCompleted,
-			"Cleaned up OAuth resources for %s/%s", namespace, name)
-	}
-
-	return cleanupResultCleaned
+) CleanupResult {
+	return CleanupNotebook(ctx, target, nb, target.Recorder)
 }
 
 func joinFailures(failures []string) string {

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/metrics"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/trustyai/otelexporter"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/authmodel"
 	workbenchcleanup "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/cleanup"
 	workbenchkueue "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
@@ -33,8 +34,10 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&modelserving.ManagedISVCConfigAction{})
 	registry.MustRegister(&upgrade.WorkbenchUpgradeAction{})
 	wbScope := &workbenches.SharedScopeOptions{}
+	cleanupAction := &workbenchcleanup.CleanupOAuthAction{Scope: wbScope}
 	registry.MustRegister(&workbenchkueue.AttachKueueLabelAction{Scope: wbScope})
-	registry.MustRegister(&workbenchcleanup.CleanupOAuthAction{Scope: wbScope})
+	registry.MustRegister(cleanupAction)
+	registry.MustRegister(&authmodel.PatchAuthModelAction{Scope: wbScope, CleanupAction: cleanupAction})
 	registry.MustRegister(&deadlock.BreakGPUDeadlockAction{})
 	registry.MustRegister(&guardrails.PatchGuardrailsAction{})
 	registry.MustRegister(&otelexporter.MigrateOtelExporterAction{})

--- a/pkg/resources/component_crs_test.go
+++ b/pkg/resources/component_crs_test.go
@@ -163,6 +163,8 @@ func TestGetComponentCR(t *testing.T) {
 
 			if got == nil {
 				t.Fatal("expected non-nil ResourceType")
+
+				return
 			}
 
 			if got.Kind != tt.wantKind {

--- a/pkg/util/conditions/conditions_test.go
+++ b/pkg/util/conditions/conditions_test.go
@@ -55,6 +55,8 @@ func TestFindCondition(t *testing.T) {
 			if tt.wantFound {
 				if got == nil {
 					t.Fatalf("expected condition, got nil")
+
+					return
 				}
 
 				if got.Status != tt.wantStatus {
@@ -78,6 +80,8 @@ func TestFindReady(t *testing.T) {
 	got := conditions.FindReady(conds)
 	if got == nil {
 		t.Fatal("expected Ready condition, got nil")
+
+		return
 	}
 
 	if got.Status != metav1.ConditionFalse {


### PR DESCRIPTION
## Description
https://redhat.atlassian.net/browse/RHOAIENG-72117 
<!-- What does this PR do? -->
Implements a port of the patch command from workbench-2.x-to-3.x-upgrade.sh into a migration action that updates workbench notebooks from OAuth-proxy (2.x) to kube-rbac-proxy (3.x) auth model

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workbench migration action to upgrade notebooks to the newer auth model, with optional legacy OAuth cleanup.
  * Added notebook lifecycle handling to support stopping, patching, restarting, and detecting terminating pods for safer post-patch behavior.
* **Bug Fixes**
  * Improved migration readiness checks, idempotent OAuth resource deletion, and cleanup result handling for more consistent outcomes.
* **Tests**
  * Improved test robustness by adding early returns after fatal failures to prevent follow-up assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->