### PR TITLE
fix(client): add API discovery fallback for DSC/DSCI v1 on RHOAI 2.x clusters

### DIFF
--- a/pkg/util/client/helpers.go
+++ b/pkg/util/client/helpers.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdiscovery "k8s.io/client-go/discovery"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util"
@@ -325,6 +326,13 @@ func (c *defaultClient) Get(ctx context.Context, gvr schema.GroupVersionResource
 
 // --- Standalone helper functions that accept Reader ---
 
+// discoverer is satisfied by types that expose a Kubernetes discovery client (e.g. Client).
+// Used internally to attempt API version negotiation when the caller passes a full Client
+// as a Reader.
+type discoverer interface {
+	Discovery() k8sdiscovery.DiscoveryInterface
+}
+
 // GetSingleton expects exactly one instance of the resource type to exist.
 // Returns error if zero or multiple instances found.
 func GetSingleton(ctx context.Context, r Reader, resourceType resources.ResourceType) (*unstructured.Unstructured, error) {
@@ -345,14 +353,105 @@ func GetSingleton(ctx context.Context, r Reader, resourceType resources.Resource
 	return items[0], nil
 }
 
+// getSingletonWithDiscovery dynamically detects the available API version and retrieves
+// a singleton resource. Tries v2 first, falls back to v1.
+//
+// When the Reader also implements discoverer (i.e. is a full Client), this function
+// uses API discovery to check whether the v2 API group exists on the cluster before
+// querying it. On RHOAI 2.x clusters that only serve v1, this avoids the "resource
+// not found" error that would otherwise occur.
+//
+// When the Reader does not implement discoverer, this falls back to v2-only behavior
+// (the previous default), preserving backward compatibility for pure Reader callers.
+func getSingletonWithDiscovery(
+	ctx context.Context,
+	r Reader,
+	v2Resource, v1Resource resources.ResourceType,
+) (*unstructured.Unstructured, error) {
+	d, hasDiscovery := r.(discoverer)
+
+	var disc k8sdiscovery.DiscoveryInterface
+	if hasDiscovery {
+		disc = d.Discovery()
+	}
+
+	if disc == nil {
+		return GetSingleton(ctx, r, v2Resource)
+	}
+
+	obj, fallbackToV1, err := tryGetV2Singleton(ctx, r, disc, v2Resource)
+	if err != nil {
+		return nil, fmt.Errorf("getting %s (v2): %w", v2Resource.Kind, err)
+	}
+
+	if !fallbackToV1 {
+		return obj, nil
+	}
+
+	obj, err = GetSingleton(ctx, r, v1Resource)
+	if err != nil {
+		return nil, fmt.Errorf("getting %s (v1): %w", v1Resource.Kind, err)
+	}
+
+	return obj, nil
+}
+
+// tryGetV2Singleton attempts to get the v2 singleton if the v2 API exists.
+// Returns:
+//   - (obj, false, nil) if v2 singleton found
+//   - (nil, true, nil) if should fall back to v1 (v2 API absent or v2 instance not found)
+//   - (nil, false, err) if a real error occurred (403, timeout, unexpected count, etc.)
+func tryGetV2Singleton(
+	ctx context.Context,
+	r Reader,
+	disc k8sdiscovery.DiscoveryInterface,
+	v2Resource resources.ResourceType,
+) (*unstructured.Unstructured, bool, error) {
+	if !hasGroupVersion(disc, schema.GroupVersion{Group: v2Resource.Group, Version: v2Resource.Version}) {
+		return nil, true, nil
+	}
+
+	obj, err := GetSingleton(ctx, r, v2Resource)
+	if err != nil {
+		if IsResourceTypeNotFound(err) {
+			return nil, true, nil
+		}
+
+		return nil, false, fmt.Errorf("getting v2 singleton: %w", err)
+	}
+
+	return obj, false, nil
+}
+
+// hasGroupVersion checks whether the API server serves the given group/version.
+func hasGroupVersion(disc k8sdiscovery.DiscoveryInterface, gv schema.GroupVersion) bool {
+	_, apiResourceLists, _ := disc.ServerGroupsAndResources()
+	if apiResourceLists == nil {
+		return false
+	}
+
+	target := gv.String()
+	for _, list := range apiResourceLists {
+		if list.GroupVersion == target {
+			return len(list.APIResources) > 0
+		}
+	}
+
+	return false
+}
+
 // GetDataScienceCluster retrieves the cluster's DataScienceCluster singleton resource.
+// Uses API discovery to negotiate between v2 (RHOAI 3.x) and v1 (RHOAI 2.x) when
+// the Reader also implements the Client interface.
 func GetDataScienceCluster(ctx context.Context, r Reader) (*unstructured.Unstructured, error) {
-	return GetSingleton(ctx, r, resources.DataScienceCluster)
+	return getSingletonWithDiscovery(ctx, r, resources.DataScienceCluster, resources.DataScienceClusterV1)
 }
 
 // GetDSCInitialization retrieves the cluster's DSCInitialization singleton resource.
+// Uses API discovery to negotiate between v2 (RHOAI 3.x) and v1 (RHOAI 2.x) when
+// the Reader also implements the Client interface.
 func GetDSCInitialization(ctx context.Context, r Reader) (*unstructured.Unstructured, error) {
-	return GetSingleton(ctx, r, resources.DSCInitialization)
+	return getSingletonWithDiscovery(ctx, r, resources.DSCInitialization, resources.DSCInitializationV1)
 }
 
 // GetApplicationsNamespace retrieves the applications namespace from DSCInitialization.

--- a/pkg/util/client/helpers_test.go
+++ b/pkg/util/client/helpers_test.go
@@ -4,6 +4,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/onsi/gomega/types"
@@ -14,8 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
+	coretesting "k8s.io/client-go/testing"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 
@@ -813,3 +816,265 @@ func (r *errorReader) OLM() OLMReader {
 
 // Compile-time check that errorReader implements Reader.
 var _ Reader = (*errorReader)(nil)
+
+// pureReader is a Reader that does NOT implement discoverer.
+// Used to test that GetDataScienceCluster falls back to v2-only when no discovery is available.
+type pureReader struct {
+	dynamic *dynamicfake.FakeDynamicClient
+}
+
+func (r *pureReader) List(
+	ctx context.Context,
+	resourceType resources.ResourceType,
+	_ ...ListResourcesOption,
+) ([]*unstructured.Unstructured, error) {
+	list, err := r.dynamic.Resource(resourceType.GVR()).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing %s: %w", resourceType.Kind, err)
+	}
+
+	result := make([]*unstructured.Unstructured, len(list.Items))
+	for i := range list.Items {
+		result[i] = &list.Items[i]
+	}
+
+	return result, nil
+}
+
+func (r *pureReader) ListMetadata(
+	_ context.Context,
+	_ resources.ResourceType,
+	_ ...ListResourcesOption,
+) ([]*metav1.PartialObjectMetadata, error) {
+	return nil, nil
+}
+
+func (r *pureReader) ListResources(
+	_ context.Context,
+	_ schema.GroupVersionResource,
+	_ ...ListResourcesOption,
+) ([]*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (r *pureReader) Get(
+	_ context.Context,
+	_ schema.GroupVersionResource,
+	_ string,
+	_ ...GetOption,
+) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (r *pureReader) GetResource(
+	_ context.Context,
+	_ resources.ResourceType,
+	_ string,
+	_ ...GetOption,
+) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func (r *pureReader) GetResourceMetadata(
+	_ context.Context,
+	_ resources.ResourceType,
+	_ string,
+	_ ...GetOption,
+) (*metav1.PartialObjectMetadata, error) {
+	return nil, nil
+}
+
+func (r *pureReader) OLM() OLMReader {
+	return newOLMReader(nil)
+}
+
+var _ Reader = (*pureReader)(nil)
+
+// --- getSingletonWithDiscovery tests ---
+
+//nolint:gochecknoglobals // Test fixture
+var dscListKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR():   resources.DataScienceCluster.ListKind(),
+	resources.DataScienceClusterV1.GVR(): resources.DataScienceClusterV1.ListKind(),
+	resources.DSCInitialization.GVR():    resources.DSCInitialization.ListKind(),
+	resources.DSCInitializationV1.GVR():  resources.DSCInitializationV1.ListKind(),
+}
+
+func newFakeDiscovery(groupVersions ...string) *discoveryfake.FakeDiscovery {
+	fd := &discoveryfake.FakeDiscovery{Fake: &coretesting.Fake{}}
+
+	lists := make([]*metav1.APIResourceList, 0, len(groupVersions))
+	for _, gv := range groupVersions {
+		lists = append(lists, &metav1.APIResourceList{
+			GroupVersion: gv,
+			APIResources: []metav1.APIResource{
+				{Name: "datascienceclusters", Kind: "DataScienceCluster"},
+				{Name: "dscinitializations", Kind: "DSCInitialization"},
+			},
+		})
+	}
+
+	fd.Resources = lists
+
+	return fd
+}
+
+func createDSCV2() runtime.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata":   map[string]any{"name": "default-dsc"},
+		},
+	}
+}
+
+func createDSCV1() runtime.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceClusterV1.APIVersion(),
+			"kind":       resources.DataScienceClusterV1.Kind,
+			"metadata":   map[string]any{"name": "default-dsc"},
+		},
+	}
+}
+
+func TestGetDataScienceCluster_V2Available(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := createDSCV2()
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, dsc)
+
+	c := NewForTesting(TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscovery(resources.DataScienceCluster.Group + "/v2"),
+	})
+
+	result, err := GetDataScienceCluster(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.GetName()).To(Equal("default-dsc"))
+	g.Expect(result.GetAPIVersion()).To(Equal(resources.DataScienceCluster.APIVersion()))
+}
+
+func TestGetDataScienceCluster_V2AbsentFallsBackToV1(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := createDSCV1()
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, dsc)
+
+	c := NewForTesting(TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscovery(resources.DataScienceCluster.Group + "/v1"),
+	})
+
+	result, err := GetDataScienceCluster(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.GetName()).To(Equal("default-dsc"))
+	g.Expect(result.GetAPIVersion()).To(Equal(resources.DataScienceClusterV1.APIVersion()))
+}
+
+func TestGetDataScienceCluster_MidUpgradeFallsBackToV1(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := createDSCV1()
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, dsc)
+
+	c := NewForTesting(TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscovery(resources.DataScienceCluster.Group+"/v2", resources.DataScienceCluster.Group+"/v1"),
+	})
+
+	result, err := GetDataScienceCluster(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.GetAPIVersion()).To(Equal(resources.DataScienceClusterV1.APIVersion()))
+}
+
+func TestGetDataScienceCluster_NeitherVersionAvailable(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds)
+
+	c := NewForTesting(TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscovery(),
+	})
+
+	_, err := GetDataScienceCluster(ctx, c)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+func TestGetDataScienceCluster_PureReaderTriesV2Only(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := createDSCV2()
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, dsc)
+
+	reader := &pureReader{
+		dynamic: dynamicClient,
+	}
+
+	result, err := GetDataScienceCluster(ctx, reader)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.GetAPIVersion()).To(Equal(resources.DataScienceCluster.APIVersion()))
+}
+
+func TestGetDataScienceCluster_NilDiscoveryUsesV2Only(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := createDSCV2()
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, dsc)
+
+	c := NewForTesting(TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: nil,
+	})
+
+	result, err := GetDataScienceCluster(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.GetAPIVersion()).To(Equal(resources.DataScienceCluster.APIVersion()))
+}
+
+func TestGetDSCInitialization_V2AbsentFallsBackToV1(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsci := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DSCInitializationV1.APIVersion(),
+			"kind":       resources.DSCInitializationV1.Kind,
+			"metadata":   map[string]any{"name": "default-dsci"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, dscListKinds, dsci)
+
+	c := NewForTesting(TestClientConfig{
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscovery(resources.DSCInitialization.Group + "/v1"),
+	})
+
+	result, err := GetDSCInitialization(ctx, c)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.GetName()).To(Equal("default-dsci"))
+	g.Expect(result.GetAPIVersion()).To(Equal(resources.DSCInitializationV1.APIVersion()))
+}

--- a/pkg/util/version/detector_test.go
+++ b/pkg/util/version/detector_test.go
@@ -56,7 +56,7 @@ func TestDetect_FromDataScienceCluster(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	// Create fake DataScienceCluster with version (using v1 API - fallback when Discovery is nil)
+	// Create fake DataScienceCluster with version (using v1 API - fallback when v2 absent)
 	dsc := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resources.DataScienceClusterV1.APIVersion(),
@@ -76,7 +76,8 @@ func TestDetect_FromDataScienceCluster(t *testing.T) {
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsc)
 
 	c := client.NewForTesting(client.TestClientConfig{
-		Dynamic: dynamicClient,
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscoveryWithResources(resources.DataScienceCluster.Group + "/v1"),
 	})
 
 	clusterVersion, err := version.Detect(ctx, c)
@@ -177,7 +178,7 @@ func TestDetect_FromDSCInitialization(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
 
-	// Create fake DSCInitialization with version (using v1 API - fallback when Discovery is nil)
+	// Create fake DSCInitialization with version (using v1 API - fallback when v2 absent)
 	dsci := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": resources.DSCInitializationV1.APIVersion(),
@@ -197,7 +198,8 @@ func TestDetect_FromDSCInitialization(t *testing.T) {
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsci)
 
 	c := client.NewForTesting(client.TestClientConfig{
-		Dynamic: dynamicClient,
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscoveryWithResources(resources.DSCInitialization.Group + "/v1"),
 	})
 
 	clusterVersion, err := version.Detect(ctx, c)
@@ -342,7 +344,8 @@ func TestDetect_PriorityOrder(t *testing.T) {
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, dsc, dsci, csv)
 
 	c := client.NewForTesting(client.TestClientConfig{
-		Dynamic: dynamicClient,
+		Dynamic:   dynamicClient,
+		Discovery: newFakeDiscoveryWithResources(resources.DataScienceCluster.Group + "/v1"),
 	})
 
 	clusterVersion, err := version.Detect(ctx, c)

--- a/pkg/util/version/sources.go
+++ b/pkg/util/version/sources.go
@@ -6,91 +6,16 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
-	"github.com/opendatahub-io/odh-cli/pkg/util/kube/discovery"
 )
-
-// getSingletonWithDiscovery dynamically detects the available API version and retrieves
-// a singleton resource. Tries v2 first, falls back to v1.
-// This avoids code duplication for resources that exist in both v1 and v2 API versions.
-func getSingletonWithDiscovery(
-	ctx context.Context,
-	c client.Client,
-	v2Resource, v1Resource resources.ResourceType,
-) (*unstructured.Unstructured, error) {
-	// Try v2 first if Discovery is available
-	obj, fallbackToV1, err := tryGetV2Singleton(ctx, c, v2Resource)
-	if err != nil {
-		return nil, fmt.Errorf("getting %s (v2): %w", v2Resource.Kind, err)
-	}
-
-	if !fallbackToV1 {
-		return obj, nil
-	}
-
-	// Fallback to v1 (ODH/RHOAI 2.x) - used when:
-	// - Discovery is not available
-	// - v2 API doesn't exist on cluster
-	// - v2 API exists but no v2 instance found (mid-upgrade scenario)
-	obj, err = client.GetSingleton(ctx, c, v1Resource)
-	if err != nil {
-		return nil, fmt.Errorf("getting %s (v1): %w", v1Resource.Kind, err)
-	}
-
-	return obj, nil
-}
-
-// tryGetV2Singleton attempts to get the v2 singleton if the v2 API exists.
-// Returns:
-//   - (obj, false, nil) if v2 singleton found
-//   - (nil, true, nil) if should fall back to v1 (v2 API absent or v2 instance not found)
-//   - (nil, false, err) if a real error occurred (403, timeout, unexpected count, etc.)
-func tryGetV2Singleton(
-	ctx context.Context,
-	c client.Client,
-	v2Resource resources.ResourceType,
-) (*unstructured.Unstructured, bool, error) {
-	if c.Discovery() == nil {
-		return nil, true, nil // No discovery available, fall back to v1
-	}
-
-	v2Resources, err := discovery.GetGroupVersionResources(
-		c.Discovery(),
-		schema.GroupVersion{Group: v2Resource.Group, Version: "v2"},
-	)
-	if err != nil {
-		// Discovery error is not fatal - fall back to v1
-		return nil, true, nil
-	}
-
-	if len(v2Resources) == 0 {
-		return nil, true, nil // v2 API doesn't exist, fall back to v1
-	}
-
-	obj, err := client.GetSingleton(ctx, c, v2Resource)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// v2 instance not found (mid-upgrade scenario) - fall back to v1
-			return nil, true, nil
-		}
-		// Real error (403, timeout, "expected single, found 2", etc.) - propagate
-		return nil, false, fmt.Errorf("getting v2 singleton: %w", err)
-	}
-
-	return obj, false, nil
-}
 
 // DetectFromDataScienceCluster attempts to detect version from DataScienceCluster resource.
 // Dynamically detects whether to use v1 or v2 API based on cluster capabilities.
 // Returns version string and true if found, empty string and false otherwise.
 func DetectFromDataScienceCluster(ctx context.Context, c client.Client) (string, bool, error) {
-	// Get the DataScienceCluster singleton using discovery-based version detection
-	dsc, err := getSingletonWithDiscovery(ctx, c, resources.DataScienceCluster, resources.DataScienceClusterV1)
+	dsc, err := client.GetDataScienceCluster(ctx, c)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", false, nil
@@ -99,7 +24,6 @@ func DetectFromDataScienceCluster(ctx context.Context, c client.Client) (string,
 		return "", false, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
-	// Query .status.release.version using JQ
 	versionStr, err := jq.Query[string](dsc, ".status.release.version")
 	if err != nil {
 		return "", false, fmt.Errorf("querying .status.release.version: %w", err)
@@ -116,8 +40,7 @@ func DetectFromDataScienceCluster(ctx context.Context, c client.Client) (string,
 // Dynamically detects whether to use v1 or v2 API based on cluster capabilities.
 // Returns version string and true if found, empty string and false otherwise.
 func DetectFromDSCInitialization(ctx context.Context, c client.Client) (string, bool, error) {
-	// Get the DSCInitialization singleton using discovery-based version detection
-	dsci, err := getSingletonWithDiscovery(ctx, c, resources.DSCInitialization, resources.DSCInitializationV1)
+	dsci, err := client.GetDSCInitialization(ctx, c)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", false, nil
@@ -126,7 +49,6 @@ func DetectFromDSCInitialization(ctx context.Context, c client.Client) (string, 
 		return "", false, fmt.Errorf("getting DSCInitialization: %w", err)
 	}
 
-	// Query .status.release.version using JQ
 	versionStr, err := jq.Query[string](dsci, ".status.release.version")
 	if err != nil {
 		return "", false, fmt.Errorf("querying .status.release.version: %w", err)


### PR DESCRIPTION
## Description

GetDataScienceCluster() and GetDSCInitialization() hardcoded v2 API resource types, causing 22/31 lint checks to fail on RHOAI 2.x clusters that only serve datasciencecluster.opendatahub.io/v1. This adds discovery-based version negotiation that tries v2 first and falls back to v1 when the v2 API group is absent, fixing all callers without signature changes. Consolidates duplicated discovery logic from version/sources.go into the client helpers.

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic API-version negotiation for retrieving DataScienceCluster and DSCInitialization resources.
  * Prefers the v2 API when available and falls back to v1 during upgrades or when v2 resources are unavailable.
  * Improved version detection across supported API versions.

* **Bug Fixes**
  * Preserved clear error handling for unavailable APIs, missing resources, and discovery failures.
  * Maintained compatibility for clients that only support v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->