### PR TITLE
feat(mcp): wire serve command and register all tools

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/cmd/get"
 	"github.com/opendatahub-io/odh-cli/cmd/lint"
 	"github.com/opendatahub-io/odh-cli/cmd/logs"
+	"github.com/opendatahub-io/odh-cli/cmd/mcp"
 	"github.com/opendatahub-io/odh-cli/cmd/migrate"
 	"github.com/opendatahub-io/odh-cli/cmd/status"
 	"github.com/opendatahub-io/odh-cli/cmd/version"
@@ -45,6 +46,7 @@ func main() {
 	status.AddCommand(cmd, flags)
 	logs.AddCommand(cmd, flags)
 	completion.AddCommand(cmd, flags)
+	mcp.AddCommand(cmd, flags)
 	migrate.AddCommand(cmd, flags)
 	events.AddCommand(cmd, flags)
 

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	mcppkg "github.com/opendatahub-io/odh-cli/pkg/mcp"
+)
+
+const (
+	cmdName  = "mcp"
+	cmdShort = "Model Context Protocol server"
+
+	serveName  = "serve"
+	serveShort = "Start MCP server exposing CLI tools"
+	serveLong  = `Start a Model Context Protocol (MCP) server that exposes all odh CLI
+commands as typed tool calls with structured inputs and outputs.
+
+This lets any MCP-capable agent (Claude, GPT, Cursor, etc.) call odh
+operations programmatically. The server inherits kubeconfig from the
+process environment.
+
+Transports:
+  stdio  JSON-RPC over stdin/stdout (default, works in containers and CI)
+  sse    HTTP Server-Sent Events for network-accessible mode
+
+Examples:
+  # Start MCP server on stdio (default)
+  kubectl odh mcp serve
+
+  # Start MCP server with SSE transport
+  kubectl odh mcp serve --transport sse --port 8080
+`
+)
+
+const defaultPort = 8080
+
+// AddCommand adds the mcp command group to the root command.
+func AddCommand(root *cobra.Command, flags *genericclioptions.ConfigFlags) {
+	mcpCmd := &cobra.Command{
+		Use:   cmdName,
+		Short: cmdShort,
+	}
+
+	var (
+		transport string
+		port      int
+	)
+
+	serveCmd := &cobra.Command{
+		Use:           serveName,
+		Short:         serveShort,
+		Long:          serveLong,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			srv := mcppkg.NewServer(flags, mcppkg.Transport(transport), port)
+
+			return srv.Serve(cmd.Context())
+		},
+	}
+
+	serveCmd.Flags().StringVar(&transport, "transport", "stdio", `Transport protocol: "stdio" or "sse"`)
+	serveCmd.Flags().IntVar(&port, "port", defaultPort, "Port for SSE transport")
+
+	mcpCmd.AddCommand(serveCmd)
+	root.AddCommand(mcpCmd)
+}

--- a/cmd/mcp/mcp_test.go
+++ b/cmd/mcp/mcp_test.go
@@ -1,0 +1,50 @@
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/opendatahub-io/odh-cli/cmd/mcp"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestAddCommand(t *testing.T) {
+	t.Run("should register mcp command with serve subcommand", func(t *testing.T) {
+		g := NewWithT(t)
+
+		root := &cobra.Command{Use: "test"}
+		flags := genericclioptions.NewConfigFlags(true)
+		mcp.AddCommand(root, flags)
+
+		mcpCmd, _, err := root.Find([]string{"mcp"})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(mcpCmd.Use).To(Equal("mcp"))
+
+		serveCmd, _, err := root.Find([]string{"mcp", "serve"})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(serveCmd.Use).To(Equal("serve"))
+	})
+
+	t.Run("should have correct flag defaults", func(t *testing.T) {
+		g := NewWithT(t)
+
+		root := &cobra.Command{Use: "test"}
+		flags := genericclioptions.NewConfigFlags(true)
+		mcp.AddCommand(root, flags)
+
+		serveCmd, _, err := root.Find([]string{"mcp", "serve"})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		transportFlag := serveCmd.Flags().Lookup("transport")
+		g.Expect(transportFlag).ToNot(BeNil())
+		g.Expect(transportFlag.DefValue).To(Equal("stdio"))
+
+		portFlag := serveCmd.Flags().Lookup("port")
+		g.Expect(portFlag).ToNot(BeNil())
+		g.Expect(portFlag.DefValue).To(Equal("8080"))
+	})
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -31,23 +31,26 @@ type Server struct {
 	mcpServer   *server.MCPServer
 }
 
-// NewServer creates a new MCP server.
-// Call registerTools to add tool definitions before calling Serve.
+// NewServer creates a new MCP server with all tools registered.
 func NewServer(configFlags *genericclioptions.ConfigFlags, transport Transport, port int) *Server {
 	mcpServer := server.NewMCPServer(
 		"odh-cli",
 		version.GetVersion(),
 	)
 
-	return &Server{
+	s := &Server{
 		configFlags: configFlags,
 		transport:   transport,
 		port:        port,
 		mcpServer:   mcpServer,
 	}
+
+	s.registerTools(allTools(configFlags))
+
+	return s
 }
 
-func (s *Server) registerTools(tools []toolDefinition) { //nolint:unused // used by tools.go in a follow-up PR
+func (s *Server) registerTools(tools []toolDefinition) {
 	for _, def := range tools {
 		s.mcpServer.AddTool(def.tool, def.handler)
 	}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -23,6 +23,28 @@ func TestNewServer(t *testing.T) {
 	})
 }
 
+func TestNewServerRegistersAllTools(t *testing.T) {
+	t.Run("should register all 12 tools on the MCP server", func(t *testing.T) {
+		g := NewWithT(t)
+
+		flags := genericclioptions.NewConfigFlags(true)
+		srv := NewServer(flags, TransportStdio, 8080)
+
+		registered := srv.mcpServer.ListTools()
+		g.Expect(registered).To(HaveLen(12))
+
+		expectedTools := []string{
+			"odh_status", "odh_lint", "odh_get", "odh_deps", "odh_deps_install",
+			"odh_backup", "odh_logs", "odh_events",
+			"odh_components_list", "odh_components_describe",
+			"odh_migrate_list", "odh_migrate_run",
+		}
+		for _, name := range expectedTools {
+			g.Expect(registered).To(HaveKey(name), "tool %s should be registered", name)
+		}
+	})
+}
+
 func TestServeUnsupportedTransport(t *testing.T) {
 	t.Run("should return error for unsupported transport", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
## Description

Wires the final pieces for the MCP server mode so that `kubectl odh mcp serve` works end-to-end. The server infrastructure (adapter, errors, tool definitions) was merged in prior PRs — this PR connects them:

- **`pkg/mcp/server.go`** — `NewServer` now calls `registerTools(allTools(...))` to register all 12 tools on startup
- **`cmd/mcp/mcp.go`** — Cobra wrapper adding `mcp serve [--transport stdio|sse] [--port 8080]`
- **`cmd/main.go`** — Registers `mcp.AddCommand` alongside existing commands

**12 tools exposed:**
`odh_status`, `odh_lint`, `odh_get`, `odh_deps`, `odh_deps_install`, `odh_backup`, `odh_logs`, `odh_events`, `odh_components_list`, `odh_components_describe`, `odh_migrate_list`, `odh_migrate_run`

**Jira:** [RHOAIENG-54633](https://redhat.atlassian.net/browse/RHOAIENG-54633)

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests
- [x] Smoke tested: `echo '..initialize..' | kubectl-odh mcp serve` returns all 12 tools

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


[RHOAIENG-54633]: https://redhat.atlassian.net/browse/RHOAIENG-54633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command group with a `serve` subcommand for starting the MCP server from the CLI.
  * Exposed runtime options for transport and port, with sensible defaults.

* **Bug Fixes**
  * MCP tools are now registered automatically when the server starts, so all available tools are ready without extra setup.

* **Tests**
  * Added coverage for command registration and default flags.
  * Added validation that the server loads the full expected set of tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->