### PR TITLE
fix(migrate): detect auth model failures in upgrade-2x-to-3x and prevent unsafe cleanup

### DIFF
--- a/pkg/migrate/action/result/result.go
+++ b/pkg/migrate/action/result/result.go
@@ -75,6 +75,10 @@ func (r *ActionResult) HasSkippedSteps() bool {
 	return hasSkipped(r.Status.Steps)
 }
 
+func (r *ActionResult) HasFailedSteps() bool {
+	return hasFailed(r.Status.Steps)
+}
+
 func hasSkipped(steps []ActionStep) bool {
 	for _, s := range steps {
 		if s.Status == StepSkipped {
@@ -82,6 +86,20 @@ func hasSkipped(steps []ActionStep) bool {
 		}
 
 		if hasSkipped(s.Children) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasFailed(steps []ActionStep) bool {
+	for _, s := range steps {
+		if s.Status == StepFailed {
+			return true
+		}
+
+		if hasFailed(s.Children) {
 			return true
 		}
 	}

--- a/pkg/migrate/action/result/result_test.go
+++ b/pkg/migrate/action/result/result_test.go
@@ -61,3 +61,54 @@ func TestHasSkippedSteps(t *testing.T) {
 		g.Expect(r.HasSkippedSteps()).To(BeFalse())
 	})
 }
+
+func TestHasFailedSteps(t *testing.T) {
+	t.Run("should return false when no steps", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		g.Expect(r.HasFailedSteps()).To(BeFalse())
+	})
+
+	t.Run("should return false when all steps completed", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		r.Status.Steps = []result.ActionStep{
+			result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+			result.NewStep("step2", "Step 2", result.StepCompleted, "done"),
+		}
+		g.Expect(r.HasFailedSteps()).To(BeFalse())
+	})
+
+	t.Run("should return true when top-level step failed", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		r.Status.Steps = []result.ActionStep{
+			result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+			result.NewStep("step2", "Step 2", result.StepFailed, "something broke"),
+		}
+		g.Expect(r.HasFailedSteps()).To(BeTrue())
+	})
+
+	t.Run("should return true when nested child step failed", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+
+		parent := result.NewStep("parent", "Parent", result.StepCompleted, "done")
+		parent.Children = []result.ActionStep{
+			result.NewStep("child", "Child", result.StepFailed, "failed"),
+		}
+
+		r.Status.Steps = []result.ActionStep{parent}
+		g.Expect(r.HasFailedSteps()).To(BeTrue())
+	})
+
+	t.Run("should return false when only skipped steps", func(t *testing.T) {
+		g := NewWithT(t)
+		r := result.New("migration", "test", "Test", "")
+		r.Status.Steps = []result.ActionStep{
+			result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+			result.NewStep("step2", "Step 2", result.StepSkipped, "skipped"),
+		}
+		g.Expect(r.HasFailedSteps()).To(BeFalse())
+	})
+}

--- a/pkg/migrate/actions/workbenches/authmodel/run_task.go
+++ b/pkg/migrate/actions/workbenches/authmodel/run_task.go
@@ -435,7 +435,7 @@ func (t *runTask) runCleanup(
 			continue
 		}
 
-		if cleanup.CleanupNotebook(ctx, target, refreshed, cleanupStep) == cleanup.CleanupResultCleaned {
+		if cleanup.CleanupNotebookAfterPatch(ctx, target, refreshed, cleanupStep) == cleanup.CleanupResultCleaned {
 			successCount++
 		} else {
 			failCount++

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup.go
@@ -138,6 +138,8 @@ const (
 
 // CleanupNotebook deletes the legacy OAuth resources for a single notebook.
 // It runs the pre-check and prompts for confirmation if the check fails.
+// When SkipConfirm is true (non-interactive mode) and the pre-check fails,
+// cleanup is refused to prevent deleting secrets from unpatched notebooks.
 func CleanupNotebook(
 	ctx context.Context,
 	target action.Target,
@@ -159,26 +161,65 @@ func CleanupNotebook(
 			result.StepFailed,
 			strings.Join(failures, "; "))
 
-		if !target.SkipConfirm {
-			target.IO.Fprintln()
-			target.IO.Errorf("Pre-checks failed for %s/%s:", namespace, name)
+		if target.SkipConfirm {
+			step.Completef(result.StepFailed,
+				"Skipping cleanup for %s/%s: notebook has not been migrated to kube-rbac-proxy (run workbenches.patch-auth-model first)",
+				namespace, name)
 
-			for _, f := range failures {
-				target.IO.Errorf("  - %s", f)
-			}
+			return CleanupResultFailed
+		}
 
-			if !confirmation.Prompt(target.IO,
-				fmt.Sprintf("Continue cleanup for %s/%s despite failed pre-checks?", namespace, name)) {
-				step.Completef(result.StepSkipped,
-					"Skipped cleanup for %s/%s (pre-check failed)", namespace, name)
+		target.IO.Fprintln()
+		target.IO.Errorf("Pre-checks failed for %s/%s:", namespace, name)
 
-				return CleanupResultSkipped
-			}
+		for _, f := range failures {
+			target.IO.Errorf("  - %s", f)
+		}
+
+		if !confirmation.Prompt(target.IO,
+			fmt.Sprintf("Continue cleanup for %s/%s despite failed pre-checks?", namespace, name)) {
+			step.Completef(result.StepSkipped,
+				"Skipped cleanup for %s/%s (pre-check failed)", namespace, name)
+
+			return CleanupResultSkipped
 		}
 
 		step.Recordf("precheck-override",
 			"Continuing cleanup despite failed pre-checks", result.StepCompleted)
 	}
+
+	return deleteOAuthResources(ctx, target, nb, step)
+}
+
+// CleanupNotebookAfterPatch deletes legacy OAuth resources for a notebook that
+// was just patched by patch-auth-model. Skips the migration pre-check because
+// the kube-rbac-proxy sidecar is injected by the controller during reconciliation,
+// not by the CLI patch.
+func CleanupNotebookAfterPatch(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+	parentStep action.StepRecorder,
+) CleanupResult {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
+
+	step := parentStep.Child(
+		fmt.Sprintf("cleanup-%s-%s", namespace, name),
+		fmt.Sprintf("Clean up OAuth resources for %s/%s", namespace, name),
+	)
+
+	return deleteOAuthResources(ctx, target, nb, step)
+}
+
+func deleteOAuthResources(
+	ctx context.Context,
+	target action.Target,
+	nb *unstructured.Unstructured,
+	step action.StepRecorder,
+) CleanupResult {
+	name := nb.GetName()
+	namespace := nb.GetNamespace()
 
 	hasFailed := !DeleteResourceIfPresent(ctx, target,
 		resources.Route.GVR(), name, namespace, step)

--- a/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
+++ b/pkg/migrate/actions/workbenches/cleanup/cleanup_test.go
@@ -775,15 +775,48 @@ func TestRunTask_Execute_PreCheckFails_SkipConfirm(t *testing.T) {
 	a := &CleanupOAuthAction{Scope: &workbenches.SharedScopeOptions{}}
 	task := a.Run()
 
-	result, err := task.Execute(ctx, target)
+	actionResult, err := task.Execute(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
 
-	// SkipConfirm=true means pre-check failure is overridden and cleanup proceeds
+	// SkipConfirm=true with failed pre-check means cleanup is refused (resources NOT deleted)
 	_, err = k8sClient.Dynamic().Resource(resources.Route.GVR()).
 		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
-	g.Expect(err).To(HaveOccurred(), "route should be deleted even with failed pre-check (SkipConfirm)")
+	g.Expect(err).ToNot(HaveOccurred(), "route should still exist when pre-check fails with SkipConfirm")
+}
+
+func TestCleanupNotebookAfterPatch_SkipsPreCheck(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("wb1", "ns1",
+		withContainers(container("my-notebook")))
+
+	objects := append(
+		[]*unstructured.Unstructured{nb},
+		allOAuthResources("wb1", "ns1")...,
+	)
+	k8sClient := newFakeClient(objects)
+	target := newTarget(k8sClient)
+
+	parentStep := target.Recorder.Child("test-parent", "Test parent step")
+
+	cleanupResult := CleanupNotebookAfterPatch(ctx, target, nb, parentStep)
+	g.Expect(cleanupResult).To(Equal(CleanupResultCleaned))
+
+	_, err := k8sClient.Dynamic().Resource(resources.Route.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "route should be deleted even though pre-check would fail")
+
+	_, err = k8sClient.Dynamic().Resource(resources.Secret.GVR()).
+		Namespace("ns1").Get(context.Background(), "wb1-oauth-config", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "oauth-config secret should be deleted")
+
+	_, err = k8sClient.Dynamic().Resource(resources.OAuthClient.GVR()).
+		Get(context.Background(), "wb1-ns1-oauth-client", metav1.GetOptions{})
+	g.Expect(err).To(HaveOccurred(), "oauthclient should be deleted")
 }
 
 func TestRunTask_Execute_PreCheckFails_UserSkips(t *testing.T) {

--- a/pkg/migrate/actions/workbenches/upgrade/run_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/run_task.go
@@ -3,11 +3,13 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/workbenches"
 )
 
 type runTask struct {
@@ -68,6 +70,8 @@ func (t *runTask) Validate(
 			"All %d stopped Notebook(s) have correct container names", len(stopped))
 	}
 
+	t.verifyAuthModel(target, stopped)
+
 	return buildResult(target.Recorder)
 }
 
@@ -105,6 +109,8 @@ func (t *runTask) Execute(
 	}
 
 	t.fixContainerNames(ctx, target, stopped)
+
+	t.verifyAuthModel(target, stopped)
 
 	return buildResult(target.Recorder)
 }
@@ -191,6 +197,41 @@ func (t *runTask) fixContainerNames(
 	} else {
 		step.Completef(result.StepCompleted,
 			"Fixed container names in %d/%d Notebook(s)", successCount, len(toFix))
+	}
+}
+
+func (t *runTask) verifyAuthModel(
+	target action.Target,
+	notebooks []*unstructured.Unstructured,
+) {
+	step := target.Recorder.Child(
+		"verify-auth-model",
+		"Verify workbench auth model migration",
+	)
+
+	needsPatchCount := 0
+
+	for _, nb := range notebooks {
+		passed, failures := workbenches.CheckMigrationState(nb)
+		if !passed {
+			step.Recordf(
+				fmt.Sprintf("auth-model-%s-%s", nb.GetNamespace(), nb.GetName()),
+				"%s/%s needs auth model patch: %s",
+				result.StepFailed,
+				nb.GetNamespace(), nb.GetName(), strings.Join(failures, "; "),
+			)
+
+			needsPatchCount++
+		}
+	}
+
+	if needsPatchCount > 0 {
+		step.Completef(result.StepFailed,
+			"%d Notebook(s) still have legacy OAuth-proxy sidecar — run workbenches.patch-auth-model to complete migration",
+			needsPatchCount)
+	} else {
+		step.Completef(result.StepCompleted,
+			"All %d Notebook(s) have correct auth model", len(notebooks))
 	}
 }
 

--- a/pkg/migrate/actions/workbenches/upgrade/run_task.go
+++ b/pkg/migrate/actions/workbenches/upgrade/run_task.go
@@ -40,6 +40,13 @@ func (t *runTask) Validate(
 
 	stopped := t.action.handleNonStoppedNotebooks(target, notebooks, step)
 
+	if len(stopped) == 0 {
+		step.Completef(result.StepSkipped,
+			"No eligible Notebook(s) to validate (all non-stopped)")
+
+		return buildResult(target.Recorder)
+	}
+
 	mismatchCount := 0
 	checkErrCount := 0
 
@@ -227,11 +234,11 @@ func (t *runTask) verifyAuthModel(
 
 	if needsPatchCount > 0 {
 		step.Completef(result.StepFailed,
-			"%d Notebook(s) still have legacy OAuth-proxy sidecar — run workbenches.patch-auth-model to complete migration",
+			"%d stopped Notebook(s) still have legacy OAuth-proxy sidecar — run workbenches.patch-auth-model to complete migration",
 			needsPatchCount)
 	} else {
 		step.Completef(result.StepCompleted,
-			"All %d Notebook(s) have correct auth model", len(notebooks))
+			"All %d stopped Notebook(s) have correct auth model", len(notebooks))
 	}
 }
 

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade.go
@@ -24,7 +24,8 @@ import (
 const (
 	actionID          = "workbenches.upgrade-2x-to-3x"
 	actionName        = "Upgrade workbenches from 2.x to 3.x"
-	actionDescription = "Updates workbench notebook container names for 3.x compatibility"
+	actionDescription = "Updates workbench notebook container names for 3.x compatibility. " +
+		"Run workbenches.patch-auth-model separately to complete the auth model migration."
 
 	annotationKubeflowResourceStopped = "kubeflow-resource-stopped"
 	annotationAcceleratorName         = "opendatahub.io/accelerator-name"

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -1400,10 +1400,15 @@ func TestRunTask_Validate_WithNonStopped(t *testing.T) {
 	a := &WorkbenchUpgradeAction{}
 	runTask := a.Run()
 
-	result, err := runTask.Validate(ctx, target)
+	actionResult, err := runTask.Validate(ctx, target)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result).ToNot(BeNil())
-	g.Expect(result.Status.Completed).To(BeTrue())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeFalse())
+
+	for _, step := range actionResult.Status.Steps {
+		g.Expect(step.Name).ToNot(Equal("verify-auth-model"))
+	}
 }
 
 func TestRunTask_Execute_NonSkipConfirm_UserConfirms(t *testing.T) {

--- a/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
+++ b/pkg/migrate/actions/workbenches/upgrade/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
@@ -1857,6 +1858,170 @@ func TestWorkbenchUpgradeAction_AddFlags(t *testing.T) {
 	flag := fs.Lookup("force-non-stopped")
 	g.Expect(flag).ToNot(BeNil())
 	g.Expect(flag.DefValue).To(Equal("false"))
+}
+
+// --- Auth Model Verification Tests ---
+
+func oauthAnnotations() map[string]any {
+	return map[string]any{
+		"kubeflow-resource-stopped":                    "2026-01-15T00:00:00Z",
+		"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+		"notebooks.opendatahub.io/inject-oauth":        "true",
+	}
+}
+
+func patchedAuthAnnotations() map[string]any {
+	return map[string]any{
+		"kubeflow-resource-stopped":                    "2026-01-15T00:00:00Z",
+		"notebooks.opendatahub.io/last-size-selection": `{"name":"Small"}`,
+		"notebooks.opendatahub.io/inject-auth":         "true",
+	}
+}
+
+func TestRunTask_Validate_DetectsLegacyAuthModel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: oauthAnnotations(),
+		Containers: []any{
+			container("my-notebook", "jupyter:latest"),
+			container("oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest"),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+
+	hasAuthModelStep := false
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "verify-auth-model" {
+			hasAuthModelStep = true
+			g.Expect(step.Status).To(Equal(result.StepFailed))
+			g.Expect(step.Message).To(ContainSubstring("patch-auth-model"))
+		}
+	}
+
+	g.Expect(hasAuthModelStep).To(BeTrue())
+}
+
+func TestRunTask_Execute_DetectsLegacyAuthModel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: oauthAnnotations(),
+		Containers: []any{
+			container("my-notebook", "jupyter:latest"),
+			container("oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest"),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+
+	hasAuthModelStep := false
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "verify-auth-model" {
+			hasAuthModelStep = true
+			g.Expect(step.Status).To(Equal(result.StepFailed))
+			g.Expect(step.Message).To(ContainSubstring("patch-auth-model"))
+		}
+	}
+
+	g.Expect(hasAuthModelStep).To(BeTrue())
+}
+
+func TestRunTask_Execute_AuthModelAlreadyPatched(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: patchedAuthAnnotations(),
+		Containers: []any{
+			container("my-notebook", "jupyter:latest"),
+			container("kube-rbac-proxy", "registry/kube-rbac-proxy:latest"),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeFalse())
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "verify-auth-model" {
+			g.Expect(step.Status).To(Equal(result.StepCompleted))
+		}
+	}
+}
+
+func TestRunTask_Execute_FixesNamesAndDetectsAuthModel(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	nb := newNotebook("my-notebook", "ns1", notebookOpts{
+		Annotations: oauthAnnotations(),
+		Containers: []any{
+			container("old-name", "jupyter:latest"),
+			container("oauth-proxy", "registry/ose-oauth-proxy-rhel9:latest"),
+		},
+	})
+
+	k8sClient := newFakeClient(newScheme(), nb)
+	target := newTarget(k8sClient)
+
+	a := &WorkbenchUpgradeAction{}
+	runTask := a.Run()
+
+	actionResult, err := runTask.Execute(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(actionResult).ToNot(BeNil())
+	g.Expect(actionResult.Status.Completed).To(BeTrue())
+	g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+
+	updated, err := k8sClient.Dynamic().Resource(resources.Notebook.GVR()).
+		Namespace("ns1").Get(context.Background(), "my-notebook", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	containers, _ := extractWorkloadContainersFromUnstructured(updated)
+	g.Expect(containers).To(HaveLen(2))
+	g.Expect(containers[0]["name"]).To(Equal("my-notebook"))
+	g.Expect(containers[1]["name"]).To(Equal("oauth-proxy"))
+
+	for _, step := range actionResult.Status.Steps {
+		if step.Name == "verify-auth-model" {
+			g.Expect(step.Status).To(Equal(result.StepFailed))
+			g.Expect(step.Message).To(ContainSubstring("patch-auth-model"))
+		}
+	}
 }
 
 // --- Test Helpers ---

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -303,6 +303,7 @@ type MigrationResultItem struct {
 	Completed       bool   `json:"completed"                 yaml:"completed"`
 	Skipped         bool   `json:"skipped,omitempty"         yaml:"skipped,omitempty"`
 	HasSkippedSteps bool   `json:"hasSkippedSteps,omitempty" yaml:"hasSkippedSteps,omitempty"`
+	HasFailedSteps  bool   `json:"hasFailedSteps,omitempty"  yaml:"hasFailedSteps,omitempty"`
 	PhaseMismatch   bool   `json:"phaseMismatch,omitempty"   yaml:"phaseMismatch,omitempty"`
 }
 
@@ -316,6 +317,18 @@ func countWarnings(migrations []MigrationResultItem) int {
 	}
 
 	return warnings
+}
+
+func countErrors(migrations []MigrationResultItem) int {
+	errs := 0
+
+	for _, m := range migrations {
+		if m.HasFailedSteps {
+			errs++
+		}
+	}
+
+	return errs
 }
 
 func (c *PrepareCommand) writePrepareResult(

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -301,14 +301,16 @@ func (c *RunCommand) runMigrationMode(
 		skippedSteps := actionResult.HasSkippedSteps()
 		failedSteps := actionResult.HasFailedSteps()
 
+		if skippedSteps {
+			hasSkips = true
+		}
+
 		if failedSteps {
 			c.IO.Errorf("Migration %s completed with failures", migrationID)
 
 			hasFailures = true
 		} else if skippedSteps {
 			c.IO.Errorf("Migration %s completed with skipped steps", migrationID)
-
-			hasSkips = true
 		} else {
 			c.IO.Errorf("Migration %s completed successfully!", migrationID)
 		}

--- a/pkg/migrate/command_run.go
+++ b/pkg/migrate/command_run.go
@@ -230,6 +230,7 @@ func (c *RunCommand) runMigrationMode(
 	actionIO := actionIOForMode(c.IO, structured)
 
 	hasSkips := false
+	hasFailures := false
 
 	var migrationResults []MigrationResultItem
 
@@ -297,9 +298,14 @@ func (c *RunCommand) runMigrationMode(
 			return clierrors.NewExitCodeError(clierrors.ExitValidation,
 				fmt.Errorf("migration halted: %s", migrationID))
 		}
-
 		skippedSteps := actionResult.HasSkippedSteps()
-		if skippedSteps {
+		failedSteps := actionResult.HasFailedSteps()
+
+		if failedSteps {
+			c.IO.Errorf("Migration %s completed with failures", migrationID)
+
+			hasFailures = true
+		} else if skippedSteps {
 			c.IO.Errorf("Migration %s completed with skipped steps", migrationID)
 
 			hasSkips = true
@@ -311,6 +317,7 @@ func (c *RunCommand) runMigrationMode(
 			ID:              migrationID,
 			Completed:       actionResult.Status.Completed,
 			HasSkippedSteps: skippedSteps,
+			HasFailedSteps:  failedSteps,
 			PhaseMismatch:   phaseMismatch,
 		})
 	}
@@ -319,7 +326,21 @@ func (c *RunCommand) runMigrationMode(
 		return c.writeRunResult(currentVersion, targetVersion, effectivePhase, migrationResults)
 	}
 
+	return c.reportRunSummary(hasFailures, hasSkips)
+}
+
+func (c *RunCommand) reportRunSummary(hasFailures, hasSkips bool) error {
 	c.IO.Fprintln()
+
+	if hasFailures {
+		if hasSkips {
+			c.IO.Errorf("All migrations completed (some steps failed, some were skipped). Review the output above for details.")
+		} else {
+			c.IO.Errorf("All migrations completed (some steps failed). Review the output above for details.")
+		}
+
+		return errors.New("one or more migrations completed with failures")
+	}
 
 	if hasSkips {
 		c.IO.Errorf("All migrations completed (some steps were skipped).")
@@ -355,7 +376,15 @@ func (c *RunCommand) writeRunResult(
 		DryRun:         c.DryRun,
 		Migrations:     migrations,
 	}
-	result.SetStatus(countWarnings(migrations), 0)
+	result.SetStatus(countWarnings(migrations), countErrors(migrations))
+
+	if errCount := countErrors(migrations); errCount > 0 {
+		if err := writeStructuredOutput(c.IO.Out(), c.OutputFormat, result); err != nil {
+			return err
+		}
+
+		return errors.New("one or more migrations completed with failures")
+	}
 
 	return writeStructuredOutput(c.IO.Out(), c.OutputFormat, result)
 }

--- a/pkg/migrate/command_run_internal_test.go
+++ b/pkg/migrate/command_run_internal_test.go
@@ -58,6 +58,17 @@ func newIncompleteResult() *result.ActionResult {
 	return r
 }
 
+func newResultWithFailedSteps() *result.ActionResult {
+	r := result.New("migration", "test", "Test", "")
+	r.Status.Completed = true
+	r.Status.Steps = []result.ActionStep{
+		result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+		result.NewStep("step2", "Step 2", result.StepFailed, "auth model not patched"),
+	}
+
+	return r
+}
+
 type runTestStreams struct {
 	cmd    *RunCommand
 	outBuf *bytes.Buffer
@@ -216,6 +227,45 @@ func TestRunMigrationMode(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(errBuf.String()).To(ContainSubstring("completed with skipped steps"))
 		g.Expect(errBuf.String()).To(ContainSubstring("some steps were skipped"))
+		g.Expect(errBuf.String()).ToNot(ContainSubstring("completed successfully"))
+	})
+
+	t.Run("should report failed steps and return error", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "fail.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newResultWithFailedSteps()},
+		})
+		cmd.MigrationIDs = []string{"fail.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("completed with failures"))
+		g.Expect(errBuf.String()).To(ContainSubstring("completed with failures"))
+		g.Expect(errBuf.String()).To(ContainSubstring("some steps failed"))
+		g.Expect(errBuf.String()).ToNot(ContainSubstring("completed successfully"))
+	})
+
+	t.Run("should report failures over skips when both present across migrations", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "fail.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newResultWithFailedSteps()},
+		})
+		cmd.registry.MustRegister(&stubAction{
+			id: "skip.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newResultWithSkippedSteps()},
+		})
+		cmd.MigrationIDs = []string{"fail.action", "skip.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("completed with failures"))
+		g.Expect(errBuf.String()).To(ContainSubstring("completed with failures"))
 		g.Expect(errBuf.String()).ToNot(ContainSubstring("completed successfully"))
 	})
 

--- a/pkg/migrate/command_run_internal_test.go
+++ b/pkg/migrate/command_run_internal_test.go
@@ -69,6 +69,18 @@ func newResultWithFailedSteps() *result.ActionResult {
 	return r
 }
 
+func newResultWithFailedAndSkippedSteps() *result.ActionResult {
+	r := result.New("migration", "test", "Test", "")
+	r.Status.Completed = true
+	r.Status.Steps = []result.ActionStep{
+		result.NewStep("step1", "Step 1", result.StepCompleted, "done"),
+		result.NewStep("step2", "Step 2", result.StepSkipped, "user cancelled"),
+		result.NewStep("step3", "Step 3", result.StepFailed, "auth model not patched"),
+	}
+
+	return r
+}
+
 type runTestStreams struct {
 	cmd    *RunCommand
 	outBuf *bytes.Buffer
@@ -265,7 +277,24 @@ func TestRunMigrationMode(t *testing.T) {
 		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("completed with failures"))
-		g.Expect(errBuf.String()).To(ContainSubstring("completed with failures"))
+		g.Expect(errBuf.String()).To(ContainSubstring("some steps failed, some were skipped"))
+		g.Expect(errBuf.String()).ToNot(ContainSubstring("completed successfully"))
+	})
+
+	t.Run("should track skips when single migration has both failed and skipped steps", func(t *testing.T) {
+		g := NewWithT(t)
+		cmd, errBuf := newTestRunCommand()
+
+		cmd.registry.MustRegister(&stubAction{
+			id: "mixed.action", phase: action.PhasePreUpgrade, canApply: true,
+			runTask: &stubTask{result: newResultWithFailedAndSkippedSteps()},
+		})
+		cmd.MigrationIDs = []string{"mixed.action"}
+
+		err := cmd.runMigrationMode(context.Background(), &current, &target, action.PhasePreUpgrade)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("completed with failures"))
+		g.Expect(errBuf.String()).To(ContainSubstring("some steps failed, some were skipped"))
 		g.Expect(errBuf.String()).ToNot(ContainSubstring("completed successfully"))
 	})
 


### PR DESCRIPTION
## Description

The upgrade-2x-to-3x migration reported success even when notebooks still had legacy oauth-proxy sidecars, causing downstream cleanup-oauth to delete secrets from unpatched notebooks and leaving them un-startable.

- Add HasFailedSteps() to ActionResult so the CLI runner returns non-zero exit on step failures
- Add auth model verification step to upgrade-2x-to-3x (both Execute and Validate paths) that detects legacy oauth-proxy and directs users to run patch-auth-model
- Refuse cleanup-oauth on unpatched notebooks in non-interactive mode (SkipConfirm=true) to prevent silent secret deletion
- Add CleanupNotebookAfterPatch for patch-auth-model's internal cleanup that skips the pre-check (kube-rbac-proxy is injected by controller)
- Enhanced summary message when both failures and skips are present

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Migration runs now clearly report failed steps and return an error when failures occur.
  - Cleanup is prevented when migration pre-checks fail in non-interactive mode.
  - Post-patch cleanup now correctly removes obsolete authentication resources.
  - Upgrade validation detects workbenches requiring authentication model updates.

- **User Experience**
  - Upgrade guidance now directs users to run the authentication model patch separately.
  - Final migration summaries distinguish failures from skipped steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->