### PR TITLE
feat: add OWNERS_ALIASES file defining platform team members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,32 @@
+aliases:
+  platform:
+    - AjayJagan
+    - asanzgom
+    - asmigala
+    - carlkyrillos
+    - CFSNM
+    - cgoodfred
+    - chambridge
+    - csams
+    - davidebianchi
+    - dayakar349
+    - den-rgb
+    - GowthamShanmugam
+    - grdryn
+    - jctanner
+    - jeffdyoung
+    - kahowell
+    - lburgazzoli
+    - lphiri
+    - macgregor
+    - MarianMacik
+    - mlassak
+    - resoluteCoder
+    - rinaldodev
+    - robotmaxtron
+    - sefroberg
+    - StevenTobin
+    - ugiordan
+    - valdar
+    - zdtsw
+    - sukumars321


### PR DESCRIPTION
  The OWNERS file references a platform alias for approvers and reviewers but the corresponding OWNERS_ALIASES was missing.

  Ref: [RHOAIENG-75791](https://redhat.atlassian.net/browse/RHOAIENG-75791)

  Description

  Add the OWNERS_ALIASES file that defines the platform alias referenced by the existing OWNERS file. Without this file, the Prow OWNERS mechanism cannot resolve the platform alias, meaning
  approver and reviewer assignments do not work correctly.

  The alias lists the current members of the RHOAI Platform team.

  Testing

  - [x] Unit tests pass (make test)
  - [x] Linter passes (make lint)
  - [ ] ~~New functionality includes tests~~ N/A — no code changes, configuration file only

  Review checklist

  - [x] Code follows project conventions (see docs/coding/)
  - [ ] ~~Changes are documented if needed~~ N/A

[RHOAIENG-75791]: https://redhat.atlassian.net/browse/RHOAIENG-75791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for platform aliases, allowing multiple user handles to be recognized under a shared alias map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->