### PR TITLE
feat(lint): detect shared OSSM and Serverless usage across namespaces

### DIFF
--- a/pkg/lint/checks/dependencies/shared/shared.go
+++ b/pkg/lint/checks/dependencies/shared/shared.go
@@ -1,0 +1,89 @@
+package shared
+
+import (
+	"context"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// RHOAIManagedNamespaces returns the set of namespaces considered RHOAI-managed.
+// It combines the provided well-known namespaces with the applications and monitoring
+// namespaces read from DSCInitialization.
+func RHOAIManagedNamespaces(ctx context.Context, r client.Reader, wellKnown []string) []string {
+	namespaces := make([]string, 0, len(wellKnown)+2) //nolint:mnd // room for applications + monitoring
+	namespaces = append(namespaces, wellKnown...)
+
+	dsciNS, err := client.GetDSCINamespaces(ctx, r)
+	if err == nil {
+		if dsciNS.Applications != "" {
+			namespaces = append(namespaces, dsciNS.Applications)
+		}
+
+		if dsciNS.Monitoring != "" {
+			namespaces = append(namespaces, dsciNS.Monitoring)
+		}
+	}
+
+	return namespaces
+}
+
+// CollectNamespaces returns a sorted, deduplicated list of namespaces from the given resource slices.
+func CollectNamespaces(resourceSlices ...[]*unstructured.Unstructured) []string {
+	seen := make(map[string]struct{})
+
+	for _, items := range resourceSlices {
+		for _, item := range items {
+			seen[item.GetNamespace()] = struct{}{}
+		}
+	}
+
+	namespaces := make([]string, 0, len(seen))
+	for ns := range seen {
+		namespaces = append(namespaces, ns)
+	}
+
+	slices.Sort(namespaces)
+
+	return namespaces
+}
+
+// ToNamespacedNames converts unstructured resources to NamespacedName references.
+func ToNamespacedNames(items []*unstructured.Unstructured) []types.NamespacedName {
+	names := make([]types.NamespacedName, 0, len(items))
+	for _, item := range items {
+		names = append(names, types.NamespacedName{
+			Namespace: item.GetNamespace(),
+			Name:      item.GetName(),
+		})
+	}
+
+	return names
+}
+
+// AddAllImpactedObjects appends impacted objects for each resource type that has results.
+func AddAllImpactedObjects(dr *result.DiagnosticResult, entries ...ImpactedEntry) {
+	for _, e := range entries {
+		if len(e.Items) > 0 {
+			dr.AddImpactedObjects(e.ResourceType, ToNamespacedNames(e.Items))
+		}
+	}
+}
+
+// ImpactedEntry pairs a resource type with its discovered items.
+type ImpactedEntry struct {
+	ResourceType resources.ResourceType
+	Items        []*unstructured.Unstructured
+}
+
+// IsNonRHOAIFilter returns a filter function that keeps only resources outside the given namespaces.
+func IsNonRHOAIFilter(managedNamespaces []string) func(*unstructured.Unstructured) (bool, error) {
+	return func(item *unstructured.Unstructured) (bool, error) {
+		return !slices.Contains(managedNamespaces, item.GetNamespace()), nil
+	}
+}

--- a/pkg/lint/checks/dependencies/sharedossm/sharedossm.go
+++ b/pkg/lint/checks/dependencies/sharedossm/sharedossm.go
@@ -1,0 +1,108 @@
+package sharedossm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/shared"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	checkKind = "shared-ossm"
+	checkType = "shared-usage"
+)
+
+func managedNamespaces() []string {
+	return []string{
+		"istio-system",
+		"openshift-operators",
+	}
+}
+
+// Check detects OSSM resources (SMCP, SMMR, SMM) outside RHOAI-managed namespaces,
+// indicating shared Service Mesh usage between AI and non-AI workloads.
+type Check struct {
+	check.BaseCheck
+}
+
+func NewCheck() *Check {
+	return &Check{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupDependency,
+			Kind:             checkKind,
+			Type:             checkType,
+			CheckID:          "dependencies.shared-ossm.shared-usage",
+			CheckName:        "Dependencies :: Shared OSSM :: Shared Usage Detection",
+			CheckDescription: "Detects OpenShift Service Mesh resources shared between RHOAI and non-AI workloads",
+			CheckRemediation: "Review the identified Service Mesh resources before migration. Non-AI workloads sharing OSSM may be impacted by the RHOAI 2.x to 3.x migration.",
+		},
+	}
+}
+
+func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
+}
+
+func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	dr := c.NewResult()
+
+	rhoaiNS := shared.RHOAIManagedNamespaces(ctx, target.Client, managedNamespaces())
+	isNonRHOAI := shared.IsNonRHOAIFilter(rhoaiNS)
+
+	smcps, err := client.List(ctx, target.Client, resources.ServiceMeshControlPlane, isNonRHOAI)
+	if err != nil {
+		return nil, fmt.Errorf("listing ServiceMeshControlPlanes: %w", err)
+	}
+
+	smmrs, err := client.List(ctx, target.Client, resources.ServiceMeshMemberRoll, isNonRHOAI)
+	if err != nil {
+		return nil, fmt.Errorf("listing ServiceMeshMemberRolls: %w", err)
+	}
+
+	smms, err := client.List(ctx, target.Client, resources.ServiceMeshMember, isNonRHOAI)
+	if err != nil {
+		return nil, fmt.Errorf("listing ServiceMeshMembers: %w", err)
+	}
+
+	totalCount := len(smcps) + len(smmrs) + len(smms)
+	if totalCount == 0 {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeValidated,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage("No shared OSSM resources detected outside RHOAI-managed namespaces"),
+		))
+
+		return dr, nil
+	}
+
+	namespaces := shared.CollectNamespaces(smcps, smmrs, smms)
+
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeValidated,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonWorkloadsImpacted),
+		check.WithMessage(
+			"Found %d OSSM resource(s) outside RHOAI-managed namespaces in: %s. These may be impacted by the RHOAI migration",
+			totalCount,
+			strings.Join(namespaces, ", "),
+		),
+		check.WithRemediation(c.CheckRemediation),
+	))
+
+	shared.AddAllImpactedObjects(dr,
+		shared.ImpactedEntry{ResourceType: resources.ServiceMeshControlPlane, Items: smcps},
+		shared.ImpactedEntry{ResourceType: resources.ServiceMeshMemberRoll, Items: smmrs},
+		shared.ImpactedEntry{ResourceType: resources.ServiceMeshMember, Items: smms},
+	)
+
+	return dr, nil
+}

--- a/pkg/lint/checks/dependencies/sharedossm/sharedossm_test.go
+++ b/pkg/lint/checks/dependencies/sharedossm/sharedossm_test.go
@@ -209,6 +209,35 @@ func TestSharedOSSMCheck_OnlySMMRsDetected(t *testing.T) {
 	g.Expect(result.ImpactedObjects).To(HaveLen(2))
 }
 
+func TestSharedOSSMCheck_NoDSCI_FallsBackToWellKnownNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	smcpManaged := newSMCP("basic", "istio-system")
+	smcpExternal := newSMCP("custom-mesh", "team-a")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{smcpManaged, smcpExternal},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedossm.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("1 OSSM resource"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("team-a"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
 func TestSharedOSSMCheck_CanApply_2xTo3x(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/lint/checks/dependencies/sharedossm/sharedossm_test.go
+++ b/pkg/lint/checks/dependencies/sharedossm/sharedossm_test.go
@@ -1,0 +1,265 @@
+package sharedossm_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/sharedossm"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func listKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		resources.ServiceMeshControlPlane.GVR(): resources.ServiceMeshControlPlane.ListKind(),
+		resources.ServiceMeshMemberRoll.GVR():   resources.ServiceMeshMemberRoll.ListKind(),
+		resources.ServiceMeshMember.GVR():       resources.ServiceMeshMember.ListKind(),
+		resources.DSCInitialization.GVR():       resources.DSCInitialization.ListKind(),
+	}
+}
+
+func newSMCP(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.ServiceMeshControlPlane.APIVersion(),
+			"kind":       resources.ServiceMeshControlPlane.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newSMMR(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.ServiceMeshMemberRoll.APIVersion(),
+			"kind":       resources.ServiceMeshMemberRoll.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newSMM(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.ServiceMeshMember.APIVersion(),
+			"kind":       resources.ServiceMeshMember.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func TestSharedOSSMCheck_NoSharedResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedossm.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+}
+
+func TestSharedOSSMCheck_RHOAIResourcesOnly(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	smcp := newSMCP("basic", "istio-system")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), smcp},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedossm.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+}
+
+func TestSharedOSSMCheck_SharedSMCPDetected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	smcp := newSMCP("custom-mesh", "my-app-namespace")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), smcp},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedossm.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("my-app-namespace"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("1 OSSM resource"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
+func TestSharedOSSMCheck_MultipleSharedResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	smcp := newSMCP("custom-mesh", "team-a")
+	smmr := newSMMR("default", "team-a")
+	smm := newSMM("default", "team-b")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds(),
+		Objects: []*unstructured.Unstructured{
+			testutil.NewDSCI("redhat-ods-applications"),
+			smcp, smmr, smm,
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedossm.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3 OSSM resource"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(3))
+}
+
+func TestSharedOSSMCheck_OnlySMMRsDetected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	smmr := newSMMR("default", "team-a")
+	smm := newSMM("default", "team-b")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds(),
+		Objects: []*unstructured.Unstructured{
+			testutil.NewDSCI("redhat-ods-applications"),
+			smmr, smm,
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedossm.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("2 OSSM resource"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(2))
+}
+
+func TestSharedOSSMCheck_CanApply_2xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedossm.NewCheck()
+
+	currentVer := semver.MustParse("2.17.0")
+	targetVer := semver.MustParse("3.0.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestSharedOSSMCheck_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedossm.NewCheck()
+
+	currentVer := semver.MustParse("3.0.0")
+	targetVer := semver.MustParse("3.1.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestSharedOSSMCheck_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedossm.NewCheck()
+
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestSharedOSSMCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedossm.NewCheck()
+
+	g.Expect(chk.ID()).To(Equal("dependencies.shared-ossm.shared-usage"))
+	g.Expect(chk.Name()).To(Equal("Dependencies :: Shared OSSM :: Shared Usage Detection"))
+	g.Expect(chk.Group()).To(Equal(check.GroupDependency))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/dependencies/sharedserverless/sharedserverless.go
+++ b/pkg/lint/checks/dependencies/sharedserverless/sharedserverless.go
@@ -1,0 +1,111 @@
+package sharedserverless
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/shared"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	checkKind = "shared-serverless"
+	checkType = "shared-usage"
+)
+
+func managedNamespaces() []string {
+	return []string{
+		"istio-system",
+		"knative-serving",
+		"knative-eventing",
+		"openshift-serverless",
+		"openshift-operators",
+	}
+}
+
+// Check detects Knative/Serverless resources (KnativeServing, KnativeEventing, KService) outside
+// RHOAI-managed namespaces, indicating shared Serverless usage between AI and non-AI workloads.
+type Check struct {
+	check.BaseCheck
+}
+
+func NewCheck() *Check {
+	return &Check{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupDependency,
+			Kind:             checkKind,
+			Type:             checkType,
+			CheckID:          "dependencies.shared-serverless.shared-usage",
+			CheckName:        "Dependencies :: Shared Serverless :: Shared Usage Detection",
+			CheckDescription: "Detects Knative/Serverless resources shared between RHOAI and non-AI workloads",
+			CheckRemediation: "Review the identified Knative/Serverless resources before migration. Non-AI workloads using OpenShift Serverless may be impacted by the RHOAI 2.x to 3.x migration.",
+		},
+	}
+}
+
+func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion), nil
+}
+
+func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	dr := c.NewResult()
+
+	rhoaiNS := shared.RHOAIManagedNamespaces(ctx, target.Client, managedNamespaces())
+	isNonRHOAI := shared.IsNonRHOAIFilter(rhoaiNS)
+
+	kservices, err := client.List(ctx, target.Client, resources.KnativeService, isNonRHOAI)
+	if err != nil {
+		return nil, fmt.Errorf("listing Knative Services: %w", err)
+	}
+
+	servings, err := client.List(ctx, target.Client, resources.KnativeServing, isNonRHOAI)
+	if err != nil {
+		return nil, fmt.Errorf("listing KnativeServings: %w", err)
+	}
+
+	eventings, err := client.List(ctx, target.Client, resources.KnativeEventing, isNonRHOAI)
+	if err != nil {
+		return nil, fmt.Errorf("listing KnativeEventings: %w", err)
+	}
+
+	totalCount := len(kservices) + len(servings) + len(eventings)
+	if totalCount == 0 {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeValidated,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage("No shared Serverless resources detected outside RHOAI-managed namespaces"),
+		))
+
+		return dr, nil
+	}
+
+	namespaces := shared.CollectNamespaces(kservices, servings, eventings)
+
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeValidated,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonWorkloadsImpacted),
+		check.WithMessage(
+			"Found %d Serverless resource(s) outside RHOAI-managed namespaces in: %s. These may be impacted by the RHOAI migration",
+			totalCount,
+			strings.Join(namespaces, ", "),
+		),
+		check.WithRemediation(c.CheckRemediation),
+	))
+
+	shared.AddAllImpactedObjects(dr,
+		shared.ImpactedEntry{ResourceType: resources.KnativeService, Items: kservices},
+		shared.ImpactedEntry{ResourceType: resources.KnativeServing, Items: servings},
+		shared.ImpactedEntry{ResourceType: resources.KnativeEventing, Items: eventings},
+	)
+
+	return dr, nil
+}

--- a/pkg/lint/checks/dependencies/sharedserverless/sharedserverless_test.go
+++ b/pkg/lint/checks/dependencies/sharedserverless/sharedserverless_test.go
@@ -1,0 +1,291 @@
+package sharedserverless_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/sharedserverless"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func listKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		resources.KnativeService.GVR():    resources.KnativeService.ListKind(),
+		resources.KnativeServing.GVR():    resources.KnativeServing.ListKind(),
+		resources.KnativeEventing.GVR():   resources.KnativeEventing.ListKind(),
+		resources.DSCInitialization.GVR(): resources.DSCInitialization.ListKind(),
+	}
+}
+
+func newKnativeService(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.KnativeService.APIVersion(),
+			"kind":       resources.KnativeService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newKnativeServing(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.KnativeServing.APIVersion(),
+			"kind":       resources.KnativeServing.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func newKnativeEventing(name, namespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.KnativeEventing.APIVersion(),
+			"kind":       resources.KnativeEventing.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func TestSharedServerlessCheck_NoSharedResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+}
+
+func TestSharedServerlessCheck_RHOAIResourcesOnly(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ksvc := newKnativeService("predictor", "redhat-ods-applications")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), ksvc},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+}
+
+func TestSharedServerlessCheck_SharedKServiceDetected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ksvc := newKnativeService("my-app", "team-a")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), ksvc},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("team-a"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("1 Serverless resource"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
+func TestSharedServerlessCheck_MultipleSharedResources(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ksvc1 := newKnativeService("app-1", "team-a")
+	ksvc2 := newKnativeService("app-2", "team-b")
+	serving := newKnativeServing("custom-serving", "team-a")
+	eventing := newKnativeEventing("custom-eventing", "team-c")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds(),
+		Objects: []*unstructured.Unstructured{
+			testutil.NewDSCI("redhat-ods-applications"),
+			ksvc1, ksvc2, serving, eventing,
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("4 Serverless resource"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(4))
+}
+
+func TestSharedServerlessCheck_KnativeServingInManagedNS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	serving := newKnativeServing("knative-serving", "knative-serving")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{testutil.NewDSCI("redhat-ods-applications"), serving},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+}
+
+func TestSharedServerlessCheck_OnlyServingAndEventingDetected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	serving := newKnativeServing("custom-serving", "team-a")
+	eventing := newKnativeEventing("custom-eventing", "team-b")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds(),
+		Objects: []*unstructured.Unstructured{
+			testutil.NewDSCI("redhat-ods-applications"),
+			serving, eventing,
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("2 Serverless resource"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(2))
+}
+
+func TestSharedServerlessCheck_CanApply_2xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedserverless.NewCheck()
+
+	currentVer := semver.MustParse("2.17.0")
+	targetVer := semver.MustParse("3.0.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestSharedServerlessCheck_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedserverless.NewCheck()
+
+	currentVer := semver.MustParse("3.0.0")
+	targetVer := semver.MustParse("3.1.0")
+	target := check.Target{
+		CurrentVersion: &currentVer,
+		TargetVersion:  &targetVer,
+	}
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestSharedServerlessCheck_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedserverless.NewCheck()
+
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestSharedServerlessCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := sharedserverless.NewCheck()
+
+	g.Expect(chk.ID()).To(Equal("dependencies.shared-serverless.shared-usage"))
+	g.Expect(chk.Name()).To(Equal("Dependencies :: Shared Serverless :: Shared Usage Detection"))
+	g.Expect(chk.Group()).To(Equal(check.GroupDependency))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/dependencies/sharedserverless/sharedserverless_test.go
+++ b/pkg/lint/checks/dependencies/sharedserverless/sharedserverless_test.go
@@ -235,6 +235,35 @@ func TestSharedServerlessCheck_OnlyServingAndEventingDetected(t *testing.T) {
 	g.Expect(result.ImpactedObjects).To(HaveLen(2))
 }
 
+func TestSharedServerlessCheck_NoDSCI_FallsBackToWellKnownNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ksvcManaged := newKnativeService("predictor", "knative-serving")
+	ksvcExternal := newKnativeService("my-app", "team-a")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{ksvcManaged, ksvcExternal},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := sharedserverless.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeValidated),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("1 Serverless resource"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("team-a"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
 func TestSharedServerlessCheck_CanApply_2xTo3x(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -29,6 +29,8 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemesh"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/sharedossm"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/sharedserverless"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/datasciencecluster"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/platform/dscinitialization"
 	datasciencepipelinesworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
@@ -123,10 +125,12 @@ func NewCommand(
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())
 
-	// Dependencies (3)
+	// Dependencies (5)
 	registry.MustRegister(certmanager.NewCheck())
 	registry.MustRegister(openshift.NewCheck())
 	registry.MustRegister(servicemesh.NewCheck())
+	registry.MustRegister(sharedossm.NewCheck())
+	registry.MustRegister(sharedserverless.NewCheck())
 
 	// Workloads (20)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -514,4 +514,52 @@ var (
 		Kind:     "TrustyAIService",
 		Resource: "trustyaiservices",
 	}
+
+	// ServiceMeshControlPlane is the OSSM v2 ServiceMeshControlPlane resource.
+	ServiceMeshControlPlane = ResourceType{
+		Group:    "maistra.io",
+		Version:  "v2",
+		Kind:     "ServiceMeshControlPlane",
+		Resource: "servicemeshcontrolplanes",
+	}
+
+	// ServiceMeshMemberRoll is the OSSM ServiceMeshMemberRoll resource.
+	ServiceMeshMemberRoll = ResourceType{
+		Group:    "maistra.io",
+		Version:  "v1",
+		Kind:     "ServiceMeshMemberRoll",
+		Resource: "servicemeshmemberrolls",
+	}
+
+	// ServiceMeshMember is the OSSM v1 ServiceMeshMember resource.
+	ServiceMeshMember = ResourceType{
+		Group:    "maistra.io",
+		Version:  "v1",
+		Kind:     "ServiceMeshMember",
+		Resource: "servicemeshmembers",
+	}
+
+	// KnativeServing is the Knative Serving operator resource.
+	KnativeServing = ResourceType{
+		Group:    "operator.knative.dev",
+		Version:  "v1beta1",
+		Kind:     "KnativeServing",
+		Resource: "knativeservings",
+	}
+
+	// KnativeEventing is the Knative Eventing operator resource.
+	KnativeEventing = ResourceType{
+		Group:    "operator.knative.dev",
+		Version:  "v1beta1",
+		Kind:     "KnativeEventing",
+		Resource: "knativeeventings",
+	}
+
+	// KnativeService is the Knative Service (KService) resource.
+	KnativeService = ResourceType{
+		Group:    "serving.knative.dev",
+		Version:  "v1",
+		Kind:     "Service",
+		Resource: "services",
+	}
 )


### PR DESCRIPTION
## Description
Add two new dependency lint checks for RHOAI 2.x to 3.x migration that scan for OpenShift Service Mesh (SMCP, SMMR, SMM) and Knative/Serverless (KnativeServing, KnativeEventing, KService) resources outside RHOAI-managed namespaces. Shared usage is reported as advisory warnings to inform migration planning when non-AI workloads depend on these shared dependencies.

Associated with: [RHOAIENG-71346](https://redhat.atlassian.net/browse/RHOAIENG-71346)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


[RHOAIENG-71346]: https://redhat.atlassian.net/browse/RHOAIENG-71346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added upgrade checks for OpenShift Service Mesh and Knative/Serverless resources used outside managed namespaces.
  - Checks run for RHOAI 2.x to 3.x upgrades and report affected namespaces, workloads, and remediation guidance.
  - Added support for identifying and tracking impacted Service Mesh and Serverless resources.

- **Tests**
  - Added coverage for detection results, upgrade applicability, managed namespaces, metadata, and impacted resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->