### PR TITLE
fix(lint): handle noOLM Gateway API mode in OSSM v3 check

### DIFF
--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -22,6 +24,8 @@ import (
 const kind = "servicemesh-v3"
 
 const displayName = "Red Hat Service Mesh v3"
+
+const subscriptionName = "servicemeshoperator3"
 
 // mirrorRemediationFmt is the shared remediation template for failures where the required
 // servicemeshoperator3 CSV is not available in the cluster catalog.
@@ -99,9 +103,9 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 			check.ConditionTypeAvailable,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonResourceNotFound),
-			check.WithMessage("ingress-operator deployment not found in openshift-ingress-operator namespace"),
-			check.WithRemediation("Check that the openshift-ingress-operator namespace and the ingress-operator deployment exist in the cluster."),
-			check.WithImpact(result.ImpactBlocking),
+			check.WithMessage("ingress-operator deployment not found in openshift-ingress-operator namespace; unable to determine required OSSM version (expected on HCP clusters)"),
+			check.WithRemediation("If this is a Hosted Control Plane (HCP) cluster, this check can be safely ignored. Otherwise, verify that the openshift-ingress-operator namespace and ingress-operator deployment exist."),
+			check.WithImpact(result.ImpactAdvisory),
 		))
 
 		return dr, nil
@@ -136,18 +140,45 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	requiredCSV := requiredVersion
 	displayVersion := strings.TrimPrefix(requiredCSV, "servicemeshoperator3.v")
 
-	// Step 5: Find the servicemeshoperator3 PackageManifest from redhat-operators in openshift-marketplace.
-	// Multiple catalog sources can produce PackageManifests with the same name, so we list all
-	// PackageManifests and filter by .status.catalogSource. A direct get-by-name would return a
-	// non-deterministic result when multiple catalog sources provide the same package.
+	// Step 5: Check for noOLM mode. On OCP 4.21.22+ / 4.22+, the Cluster Ingress Operator
+	// deploys istiod directly (Sail Library) without an OSSM OLM subscription. When no
+	// servicemeshoperator3 subscription exists, the PackageManifest validation is not applicable.
+	noOLM, err := isNoOLMMode(ctx, target)
+	if err != nil {
+		return nil, fmt.Errorf("checking noOLM mode: %w", err)
+	}
+
+	if noOLM {
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeAvailable,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonRequirementsMet),
+			check.WithMessage("Gateway API is managed by the Cluster Ingress Operator (noOLM mode); %s catalog entry not required", subscriptionName),
+		))
+
+		return dr, nil
+	}
+
+	// Step 6: Validate that the required CSV is available in the OLM catalog.
+	return validateCatalogCSV(ctx, target, dr, requiredCSV, requiredChannel, displayVersion)
+}
+
+// validateCatalogCSV validates that the required servicemeshoperator3 CSV is available
+// in the redhat-operators catalog. Reached only when a subscription exists (OLM mode).
+func validateCatalogCSV(
+	ctx context.Context,
+	target check.Target,
+	dr *result.DiagnosticResult,
+	requiredCSV, requiredChannel, displayVersion string,
+) (*result.DiagnosticResult, error) {
 	manifests, err := client.List[*unstructured.Unstructured](ctx, target.Client, resources.PackageManifest,
 		func(pm *unstructured.Unstructured) (bool, error) {
 			if pm.GetName() != "servicemeshoperator3" || pm.GetNamespace() != "openshift-marketplace" {
 				return false, nil
 			}
 
-			catalogSource, err := jq.Query[string](pm, ".status.catalogSource")
-			if err != nil {
+			catalogSource, queryErr := jq.Query[string](pm, ".status.catalogSource")
+			if queryErr != nil {
 				return false, nil
 			}
 
@@ -172,14 +203,12 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 
 	pm := manifests[0]
 
-	// Step 6: Extract available CSVs from the required channel.
 	availableCSVs, err := jq.Query[[]string](pm,
 		fmt.Sprintf(`[.status.channels[]? | select(.name == "%s") | .entries[]?.name]`, requiredChannel))
 	if err != nil {
 		return nil, fmt.Errorf("querying available CSVs: %w", err)
 	}
 
-	// Step 7: Check if the required CSV is available.
 	if slices.Contains(availableCSVs, requiredCSV) {
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeAvailable,
@@ -199,4 +228,31 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	}
 
 	return dr, nil
+}
+
+// isNoOLMMode checks whether the cluster is running in noOLM Gateway API mode.
+// Returns true when OLM is unavailable or no servicemeshoperator3 subscription exists.
+func isNoOLMMode(ctx context.Context, target check.Target) (bool, error) {
+	if !target.Client.OLM().Available() {
+		return true, nil
+	}
+
+	subscriptions, err := target.Client.OLM().Subscriptions("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// Cannot determine subscription state (e.g. RBAC restriction);
+		// fall through to OLM catalog validation rather than failing the check.
+		return false, nil
+	}
+
+	return findSubscription(subscriptions) == nil, nil
+}
+
+func findSubscription(list *operatorsv1alpha1.SubscriptionList) *operatorsv1alpha1.Subscription {
+	for i := range list.Items {
+		if list.Items[i].Name == subscriptionName {
+			return &list.Items[i]
+		}
+	}
+
+	return nil
 }

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -143,12 +143,7 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 	// Step 5: Check for noOLM mode. On OCP 4.21.22+ / 4.22+, the Cluster Ingress Operator
 	// deploys istiod directly (Sail Library) without an OSSM OLM subscription. When no
 	// servicemeshoperator3 subscription exists, the PackageManifest validation is not applicable.
-	noOLM, err := isNoOLMMode(ctx, target)
-	if err != nil {
-		return nil, fmt.Errorf("checking noOLM mode: %w", err)
-	}
-
-	if noOLM {
+	if isNoOLMMode(ctx, target) {
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeAvailable,
 			metav1.ConditionTrue,
@@ -232,19 +227,19 @@ func validateCatalogCSV(
 
 // isNoOLMMode checks whether the cluster is running in noOLM Gateway API mode.
 // Returns true when OLM is unavailable or no servicemeshoperator3 subscription exists.
-func isNoOLMMode(ctx context.Context, target check.Target) (bool, error) {
+func isNoOLMMode(ctx context.Context, target check.Target) bool {
 	if !target.Client.OLM().Available() {
-		return true, nil
+		return true
 	}
 
 	subscriptions, err := target.Client.OLM().Subscriptions("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		// Cannot determine subscription state (e.g. RBAC restriction);
 		// fall through to OLM catalog validation rather than failing the check.
-		return false, nil
+		return false
 	}
 
-	return findSubscription(subscriptions) == nil, nil
+	return findSubscription(subscriptions) == nil
 }
 
 func findSubscription(list *operatorsv1alpha1.SubscriptionList) *operatorsv1alpha1.Subscription {

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh.go
@@ -124,25 +124,11 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 		return dr, nil
 	}
 
-	// Step 2: Extract the required version from the GATEWAY_API_OPERATOR_VERSION env var.
-	requiredVersion, earlyResult, err := extractEnvVar(deploy, dr, "GATEWAY_API_OPERATOR_VERSION")
-	if earlyResult != nil || err != nil {
-		return earlyResult, err
-	}
-
-	// Step 3: Extract the required channel from the GATEWAY_API_OPERATOR_CHANNEL env var.
-	requiredChannel, earlyResult, err := extractEnvVar(deploy, dr, "GATEWAY_API_OPERATOR_CHANNEL")
-	if earlyResult != nil || err != nil {
-		return earlyResult, err
-	}
-
-	// Step 4: The env var contains the full CSV name (e.g. "servicemeshoperator3.v3.1.0").
-	requiredCSV := requiredVersion
-	displayVersion := strings.TrimPrefix(requiredCSV, "servicemeshoperator3.v")
-
-	// Step 5: Check for noOLM mode. On OCP 4.21.22+ / 4.22+, the Cluster Ingress Operator
+	// Step 2: Check for noOLM mode. On OCP 4.21.22+ / 4.22+, the Cluster Ingress Operator
 	// deploys istiod directly (Sail Library) without an OSSM OLM subscription. When no
 	// servicemeshoperator3 subscription exists, the PackageManifest validation is not applicable.
+	// This must run before env var extraction: noOLM clusters may lack the GATEWAY_API_OPERATOR_*
+	// env vars entirely, which would otherwise produce false-positive blocking failures.
 	if isNoOLMMode(ctx, target) {
 		dr.SetCondition(check.NewCondition(
 			check.ConditionTypeAvailable,
@@ -153,6 +139,22 @@ func (c *Check) Validate(ctx context.Context, target check.Target) (*result.Diag
 
 		return dr, nil
 	}
+
+	// Step 3: Extract the required version from the GATEWAY_API_OPERATOR_VERSION env var.
+	requiredVersion, earlyResult, err := extractEnvVar(deploy, dr, "GATEWAY_API_OPERATOR_VERSION")
+	if earlyResult != nil || err != nil {
+		return earlyResult, err
+	}
+
+	// Step 4: Extract the required channel from the GATEWAY_API_OPERATOR_CHANNEL env var.
+	requiredChannel, earlyResult, err := extractEnvVar(deploy, dr, "GATEWAY_API_OPERATOR_CHANNEL")
+	if earlyResult != nil || err != nil {
+		return earlyResult, err
+	}
+
+	// Step 5: The env var contains the full CSV name (e.g. "servicemeshoperator3.v3.1.0").
+	requiredCSV := requiredVersion
+	displayVersion := strings.TrimPrefix(requiredCSV, "servicemeshoperator3.v")
 
 	// Step 6: Validate that the required CSV is available in the OLM catalog.
 	return validateCatalogCSV(ctx, target, dr, requiredCSV, requiredChannel, displayVersion)

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,6 +98,21 @@ func newPackageManifest(catalogSource string, channel string, csvNames []string)
 	return &unstructured.Unstructured{Object: obj}
 }
 
+func newOSSMSubscription(installedCSV string) *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "servicemeshoperator3",
+			Namespace: "openshift-operators",
+		},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			Channel: "stable",
+		},
+		Status: operatorsv1alpha1.SubscriptionStatus{
+			InstalledCSV: installedCSV,
+		},
+	}
+}
+
 func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
@@ -105,10 +122,12 @@ func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -130,7 +149,7 @@ func TestServiceMeshV3Check_VersionAvailable(t *testing.T) {
 	))
 }
 
-func TestServiceMeshV3Check_DeploymentNotFound(t *testing.T) {
+func TestServiceMeshV3Check_DeploymentNotFound_Advisory(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
@@ -153,7 +172,102 @@ func TestServiceMeshV3Check_DeploymentNotFound(t *testing.T) {
 		"Status": Equal(metav1.ConditionFalse),
 		"Reason": Equal(check.ReasonResourceNotFound),
 	}))
-	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("HCP"))
+}
+
+func TestServiceMeshV3Check_NoOLMMode_NoSubscription(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy},
+		OLM:            operatorfake.NewSimpleClientset(), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("noOLM mode"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("servicemeshoperator3"))
+}
+
+func TestServiceMeshV3Check_NoOLMMode_OLMUnavailable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
+	})
+
+	// No OLM client provided — OLM().Available() returns false.
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("noOLM mode"))
+}
+
+func TestServiceMeshV3Check_OLMMode_WithSubscription(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{
+		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
+		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
+	})
+	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceFound),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("servicemeshoperator3.v3.1.0"))
 }
 
 func TestServiceMeshV3Check_InsufficientPermissions(t *testing.T) {
@@ -237,10 +351,12 @@ func TestServiceMeshV3Check_PackageManifestNotFound(t *testing.T) {
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -280,10 +396,12 @@ func TestServiceMeshV3Check_WrongCatalogSource(t *testing.T) {
 	})
 	// PackageManifest exists but from a non-redhat-operators catalog; the check should not find it.
 	pm := newPackageManifest("custom-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -322,10 +440,12 @@ func TestServiceMeshV3Check_VersionNotAvailable(t *testing.T) {
 		"GATEWAY_API_OPERATOR_CHANNEL": "stable",
 	})
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.0.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.0.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -440,10 +560,12 @@ func TestServiceMeshV3Check_VersionAvailableAmongMultipleEntries(t *testing.T) {
 		"servicemeshoperator3.v3.1.0",
 		"servicemeshoperator3.v3.2.0",
 	})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.2.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -496,10 +618,12 @@ func TestServiceMeshV3Check_MissingCatalogSource(t *testing.T) {
 			},
 		},
 	}
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -600,10 +724,12 @@ func TestServiceMeshV3Check_VersionInDifferentChannel(t *testing.T) {
 	})
 	// The CSV exists in the "candidate" channel, but the check requires "stable".
 	pm := newPackageManifest("redhat-operators", "candidate", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})

--- a/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
+++ b/pkg/lint/checks/dependencies/servicemesh/servicemesh_test.go
@@ -176,6 +176,34 @@ func TestServiceMeshV3Check_DeploymentNotFound_Advisory(t *testing.T) {
 	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("HCP"))
 }
 
+func TestServiceMeshV3Check_NoOLMMode_NoSubscription_NoEnvVars(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	deploy := newIngressOperatorDeployment(map[string]string{})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds(),
+		Objects:        []*unstructured.Unstructured{deploy},
+		OLM:            operatorfake.NewSimpleClientset(), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	smCheck := servicemesh.NewCheck()
+	result, err := smCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeAvailable),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("noOLM mode"))
+	g.Expect(result.Status.Conditions[0].Message).To(ContainSubstring("servicemeshoperator3"))
+}
+
 func TestServiceMeshV3Check_NoOLMMode_NoSubscription(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
@@ -322,10 +350,12 @@ func TestServiceMeshV3Check_EnvVarMissing(t *testing.T) {
 
 	deploy := newIngressOperatorDeployment(map[string]string{})
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -497,10 +527,12 @@ func TestServiceMeshV3Check_ContainerWithNoEnvKey(t *testing.T) {
 		},
 	}
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -526,10 +558,12 @@ func TestServiceMeshV3Check_EnvVarEmpty(t *testing.T) {
 		"GATEWAY_API_OPERATOR_VERSION": "",
 	})
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -661,10 +695,12 @@ func TestServiceMeshV3Check_ChannelEnvVarMissing(t *testing.T) {
 		"GATEWAY_API_OPERATOR_VERSION": "servicemeshoperator3.v3.1.0",
 	})
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})
@@ -692,10 +728,12 @@ func TestServiceMeshV3Check_ChannelEnvVarEmpty(t *testing.T) {
 		"GATEWAY_API_OPERATOR_CHANNEL": "",
 	})
 	pm := newPackageManifest("redhat-operators", "stable", []string{"servicemeshoperator3.v3.1.0"})
+	sub := newOSSMSubscription("servicemeshoperator3.v3.1.0")
 
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds(),
 		Objects:        []*unstructured.Unstructured{deploy, pm},
+		OLM:            operatorfake.NewSimpleClientset(sub), //nolint:staticcheck // NewClientset requires generated apply configs not available in OLM
 		CurrentVersion: "2.17.0",
 		TargetVersion:  "3.0.0",
 	})


### PR DESCRIPTION
## Description
On OCP 4.21.22+/4.22+, the Cluster Ingress Operator deploys istiod directly via Sail Library without an OSSM OLM subscription. The servicemesh.installed lint check assumed OSSM was always OLM-managed, causing false-positive blocking failures on noOLM and HCP clusters.

Detect noOLM mode by checking for servicemeshoperator3 subscription absence before validating the PackageManifest catalog. Downgrade the deployment-not-found case (HCP) from blocking to advisory.

Resolves: [RHOAIENG-78316](https://redhat.atlassian.net/browse/RHOAIENG-78316)
Resolves: [RHOAIENG-78804](https://redhat.atlassian.net/browse/RHOAIENG-78804)
## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


[RHOAIENG-78316]: https://redhat.atlassian.net/browse/RHOAIENG-78316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-78804]: https://redhat.atlassian.net/browse/RHOAIENG-78804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Service Mesh dependency checks for Gateway API environments without Operator Lifecycle Manager (OLM).
  - Missing `ingress-operator` deployments are now reported as advisories instead of blocking validation.
  - Added more accurate detection of Service Mesh installation modes.
  - Improved validation of available Service Mesh versions and channels when OLM is enabled.
  - Updated condition messages and remediation guidance, including support for HCP environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->