### PR TITLE
doc(migrate): refine RHBOK migration docs

### DIFF
--- a/docs/migrate/rhbok-migration.md
+++ b/docs/migrate/rhbok-migration.md
@@ -47,9 +47,11 @@ Shared command flags (`--dry-run`, `--yes`, `--output-dir`, etc.) come from the 
 | `--cluster-queue-name` | `""` | Optional DSC `defaultClusterQueueName` |
 | `--local-queue-name` | `""` | Optional DSC `defaultLocalQueueName` |
 | `--workload-queue-name` | `default` | Value for `kueue.x-k8s.io/queue-name` on workloads |
-| `--channel` | catalog-resolved | OLM channel; fallback `stable-v1.2` |
+| `--channel` | resolved (see below) | OLM channel |
 | `--skip-remove-embedded` | `false` | Skip Managed → Removed (not recommended) |
-| `--force-delete-legacy-crds` | `false` | Delete legacy CRDs even when instances exist |
+| `--force-delete-legacy-crds` | `false` | Delete legacy CRDs even when instances exist (irreversible — also deletes existing Cohort/Topology instances; prepare does not back them up) |
+
+`--channel` resolution order when the flag is empty: existing `kueue-operator` Subscription channel → catalog PackageManifest lookup → fallback `stable-v1.2`.
 
 ## Package Map
 
@@ -152,6 +154,7 @@ Workload kinds labeled/verified (from `pkg/lint/checks/kueue/discovery`): Notebo
 - Applications namespace is hardcoded to `redhat-ods-applications` (RHOAI), not ODH `opendatahub`.
 - Queue “preservation” verification compares **counts**, not backup diffs.
 - Prepare does not backup LocalQueues or DSC.
+- If the migration is already complete (Unmanaged + operator ready), `--cluster-queue-name`, `--local-queue-name`, and `--workload-queue-name` are ignored — the full migration action (including activation and workload labeling) is skipped.
 - `waitForKueueReady` lists all pods in the operator namespace; some verify/complete checks filter `app.kubernetes.io/name=kueue`.
 
 ## Related

--- a/docs/migrate/upgrade-helpers-comparison.md
+++ b/docs/migrate/upgrade-helpers-comparison.md
@@ -2012,9 +2012,9 @@ rhai-cli migrate run \
 | `--cluster-queue-name` | *(empty)* | Optional DSC `defaultClusterQueueName` |
 | `--local-queue-name` | *(empty)* | Optional DSC `defaultLocalQueueName` |
 | `--workload-queue-name` | `default` | Value for `kueue.x-k8s.io/queue-name` on workloads |
-| `--channel` | catalog-resolved | OLM channel (fallback `stable-v1.2`) |
+| `--channel` | resolved | OLM channel: existing Subscription → PackageManifest → fallback `stable-v1.2` |
 | `--skip-remove-embedded` | `false` | Skip Managed → Removed (not recommended) |
-| `--force-delete-legacy-crds` | `false` | Delete legacy cohorts/topologies CRDs even when instances exist |
+| `--force-delete-legacy-crds` | `false` | Delete legacy cohorts/topologies CRDs even when instances exist (irreversible — also deletes existing Cohort/Topology instances; prepare does not back them up) |
 
 <details>
 <summary><b>Example: Kueue RHBOK migration output</b></summary>
@@ -2059,8 +2059,8 @@ Running migration: kueue.rhbok.migrate (confirmations skipped)
   → Apply kueue.x-k8s.io/queue-name to workloads
   → Verify RHBOK migration completed successfully
     ✓ Migration verification passed
-  → Verify ClusterQueue and LocalQueue resources preserved
-    ✓ All ClusterQueues and LocalQueues preserved
+  → Check ClusterQueue and LocalQueue counts
+    ✓ ClusterQueue and LocalQueue counts matched
 
 Migration kueue.rhbok.migrate completed successfully!
 ```
@@ -2241,7 +2241,7 @@ Running migration: kueue.rhbok.migrate (confirmations skipped)
   → Apply kueue.openshift.io/managed=true to namespaces
   → Apply kueue.x-k8s.io/queue-name to workloads
   → Verify RHBOK migration completed successfully
-  → Verify ClusterQueue and LocalQueue resources preserved
+  → Check ClusterQueue and LocalQueue counts
 
 Migration kueue.rhbok.migrate completed successfully!
 


### PR DESCRIPTION


## Description

Clarify `--channel` resolution order, warn that `--force-delete-legacy-crds` is irreversible for Cohort/Topology instances, note that queue preservation compares counts rather than full backup diffs, and document that activation is skipped when the migration is already complete.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified migration channel resolution and its fallback behavior.
  * Documented that queue-name options are ignored after migration completion.
  * Added warnings about irreversible legacy resource deletion and backup limitations.
  * Clarified migration verification using ClusterQueue and LocalQueue counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->