### PR TITLE
feat(migrate): add structured JSON/YAML output to list, prepare, and run

### DIFF
--- a/cmd/migrate/list/list.go
+++ b/cmd/migrate/list/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
 const (
@@ -56,16 +57,21 @@ func AddCommand(
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			//nolint:wrapcheck // Errors from Complete and Validate are already contextualized
+			outputFormat := string(command.OutputFormat)
+
 			if err := command.Complete(); err != nil {
-				return err
-			}
-			//nolint:wrapcheck // Errors from Validate are already contextualized
-			if err := command.Validate(); err != nil {
-				return err
+				return clierrors.HandleError(cmd, err, outputFormat)
 			}
 
-			return command.Run(cmd.Context())
+			if err := command.Validate(); err != nil {
+				return clierrors.HandleError(cmd, err, outputFormat)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				return clierrors.HandleError(cmd, err, outputFormat)
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/migrate/prepare/prepare.go
+++ b/cmd/migrate/prepare/prepare.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
 const (
@@ -66,16 +67,21 @@ func AddCommand(
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			//nolint:wrapcheck // Errors from Complete and Validate are already contextualized
+			outputFormat := string(command.OutputFormat)
+
 			if err := command.Complete(); err != nil {
-				return err
-			}
-			//nolint:wrapcheck // Errors from Validate are already contextualized
-			if err := command.Validate(); err != nil {
-				return err
+				return clierrors.HandleError(cmd, err, outputFormat)
 			}
 
-			return command.Run(cmd.Context())
+			if err := command.Validate(); err != nil {
+				return clierrors.HandleError(cmd, err, outputFormat)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				return clierrors.HandleError(cmd, err, outputFormat)
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/migrate/run/run.go
+++ b/cmd/migrate/run/run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
 const (
@@ -63,16 +64,21 @@ func AddCommand(
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			//nolint:wrapcheck // Errors from Complete and Validate are already contextualized
+			outputFormat := string(command.OutputFormat)
+
 			if err := command.Complete(); err != nil {
-				return err
-			}
-			//nolint:wrapcheck // Errors from Validate are already contextualized
-			if err := command.Validate(); err != nil {
-				return err
+				return clierrors.HandleError(cmd, err, outputFormat)
 			}
 
-			return command.Run(cmd.Context())
+			if err := command.Validate(); err != nil {
+				return clierrors.HandleError(cmd, err, outputFormat)
+			}
+
+			if err := command.Run(cmd.Context()); err != nil {
+				return clierrors.HandleError(cmd, err, outputFormat)
+			}
+
+			return nil
 		},
 	}
 

--- a/pkg/migrate/action/result/result.go
+++ b/pkg/migrate/action/result/result.go
@@ -15,35 +15,35 @@ const (
 )
 
 type ActionResult struct {
-	Metadata ActionMetadata
-	Spec     ActionSpec
-	Status   ActionStatus
+	Metadata ActionMetadata `json:"metadata" yaml:"metadata"`
+	Spec     ActionSpec     `json:"spec"     yaml:"spec"`
+	Status   ActionStatus   `json:"status"   yaml:"status"`
 }
 
 type ActionMetadata struct {
-	Group       string
-	Kind        string
-	Name        string
-	Annotations map[string]string
+	Group       string            `json:"group"                 yaml:"group"`
+	Kind        string            `json:"kind"                  yaml:"kind"`
+	Name        string            `json:"name"                  yaml:"name"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 type ActionSpec struct {
-	Description string
-	DryRun      bool
+	Description string `json:"description" yaml:"description"`
+	DryRun      bool   `json:"dryRun"      yaml:"dryRun"`
 }
 
 type ActionStatus struct {
-	Steps     []ActionStep
-	Completed bool
-	Error     string
+	Steps     []ActionStep `json:"steps"           yaml:"steps"`
+	Completed bool         `json:"completed"       yaml:"completed"`
+	Error     string       `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 type ActionStep struct {
-	Name        string
-	Description string
-	Status      StepStatus
-	Message     string
-	Timestamp   time.Time
+	Name        string         `json:"name"               yaml:"name"`
+	Description string         `json:"description"        yaml:"description"`
+	Status      StepStatus     `json:"status"             yaml:"status"`
+	Message     string         `json:"message,omitempty"  yaml:"message,omitempty"`
+	Timestamp   time.Time      `json:"timestamp"          yaml:"timestamp"`
 	Children    []ActionStep   `json:"children,omitempty" yaml:"children,omitempty"`
 	Details     map[string]any `json:"details,omitempty"  yaml:"details,omitempty"`
 }

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -16,6 +16,9 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/output"
+	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
 
@@ -53,6 +56,8 @@ func (c *PrepareCommand) ActionIDs() []string {
 }
 
 func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), "Output format: table, json, yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescPrepareVerbose)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescPrepareTimeout)
 	fs.BoolVar(&c.DryRun, "dry-run", false, flagDescPrepareDryRun)
@@ -75,6 +80,11 @@ func (c *PrepareCommand) AddFlags(fs *pflag.FlagSet) {
 func (c *PrepareCommand) Complete() error {
 	if err := c.SharedOptions.Complete(); err != nil {
 		return fmt.Errorf("completing shared options: %w", err)
+	}
+
+	// Suppress text output for structured formats (matching codebase pattern)
+	if c.OutputFormat != OutputFormatTable {
+		c.IO = iostreams.NewQuietWrapper(c.IO)
 	}
 
 	// Always enable verbose for migrate prepare
@@ -148,7 +158,9 @@ func (c *PrepareCommand) Run(ctx context.Context) error {
 	c.MigrationIDs = resolvedIDs
 
 	if len(c.MigrationIDs) == 0 {
-		return fmt.Errorf("no applicable migrations found for phase %s", string(effectivePhase))
+		//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+		return clierrors.NewExitCodeError(clierrors.ExitValidation,
+			fmt.Errorf("no applicable migrations found for phase %s", string(effectivePhase)))
 	}
 
 	return c.runPrepareMode(ctx, currentVersion, c.parsedTargetVersion, effectivePhase)
@@ -160,10 +172,17 @@ func (c *PrepareCommand) runPrepareMode(
 	targetVersion *semver.Version,
 	effectivePhase action.ActionPhase,
 ) error {
+	structured := c.OutputFormat != OutputFormatTable
+
 	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
 	c.IO.Errorf("Target OpenShift AI version: %s", targetVersion.String())
 	c.IO.Errorf("Phase: %s", string(effectivePhase))
 	c.IO.Errorf("Backup directory: %s\n", c.OutputDir)
+
+	// Use FullQuietWrapper for action IO to prevent stdout corruption in structured mode
+	actionIO := actionIOForMode(c.IO, structured)
+
+	var migrationResults []MigrationResultItem
 
 	for idx, migrationID := range c.MigrationIDs {
 		if len(c.MigrationIDs) > 1 {
@@ -172,10 +191,14 @@ func (c *PrepareCommand) runPrepareMode(
 
 		selectedAction, ok := c.registry.Get(migrationID)
 		if !ok {
-			return fmt.Errorf("migration %q not found", migrationID)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("migration %q not found", migrationID))
 		}
 
+		var phaseMismatch bool
 		if selectedAction.Phase() != effectivePhase {
+			phaseMismatch = true
 			c.IO.Errorf("WARNING: migration %s has phase %s but effective phase is %s; proceeding because --migration was explicit",
 				migrationID, string(selectedAction.Phase()), string(effectivePhase))
 		}
@@ -183,12 +206,16 @@ func (c *PrepareCommand) runPrepareMode(
 		prepareTask := selectedAction.Prepare()
 		if prepareTask == nil {
 			c.IO.Errorf("Migration %s has no prepare phase (skipped)\n", migrationID)
+			migrationResults = append(migrationResults, MigrationResultItem{
+				ID:            migrationID,
+				Skipped:       true,
+				PhaseMismatch: phaseMismatch,
+			})
 
 			continue
 		}
 
-		// Use verbose recorder for real-time streaming output
-		recorder := action.NewVerboseRootRecorder(c.IO)
+		recorder := action.NewVerboseRootRecorder(actionIO)
 		c.IO.Errorf("\n%s:\n", migrationID)
 
 		target := action.Target{
@@ -200,7 +227,7 @@ func (c *PrepareCommand) runPrepareMode(
 			SkipConfirm:    c.Yes,
 			OutputDir:      c.OutputDir,
 			Recorder:       recorder,
-			IO:             c.IO,
+			IO:             actionIO,
 		}
 
 		if c.DryRun {
@@ -209,17 +236,32 @@ func (c *PrepareCommand) runPrepareMode(
 
 		actionResult, err := prepareTask.Execute(ctx, target)
 		if err != nil {
-			return fmt.Errorf("preparation failed: %w", err)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("preparation failed: %w", err))
 		}
 
-		// Output has already been streamed during execution
-		c.IO.Fprintln()
+		c.IO.Errorln()
+
 		if !actionResult.Status.Completed {
 			c.IO.Errorf("Preparation %s incomplete - please review the output above", migrationID)
 
-			return fmt.Errorf("preparation halted: %s", migrationID)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("preparation halted: %s", migrationID))
 		}
+
 		c.IO.Errorf("Preparation %s completed successfully!", migrationID)
+		migrationResults = append(migrationResults, MigrationResultItem{
+			ID:              migrationID,
+			Completed:       actionResult.Status.Completed,
+			HasSkippedSteps: actionResult.HasSkippedSteps(),
+			PhaseMismatch:   phaseMismatch,
+		})
+	}
+
+	if structured {
+		return c.writePrepareResult(currentVersion, targetVersion, effectivePhase, migrationResults)
 	}
 
 	c.IO.Fprintln()
@@ -241,4 +283,57 @@ func (c *PrepareCommand) runPrepareMode(
 	}
 
 	return nil
+}
+
+// PrepareResult is the structured success output for migrate prepare.
+type PrepareResult struct {
+	output.Envelope `json:",inline" yaml:",inline"`
+
+	CurrentVersion string                `json:"currentVersion" yaml:"currentVersion"`
+	TargetVersion  string                `json:"targetVersion"  yaml:"targetVersion"`
+	Phase          string                `json:"phase"          yaml:"phase"`
+	DryRun         bool                  `json:"dryRun"         yaml:"dryRun"`
+	OutputDir      string                `json:"outputDir"      yaml:"outputDir"`
+	Migrations     []MigrationResultItem `json:"migrations"     yaml:"migrations"`
+}
+
+// MigrationResultItem represents the result of a single migration in structured output.
+type MigrationResultItem struct {
+	ID              string `json:"id"                        yaml:"id"`
+	Completed       bool   `json:"completed"                 yaml:"completed"`
+	Skipped         bool   `json:"skipped,omitempty"         yaml:"skipped,omitempty"`
+	HasSkippedSteps bool   `json:"hasSkippedSteps,omitempty" yaml:"hasSkippedSteps,omitempty"`
+	PhaseMismatch   bool   `json:"phaseMismatch,omitempty"   yaml:"phaseMismatch,omitempty"`
+}
+
+func countWarnings(migrations []MigrationResultItem) int {
+	warnings := 0
+
+	for _, m := range migrations {
+		if m.Skipped || m.HasSkippedSteps || m.PhaseMismatch {
+			warnings++
+		}
+	}
+
+	return warnings
+}
+
+func (c *PrepareCommand) writePrepareResult(
+	currentVersion *semver.Version,
+	targetVersion *semver.Version,
+	phase action.ActionPhase,
+	migrations []MigrationResultItem,
+) error {
+	result := PrepareResult{
+		Envelope:       output.NewEnvelope("MigratePrepareResult", "migrate prepare"),
+		CurrentVersion: currentVersion.String(),
+		TargetVersion:  targetVersion.String(),
+		Phase:          string(phase),
+		DryRun:         c.DryRun,
+		OutputDir:      c.OutputDir,
+		Migrations:     migrations,
+	}
+	result.SetStatus(countWarnings(migrations), 0)
+
+	return writeStructuredOutput(c.IO.Out(), c.OutputFormat, result)
 }

--- a/pkg/migrate/command_prepare_internal_test.go
+++ b/pkg/migrate/command_prepare_internal_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,13 +18,28 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type prepareTestStreams struct {
+	cmd    *PrepareCommand
+	outBuf *bytes.Buffer
+	errBuf *bytes.Buffer
+}
+
 func newTestPrepareCommand(t *testing.T) (*PrepareCommand, *bytes.Buffer) {
 	t.Helper()
 
+	s := newTestPrepareCommandWithStdout(t)
+
+	return s.cmd, s.errBuf
+}
+
+func newTestPrepareCommandWithStdout(t *testing.T) prepareTestStreams {
+	t.Helper()
+
+	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	streams := genericiooptions.IOStreams{
 		In:     &bytes.Buffer{},
-		Out:    &bytes.Buffer{},
+		Out:    outBuf,
 		ErrOut: errBuf,
 	}
 
@@ -33,7 +49,7 @@ func newTestPrepareCommand(t *testing.T) (*PrepareCommand, *bytes.Buffer) {
 		OutputDir:     filepath.Join(t.TempDir(), "backup-test"),
 	}
 
-	return cmd, errBuf
+	return prepareTestStreams{cmd: cmd, outBuf: outBuf, errBuf: errBuf}
 }
 
 func TestRunPrepareMode(t *testing.T) {
@@ -184,5 +200,76 @@ func TestRunPrepareMode(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(task1.execCount).To(Equal(1))
 		g.Expect(task2.execCount).To(Equal(1))
+	})
+
+	t.Run("should emit JSON structured output when format is json", func(t *testing.T) {
+		g := NewWithT(t)
+		s := newTestPrepareCommandWithStdout(t)
+		s.cmd.OutputFormat = OutputFormatJSON
+
+		task := &stubTask{result: newSuccessResult()}
+		s.cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task,
+		})
+		s.cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := s.cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result PrepareResult
+		g.Expect(json.Unmarshal(s.outBuf.Bytes(), &result)).To(Succeed())
+		g.Expect(result.Kind).To(Equal("MigratePrepareResult"))
+		g.Expect(result.APIVersion).To(Equal("cli.opendatahub.io/v1"))
+		g.Expect(result.CurrentVersion).To(Equal("2.25.0"))
+		g.Expect(result.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(result.Phase).To(Equal("pre-upgrade"))
+		g.Expect(result.Migrations).To(HaveLen(1))
+		g.Expect(result.Migrations[0].ID).To(Equal("test.migrate"))
+		g.Expect(result.Migrations[0].Completed).To(BeTrue())
+		g.Expect(result.Status).ToNot(BeNil())
+		g.Expect(result.Status.Result).To(Equal("success"))
+	})
+
+	t.Run("should emit YAML structured output when format is yaml", func(t *testing.T) {
+		g := NewWithT(t)
+		s := newTestPrepareCommandWithStdout(t)
+		s.cmd.OutputFormat = OutputFormatYAML
+
+		task := &stubTask{result: newSuccessResult()}
+		s.cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: task,
+		})
+		s.cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := s.cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := s.outBuf.String()
+		g.Expect(output).To(ContainSubstring("kind: MigratePrepareResult"))
+		g.Expect(output).To(ContainSubstring("currentVersion: 2.25.0"))
+		g.Expect(output).To(ContainSubstring("targetVersion: 3.0.0"))
+	})
+
+	t.Run("should include skipped migrations in structured output", func(t *testing.T) {
+		g := NewWithT(t)
+		s := newTestPrepareCommandWithStdout(t)
+		s.cmd.OutputFormat = OutputFormatJSON
+
+		s.cmd.registry.MustRegister(&stubAction{
+			id: "no.prepare", phase: action.PhasePreUpgrade, canApply: true,
+			prepareTask: nil,
+		})
+		s.cmd.MigrationIDs = []string{"no.prepare"}
+
+		err := s.cmd.runPrepareMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result PrepareResult
+		g.Expect(json.Unmarshal(s.outBuf.Bytes(), &result)).To(Succeed())
+		g.Expect(result.Migrations).To(HaveLen(1))
+		g.Expect(result.Migrations[0].ID).To(Equal("no.prepare"))
+		g.Expect(result.Migrations[0].Skipped).To(BeTrue())
 	})
 }

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -13,7 +13,9 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/api"
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/output"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
 	"github.com/opendatahub-io/odh-cli/pkg/util/stdin"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
@@ -56,6 +58,8 @@ func (c *RunCommand) ActionIDs() []string {
 
 func (c *RunCommand) AddFlags(fs *pflag.FlagSet) {
 	c.flags = fs
+	fs.StringVarP((*string)(&c.OutputFormat), "output", "o", string(OutputFormatTable), "Output format: table, json, yaml")
+	_ = fs.SetAnnotation("output", api.AnnotationValidValues, []string{"table", "json", "yaml"})
 	fs.BoolVarP(&c.Verbose, "verbose", "v", false, flagDescRunVerbose)
 	fs.DurationVar(&c.Timeout, "timeout", c.Timeout, flagDescRunTimeout)
 	fs.BoolVar(&c.DryRun, "dry-run", false, flagDescRunDryRun)
@@ -132,6 +136,11 @@ func (c *RunCommand) Complete() error {
 		return fmt.Errorf("completing shared options: %w", err)
 	}
 
+	// Suppress text output for structured formats (matching codebase pattern)
+	if c.OutputFormat != OutputFormatTable {
+		c.IO = iostreams.NewQuietWrapper(c.IO)
+	}
+
 	// Always enable verbose for migrate run (both dry-run and actual execution)
 	c.Verbose = true
 
@@ -197,7 +206,9 @@ func (c *RunCommand) Run(ctx context.Context) error {
 	c.MigrationIDs = resolvedIDs
 
 	if len(c.MigrationIDs) == 0 {
-		return fmt.Errorf("no applicable migrations found for phase %s", string(effectivePhase))
+		//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+		return clierrors.NewExitCodeError(clierrors.ExitValidation,
+			fmt.Errorf("no applicable migrations found for phase %s", string(effectivePhase)))
 	}
 
 	return c.runMigrationMode(ctx, currentVersion, c.parsedTargetVersion, effectivePhase)
@@ -209,11 +220,18 @@ func (c *RunCommand) runMigrationMode(
 	targetVersion *semver.Version,
 	effectivePhase action.ActionPhase,
 ) error {
+	structured := c.OutputFormat != OutputFormatTable
+
 	c.IO.Errorf("Current OpenShift AI version: %s", currentVersion.String())
 	c.IO.Errorf("Target OpenShift AI version: %s", targetVersion.String())
 	c.IO.Errorf("Phase: %s\n", string(effectivePhase))
 
+	// Use FullQuietWrapper for action IO to prevent stdout corruption in structured mode
+	actionIO := actionIOForMode(c.IO, structured)
+
 	hasSkips := false
+
+	var migrationResults []MigrationResultItem
 
 	for idx, migrationID := range c.MigrationIDs {
 		if len(c.MigrationIDs) > 1 {
@@ -222,16 +240,19 @@ func (c *RunCommand) runMigrationMode(
 
 		selectedAction, ok := c.registry.Get(migrationID)
 		if !ok {
-			return fmt.Errorf("migration %q not found", migrationID)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("migration %q not found", migrationID))
 		}
 
+		var phaseMismatch bool
 		if selectedAction.Phase() != effectivePhase {
+			phaseMismatch = true
 			c.IO.Errorf("WARNING: migration %s has phase %s but effective phase is %s; proceeding because --migration was explicit",
 				migrationID, string(selectedAction.Phase()), string(effectivePhase))
 		}
 
-		// Use verbose recorder for real-time streaming output
-		recorder := action.NewVerboseRootRecorder(c.IO)
+		recorder := action.NewVerboseRootRecorder(actionIO)
 		c.IO.Errorf("\n%s:\n", migrationID)
 
 		target := action.Target{
@@ -242,7 +263,7 @@ func (c *RunCommand) runMigrationMode(
 			DryRun:         c.DryRun,
 			SkipConfirm:    c.Yes,
 			Recorder:       recorder,
-			IO:             c.IO,
+			IO:             actionIO,
 		}
 
 		if c.DryRun {
@@ -255,28 +276,47 @@ func (c *RunCommand) runMigrationMode(
 
 		runTask := selectedAction.Run()
 		if runTask == nil {
-			return fmt.Errorf("migration %q has no run task", migrationID)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("migration %q has no run task", migrationID))
 		}
 
 		actionResult, err := runTask.Execute(ctx, target)
 		if err != nil {
-			return fmt.Errorf("migration failed: %w", err)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("migration failed: %w", err))
 		}
 
-		// Output has already been streamed during execution, no need to render again
-		c.IO.Fprintln()
+		c.IO.Errorln()
+
 		if !actionResult.Status.Completed {
 			c.IO.Errorf("Migration %s incomplete - please review the output above", migrationID)
 
-			return fmt.Errorf("migration halted: %s", migrationID)
+			//nolint:wrapcheck // NewExitCodeError is a same-module constructor
+			return clierrors.NewExitCodeError(clierrors.ExitValidation,
+				fmt.Errorf("migration halted: %s", migrationID))
 		}
-		if actionResult.HasSkippedSteps() {
+
+		skippedSteps := actionResult.HasSkippedSteps()
+		if skippedSteps {
 			c.IO.Errorf("Migration %s completed with skipped steps", migrationID)
 
 			hasSkips = true
 		} else {
 			c.IO.Errorf("Migration %s completed successfully!", migrationID)
 		}
+
+		migrationResults = append(migrationResults, MigrationResultItem{
+			ID:              migrationID,
+			Completed:       actionResult.Status.Completed,
+			HasSkippedSteps: skippedSteps,
+			PhaseMismatch:   phaseMismatch,
+		})
+	}
+
+	if structured {
+		return c.writeRunResult(currentVersion, targetVersion, effectivePhase, migrationResults)
 	}
 
 	c.IO.Fprintln()
@@ -288,4 +328,34 @@ func (c *RunCommand) runMigrationMode(
 	}
 
 	return nil
+}
+
+// RunResult is the structured success output for migrate run.
+type RunResult struct {
+	output.Envelope `json:",inline" yaml:",inline"`
+
+	CurrentVersion string                `json:"currentVersion" yaml:"currentVersion"`
+	TargetVersion  string                `json:"targetVersion"  yaml:"targetVersion"`
+	Phase          string                `json:"phase"          yaml:"phase"`
+	DryRun         bool                  `json:"dryRun"         yaml:"dryRun"`
+	Migrations     []MigrationResultItem `json:"migrations"     yaml:"migrations"`
+}
+
+func (c *RunCommand) writeRunResult(
+	currentVersion *semver.Version,
+	targetVersion *semver.Version,
+	phase action.ActionPhase,
+	migrations []MigrationResultItem,
+) error {
+	result := RunResult{
+		Envelope:       output.NewEnvelope("MigrateRunResult", "migrate run"),
+		CurrentVersion: currentVersion.String(),
+		TargetVersion:  targetVersion.String(),
+		Phase:          string(phase),
+		DryRun:         c.DryRun,
+		Migrations:     migrations,
+	}
+	result.SetStatus(countWarnings(migrations), 0)
+
+	return writeStructuredOutput(c.IO.Out(), c.OutputFormat, result)
 }

--- a/pkg/migrate/command_run_internal_test.go
+++ b/pkg/migrate/command_run_internal_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -57,11 +58,24 @@ func newIncompleteResult() *result.ActionResult {
 	return r
 }
 
+type runTestStreams struct {
+	cmd    *RunCommand
+	outBuf *bytes.Buffer
+	errBuf *bytes.Buffer
+}
+
 func newTestRunCommand() (*RunCommand, *bytes.Buffer) {
+	s := newTestRunCommandWithStdout()
+
+	return s.cmd, s.errBuf
+}
+
+func newTestRunCommandWithStdout() runTestStreams {
+	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	streams := genericiooptions.IOStreams{
 		In:     &bytes.Buffer{},
-		Out:    &bytes.Buffer{},
+		Out:    outBuf,
 		ErrOut: errBuf,
 	}
 
@@ -70,7 +84,7 @@ func newTestRunCommand() (*RunCommand, *bytes.Buffer) {
 		registry:      action.NewActionRegistry(),
 	}
 
-	return cmd, errBuf
+	return runTestStreams{cmd: cmd, outBuf: outBuf, errBuf: errBuf}
 }
 
 func TestRunMigrationMode(t *testing.T) {
@@ -219,5 +233,75 @@ func TestRunMigrationMode(t *testing.T) {
 		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(task.execCount).To(Equal(1))
+	})
+
+	t.Run("should emit JSON structured output when format is json", func(t *testing.T) {
+		g := NewWithT(t)
+		s := newTestRunCommandWithStdout()
+		s.cmd.OutputFormat = OutputFormatJSON
+
+		task := &stubTask{result: newSuccessResult()}
+		s.cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task,
+		})
+		s.cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := s.cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result RunResult
+		g.Expect(json.Unmarshal(s.outBuf.Bytes(), &result)).To(Succeed())
+		g.Expect(result.Kind).To(Equal("MigrateRunResult"))
+		g.Expect(result.APIVersion).To(Equal("cli.opendatahub.io/v1"))
+		g.Expect(result.CurrentVersion).To(Equal("2.25.0"))
+		g.Expect(result.TargetVersion).To(Equal("3.0.0"))
+		g.Expect(result.Phase).To(Equal("pre-upgrade"))
+		g.Expect(result.Migrations).To(HaveLen(1))
+		g.Expect(result.Migrations[0].ID).To(Equal("test.migrate"))
+		g.Expect(result.Migrations[0].Completed).To(BeTrue())
+		g.Expect(result.Status).ToNot(BeNil())
+		g.Expect(result.Status.Result).To(Equal("success"))
+	})
+
+	t.Run("should emit YAML structured output when format is yaml", func(t *testing.T) {
+		g := NewWithT(t)
+		s := newTestRunCommandWithStdout()
+		s.cmd.OutputFormat = OutputFormatYAML
+
+		task := &stubTask{result: newSuccessResult()}
+		s.cmd.registry.MustRegister(&stubAction{
+			id: "test.migrate", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: task,
+		})
+		s.cmd.MigrationIDs = []string{"test.migrate"}
+
+		err := s.cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		output := s.outBuf.String()
+		g.Expect(output).To(ContainSubstring("kind: MigrateRunResult"))
+		g.Expect(output).To(ContainSubstring("currentVersion: 2.25.0"))
+		g.Expect(output).To(ContainSubstring("targetVersion: 3.0.0"))
+	})
+
+	t.Run("should include skipped steps in JSON structured output", func(t *testing.T) {
+		g := NewWithT(t)
+		s := newTestRunCommandWithStdout()
+		s.cmd.OutputFormat = OutputFormatJSON
+
+		s.cmd.registry.MustRegister(&stubAction{
+			id: "skip.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newResultWithSkippedSteps()},
+		})
+		s.cmd.MigrationIDs = []string{"skip.action"}
+
+		err := s.cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var result RunResult
+		g.Expect(json.Unmarshal(s.outBuf.Bytes(), &result)).To(Succeed())
+		g.Expect(result.Migrations).To(HaveLen(1))
+		g.Expect(result.Migrations[0].HasSkippedSteps).To(BeTrue())
 	})
 }

--- a/pkg/migrate/output.go
+++ b/pkg/migrate/output.go
@@ -1,0 +1,48 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+)
+
+func actionIOForMode(streams iostreams.Interface, structured bool) iostreams.Interface {
+	if structured {
+		return iostreams.NewFullQuietWrapper(streams)
+	}
+
+	return streams
+}
+
+func writeStructuredOutput(w io.Writer, format OutputFormat, result any) error {
+	switch format { //nolint:exhaustive // table is handled by caller before this function
+	case OutputFormatJSON:
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling JSON: %w", err)
+		}
+
+		if _, err = fmt.Fprintln(w, string(data)); err != nil {
+			return fmt.Errorf("writing JSON output: %w", err)
+		}
+
+		return nil
+	case OutputFormatYAML:
+		data, err := yaml.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("marshaling YAML: %w", err)
+		}
+
+		if _, err = fmt.Fprint(w, string(data)); err != nil {
+			return fmt.Errorf("writing YAML output: %w", err)
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}


### PR DESCRIPTION
## Description

Adds `-o json/yaml` structured output to `migrate list` (errors), `migrate prepare`, and `migrate run` commands.

**Changes:**
- **migrate list**: Wires `HandleError` for structured error output on failure
- **migrate prepare/run**: Adds `-o json/yaml` flag with structured success (`MigratePrepareResult`/`MigrateRunResult` envelopes) and structured errors
- Suppresses text output in structured mode via `QuietWrapper` (stderr) and `FullQuietWrapper` (action IO) to prevent stdout corruption
- Classifies operational errors (`migration not found`, `no run task`) as `VALIDATION_FAILED` instead of `INTERNAL`
- Adds `PhaseMismatch` field to `MigrationResultItem` for phase mismatch visibility in JSON
- Adds JSON/YAML struct tags to `ActionResult` types for proper serialization
- Shared `writeStructuredOutput` and `actionIOForMode` helpers in `pkg/migrate/output.go`

Jira: [RHOAIENG-76258](https://redhat.atlassian.net/browse/RHOAIENG-76258)

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests
- [x] Verified on cluster: `migrate list/prepare/run -o json` produces clean JSON parseable by `jq`
- [x] Verified table mode behavior unchanged

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


[RHOAIENG-76258]: https://redhat.atlassian.net/browse/RHOAIENG-76258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON and YAML output options (via `--output`) to `migrate prepare` and `migrate run`, producing structured, automation-friendly results.
  * Structured output now reports per-migration status, phase handling, and skipped steps (including skipped preparations/runs when applicable).
* **Bug Fixes**
  * Standardized command error handling and improved exit-code behavior across `migrate list`, `migrate prepare`, and `migrate run`.
  * Prevented regular console output from interfering with structured results to keep JSON/YAML clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->