### PR TITLE
feat(lint): add OSSM v3.4 subscription drift compatibility check

### DIFF
--- a/pkg/lint/checks/dependencies/ossm34/ossm34.go
+++ b/pkg/lint/checks/dependencies/ossm34/ossm34.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
@@ -19,8 +19,7 @@ const (
 	checkKind = "ossm-v3-compatibility"
 	checkType = "compatibility"
 
-	subscriptionName      = "servicemeshoperator3"
-	subscriptionNamespace = "openshift-operators"
+	subscriptionName = "servicemeshoperator3"
 
 	csvPrefix = "servicemeshoperator3.v"
 )
@@ -68,20 +67,21 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 		return dr, nil
 	}
 
-	sub, err := target.Client.OLM().Subscriptions(subscriptionNamespace).Get(ctx, subscriptionName, metav1.GetOptions{})
+	subscriptions, err := target.Client.OLM().Subscriptions("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			dr.SetCondition(check.NewCondition(
-				check.ConditionTypeCompatible,
-				metav1.ConditionTrue,
-				check.WithReason(check.ReasonRequirementsMet),
-				check.WithMessage("servicemeshoperator3 subscription not found in %s namespace; OSSM v3 is not installed via OLM", subscriptionNamespace),
-			))
+		return nil, fmt.Errorf("listing subscriptions: %w", err)
+	}
 
-			return dr, nil
-		}
+	sub := findSubscription(subscriptions)
+	if sub == nil {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage("servicemeshoperator3 subscription not found; OSSM v3 is not installed via OLM"),
+		))
 
-		return nil, fmt.Errorf("getting servicemeshoperator3 subscription: %w", err)
+		return dr, nil
 	}
 
 	installedCSV := sub.Status.InstalledCSV
@@ -134,6 +134,16 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	))
 
 	return dr, nil
+}
+
+func findSubscription(list *operatorsv1alpha1.SubscriptionList) *operatorsv1alpha1.Subscription {
+	for i := range list.Items {
+		if list.Items[i].Name == subscriptionName {
+			return &list.Items[i]
+		}
+	}
+
+	return nil
 }
 
 func buildDriftMessage(installedVersion semver.Version, installedCSV, startingCSV string) string {

--- a/pkg/lint/checks/dependencies/ossm34/ossm34.go
+++ b/pkg/lint/checks/dependencies/ossm34/ossm34.go
@@ -26,6 +26,8 @@ const (
 
 var minAffectedVersion = semver.Version{Major: 3, Minor: 4, Patch: 0} //nolint:gochecknoglobals,mnd // constant-like semver
 
+var minFixedOCPVersion = semver.Version{Major: 4, Minor: 21, Patch: 22} //nolint:gochecknoglobals,mnd // OCP 4.21.22 includes Sail Library fix
+
 // Check detects servicemeshoperator3 subscription drift to v3.4.0+, which causes
 // GatewayConfig to get stuck NotReady on OCP 4.19-4.21 due to Istio v1.26.2
 // being rejected as end-of-life by the stricter version gate in OSSM 3.4.
@@ -41,7 +43,7 @@ func NewCheck() *Check {
 			Type:             checkType,
 			CheckID:          "dependencies.ossm-v3-compatibility.compatibility",
 			CheckName:        "Dependencies :: OSSM v3 Compatibility :: Version Compatibility",
-			CheckDescription: "Detects servicemeshoperator3 subscription drift to v3.4.0+ which causes GatewayConfig failures on OCP 4.19-4.21",
+			CheckDescription: "Detects servicemeshoperator3 subscription drift to v3.4.0+ which causes GatewayConfig failures on unpatched OCP 4.19-4.21",
 			CheckRemediation: "Do not approve servicemeshoperator3 InstallPlans beyond v3.3.x on OCP 4.19-4.21. " +
 				"Upgrade to OpenShift Container Platform 4.21.22 or higher to resolve via the Sail Library (no OLM dependency). " +
 				"See https://access.redhat.com/solutions/7145505 for details.",
@@ -109,6 +111,21 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	}
 
 	if installedVersion.GTE(minAffectedVersion) {
+		ocpVersion, ocpErr := version.DetectOpenShiftVersion(ctx, target.Client)
+		if ocpErr == nil && ocpVersion.GTE(minFixedOCPVersion) {
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeCompatible,
+				metav1.ConditionTrue,
+				check.WithReason(check.ReasonVersionCompatible),
+				check.WithMessage(
+					"servicemeshoperator3 is at %s (affected), but OCP %s includes the fix (Sail Library); no action required",
+					installedVersion, ocpVersion,
+				),
+			))
+
+			return dr, nil
+		}
+
 		var startingCSV string
 		if sub.Spec != nil {
 			startingCSV = sub.Spec.StartingCSV

--- a/pkg/lint/checks/dependencies/ossm34/ossm34.go
+++ b/pkg/lint/checks/dependencies/ossm34/ossm34.go
@@ -1,0 +1,166 @@
+package ossm34
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/blang/semver/v4"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	checkKind = "ossm-v3-compatibility"
+	checkType = "compatibility"
+
+	subscriptionName      = "servicemeshoperator3"
+	subscriptionNamespace = "openshift-operators"
+
+	csvPrefix = "servicemeshoperator3.v"
+)
+
+var minAffectedVersion = semver.Version{Major: 3, Minor: 4, Patch: 0} //nolint:gochecknoglobals,mnd // constant-like semver
+
+// Check detects servicemeshoperator3 subscription drift to v3.4.0+, which causes
+// GatewayConfig to get stuck NotReady on OCP 4.19-4.21 due to Istio v1.26.2
+// being rejected as end-of-life by the stricter version gate in OSSM 3.4.
+type Check struct {
+	check.BaseCheck
+}
+
+func NewCheck() *Check {
+	return &Check{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupDependency,
+			Kind:             checkKind,
+			Type:             checkType,
+			CheckID:          "dependencies.ossm-v3-compatibility.compatibility",
+			CheckName:        "Dependencies :: OSSM v3 Compatibility :: Version Compatibility",
+			CheckDescription: "Detects servicemeshoperator3 subscription drift to v3.4.0+ which causes GatewayConfig failures on OCP 4.19-4.21",
+			CheckRemediation: "Do not approve servicemeshoperator3 InstallPlans beyond v3.3.x on OCP 4.19-4.21. " +
+				"Upgrade to OpenShift Container Platform 4.21.22 or higher to resolve via the Sail Library (no OLM dependency). " +
+				"See https://access.redhat.com/solutions/7145505 for details.",
+		},
+	}
+}
+
+func (c *Check) CanApply(_ context.Context, target check.Target) (bool, error) {
+	return version.IsVersion3x(target.TargetVersion), nil
+}
+
+func (c *Check) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	dr := c.NewResult()
+
+	if !target.Client.OLM().Available() {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonCheckSkipped),
+			check.WithMessage("OLM client not available; skipping OSSM v3 compatibility check"),
+		))
+
+		return dr, nil
+	}
+
+	sub, err := target.Client.OLM().Subscriptions(subscriptionNamespace).Get(ctx, subscriptionName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeCompatible,
+				metav1.ConditionTrue,
+				check.WithReason(check.ReasonRequirementsMet),
+				check.WithMessage("servicemeshoperator3 subscription not found in %s namespace; OSSM v3 is not installed via OLM", subscriptionNamespace),
+			))
+
+			return dr, nil
+		}
+
+		return nil, fmt.Errorf("getting servicemeshoperator3 subscription: %w", err)
+	}
+
+	installedCSV := sub.Status.InstalledCSV
+	if installedCSV == "" {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage("servicemeshoperator3 subscription has no installed CSV; operator may be pending installation"),
+		))
+
+		return dr, nil
+	}
+
+	installedVersion, err := parseCSVVersion(installedCSV)
+	if err != nil {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionUnknown,
+			check.WithReason(check.ReasonInsufficientData),
+			check.WithMessage("Unable to parse version from installed CSV %q: %v", installedCSV, err),
+		))
+
+		return dr, nil
+	}
+
+	if installedVersion.GTE(minAffectedVersion) {
+		var startingCSV string
+		if sub.Spec != nil {
+			startingCSV = sub.Spec.StartingCSV
+		}
+
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonVersionIncompatible),
+			check.WithMessage("%s", buildDriftMessage(installedVersion, installedCSV, startingCSV)),
+			check.WithRemediation(c.CheckRemediation),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return dr, nil
+	}
+
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionTrue,
+		check.WithReason(check.ReasonVersionCompatible),
+		check.WithMessage("servicemeshoperator3 is installed at %s, which is not affected by the OSSM v3.4 compatibility issue", installedVersion),
+	))
+
+	return dr, nil
+}
+
+func buildDriftMessage(installedVersion semver.Version, installedCSV, startingCSV string) string {
+	message := fmt.Sprintf(
+		"servicemeshoperator3 is installed at %s (CSV: %s), which is affected by a known issue: "+
+			"OSSM v3.4.0+ rejects Istio v1.26.2 as end-of-life on OCP 4.19-4.21, "+
+			"causing GatewayConfig to get stuck NotReady",
+		installedVersion, installedCSV,
+	)
+
+	if startingCSV != "" && startingCSV != installedCSV {
+		message += ". Subscription has drifted from pinned version " + startingCSV
+	}
+
+	return message
+}
+
+func parseCSVVersion(csv string) (semver.Version, error) {
+	versionStr := strings.TrimPrefix(csv, csvPrefix)
+	if versionStr == csv {
+		return semver.Version{}, fmt.Errorf("CSV %q does not start with expected prefix %q", csv, csvPrefix)
+	}
+
+	v, err := semver.Parse(versionStr)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("parsing version %q: %w", versionStr, err)
+	}
+
+	return v, nil
+}

--- a/pkg/lint/checks/dependencies/ossm34/ossm34_test.go
+++ b/pkg/lint/checks/dependencies/ossm34/ossm34_test.go
@@ -84,7 +84,7 @@ func TestOSSM34Check_APIError_Propagated(t *testing.T) {
 	ctx := t.Context()
 
 	olmClient := operatorfake.NewSimpleClientset() //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
-	olmClient.PrependReactor("get", "subscriptions", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+	olmClient.PrependReactor("list", "subscriptions", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("connection refused")
 	})
 
@@ -97,7 +97,7 @@ func TestOSSM34Check_APIError_Propagated(t *testing.T) {
 	_, err := chk.Validate(ctx, target)
 
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("getting servicemeshoperator3 subscription"))
+	g.Expect(err.Error()).To(ContainSubstring("listing subscriptions"))
 	g.Expect(err.Error()).To(ContainSubstring("connection refused"))
 }
 
@@ -223,6 +223,29 @@ func TestOSSM34Check_NoStartingCSV_StillFlags(t *testing.T) {
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 	g.Expect(result.Status.Conditions[0].Message).ToNot(ContainSubstring("drifted from pinned version"))
+}
+
+func TestOSSM34Check_UnparsableCSV(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("", "servicemeshoperator3.vNOTASEMVER")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionUnknown),
+		"Reason": Equal(check.ReasonInsufficientData),
+	}))
 }
 
 func TestOSSM34Check_EmptyInstalledCSV(t *testing.T) {

--- a/pkg/lint/checks/dependencies/ossm34/ossm34_test.go
+++ b/pkg/lint/checks/dependencies/ossm34/ossm34_test.go
@@ -1,0 +1,301 @@
+package ossm34_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/ossm34"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func newSubscription(startingCSV, installedCSV string) *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemeshoperator3",
+			Namespace: "openshift-operators",
+		},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			StartingCSV: startingCSV,
+			Channel:     "stable",
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: installedCSV,
+		},
+	}
+}
+
+func TestOSSM34Check_NoOLM(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonCheckSkipped),
+	}))
+}
+
+func TestOSSM34Check_NoSubscription(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("not found"))
+}
+
+func TestOSSM34Check_APIError_Propagated(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	olmClient := operatorfake.NewSimpleClientset() //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+	olmClient.PrependReactor("get", "subscriptions", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           olmClient,
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	_, err := chk.Validate(ctx, target)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("getting servicemeshoperator3 subscription"))
+	g.Expect(err.Error()).To(ContainSubstring("connection refused"))
+}
+
+func TestOSSM34Check_NoDrift(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.1.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("not affected"))
+}
+
+func TestOSSM34Check_V33NotAffected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.3.5")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+}
+
+func TestOSSM34Check_DriftToV34_Blocking(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3.4.0"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("GatewayConfig"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("drifted from pinned version"))
+}
+
+func TestOSSM34Check_DriftToHigherVersion_Blocking(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.5.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("3.5.0"))
+}
+
+func TestOSSM34Check_NoStartingCSV_StillFlags(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("", "servicemeshoperator3.v3.4.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Message).ToNot(ContainSubstring("drifted from pinned version"))
+}
+
+func TestOSSM34Check_EmptyInstalledCSV(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("pending installation"))
+}
+
+func TestOSSM34Check_CanApply_3xTarget(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := ossm34.NewCheck()
+
+	targetVer := semver.MustParse("3.0.0")
+	target := check.Target{
+		TargetVersion: &targetVer,
+	}
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestOSSM34Check_CanApply_2xTarget(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := ossm34.NewCheck()
+
+	targetVer := semver.MustParse("2.17.0")
+	target := check.Target{
+		TargetVersion: &targetVer,
+	}
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestOSSM34Check_CanApply_NilVersion(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := ossm34.NewCheck()
+
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestOSSM34Check_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := ossm34.NewCheck()
+
+	g.Expect(chk.ID()).To(Equal("dependencies.ossm-v3-compatibility.compatibility"))
+	g.Expect(chk.Name()).To(Equal("Dependencies :: OSSM v3 Compatibility :: Version Compatibility"))
+	g.Expect(chk.Group()).To(Equal(check.GroupDependency))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/dependencies/ossm34/ossm34_test.go
+++ b/pkg/lint/checks/dependencies/ossm34/ossm34_test.go
@@ -9,13 +9,16 @@ import (
 	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/ossm34"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -246,6 +249,185 @@ func TestOSSM34Check_UnparsableCSV(t *testing.T) {
 		"Status": Equal(metav1.ConditionUnknown),
 		"Reason": Equal(check.ReasonInsufficientData),
 	}))
+}
+
+func createClusterVersion(ver string) *unstructured.Unstructured {
+	cv := &unstructured.Unstructured{}
+	cv.SetAPIVersion("config.openshift.io/v1")
+	cv.SetKind("ClusterVersion")
+	cv.SetName("version")
+
+	_ = unstructured.SetNestedField(cv.Object, ver, "status", "desired", "version")
+
+	return cv
+}
+
+func TestOSSM34Check_DriftToV34_OCPPatched(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+	cv := createClusterVersion("4.21.22")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM: operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds: map[schema.GroupVersionResource]string{
+			resources.ClusterVersion.GVR(): "ClusterVersionList",
+		},
+		Objects:       []*unstructured.Unstructured{cv},
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("includes the fix"))
+}
+
+func TestOSSM34Check_DriftToV34_OCPHigherPatched(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+	cv := createClusterVersion("4.22.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM: operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds: map[schema.GroupVersionResource]string{
+			resources.ClusterVersion.GVR(): "ClusterVersionList",
+		},
+		Objects:       []*unstructured.Unstructured{cv},
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+}
+
+func TestOSSM34Check_DriftToV34_OCPBelowFix(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+	cv := createClusterVersion("4.21.21")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM: operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds: map[schema.GroupVersionResource]string{
+			resources.ClusterVersion.GVR(): "ClusterVersionList",
+		},
+		Objects:       []*unstructured.Unstructured{cv},
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestOSSM34Check_DriftToV34_OCP420Affected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+	cv := createClusterVersion("4.20.15")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM: operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds: map[schema.GroupVersionResource]string{
+			resources.ClusterVersion.GVR(): "ClusterVersionList",
+		},
+		Objects:       []*unstructured.Unstructured{cv},
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestOSSM34Check_DriftToV34_OCP419Affected(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+	cv := createClusterVersion("4.19.30")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM: operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		ListKinds: map[schema.GroupVersionResource]string{
+			resources.ClusterVersion.GVR(): "ClusterVersionList",
+		},
+		Objects:       []*unstructured.Unstructured{cv},
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestOSSM34Check_DriftToV34_OCPUndetectable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	sub := newSubscription("servicemeshoperator3.v3.1.0", "servicemeshoperator3.v3.4.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		OLM:           operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		TargetVersion: "3.0.0",
+	})
+
+	chk := ossm34.NewCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
 }
 
 func TestOSSM34Check_EmptyInstalledCSV(t *testing.T) {

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/certmanager"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/openshift"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/ossm34"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/servicemesh"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/sharedossm"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/dependencies/sharedserverless"
@@ -125,9 +126,10 @@ func NewCommand(
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())
 
-	// Dependencies (5)
+	// Dependencies (6)
 	registry.MustRegister(certmanager.NewCheck())
 	registry.MustRegister(openshift.NewCheck())
+	registry.MustRegister(ossm34.NewCheck())
 	registry.MustRegister(servicemesh.NewCheck())
 	registry.MustRegister(sharedossm.NewCheck())
 	registry.MustRegister(sharedserverless.NewCheck())


### PR DESCRIPTION
## Description

Detects servicemeshoperator3 subscription drift to v3.4.0+ which causes GatewayConfig to get stuck NotReady on OCP 4.19-4.21 due to Istio v1.26.2 being rejected as end-of-life. Emits a blocking condition with remediation guidance linking to KCS https://access.redhat.com/solutions/7145505.
## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an OSSM v3 dependency check for OpenShift 4.19–4.21 subscription drift based on the installed subscription CSV.
  - Detects drift into OSSM versions and marks results as compatible, incompatible (blocking), unknown (insufficient data), or skipped when data is unavailable.
  - Automatically applies only to OSSM v3 targets and registers the check in the dependencies set.

- **Tests**
  - Expanded test coverage for missing OLM/subscriptions, API errors, unparsable/empty CSV states, OCP-version-dependent outcomes, applicability, and check metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->