### PR TITLE
[RHOAIENG-72118] Port Workbench verify and list bash functionality to Go migrate action

### DIFF
--- a/pkg/migrate/actions/workbenches/authmodel/authmodel.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel.go
@@ -75,14 +75,14 @@ func (a *PatchAuthModelAction) Run() action.Task {
 	return &runTask{action: a}
 }
 
-// isStopped returns true if the notebook has the kubeflow-resource-stopped annotation.
+// isStopped returns true if the notebook has a non-empty kubeflow-resource-stopped annotation.
 func isStopped(nb *unstructured.Unstructured) bool {
 	annotations := nb.GetAnnotations()
 	if annotations == nil {
 		return false
 	}
 
-	_, stopped := annotations[annotationKubeflowResourceStopped]
+	stopped, ok := annotations[annotationKubeflowResourceStopped]
 
-	return stopped
+	return ok && stopped != ""
 }

--- a/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
@@ -800,6 +800,18 @@ func TestIsStopped_WithoutAnnotation(t *testing.T) {
 	g.Expect(isStopped(nb)).To(BeFalse())
 }
 
+func TestIsStopped_EmptyAnnotationValue(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			annotationKubeflowResourceStopped: "",
+		}),
+	)
+
+	g.Expect(isStopped(nb)).To(BeFalse())
+}
+
 // --- Validate Tests ---
 
 func TestRunTask_Validate_NoNotebooks(t *testing.T) {
@@ -1566,7 +1578,8 @@ func TestDeleteStatefulSet(t *testing.T) {
 	target := newTarget(k8sClient)
 	step := target.Recorder.Child("test", "test")
 
-	deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+	ok := deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+	g.Expect(ok).To(BeTrue())
 
 	// Verify it was deleted
 	_, err := k8sClient.Dynamic().Resource(resources.StatefulSet.GVR()).
@@ -1581,9 +1594,8 @@ func TestDeleteStatefulSet_NotFound(t *testing.T) {
 	target := newTarget(k8sClient)
 	step := target.Recorder.Child("test", "test")
 
-	// Should not panic or error
-	deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
-	g.Expect(true).To(BeTrue())
+	ok := deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+	g.Expect(ok).To(BeTrue())
 }
 
 func TestDeleteStatefulSet_Error(t *testing.T) {
@@ -1602,9 +1614,8 @@ func TestDeleteStatefulSet_Error(t *testing.T) {
 	target := newTarget(k8sClient)
 	step := target.Recorder.Child("test", "test")
 
-	// Should record the error but not panic
-	deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
-	g.Expect(true).To(BeTrue())
+	ok := deleteStatefulSet(context.Background(), target, "wb1", "ns1", step)
+	g.Expect(ok).To(BeFalse())
 }
 
 func TestCheckKueueTerminatingPods_NoKueueNamespaces(t *testing.T) {

--- a/pkg/migrate/actions/workbenches/authmodel/lifecycle.go
+++ b/pkg/migrate/actions/workbenches/authmodel/lifecycle.go
@@ -168,13 +168,14 @@ func restartWorkbench(
 }
 
 // deleteStatefulSet deletes the StatefulSet associated with a notebook. IsNotFound is not an error.
+// Returns true when the StatefulSet was successfully deleted or already absent.
 func deleteStatefulSet(
 	ctx context.Context,
 	target action.Target,
 	name string,
 	namespace string,
 	step action.StepRecorder,
-) {
+) bool {
 	err := target.Client.Dynamic().Resource(resources.StatefulSet.GVR()).
 		Namespace(namespace).
 		Delete(ctx, name, metav1.DeleteOptions{})
@@ -186,7 +187,7 @@ func deleteStatefulSet(
 			namespace, name,
 		)
 
-		return
+		return true
 	}
 
 	if err != nil {
@@ -197,7 +198,7 @@ func deleteStatefulSet(
 			namespace, name, err,
 		)
 
-		return
+		return false
 	}
 
 	step.Recordf(
@@ -206,6 +207,8 @@ func deleteStatefulSet(
 		result.StepCompleted,
 		namespace, name,
 	)
+
+	return true
 }
 
 // checkKueueTerminatingPods detects pods stuck in Terminating state in

--- a/pkg/migrate/actions/workbenches/authmodel/patch.go
+++ b/pkg/migrate/actions/workbenches/authmodel/patch.go
@@ -40,6 +40,9 @@ func isArgWhitespace(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
+// findBraceEnd finds the end of a brace-delimited block by counting {/} depth.
+// It does not account for braces inside JSON string literals, which is safe for
+// known tornado_settings values (CSP headers) but not arbitrary JSON.
 func findBraceEnd(s string, start int) int {
 	depth := 0
 

--- a/pkg/migrate/actions/workbenches/authmodel/run_task.go
+++ b/pkg/migrate/actions/workbenches/authmodel/run_task.go
@@ -104,6 +104,8 @@ func (t *runTask) Execute(
 	toPatch, stoppedByAction = t.handleLifecycle(ctx, target, toPatch)
 
 	if len(toPatch) == 0 {
+		t.restartNotebooks(ctx, target, stoppedByAction)
+
 		return action.BuildResult(target)
 	}
 
@@ -119,9 +121,7 @@ func (t *runTask) Execute(
 		target.Recorder.Recordf("patch-cancelled",
 			"User cancelled auth model patch", result.StepSkipped)
 
-		if len(stoppedByAction) > 0 {
-			t.restartNotebooks(ctx, target, stoppedByAction)
-		}
+		t.restartNotebooks(ctx, target, stoppedByAction)
 
 		return action.BuildResult(target)
 	}
@@ -135,9 +135,7 @@ func (t *runTask) Execute(
 	}
 
 	// Step 8: Restart notebooks that were stopped by this action
-	if len(stoppedByAction) > 0 {
-		t.restartNotebooks(ctx, target, stoppedByAction)
-	}
+	t.restartNotebooks(ctx, target, stoppedByAction)
 
 	// Step 9: Check for Kueue terminating pods (when --skip-stop was used)
 	if t.action.SkipStop && len(patched) > 0 {
@@ -265,8 +263,26 @@ func (t *runTask) handleLifecycle(
 			continue
 		}
 
-		stoppedByAction = append(stoppedByAction, nb)
-		toPatch = append(toPatch, nb)
+		// Re-fetch after stop to get the current resourceVersion;
+		// stopWorkbench's MergePatch advanced it on the server.
+		refreshed, err := target.Client.Dynamic().Resource(resources.Notebook.GVR()).
+			Namespace(nb.GetNamespace()).
+			Get(ctx, nb.GetName(), metav1.GetOptions{})
+		if err != nil {
+			step.Recordf(
+				fmt.Sprintf("refetch-failed-%s-%s", nb.GetNamespace(), nb.GetName()),
+				"Failed to re-fetch %s/%s after stop, skipping patch: %v",
+				result.StepFailed,
+				nb.GetNamespace(), nb.GetName(), err,
+			)
+
+			stoppedByAction = append(stoppedByAction, nb)
+
+			continue
+		}
+
+		stoppedByAction = append(stoppedByAction, refreshed)
+		toPatch = append(toPatch, refreshed)
 	}
 
 	if len(stoppedByAction) > 0 {
@@ -351,7 +367,16 @@ func (t *runTask) patchNotebooks(
 			"Auth model patch applied to %s/%s",
 			result.StepCompleted, namespace, name)
 
-		deleteStatefulSet(ctx, target, name, namespace, nbStep)
+		stsDeleted := deleteStatefulSet(ctx, target, name, namespace, nbStep)
+
+		if !stsDeleted {
+			nbStep.Completef(result.StepFailed,
+				"Patched %s/%s but StatefulSet deletion failed, may reconcile with old spec until controller catches up",
+				namespace, name)
+			failCount++
+
+			continue
+		}
 
 		nbStep.Completef(result.StepCompleted,
 			"Patched %s/%s", namespace, name)
@@ -435,6 +460,10 @@ func (t *runTask) restartNotebooks(
 	target action.Target,
 	stoppedByAction []*unstructured.Unstructured,
 ) {
+	if len(stoppedByAction) == 0 {
+		return
+	}
+
 	step := target.Recorder.Child(
 		"restart-workbenches",
 		"Restart workbenches stopped by this action",

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup.go
@@ -17,7 +17,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/confirmation"
-	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
 )
 
 const (
@@ -25,15 +24,6 @@ const (
 	actionName        = "Clean up legacy OAuth resources from workbenches"
 	actionDescription = "Removes stale OAuth-proxy resources (Route, Service, Secrets, OAuthClient) " +
 		"left behind after migrating workbenches from 2.x to 3.x"
-
-	annotationInjectAuth  = "notebooks.opendatahub.io/inject-auth"
-	annotationInjectOAuth = "notebooks.opendatahub.io/inject-oauth"
-
-	containerKubeRBACProxy = "kube-rbac-proxy"
-	containerOAuthProxy    = "oauth-proxy"
-
-	envNotebookArgs       = "NOTEBOOK_ARGS"
-	tornadoSettingsPrefix = "--ServerApp.tornado_settings="
 
 	minTargetMajorVersion = 3
 )
@@ -77,97 +67,9 @@ func (a *CleanupOAuthAction) Run() action.Task {
 	return &runTask{action: a}
 }
 
-// CheckMigrationState verifies that a notebook has been successfully migrated
-// from OAuth-proxy to kube-rbac-proxy. Returns true if all checks pass, along
-// with a list of failure messages for any checks that did not pass.
+// CheckMigrationState delegates to the shared workbenches.CheckMigrationState.
 func CheckMigrationState(nb *unstructured.Unstructured) (bool, []string) {
-	var failures []string
-
-	annotations := nb.GetAnnotations()
-
-	if annotations[annotationInjectAuth] != "true" {
-		failures = append(failures,
-			fmt.Sprintf("inject-auth annotation missing or not 'true' (found: %q)",
-				annotations[annotationInjectAuth]))
-	}
-
-	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
-	if err != nil {
-		failures = append(failures, fmt.Sprintf("could not read containers: %v", err))
-
-		return false, failures
-	}
-
-	hasKubeRBACProxy := false
-	hasOAuthProxy := false
-
-	for _, raw := range containers {
-		containerMap, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		name, _ := containerMap["name"].(string)
-
-		switch name {
-		case containerKubeRBACProxy:
-			hasKubeRBACProxy = true
-		case containerOAuthProxy:
-			hasOAuthProxy = true
-		}
-	}
-
-	if !hasKubeRBACProxy {
-		failures = append(failures, "kube-rbac-proxy sidecar container missing")
-	}
-
-	if hasOAuthProxy {
-		failures = append(failures, "legacy oauth-proxy sidecar still present")
-	}
-
-	if injectOAuth, exists := annotations[annotationInjectOAuth]; exists {
-		if !hasKubeRBACProxy || hasOAuthProxy {
-			failures = append(failures,
-				fmt.Sprintf("legacy inject-oauth annotation still exists: %q", injectOAuth))
-		}
-	}
-
-	if hasTornadoSettings(containers) {
-		failures = append(failures,
-			"--ServerApp.tornado_settings still present in NOTEBOOK_ARGS")
-	}
-
-	return len(failures) == 0, failures
-}
-
-func hasTornadoSettings(containers []any) bool {
-	for _, raw := range containers {
-		containerMap, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		envVars, ok := containerMap["env"].([]any)
-		if !ok {
-			continue
-		}
-
-		for _, envRaw := range envVars {
-			envMap, ok := envRaw.(map[string]any)
-			if !ok {
-				continue
-			}
-
-			name, _ := envMap["name"].(string)
-			value, _ := envMap["value"].(string)
-
-			if name == envNotebookArgs && strings.Contains(value, tornadoSettingsPrefix) {
-				return true
-			}
-		}
-	}
-
-	return false
+	return workbenches.CheckMigrationState(nb)
 }
 
 // DeleteResourceIfPresent performs an idempotent deletion: if the resource

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
@@ -107,14 +107,14 @@ func envVar(name, value string) map[string]any {
 
 func migratedAnnotations() map[string]string {
 	return map[string]string{
-		annotationInjectAuth: "true",
+		workbenches.AnnotationInjectAuth: "true",
 	}
 }
 
 func migratedContainers() []map[string]any {
 	return []map[string]any{
 		container("my-notebook"),
-		container(containerKubeRBACProxy),
+		container(workbenches.ContainerKubeRBACProxy),
 	}
 }
 
@@ -393,8 +393,8 @@ func TestCheckMigrationState_OAuthProxyStillPresent(t *testing.T) {
 		withAnnotations(migratedAnnotations()),
 		withContainers(
 			container("my-notebook"),
-			container(containerKubeRBACProxy),
-			container(containerOAuthProxy)))
+			container(workbenches.ContainerKubeRBACProxy),
+			container(workbenches.ContainerOAuthProxy)))
 
 	passed, failures := CheckMigrationState(nb)
 
@@ -407,12 +407,12 @@ func TestCheckMigrationState_InjectOAuthTolerated(t *testing.T) {
 
 	nb := newNotebook("wb1", "ns1",
 		withAnnotations(map[string]string{
-			annotationInjectAuth:  "true",
-			annotationInjectOAuth: "true",
+			workbenches.AnnotationInjectAuth:  "true",
+			workbenches.AnnotationInjectOAuth: "true",
 		}),
 		withContainers(
 			container("my-notebook"),
-			container(containerKubeRBACProxy)))
+			container(workbenches.ContainerKubeRBACProxy)))
 
 	passed, failures := CheckMigrationState(nb)
 
@@ -425,8 +425,8 @@ func TestCheckMigrationState_InjectOAuthFails(t *testing.T) {
 
 	nb := newNotebook("wb1", "ns1",
 		withAnnotations(map[string]string{
-			annotationInjectAuth:  "true",
-			annotationInjectOAuth: "true",
+			workbenches.AnnotationInjectAuth:  "true",
+			workbenches.AnnotationInjectOAuth: "true",
 		}),
 		withContainers(container("my-notebook")))
 
@@ -444,7 +444,7 @@ func TestCheckMigrationState_TornadoSettingsPresent(t *testing.T) {
 		withContainers(
 			containerWithEnv("my-notebook",
 				envVar("NOTEBOOK_ARGS", "--ServerApp.tornado_settings={\"xsrf_cookies\": false}")),
-			container(containerKubeRBACProxy)))
+			container(workbenches.ContainerKubeRBACProxy)))
 
 	passed, failures := CheckMigrationState(nb)
 
@@ -472,7 +472,7 @@ func TestCheckMigrationState_TornadoSettingsInDifferentEnvVar(t *testing.T) {
 		withContainers(
 			containerWithEnv("my-notebook",
 				envVar("OTHER_VAR", "--ServerApp.tornado_settings={\"xsrf_cookies\": false}")),
-			container(containerKubeRBACProxy)))
+			container(workbenches.ContainerKubeRBACProxy)))
 
 	passed, failures := CheckMigrationState(nb)
 

--- a/pkg/migrate/actions/workbenches/migration_checks.go
+++ b/pkg/migrate/actions/workbenches/migration_checks.go
@@ -1,0 +1,116 @@
+package workbenches
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	AnnotationInjectAuth  = "notebooks.opendatahub.io/inject-auth"
+	AnnotationInjectOAuth = "notebooks.opendatahub.io/inject-oauth"
+
+	ContainerKubeRBACProxy = "kube-rbac-proxy"
+	ContainerOAuthProxy    = "oauth-proxy"
+
+	EnvNotebookArgs       = "NOTEBOOK_ARGS"
+	TornadoSettingsPrefix = "--ServerApp.tornado_settings="
+)
+
+// CheckMigrationState verifies that a notebook has been successfully migrated
+// from OAuth-proxy to kube-rbac-proxy. Returns true if all checks pass, along
+// with a list of failure messages for any checks that did not pass.
+func CheckMigrationState(nb *unstructured.Unstructured) (bool, []string) {
+	var failures []string
+
+	annotations := nb.GetAnnotations()
+
+	if annotations[AnnotationInjectAuth] != "true" {
+		failures = append(failures,
+			fmt.Sprintf("inject-auth annotation missing or not 'true' (found: %q)",
+				annotations[AnnotationInjectAuth]))
+	}
+
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		failures = append(failures, fmt.Sprintf("could not read containers: %v", err))
+
+		return false, failures
+	}
+
+	hasKubeRBACProxy := false
+	hasOAuthProxy := false
+
+	for _, raw := range containers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := containerMap["name"].(string)
+
+		switch name {
+		case ContainerKubeRBACProxy:
+			hasKubeRBACProxy = true
+		case ContainerOAuthProxy:
+			hasOAuthProxy = true
+		}
+	}
+
+	if !hasKubeRBACProxy {
+		failures = append(failures, "kube-rbac-proxy sidecar container missing")
+	}
+
+	if hasOAuthProxy {
+		failures = append(failures, "legacy oauth-proxy sidecar still present")
+	}
+
+	if injectOAuth, exists := annotations[AnnotationInjectOAuth]; exists {
+		if !hasKubeRBACProxy || hasOAuthProxy {
+			failures = append(failures,
+				fmt.Sprintf("legacy inject-oauth annotation still exists: %q", injectOAuth))
+		}
+	}
+
+	if HasTornadoSettings(containers) {
+		failures = append(failures,
+			"--ServerApp.tornado_settings still present in NOTEBOOK_ARGS")
+	}
+
+	return len(failures) == 0, failures
+}
+
+// HasTornadoSettings checks whether any container has --ServerApp.tornado_settings
+// in its NOTEBOOK_ARGS environment variable.
+func HasTornadoSettings(containers []any) bool {
+	for _, raw := range containers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		envVars, ok := containerMap["env"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, envRaw := range envVars {
+			envMap, ok := envRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			name, _ := envMap["name"].(string)
+			value, _ := envMap["value"].(string)
+
+			if name == EnvNotebookArgs && strings.Contains(value, TornadoSettingsPrefix) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade.go
@@ -98,16 +98,16 @@ func (a *WorkbenchUpgradeAction) listNotebooks(
 	return nbs, nil
 }
 
-// isStopped returns true if the notebook has the kubeflow-resource-stopped annotation.
+// isStopped returns true if the notebook has a non-empty kubeflow-resource-stopped annotation.
 func isStopped(nb *unstructured.Unstructured) bool {
 	annotations := nb.GetAnnotations()
 	if annotations == nil {
 		return false
 	}
 
-	_, stopped := annotations[annotationKubeflowResourceStopped]
+	stopped, ok := annotations[annotationKubeflowResourceStopped]
 
-	return stopped
+	return ok && stopped != ""
 }
 
 // hasDashboardAnnotation returns true if the notebook has Dashboard-managed annotations.

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -324,6 +324,15 @@ func TestIsStopped(t *testing.T) {
 			}),
 			true,
 		},
+		{
+			"empty annotation value treated as not stopped",
+			newNotebook("nb1", "ns1", notebookOpts{
+				Annotations: map[string]any{
+					"kubeflow-resource-stopped": "",
+				},
+			}),
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/migrate/actions/workbenches/verify/checks.go
+++ b/pkg/migrate/actions/workbenches/verify/checks.go
@@ -1,0 +1,206 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+// MigrationStatus classifies a notebook's migration state.
+type MigrationStatus string
+
+const (
+	StatusLegacy       MigrationStatus = "LEGACY"
+	StatusMigrated     MigrationStatus = "MIGRATED"
+	StatusUnreconciled MigrationStatus = "UNRECONCILED"
+	StatusInvalid      MigrationStatus = "INVALID"
+	StatusUnknown      MigrationStatus = "UNKNOWN"
+)
+
+// RunningState describes whether a workbench is running, stopped, or starting.
+type RunningState string
+
+const (
+	StateRunning  RunningState = "Running"
+	StateStopped  RunningState = "Stopped"
+	StateStarting RunningState = "Starting"
+	StateError    RunningState = "Error"
+)
+
+// ClassifyNotebook determines migration status from sidecar and annotation state.
+// Returns the status and a human-readable detail string.
+func ClassifyNotebook(nb *unstructured.Unstructured) (MigrationStatus, string) {
+	annotations := nb.GetAnnotations()
+	injectAuth := annotations[workbenches.AnnotationInjectAuth]
+	injectOAuth := annotations[workbenches.AnnotationInjectOAuth]
+
+	containers, err := jq.Query[[]any](nb, ".spec.template.spec.containers")
+	if err != nil {
+		return StatusUnknown, "could not read containers"
+	}
+
+	hasKubeRBACProxy := false
+	hasOAuthProxy := false
+
+	for _, raw := range containers {
+		containerMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := containerMap["name"].(string)
+
+		switch name {
+		case workbenches.ContainerKubeRBACProxy:
+			hasKubeRBACProxy = true
+		case workbenches.ContainerOAuthProxy:
+			hasOAuthProxy = true
+		}
+	}
+
+	switch {
+	case hasKubeRBACProxy && hasOAuthProxy:
+		return StatusInvalid, "both kube-rbac-proxy and oauth-proxy sidecars present"
+
+	case hasKubeRBACProxy:
+		if injectOAuth == "true" {
+			return StatusMigrated, "leftover inject-oauth annotation"
+		}
+
+		return StatusMigrated, ""
+
+	case hasOAuthProxy:
+		if injectAuth == "true" {
+			return StatusUnreconciled,
+				"inject-auth is set but oauth-proxy sidecar still present"
+		}
+
+		return StatusLegacy, "needs migration to 3.x"
+
+	default:
+		return StatusUnknown, "no auth sidecars found"
+	}
+}
+
+// GetRunningState determines whether a workbench is running, stopped, or starting
+// by checking the kubeflow-resource-stopped annotation and querying the pod.
+func GetRunningState(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+) (RunningState, string) {
+	annotations := nb.GetAnnotations()
+
+	if stopped, ok := annotations["kubeflow-resource-stopped"]; ok && stopped != "" {
+		return StateStopped, "since " + stopped
+	}
+
+	podName := nb.GetName() + "-0"
+	namespace := nb.GetNamespace()
+
+	pod, err := target.Client.Dynamic().Resource(resources.Pod.GVR()).
+		Namespace(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return StateStarting, "no pod yet"
+		}
+
+		return StateError, fmt.Sprintf("error checking pod %q: %v", podName, err)
+	}
+
+	phase, _, _ := unstructured.NestedString(pod.Object, "status", "phase")
+
+	switch phase {
+	case "Running":
+		return StateRunning, ""
+	case "Pending":
+		return StateStarting, "pod pending"
+	default:
+		return RunningState(phase), ""
+	}
+}
+
+// CheckCleanupState verifies that legacy OAuth resources have been removed.
+// Returns true if all resources are absent, along with a list of failure
+// messages for any resources that still exist.
+func CheckCleanupState(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+) (bool, []string) {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	var failures []string
+
+	checks := []struct {
+		gvr       resources.ResourceType
+		resName   string
+		namespace string
+		label     string
+	}{
+		{resources.Route, name, namespace,
+			fmt.Sprintf("Route '%s'", name)},
+		{resources.Service, name + "-tls", namespace,
+			fmt.Sprintf("Service '%s-tls'", name)},
+		{resources.Secret, name + "-oauth-client", namespace,
+			fmt.Sprintf("Secret '%s-oauth-client'", name)},
+		{resources.Secret, name + "-oauth-config", namespace,
+			fmt.Sprintf("Secret '%s-oauth-config'", name)},
+		{resources.Secret, name + "-tls", namespace,
+			fmt.Sprintf("Secret '%s-tls'", name)},
+		{resources.OAuthClient, fmt.Sprintf("%s-%s-oauth-client", name, namespace), "",
+			fmt.Sprintf("OAuthClient '%s-%s-oauth-client'", name, namespace)},
+	}
+
+	for _, check := range checks {
+		exists, err := resourceExists(ctx, target, check.gvr, check.resName, check.namespace)
+		if err != nil {
+			failures = append(failures,
+				fmt.Sprintf("error checking %s: %v", check.label, err))
+
+			continue
+		}
+
+		if exists {
+			failures = append(failures, check.label+" still exists")
+		}
+	}
+
+	return len(failures) == 0, failures
+}
+
+func resourceExists(
+	ctx context.Context,
+	target action.Target,
+	rt resources.ResourceType,
+	name string,
+	namespace string,
+) (bool, error) {
+	ri := target.Client.Dynamic().Resource(rt.GVR())
+
+	var err error
+	if namespace != "" {
+		_, err = ri.Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	} else {
+		_, err = ri.Get(ctx, name, metav1.GetOptions{})
+	}
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("getting %s %q: %w", rt.Resource, name, err)
+	}
+
+	return true, nil
+}

--- a/pkg/migrate/actions/workbenches/verify/run_task.go
+++ b/pkg/migrate/actions/workbenches/verify/run_task.go
@@ -1,0 +1,263 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+)
+
+type runTask struct {
+	action *VerifyMigrationAction
+}
+
+func (t *runTask) Validate(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	return t.Execute(ctx, target)
+}
+
+func (t *runTask) Execute(
+	ctx context.Context,
+	target action.Target,
+) (*result.ActionResult, error) {
+	if err := t.action.Scope.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid flags: %w", err)
+	}
+
+	if err := t.action.validatePhase(); err != nil {
+		return nil, err
+	}
+
+	recorder := action.NewVerboseRootRecorder(target.IO)
+
+	discoverStep := recorder.Child(
+		"discover-notebooks",
+		"Discover notebooks for migration verification",
+	)
+
+	notebooks, err := t.action.Scope.ListNotebooks(ctx, target)
+	if err != nil {
+		discoverStep.Completef(result.StepFailed, "Failed to list Notebooks: %v", err)
+
+		return recorder.Build(), nil
+	}
+
+	if len(notebooks) == 0 {
+		discoverStep.Completef(result.StepCompleted,
+			"No Notebook instances found")
+
+		return recorder.Build(), nil
+	}
+
+	discoverStep.Completef(result.StepCompleted,
+		"Found %d Notebook(s) to verify", len(notebooks))
+
+	summary := newSummary()
+
+	for _, nb := range notebooks {
+		t.verifyNotebook(ctx, target, nb, recorder, summary)
+	}
+
+	t.buildSummaryStep(recorder, summary, len(notebooks))
+
+	return recorder.Build(), nil
+}
+
+func (t *runTask) verifyNotebook(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+	recorder action.RootRecorder,
+	summary *verifySummary,
+) {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	step := recorder.Child(
+		fmt.Sprintf("verify-%s-%s", namespace, name),
+		fmt.Sprintf("Verify %s/%s", namespace, name),
+	)
+
+	status, detail := ClassifyNotebook(nb)
+	summary.countStatus(status)
+
+	runState, runDetail := GetRunningState(ctx, target, nb)
+	summary.countRunState(runState)
+
+	statusMsg := string(status)
+	if detail != "" {
+		statusMsg += " (" + detail + ")"
+	}
+
+	stateMsg := string(runState)
+	if runDetail != "" {
+		stateMsg += " (" + runDetail + ")"
+	}
+
+	classificationOK := status == StatusMigrated || status == StatusLegacy
+	classificationStep := result.StepCompleted
+
+	if !classificationOK {
+		classificationStep = result.StepFailed
+		summary.classificationFail++
+	}
+
+	step.Recordf("classification",
+		"Status: %s | State: %s", classificationStep,
+		statusMsg, stateMsg)
+
+	allPassed := classificationOK
+
+	if t.action.includeMigration() {
+		passed, failures := workbenches.CheckMigrationState(nb)
+		if passed {
+			step.Recordf("migration-checks",
+				"Migration checks: all passed", result.StepCompleted)
+		} else {
+			step.Recordf("migration-checks",
+				"Migration checks failed: %s", result.StepFailed,
+				strings.Join(failures, "; "))
+			allPassed = false
+		}
+
+		if passed {
+			summary.migrationPass++
+		} else {
+			summary.migrationFail++
+		}
+	}
+
+	if t.action.includeCleanup() {
+		passed, failures := CheckCleanupState(ctx, target, nb)
+		if passed {
+			step.Recordf("cleanup-checks",
+				"Cleanup checks: all passed", result.StepCompleted)
+		} else {
+			step.Recordf("cleanup-checks",
+				"Cleanup checks failed: %s", result.StepFailed,
+				strings.Join(failures, "; "))
+			allPassed = false
+		}
+
+		if passed {
+			summary.cleanupPass++
+		} else {
+			summary.cleanupFail++
+		}
+	}
+
+	if allPassed {
+		step.Completef(result.StepCompleted,
+			"All checks passed for %s/%s [%s]", namespace, name, statusMsg)
+	} else {
+		step.Completef(result.StepFailed,
+			"Some checks failed for %s/%s [%s]", namespace, name, statusMsg)
+	}
+}
+
+func (t *runTask) buildSummaryStep(
+	recorder action.RootRecorder,
+	summary *verifySummary,
+	total int,
+) {
+	step := recorder.Child("summary", "Verification summary")
+
+	step.AddDetail("total", total)
+	step.AddDetail("byStatus", map[string]int{
+		"legacy":       summary.legacy,
+		"migrated":     summary.migrated,
+		"unreconciled": summary.unreconciled,
+		"invalid":      summary.invalid,
+		"unknown":      summary.unknown,
+	})
+	step.AddDetail("byRunState", map[string]int{
+		"running":  summary.running,
+		"stopped":  summary.stopped,
+		"starting": summary.starting,
+		"other":    summary.otherState,
+	})
+
+	if t.action.includeMigration() {
+		step.AddDetail("migrationPass", summary.migrationPass)
+		step.AddDetail("migrationFail", summary.migrationFail)
+	}
+
+	if t.action.includeCleanup() {
+		step.AddDetail("cleanupPass", summary.cleanupPass)
+		step.AddDetail("cleanupFail", summary.cleanupFail)
+	}
+
+	if summary.classificationFail > 0 {
+		step.AddDetail("classificationFail", summary.classificationFail)
+	}
+
+	totalFailed := summary.classificationFail + summary.migrationFail + summary.cleanupFail
+	if totalFailed > 0 {
+		step.Completef(result.StepFailed,
+			"Verified %d Notebook(s): %d with failures", total, totalFailed)
+	} else {
+		step.Completef(result.StepCompleted,
+			"Verified %d Notebook(s): all checks passed", total)
+	}
+}
+
+type verifySummary struct {
+	legacy       int
+	migrated     int
+	unreconciled int
+	invalid      int
+	unknown      int
+
+	running    int
+	stopped    int
+	starting   int
+	otherState int
+
+	classificationFail int
+
+	migrationPass int
+	migrationFail int
+	cleanupPass   int
+	cleanupFail   int
+}
+
+func newSummary() *verifySummary {
+	return &verifySummary{}
+}
+
+func (s *verifySummary) countStatus(status MigrationStatus) {
+	switch status {
+	case StatusLegacy:
+		s.legacy++
+	case StatusMigrated:
+		s.migrated++
+	case StatusUnreconciled:
+		s.unreconciled++
+	case StatusInvalid:
+		s.invalid++
+	case StatusUnknown:
+		s.unknown++
+	}
+}
+
+func (s *verifySummary) countRunState(state RunningState) {
+	switch state {
+	case StateRunning:
+		s.running++
+	case StateStopped:
+		s.stopped++
+	case StateStarting:
+		s.starting++
+	case StateError: // counted alongside unrecognized phases
+		fallthrough
+	default:
+		s.otherState++
+	}
+}

--- a/pkg/migrate/actions/workbenches/verify/verify.go
+++ b/pkg/migrate/actions/workbenches/verify/verify.go
@@ -1,0 +1,96 @@
+package verify
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+)
+
+const (
+	actionID          = "workbenches.verify-migration"
+	actionName        = "Verify workbench migration status"
+	actionDescription = "Verifies migration and cleanup status of workbench notebooks " +
+		"and classifies them by migration state (LEGACY, MIGRATED, UNRECONCILED, INVALID, UNKNOWN)"
+
+	minTargetMajorVersion = 3
+
+	phaseMigration = "migration"
+	phaseCleanup   = "cleanup"
+	phaseAll       = "all"
+)
+
+// VerifyMigrationAction implements a read-only validation action that assesses
+// workbench migration status and classifies notebooks by migration state.
+type VerifyMigrationAction struct {
+	Scope       *workbenches.SharedScopeOptions
+	VerifyPhase string
+}
+
+func (a *VerifyMigrationAction) ID() string          { return actionID }
+func (a *VerifyMigrationAction) Name() string        { return actionName }
+func (a *VerifyMigrationAction) Description() string { return actionDescription }
+
+func (a *VerifyMigrationAction) Group() action.ActionGroup {
+	return action.GroupValidation
+}
+
+func (a *VerifyMigrationAction) Phase() action.ActionPhase {
+	return action.PhasePostUpgrade
+}
+
+func (a *VerifyMigrationAction) AddFlags(fs *pflag.FlagSet) {
+	workbenches.AddScopeFlags(a.Scope, fs)
+
+	if fs.Lookup("verify-phase") == nil {
+		fs.StringVar(&a.VerifyPhase, "verify-phase", phaseMigration,
+			"Verification phase: migration, cleanup, or all (default: migration)")
+	}
+}
+
+func (a *VerifyMigrationAction) CanApply(target action.Target) bool {
+	if target.TargetVersion == nil {
+		return false
+	}
+
+	return target.TargetVersion.Major >= minTargetMajorVersion
+}
+
+func (a *VerifyMigrationAction) Prepare() action.Task {
+	return nil
+}
+
+func (a *VerifyMigrationAction) Run() action.Task {
+	return &runTask{action: a}
+}
+
+func (a *VerifyMigrationAction) validatePhase() error {
+	switch a.VerifyPhase {
+	case phaseMigration, phaseCleanup, phaseAll, "":
+		return nil
+	default:
+		return fmt.Errorf("invalid --verify-phase %q: must be one of: migration, cleanup, all", a.VerifyPhase)
+	}
+}
+
+func (a *VerifyMigrationAction) effectivePhase() string {
+	if a.VerifyPhase == "" {
+		return phaseMigration
+	}
+
+	return a.VerifyPhase
+}
+
+func (a *VerifyMigrationAction) includeMigration() bool {
+	p := a.effectivePhase()
+
+	return p == phaseMigration || p == phaseAll
+}
+
+func (a *VerifyMigrationAction) includeCleanup() bool {
+	p := a.effectivePhase()
+
+	return p == phaseCleanup || p == phaseAll
+}

--- a/pkg/migrate/actions/workbenches/verify/verify_test.go
+++ b/pkg/migrate/actions/workbenches/verify/verify_test.go
@@ -1,0 +1,1092 @@
+//nolint:testpackage // Tests internal implementation (classification, checks, run task)
+package verify
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+	"github.com/opendatahub-io/odh-cli/pkg/util/kube"
+
+	. "github.com/onsi/gomega"
+)
+
+// --- Test Fixtures ---
+
+//nolint:gochecknoglobals // test-only GVR→ListKind mapping
+var testListKinds = map[schema.GroupVersionResource]string{
+	resources.Notebook.GVR():    resources.Notebook.ListKind(),
+	resources.Route.GVR():       resources.Route.ListKind(),
+	resources.Service.GVR():     resources.Service.ListKind(),
+	resources.Secret.GVR():      resources.Secret.ListKind(),
+	resources.OAuthClient.GVR(): resources.OAuthClient.ListKind(),
+	resources.Pod.GVR():         resources.Pod.ListKind(),
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+
+	return scheme
+}
+
+type notebookOption func(map[string]any)
+
+func withAnnotations(annotations map[string]string) notebookOption {
+	return func(obj map[string]any) {
+		metadata := obj["metadata"].(map[string]any)
+		anyAnnotations := make(map[string]any, len(annotations))
+
+		for k, v := range annotations {
+			anyAnnotations[k] = v
+		}
+
+		metadata["annotations"] = anyAnnotations
+	}
+}
+
+func withContainers(containers ...map[string]any) notebookOption {
+	return func(obj map[string]any) {
+		obj["spec"] = map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": toAnySlice(containers),
+				},
+			},
+		}
+	}
+}
+
+func toAnySlice(items []map[string]any) []any {
+	result := make([]any, len(items))
+	for i, item := range items {
+		result[i] = item
+	}
+
+	return result
+}
+
+func container(name string) map[string]any {
+	return map[string]any{
+		"name":  name,
+		"image": "registry.example.com/" + name + ":latest",
+	}
+}
+
+func newNotebook(name, namespace string, opts ...notebookOption) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": resources.Notebook.APIVersion(),
+		"kind":       resources.Notebook.Kind,
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": namespace,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(obj)
+	}
+
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newMigratedNotebook(name, namespace string) *unstructured.Unstructured {
+	return newNotebook(name, namespace,
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerKubeRBACProxy),
+		))
+}
+
+func newLegacyNotebook(name, namespace string) *unstructured.Unstructured {
+	return newNotebook(name, namespace,
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectOAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerOAuthProxy),
+		))
+}
+
+func newStoppedNotebook(name, namespace string, opts ...notebookOption) *unstructured.Unstructured {
+	allOpts := make([]notebookOption, 0, 2+len(opts))
+	allOpts = append(allOpts,
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectAuth: "true",
+			"kubeflow-resource-stopped":      "2024-01-01T00:00:00Z",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerKubeRBACProxy),
+		),
+	)
+	allOpts = append(allOpts, opts...)
+
+	return newNotebook(name, namespace, allOpts...)
+}
+
+func newPod(name, namespace, phase string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Pod.APIVersion(),
+			"kind":       resources.Pod.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"status": map[string]any{
+				"phase": phase,
+			},
+		},
+	}
+}
+
+func newRoute(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Route.APIVersion(),
+			"kind":       resources.Route.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newService(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Service.APIVersion(),
+			"kind":       resources.Service.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newSecret(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Secret.APIVersion(),
+			"kind":       resources.Secret.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newOAuthClient(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.OAuthClient.APIVersion(),
+			"kind":       resources.OAuthClient.Kind,
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+}
+
+func allOAuthResources(nbName, namespace string) []*unstructured.Unstructured {
+	return []*unstructured.Unstructured{
+		newRoute(nbName, namespace),
+		newService(nbName+"-tls", namespace),
+		newSecret(nbName+"-oauth-client", namespace),
+		newSecret(nbName+"-oauth-config", namespace),
+		newSecret(nbName+"-tls", namespace),
+		newOAuthClient(nbName + "-" + namespace + "-oauth-client"),
+	}
+}
+
+func newFakeClient(objects []*unstructured.Unstructured, reactors ...k8stesting.Reactor) client.Client {
+	scheme := newScheme()
+
+	dynamicObjs := make([]runtime.Object, len(objects))
+	for i, obj := range objects {
+		dynamicObjs[i] = obj
+	}
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		testListKinds,
+		dynamicObjs...,
+	)
+
+	for _, r := range reactors {
+		dynamicClient.ReactionChain = append([]k8stesting.Reactor{r}, dynamicClient.ReactionChain...)
+	}
+
+	metadataClient := metadatafake.NewSimpleMetadataClient(
+		scheme,
+		kube.ToPartialObjectMetadata(objects...)...,
+	)
+
+	return client.NewForTesting(client.TestClientConfig{
+		Dynamic:  dynamicClient,
+		Metadata: metadataClient,
+	})
+}
+
+func listErrorReactor() k8stesting.Reactor {
+	return &k8stesting.SimpleReactor{
+		Verb:     "list",
+		Resource: "notebooks",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated API server error")
+		},
+	}
+}
+
+func newTarget(k8sClient client.Client) action.Target {
+	targetVersion := semver.MustParse("3.0.0")
+
+	io := iostreams.NewIOStreams(
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+
+	return action.Target{
+		Client:        k8sClient,
+		TargetVersion: &targetVersion,
+		DryRun:        false,
+		SkipConfirm:   true,
+		Recorder:      action.NewVerboseRootRecorder(io),
+		IO:            io,
+	}
+}
+
+// --- Action Metadata Tests ---
+
+func TestVerifyMigrationAction_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+
+	g.Expect(a.ID()).To(Equal("workbenches.verify-migration"))
+	g.Expect(a.Name()).To(Equal("Verify workbench migration status"))
+	g.Expect(a.Description()).To(ContainSubstring("migration state"))
+	g.Expect(a.Group()).To(Equal(action.GroupValidation))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
+}
+
+func TestVerifyMigrationAction_CanApply(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+
+	g.Expect(a.CanApply(action.Target{})).To(BeFalse(), "nil target version")
+
+	v2 := semver.MustParse("2.16.0")
+	g.Expect(a.CanApply(action.Target{TargetVersion: &v2})).To(BeFalse(), "target 2.x")
+
+	v3 := semver.MustParse("3.0.0")
+	g.Expect(a.CanApply(action.Target{TargetVersion: &v3})).To(BeTrue(), "target 3.0")
+
+	v35 := semver.MustParse("3.5.0")
+	g.Expect(a.CanApply(action.Target{TargetVersion: &v35})).To(BeTrue(), "target 3.5")
+}
+
+func TestVerifyMigrationAction_PrepareIsNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	g.Expect(a.Prepare()).To(BeNil())
+}
+
+func TestVerifyMigrationAction_RunNotNil(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	g.Expect(a.Run()).ToNot(BeNil())
+}
+
+func TestVerifyMigrationAction_AddFlags(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	a.AddFlags(fs)
+
+	g.Expect(fs.Lookup("workbench-namespace")).ToNot(BeNil())
+	g.Expect(fs.Lookup("workbench-name")).ToNot(BeNil())
+	g.Expect(fs.Lookup("verify-phase")).ToNot(BeNil())
+
+	phaseFlag := fs.Lookup("verify-phase")
+	g.Expect(phaseFlag.DefValue).To(Equal("migration"))
+}
+
+// --- Classification Tests ---
+
+func TestClassifyNotebook_Legacy(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newLegacyNotebook("wb1", "ns1")
+	status, detail := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusLegacy))
+	g.Expect(detail).To(ContainSubstring("migration"))
+}
+
+func TestClassifyNotebook_Migrated(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newMigratedNotebook("wb1", "ns1")
+	status, _ := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusMigrated))
+}
+
+func TestClassifyNotebook_MigratedWithLeftoverAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectAuth:  "true",
+			workbenches.AnnotationInjectOAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerKubeRBACProxy)))
+
+	status, detail := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusMigrated))
+	g.Expect(detail).To(ContainSubstring("leftover"))
+}
+
+func TestClassifyNotebook_Unreconciled(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerOAuthProxy)))
+
+	status, detail := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusUnreconciled))
+	g.Expect(detail).To(ContainSubstring("oauth-proxy"))
+}
+
+func TestClassifyNotebook_Invalid(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerKubeRBACProxy),
+			container(workbenches.ContainerOAuthProxy)))
+
+	status, detail := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusInvalid))
+	g.Expect(detail).To(ContainSubstring("both"))
+}
+
+func TestClassifyNotebook_Unknown(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")))
+
+	status, detail := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusUnknown))
+	g.Expect(detail).To(ContainSubstring("no auth"))
+}
+
+func TestClassifyNotebook_NoContainers(t *testing.T) {
+	g := NewWithT(t)
+
+	nb := newNotebook("wb1", "ns1")
+
+	status, detail := ClassifyNotebook(nb)
+
+	g.Expect(status).To(Equal(StatusUnknown))
+	g.Expect(detail).To(ContainSubstring("could not read"))
+}
+
+// --- Running State Tests ---
+
+func TestGetRunningState_Stopped(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newStoppedNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	state, detail := GetRunningState(ctx, target, nb)
+
+	g.Expect(state).To(Equal(StateStopped))
+	g.Expect(detail).To(ContainSubstring("since"))
+}
+
+func TestGetRunningState_Running(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newMigratedNotebook("wb1", "ns1")
+	pod := newPod("wb1-0", "ns1", "Running")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, pod})
+	target := newTarget(k8sClient)
+
+	state, _ := GetRunningState(ctx, target, nb)
+
+	g.Expect(state).To(Equal(StateRunning))
+}
+
+func TestGetRunningState_Pending(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newMigratedNotebook("wb1", "ns1")
+	pod := newPod("wb1-0", "ns1", "Pending")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb, pod})
+	target := newTarget(k8sClient)
+
+	state, detail := GetRunningState(ctx, target, nb)
+
+	g.Expect(state).To(Equal(StateStarting))
+	g.Expect(detail).To(ContainSubstring("pending"))
+}
+
+func TestGetRunningState_NoPod(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newMigratedNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	state, detail := GetRunningState(ctx, target, nb)
+
+	g.Expect(state).To(Equal(StateStarting))
+	g.Expect(detail).To(ContainSubstring("no pod"))
+}
+
+func TestGetRunningState_PodGetError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newMigratedNotebook("wb1", "ns1")
+
+	podGetErrorReactor := &k8stesting.SimpleReactor{
+		Verb:     "get",
+		Resource: "pods",
+		Reaction: func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("simulated forbidden error")
+		},
+	}
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb}, podGetErrorReactor)
+	target := newTarget(k8sClient)
+
+	state, detail := GetRunningState(ctx, target, nb)
+
+	g.Expect(state).To(Equal(StateError))
+	g.Expect(detail).To(ContainSubstring("simulated forbidden error"))
+}
+
+// --- Cleanup Check Tests ---
+
+func TestCheckCleanupState_AllAbsent(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newMigratedNotebook("wb1", "ns1")
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb})
+	target := newTarget(k8sClient)
+
+	passed, failures := CheckCleanupState(ctx, target, nb)
+
+	g.Expect(passed).To(BeTrue())
+	g.Expect(failures).To(BeEmpty())
+}
+
+func TestCheckCleanupState_AllPresent(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	nb := objects[0]
+	passed, failures := CheckCleanupState(ctx, target, nb)
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(HaveLen(6))
+	g.Expect(failures).To(ContainElement(ContainSubstring("Route")))
+	g.Expect(failures).To(ContainElement(ContainSubstring("Service")))
+	g.Expect(failures).To(ContainElement(ContainSubstring("oauth-client")))
+	g.Expect(failures).To(ContainElement(ContainSubstring("oauth-config")))
+	g.Expect(failures).To(ContainElement(ContainSubstring("tls")))
+	g.Expect(failures).To(ContainElement(ContainSubstring("OAuthClient")))
+}
+
+func TestCheckCleanupState_MixedPresence(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := []*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+		newRoute("wb1", "ns1"),
+		newSecret("wb1-oauth-client", "ns1"),
+	}
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	passed, failures := CheckCleanupState(ctx, target, objects[0])
+
+	g.Expect(passed).To(BeFalse())
+	g.Expect(failures).To(HaveLen(2))
+	g.Expect(failures).To(ContainElement(ContainSubstring("Route")))
+	g.Expect(failures).To(ContainElement(ContainSubstring("oauth-client")))
+}
+
+// --- Phase Validation Tests ---
+
+func TestValidatePhase_Valid(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, phase := range []string{"migration", "cleanup", "all", ""} {
+		a := &VerifyMigrationAction{
+			Scope:       &workbenches.SharedScopeOptions{},
+			VerifyPhase: phase,
+		}
+		g.Expect(a.validatePhase()).ToNot(HaveOccurred(), "phase: %q", phase)
+	}
+}
+
+func TestValidatePhase_Invalid(t *testing.T) {
+	g := NewWithT(t)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "invalid",
+	}
+
+	err := a.validatePhase()
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("invalid"))
+}
+
+func TestIncludeMigration(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		phase    string
+		expected bool
+	}{
+		{"migration", true},
+		{"cleanup", false},
+		{"all", true},
+		{"", true}, // default
+	}
+
+	for _, tt := range tests {
+		a := &VerifyMigrationAction{
+			Scope:       &workbenches.SharedScopeOptions{},
+			VerifyPhase: tt.phase,
+		}
+		g.Expect(a.includeMigration()).To(Equal(tt.expected), "phase: %q", tt.phase)
+	}
+}
+
+func TestIncludeCleanup(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		phase    string
+		expected bool
+	}{
+		{"migration", false},
+		{"cleanup", true},
+		{"all", true},
+		{"", false}, // default (migration)
+	}
+
+	for _, tt := range tests {
+		a := &VerifyMigrationAction{
+			Scope:       &workbenches.SharedScopeOptions{},
+			VerifyPhase: tt.phase,
+		}
+		g.Expect(a.includeCleanup()).To(Equal(tt.expected), "phase: %q", tt.phase)
+	}
+}
+
+// --- Execute Tests ---
+
+func TestRunTask_Execute_NoNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+	g.Expect(res.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_SingleMigratedNotebook(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+	g.Expect(res.Status.Completed).To(BeTrue())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepCompleted))
+	g.Expect(summaryStep.Message).To(ContainSubstring("all checks passed"))
+}
+
+func TestRunTask_Execute_SingleLegacyNotebook(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newLegacyNotebook("wb1", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepFailed))
+	g.Expect(summaryStep.Message).To(ContainSubstring("failures"))
+}
+
+func TestRunTask_Execute_MixedNotebooks(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb-good", "ns1"),
+		newLegacyNotebook("wb-legacy", "ns1"),
+		newMigratedNotebook("wb-also-good", "ns2"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepFailed))
+
+	byStatus, ok := summaryStep.Details["byStatus"].(map[string]int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(byStatus["migrated"]).To(Equal(2))
+	g.Expect(byStatus["legacy"]).To(Equal(1))
+}
+
+func TestRunTask_Execute_PhaseMigrationOnly(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "migration",
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	// Migration checks pass (migrated notebook), cleanup not checked
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepCompleted))
+
+	// Cleanup details should not be present
+	_, hasCleanupPass := summaryStep.Details["cleanupPass"]
+	g.Expect(hasCleanupPass).To(BeFalse())
+}
+
+func TestRunTask_Execute_PhaseCleanupOnly(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "cleanup",
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	// Cleanup checks fail (OAuth resources still present)
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepFailed))
+
+	// Migration details should not be present
+	_, hasMigrationPass := summaryStep.Details["migrationPass"]
+	g.Expect(hasMigrationPass).To(BeFalse())
+}
+
+func TestRunTask_Execute_PhaseCleanupOnly_InvalidNotebookFails(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	invalidNb := newNotebook("wb-invalid", "ns1",
+		withAnnotations(map[string]string{
+			workbenches.AnnotationInjectAuth: "true",
+		}),
+		withContainers(
+			container("my-notebook"),
+			container(workbenches.ContainerKubeRBACProxy),
+			container(workbenches.ContainerOAuthProxy),
+		))
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{invalidNb})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "cleanup",
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepFailed))
+	g.Expect(summaryStep.Details["classificationFail"]).To(Equal(1))
+}
+
+func TestRunTask_Execute_PhaseAll(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "all",
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+	g.Expect(summaryStep.Status).To(Equal(result.StepCompleted))
+
+	// Both phase details should be present
+	_, hasMigrationPass := summaryStep.Details["migrationPass"]
+	g.Expect(hasMigrationPass).To(BeTrue())
+
+	_, hasCleanupPass := summaryStep.Details["cleanupPass"]
+	g.Expect(hasCleanupPass).To(BeTrue())
+}
+
+func TestRunTask_Execute_InvalidPhase(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "bogus",
+	}
+	task := a.Run()
+
+	_, err := task.Execute(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("invalid"))
+}
+
+func TestRunTask_Execute_NamespaceScopedTargeting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+		newMigratedNotebook("wb2", "ns2"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope: &workbenches.SharedScopeOptions{
+			WorkbenchNamespace: "ns1",
+		},
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+
+	total, ok := summaryStep.Details["total"].(int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(total).To(Equal(1))
+}
+
+func TestRunTask_Execute_SingleNotebookTargeting(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+		newMigratedNotebook("wb2", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope: &workbenches.SharedScopeOptions{
+			WorkbenchNamespace: "ns1",
+			WorkbenchName:      "wb1",
+		},
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+
+	total, ok := summaryStep.Details["total"].(int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(total).To(Equal(1))
+}
+
+func TestRunTask_Execute_NameRequiresNamespace(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil)
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope: &workbenches.SharedScopeOptions{WorkbenchName: "wb1"},
+	}
+	task := a.Run()
+
+	_, err := task.Execute(ctx, target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("--workbench-name requires --workbench-namespace"))
+}
+
+func TestRunTask_Execute_ListError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient(nil, listErrorReactor())
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+
+	hasFailedStep := false
+
+	for _, step := range res.Status.Steps {
+		if step.Status == result.StepFailed {
+			hasFailedStep = true
+		}
+	}
+
+	g.Expect(hasFailedStep).To(BeTrue())
+}
+
+func TestRunTask_Validate_DelegatesToExecute(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{
+		newMigratedNotebook("wb1", "ns1"),
+	})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).ToNot(BeNil())
+	g.Expect(res.Status.Completed).To(BeTrue())
+}
+
+func TestRunTask_Execute_SummaryCountsCorrectness(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb1 := newMigratedNotebook("wb-migrated", "ns1")
+	nb2 := newLegacyNotebook("wb-legacy", "ns1")
+	nb3 := newStoppedNotebook("wb-stopped", "ns1")
+	pod1 := newPod("wb-migrated-0", "ns1", "Running")
+	pod2 := newPod("wb-legacy-0", "ns1", "Running")
+
+	k8sClient := newFakeClient([]*unstructured.Unstructured{nb1, nb2, nb3, pod1, pod2})
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{Scope: &workbenches.SharedScopeOptions{}}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+
+	total, ok := summaryStep.Details["total"].(int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(total).To(Equal(3))
+
+	byStatus, ok := summaryStep.Details["byStatus"].(map[string]int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(byStatus["migrated"]).To(Equal(2)) // wb-migrated + wb-stopped (both have kube-rbac-proxy)
+	g.Expect(byStatus["legacy"]).To(Equal(1))
+
+	byRunState, ok := summaryStep.Details["byRunState"].(map[string]int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(byRunState["running"]).To(Equal(2))
+	g.Expect(byRunState["stopped"]).To(Equal(1))
+}
+
+func TestRunTask_Execute_CleanupChecksWithResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	objects := append(
+		[]*unstructured.Unstructured{newMigratedNotebook("wb1", "ns1")},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	a := &VerifyMigrationAction{
+		Scope:       &workbenches.SharedScopeOptions{},
+		VerifyPhase: "all",
+	}
+	task := a.Run()
+
+	res, err := task.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	summaryStep := findStep(res.Status.Steps, "summary")
+	g.Expect(summaryStep).ToNot(BeNil())
+
+	cleanupFail, ok := summaryStep.Details["cleanupFail"].(int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(cleanupFail).To(Equal(1))
+
+	migrationPass, ok := summaryStep.Details["migrationPass"].(int)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(migrationPass).To(Equal(1))
+}
+
+// --- Helpers ---
+
+func findStep(steps []result.ActionStep, name string) *result.ActionStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+
+		if found := findStep(steps[i].Children, name); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}

--- a/pkg/migrate/registry.go
+++ b/pkg/migrate/registry.go
@@ -18,6 +18,7 @@ import (
 	workbenchcleanup "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/cleanup"
 	workbenchkueue "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/kueue"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/upgrade"
+	workbenchverify "github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches/verify"
 )
 
 func newDefaultRegistry() *action.ActionRegistry {
@@ -38,6 +39,7 @@ func newDefaultRegistry() *action.ActionRegistry {
 	registry.MustRegister(&workbenchkueue.AttachKueueLabelAction{Scope: wbScope})
 	registry.MustRegister(cleanupAction)
 	registry.MustRegister(&authmodel.PatchAuthModelAction{Scope: wbScope, CleanupAction: cleanupAction})
+	registry.MustRegister(&workbenchverify.VerifyMigrationAction{Scope: wbScope})
 	registry.MustRegister(&deadlock.BreakGPUDeadlockAction{})
 	registry.MustRegister(&guardrails.PatchGuardrailsAction{})
 	registry.MustRegister(&otelexporter.MigrateOtelExporterAction{})


### PR DESCRIPTION
## Description
https://redhat.atlassian.net/browse/RHOAIENG-72118 
<!-- What does this PR do? -->
Building on top of PR#115 (https://github.com/opendatahub-io/odh-cli/pull/115) , this change implements a Go port of the Workbench verify and list bash script functionality as part of the migration command to validate changes made during the migration.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workbench migration verification covering notebook migration status, runtime state, and detection of remaining legacy OAuth-related resources.
  * Introduced phase-based verification (migration, cleanup, or all) with per-notebook steps and an aggregate summary.
  * Enhanced legacy OAuth-proxy cleanup with idempotent, dry-run-friendly deletion and safer partial-failure handling (including extra migration checks such as Tornado settings).
  * Included the verification action in the default migration workflow.
* **Bug Fixes**
  * Improved “stopped” detection to treat empty stopped annotation values as not stopped.
  * More accurate reporting of notebook stop/patch and StatefulSet deletion outcomes.
* **Tests**
  * Added/expanded verification and migration-related coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->