### PR TITLE
RHOAIENG-82044: downgrade kueue data-integrity check from prohibited to advisor

### DIFF
--- a/pkg/lint/checks/workloads/kueue/check.go
+++ b/pkg/lint/checks/workloads/kueue/check.go
@@ -120,7 +120,7 @@ func (c *DataIntegrityCheck) Validate(
 		metav1.ConditionFalse,
 		check.WithReason(check.ReasonConfigurationInvalid),
 		check.WithMessage(msgInconsistent, len(violations)),
-		check.WithImpact(result.ImpactProhibited),
+		check.WithImpact(result.ImpactAdvisory),
 		check.WithRemediation(c.CheckRemediation),
 	))
 

--- a/pkg/lint/checks/workloads/kueue/check_test.go
+++ b/pkg/lint/checks/workloads/kueue/check_test.go
@@ -542,7 +542,7 @@ func TestDataIntegrityCheck_MixedViolationsAcrossNamespaces(t *testing.T) {
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "2"))
 }
 
-func TestDataIntegrityCheck_BlockingImpact(t *testing.T) {
+func TestDataIntegrityCheck_AdvisoryImpact(t *testing.T) {
 	g := NewWithT(t)
 
 	dsc := testutil.NewDSC(map[string]string{
@@ -567,7 +567,7 @@ func TestDataIntegrityCheck_BlockingImpact(t *testing.T) {
 	result, err := chk.Validate(t.Context(), target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Conditions[0]).To(HaveField("Impact", Equal(resultpkg.ImpactProhibited)))
+	g.Expect(result.Status.Conditions[0]).To(HaveField("Impact", Equal(resultpkg.ImpactAdvisory)))
 }
 
 func TestDataIntegrityCheck_AnnotationCheckTargetVersion(t *testing.T) {


### PR DESCRIPTION
## Description
https://redhat.atlassian.net/browse/RHOAIENG-82044

Kueue check downgraded to warning in order to better support migrations from Managed and Unmanaged states.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kueue data-integrity diagnostics now classify inconsistent configurations as advisory rather than prohibited.
  * Validation and remediation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->