### PR TITLE
RHOAIENG-82045: re-enable kueue operator-installed check

### DIFF
--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -120,8 +120,7 @@ func NewCommand(
 	registry.MustRegister(kserve.NewServiceMeshOperatorCheck())
 	registry.MustRegister(kserve.NewServiceMeshRemovalCheck())
 	registry.MustRegister(kueue.NewManagementStateCheck())
-	// Deferred: re-enable when a future 3.3.x release supports Unmanaged + Red Hat build of Kueue Operator.
-	// registry.MustRegister(kueue.NewOperatorInstalledCheck())
+	registry.MustRegister(kueue.NewOperatorInstalledCheck())
 	registry.MustRegister(llamastack.NewRemovalCheck())
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())


### PR DESCRIPTION


## Description
The Red Hat build of Kueue operator is now supported with Unmanaged state. Uncomment the check registration so the lint command validates RHBoK operator presence during upgrades.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Kueue operator-installed check to the standard lint checks.

* **Bug Fixes**
  * Ensured the check runs automatically as part of lint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->