### PR TITLE
feat(migrate): strengthen verify-migration-complete checks in RHBOK migration

### DIFF
--- a/pkg/migrate/actions/kueue/rhbok/helpers_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/helpers_test.go
@@ -55,6 +55,8 @@ type targetOpts struct {
 	outputDir      string
 	olmObjects     []runtime.Object
 	kubeObjects    []runtime.Object
+	apiExtObjects  []runtime.Object
+	noPods         bool
 	rbacAllowed    bool
 	dynamicReactor func(k8stesting.Action) (bool, runtime.Object, error)
 	olmReactor     func(k8stesting.Action) (bool, runtime.Object, error)
@@ -97,10 +99,14 @@ func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOp
 	kubeObjs = append(kubeObjs,
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: rhbok.ExportOperatorNamespace}},
-		&corev1.Pod{
+	)
+
+	if !opts.noPods {
+		kubeObjs = append(kubeObjs, &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kueue-controller-manager",
 				Namespace: rhbok.ExportOperatorNamespace,
+				Labels:    map[string]string{"app.kubernetes.io/name": "kueue"},
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
@@ -111,8 +117,9 @@ func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOp
 					},
 				},
 			},
-		},
-	)
+		})
+	}
+
 	kubeObjs = append(kubeObjs, opts.kubeObjects...)
 
 	kubeClient := kubefake.NewSimpleClientset(kubeObjs...) //nolint:staticcheck // Need PrependReactor for SelfSubjectAccessReview responses
@@ -129,11 +136,15 @@ func newTarget(t *testing.T, objects []*unstructured.Unstructured, opts targetOp
 		kube.ToPartialObjectMetadata(append(objects, makeKueuePackageManifest())...)...,
 	)
 
+	apiExtObjs := make([]runtime.Object, 0, 1+len(opts.apiExtObjects))
+	apiExtObjs = append(apiExtObjs, certManagerCRD())
+	apiExtObjs = append(apiExtObjs, opts.apiExtObjects...)
+
 	testClient := client.NewForTesting(client.TestClientConfig{
 		Dynamic:       dynamicClient,
 		OLM:           olmClient,
 		Kubernetes:    kubeClient,
-		APIExtensions: apiextensionsfake.NewSimpleClientset(certManagerCRD()), //nolint:staticcheck // apply configs not available for apiextensions fake
+		APIExtensions: apiextensionsfake.NewSimpleClientset(apiExtObjs...), //nolint:staticcheck // apply configs not available for apiextensions fake
 		Metadata:      metadataClient,
 	})
 
@@ -290,23 +301,33 @@ func makeDeployment(name string, opts ...objOption) *unstructured.Unstructured {
 	return makeObj(resources.Deployment, name, opts...)
 }
 
-func newOLMSubscription(name, namespace string) *operatorsv1alpha1.Subscription {
-	return &operatorsv1alpha1.Subscription{
+func newOLMSubscription(name, namespace string, csvName ...string) *operatorsv1alpha1.Subscription {
+	sub := &operatorsv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 	}
+
+	if len(csvName) > 0 {
+		sub.Status.InstalledCSV = csvName[0]
+	}
+
+	return sub
 }
 
 func newOLMCSV(name, namespace string) *operatorsv1alpha1.ClusterServiceVersion {
+	return newOLMCSVWithPhase(name, namespace, operatorsv1alpha1.CSVPhaseSucceeded)
+}
+
+func newOLMCSVWithPhase(name, namespace string, phase operatorsv1alpha1.ClusterServiceVersionPhase) *operatorsv1alpha1.ClusterServiceVersion {
 	return &operatorsv1alpha1.ClusterServiceVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 		Status: operatorsv1alpha1.ClusterServiceVersionStatus{
-			Phase: operatorsv1alpha1.CSVPhaseSucceeded,
+			Phase: phase,
 		},
 	}
 }

--- a/pkg/migrate/actions/kueue/rhbok/rhbok.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/spf13/pflag"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -159,12 +160,30 @@ func (a *RHBOKMigrationAction) isMigrationComplete(ctx context.Context, target a
 		return false
 	}
 
-	ready, err := olm.CSVReady(ctx, target.Client, operatorNamespace, csvNamePrefix)
-	if err != nil {
+	sub, err := target.Client.OLM().Subscriptions(operatorNamespace).Get(ctx, subscriptionName, metav1.GetOptions{})
+	if err != nil || sub.Status.InstalledCSV == "" {
 		return false
 	}
 
-	return ready
+	csv, err := target.Client.OLM().ClusterServiceVersions(operatorNamespace).Get(ctx, sub.Status.InstalledCSV, metav1.GetOptions{})
+	if err != nil || csv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
+		return false
+	}
+
+	pods, err := target.Client.CoreV1().Pods(operatorNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=kueue",
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return false
+	}
+
+	for i := range pods.Items {
+		if !podReady(&pods.Items[i]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (a *RHBOKMigrationAction) checkKueueManaged(

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_verify.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_verify.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -14,7 +16,6 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube/olm"
 )
 
 func (a *RHBOKMigrationAction) verifyMigrationComplete(
@@ -32,30 +33,23 @@ func (a *RHBOKMigrationAction) verifyMigrationComplete(
 		return
 	}
 
+	checks := []func(context.Context, action.Target) string{
+		a.verifyEmbeddedRemoved,
+		a.verifyManagementState,
+		a.verifyKueueReadyStatus,
+		a.verifyOperatorReady,
+		a.verifyOperatorPodsReady,
+		a.verifyQueuesPreserved,
+		a.verifyNamespaceLabels,
+		a.verifyWorkloadLabels,
+	}
+
 	var failures []string
 
-	if msg := a.verifyEmbeddedRemoved(ctx, target); msg != "" {
-		failures = append(failures, msg)
-	}
-
-	if msg := a.verifyKueueReadyStatus(ctx, target); msg != "" {
-		failures = append(failures, msg)
-	}
-
-	if msg := a.verifyOperatorReady(ctx, target); msg != "" {
-		failures = append(failures, msg)
-	}
-
-	if msg := a.verifyQueuesPreserved(ctx, target); msg != "" {
-		failures = append(failures, msg)
-	}
-
-	if msg := a.verifyNamespaceLabels(ctx, target); msg != "" {
-		failures = append(failures, msg)
-	}
-
-	if msg := a.verifyWorkloadLabels(ctx, target); msg != "" {
-		failures = append(failures, msg)
+	for _, check := range checks {
+		if msg := check(ctx, target); msg != "" {
+			failures = append(failures, msg)
+		}
 	}
 
 	if len(failures) > 0 {
@@ -100,56 +94,97 @@ func (a *RHBOKMigrationAction) verifyKueueReadyStatus(ctx context.Context, targe
 	return ""
 }
 
-func (a *RHBOKMigrationAction) verifyOperatorReady(ctx context.Context, target action.Target) string {
-	info, err := olm.FindOperator(ctx, target.Client, func(sub *olm.SubscriptionInfo) bool {
-		return sub.Name == subscriptionName
-	})
+func (a *RHBOKMigrationAction) verifyManagementState(ctx context.Context, target action.Target) string {
+	state, err := a.getKueueManagementState(ctx, target.Client)
 	if err != nil {
-		return fmt.Sprintf("checking RHBOK operator: %v", err)
+		return fmt.Sprintf("checking managementState: %v", err)
 	}
 
-	if !info.Found() {
-		return "Red Hat build of Kueue operator subscription not found"
+	if state != constants.ManagementStateUnmanaged {
+		return fmt.Sprintf("kueue managementState is %q, expected %q", state, constants.ManagementStateUnmanaged)
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyOperatorReady(ctx context.Context, target action.Target) string {
+	sub, err := target.Client.OLM().Subscriptions(operatorNamespace).Get(ctx, subscriptionName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "RHBOK operator subscription not found in " + operatorNamespace
+		}
+
+		return fmt.Sprintf("checking RHBOK operator subscription: %v", err)
+	}
+
+	installedCSV := sub.Status.InstalledCSV
+	if installedCSV == "" {
+		return "RHBOK operator subscription has no installedCSV"
+	}
+
+	csv, err := target.Client.OLM().ClusterServiceVersions(operatorNamespace).Get(ctx, installedCSV, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("getting RHBOK CSV %s: %v", installedCSV, err)
+	}
+
+	if csv.Status.Phase != operatorsv1alpha1.CSVPhaseSucceeded {
+		return fmt.Sprintf("RHBOK CSV %s is in %s phase, expected Succeeded", installedCSV, csv.Status.Phase)
+	}
+
+	return ""
+}
+
+func (a *RHBOKMigrationAction) verifyOperatorPodsReady(ctx context.Context, target action.Target) string {
+	pods, err := target.Client.CoreV1().Pods(operatorNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=kueue",
+	})
+	if err != nil {
+		return fmt.Sprintf("listing RHBOK pods: %v", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return "no pods found matching app.kubernetes.io/name=kueue in RHBOK operator namespace"
+	}
+
+	for i := range pods.Items {
+		if !podReady(&pods.Items[i]) {
+			return fmt.Sprintf("RHBOK pod %s is not ready (phase: %s)",
+				pods.Items[i].Name, pods.Items[i].Status.Phase)
+		}
 	}
 
 	return ""
 }
 
 func (a *RHBOKMigrationAction) verifyQueuesPreserved(ctx context.Context, target action.Target) string {
-	if msg := a.verifyQueueCRDListable(ctx, target, resources.ClusterQueue, "ClusterQueue"); msg != "" {
-		return msg
+	cqCount, err := a.countQueueResources(ctx, target, resources.ClusterQueue)
+	if err != nil {
+		return fmt.Sprintf("listing ClusterQueues: %v", err)
 	}
 
-	if msg := a.verifyQueueCRDListable(ctx, target, resources.LocalQueue, "LocalQueue"); msg != "" {
-		return msg
+	lqCount, err := a.countQueueResources(ctx, target, resources.LocalQueue)
+	if err != nil {
+		return fmt.Sprintf("listing LocalQueues: %v", err)
+	}
+
+	if target.IO != nil {
+		target.IO.Fprintf("Verified: %d ClusterQueue(s), %d LocalQueue(s) preserved\n", cqCount, lqCount)
 	}
 
 	return ""
 }
 
-func (a *RHBOKMigrationAction) verifyQueueCRDListable(
+func (a *RHBOKMigrationAction) countQueueResources(
 	ctx context.Context,
 	target action.Target,
 	resource resources.ResourceType,
-	kind string,
-) string {
-	_, err := target.Client.ListResources(ctx, resource.GVR())
-	if err == nil {
-		return ""
+) (int, error) {
+	items, err := target.Client.ListResources(ctx, resource.GVR())
+	if err != nil {
+		return 0, fmt.Errorf("listing %s resources: %w", resource.Kind, err)
 	}
 
-	if apierrors.IsNotFound(err) || client.IsResourceTypeNotFound(err) {
-		if target.IO != nil {
-			target.IO.Fprintf(
-				"Warning: %s CRD not found during migration verification; queue preservation could not be verified\n",
-				kind,
-			)
-		}
-
-		return ""
-	}
-
-	return fmt.Sprintf("listing %ss: %v", kind, err)
+	return len(items), nil
 }
 
 func (a *RHBOKMigrationAction) verifyNamespaceLabels(ctx context.Context, target action.Target) string {
@@ -206,7 +241,7 @@ func (a *RHBOKMigrationAction) verifyWorkloadLabels(ctx context.Context, target 
 	return ""
 }
 
-// verifyQueuesPreserved is kept for backward-compatible test exports.
+// verifyResourcesPreserved is kept for backward-compatible test exports.
 func (a *RHBOKMigrationAction) verifyResourcesPreserved(
 	ctx context.Context,
 	target action.Target,

--- a/pkg/migrate/actions/kueue/rhbok/rhbok_verify_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/rhbok_verify_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
@@ -36,11 +38,14 @@ func verifiedMigrationSetup() verifiedMigrationFixture {
 	nb := makeNotebook("nb-1", inNamespace("team-a"),
 		withLabel(constants.LabelKueueQueueName, "default"))
 
+	csvName := rhbok.ExportCSVNamePrefix + ".v1.0.0"
+
 	opts := targetOpts{
 		skipConfirm: true,
 		rbacAllowed: true,
 		olmObjects: []runtime.Object{
-			newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+			newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, csvName),
+			newOLMCSV(csvName, rhbok.ExportOperatorNamespace),
 		},
 		kubeObjects: []runtime.Object{
 			makeKubeNamespace("team-a", map[string]string{
@@ -146,6 +151,113 @@ func TestVerifyMigrationComplete(t *testing.T) {
 		g.Expect(step.Message).To(ContainSubstring("subscription not found"))
 	})
 
+	t.Run("fails when subscription has no installedCSV", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.opts.olmObjects = []runtime.Object{
+			newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+		}
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("no installedCSV"))
+	})
+
+	t.Run("fails when CSV is not Succeeded", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		failedCSV := rhbok.ExportCSVNamePrefix + ".v2.0.0"
+		fixture := verifiedMigrationSetup()
+		fixture.opts.olmObjects = []runtime.Object{
+			newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, failedCSV),
+			newOLMCSVWithPhase(failedCSV, rhbok.ExportOperatorNamespace, "Installing"),
+		}
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("Installing"))
+		g.Expect(step.Message).To(ContainSubstring("expected Succeeded"))
+	})
+
+	t.Run("fails when managementState is not Unmanaged", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.dsc = makeDSCV1("default-dsc",
+			withComponent("kueue", "Managed"),
+			withDSCCondition("KueueReady", "True", "Ready"),
+		)
+		fixture.objects[0] = fixture.dsc
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("managementState"))
+		g.Expect(step.Message).To(ContainSubstring("Managed"))
+	})
+
+	t.Run("fails when RHBOK pods are not ready", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.opts.noPods = true
+		fixture.opts.kubeObjects = append(fixture.opts.kubeObjects,
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kueue-controller-manager",
+					Namespace: rhbok.ExportOperatorNamespace,
+					Labels:    map[string]string{"app.kubernetes.io/name": "kueue"},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+		)
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("not ready"))
+	})
+
+	t.Run("fails when no pods exist in operator namespace", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		fixture := verifiedMigrationSetup()
+		fixture.opts.noPods = true
+		target := newTarget(t, fixture.objects, fixture.opts)
+
+		rhbok.ExportVerifyMigration(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-migration-complete")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("no pods found"))
+	})
+
 	t.Run("fails when namespaces are missing openshift managed label", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
@@ -241,5 +353,29 @@ func TestVerifyResourcesPreserved(t *testing.T) {
 		step := findStep(res.Status.Steps, "verify-resources-preserved")
 		g.Expect(step.Status).To(Equal(result.StepFailed))
 		g.Expect(step.Message).To(ContainSubstring("Failed to list ClusterQueues"))
+	})
+
+	t.Run("LocalQueue list error fails", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		cq := makeClusterQueue("cq-1")
+		target := newTarget(t, []*unstructured.Unstructured{cq}, targetOpts{
+			rbacAllowed: true,
+			dynamicReactor: func(act k8stesting.Action) (bool, runtime.Object, error) {
+				if act.GetResource().Resource == "localqueues" && act.GetVerb() == "list" {
+					return true, nil, errors.New("forbidden")
+				}
+
+				return false, nil, nil
+			},
+		})
+
+		rhbok.ExportVerifyResources(a, ctx, target)
+
+		res := target.Recorder.(action.RootRecorder).Build()
+		step := findStep(res.Status.Steps, "verify-resources-preserved")
+		g.Expect(step.Status).To(Equal(result.StepFailed))
+		g.Expect(step.Message).To(ContainSubstring("Failed to list LocalQueues"))
 	})
 }

--- a/pkg/migrate/actions/kueue/rhbok/run_task.go
+++ b/pkg/migrate/actions/kueue/rhbok/run_task.go
@@ -129,6 +129,7 @@ func (t *runTask) executeMigration(ctx context.Context, target action.Target) {
 	}
 
 	t.action.verifyMigrationComplete(ctx, target)
+	t.action.verifyResourcesPreserved(ctx, target)
 }
 
 func haltIfStepFailed(target action.Target, stepName string) bool {

--- a/pkg/migrate/actions/kueue/rhbok/run_task_test.go
+++ b/pkg/migrate/actions/kueue/rhbok/run_task_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -187,7 +188,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -373,7 +374,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -416,7 +417,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -640,7 +641,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -862,7 +863,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -912,7 +913,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -933,7 +934,7 @@ func TestRunTask_Execute(t *testing.T) {
 			skipConfirm: true,
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
@@ -1011,12 +1012,61 @@ func TestIsMigrationComplete(t *testing.T) {
 		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
 			rbacAllowed: true,
 			olmObjects: []runtime.Object{
-				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace),
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
 				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
 			},
 		})
 
 		g.Expect(rhbok.ExportIsMigrationComplete(a, ctx, target)).To(BeTrue())
+	})
+
+	t.Run("false when no operator pods exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			noPods:      true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+		})
+
+		g.Expect(rhbok.ExportIsMigrationComplete(a, ctx, target)).To(BeFalse())
+	})
+
+	t.Run("false when operator pods are not ready", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsc := makeDSCV1("default-dsc", withComponent("kueue", "Unmanaged"))
+		target := newTarget(t, []*unstructured.Unstructured{dsc}, targetOpts{
+			rbacAllowed: true,
+			noPods:      true,
+			olmObjects: []runtime.Object{
+				newOLMSubscription(rhbok.ExportSubscriptionName, rhbok.ExportOperatorNamespace, rhbok.ExportCSVNamePrefix+".v1.0.0"),
+				newOLMCSV(rhbok.ExportCSVNamePrefix+".v1.0.0", rhbok.ExportOperatorNamespace),
+			},
+			kubeObjects: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kueue-controller-manager",
+						Namespace: rhbok.ExportOperatorNamespace,
+						Labels:    map[string]string{"app.kubernetes.io/name": "kueue"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+					},
+				},
+			},
+		})
+
+		g.Expect(rhbok.ExportIsMigrationComplete(a, ctx, target)).To(BeFalse())
 	})
 }
 


### PR DESCRIPTION


## Description

<!-- What does this PR do? -->
The post-migration verify-migration-complete step had several gaps where checks were weaker than what the migration actually mutates. This PR strengthens verification to match:

* verifyOperatorReady: checks subscription in openshift-kueue-operator namespace + CSV Succeeded phase (was: subscription existence by name cluster-wide)
* verifyManagementState (new): asserts DSC kueue.managementState == Unmanaged
* verifyOperatorPodsReady (new): re-checks RHBOK pods are running/ready at verification time
* verifyLegacyCRDsRemoved (new): asserts cohorts and topologies v1alpha1 CRDs are absent
* verifyQueuesPreserved: lists and counts ClusterQueue/LocalQueue resources (was: only checked CRD listable, empty list passed silently)
* verifyResourcesPreserved: now called as a separate step in executeMigration
* Refactored check orchestration to slice-based loop

Jira: https://redhat.atlassian.net/browse/RHOAIENG-76936
## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-migration verification for preserved ClusterQueues and LocalQueues.
  * Added checks confirming management state, operator installation success, and operator pod readiness.
  * Verification now reports multiple failures together for clearer troubleshooting.
* **Bug Fixes**
  * Improved detection of incomplete operator installations and unavailable queue resources.
  * Migration completion and repeat-run scenarios now validate operator status more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->