### PR TITLE
[RHOAIENG-81955] Enhance Kueue management-state check to include LocalQueue and when in an Unmanaged state

### DIFF
--- a/pkg/lint/check/condition.go
+++ b/pkg/lint/check/condition.go
@@ -194,6 +194,11 @@ const (
 
 	// ReasonConfigurationUnmanaged indicates a configuration is not managed by the operator.
 	ReasonConfigurationUnmanaged = "ConfigurationUnmanaged"
+
+	// ReasonDefaultLocalQueueConflict indicates a potentially dangerous "default" LocalQueue
+	// naming configuration was detected (a LocalQueue named "default", or
+	// spec.components.kueue.defaultLocalQueueName set to "default").
+	ReasonDefaultLocalQueueConflict = "DefaultLocalQueueConflict"
 )
 
 // Standard Reason Values - Unknown/Error.

--- a/pkg/lint/checks/components/kueue/default_queue.go
+++ b/pkg/lint/checks/components/kueue/default_queue.go
@@ -1,0 +1,68 @@
+package kueue
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// defaultLocalQueueName is the LocalQueue name Kueue implicitly assigns to workloads that live
+// in a kueue-managed namespace but are not explicitly bound to a queue. When Kueue is Unmanaged,
+// reusing this name for an unrelated queue can silently route workloads to the wrong LocalQueue.
+const defaultLocalQueueName = "default"
+
+// detectDefaultLocalQueue reports whether a potentially dangerous "default" LocalQueue
+// configuration exists. It triggers when either:
+//   - DSC spec.components.kueue.defaultLocalQueueName is set to "default", or
+//   - a LocalQueue resource named "default" exists in any namespace.
+//
+// triggers holds human-readable descriptions of each condition that fired (for the warning
+// message); a non-empty triggers slice means the hazard was detected. impacted lists the
+// LocalQueue objects named "default" (for ImpactedObjects). A cluster without the LocalQueue CRD
+// is treated as "no LocalQueues" rather than an error.
+func detectDefaultLocalQueue(
+	ctx context.Context,
+	r client.Reader,
+	dsc *unstructured.Unstructured,
+) ([]string, []types.NamespacedName, error) {
+	var (
+		triggers []string
+		impacted []types.NamespacedName
+	)
+
+	if name, found, nErr := unstructured.NestedString(
+		dsc.Object, "spec", "components", "kueue", "defaultLocalQueueName",
+	); nErr == nil && found && name == defaultLocalQueueName {
+		triggers = append(triggers,
+			fmt.Sprintf("DSC spec.components.kueue.defaultLocalQueueName is set to %q", defaultLocalQueueName))
+	}
+
+	items, err := r.ListMetadata(ctx, resources.LocalQueue)
+	switch {
+	case client.IsResourceTypeNotFound(err):
+		// LocalQueue CRD is not installed — nothing to inspect.
+	case err != nil:
+		return nil, nil, fmt.Errorf("listing LocalQueues: %w", err)
+	default:
+		for _, item := range items {
+			if item.GetName() == defaultLocalQueueName {
+				impacted = append(impacted, types.NamespacedName{
+					Namespace: item.GetNamespace(),
+					Name:      item.GetName(),
+				})
+			}
+		}
+	}
+
+	if len(impacted) > 0 {
+		triggers = append(triggers,
+			fmt.Sprintf("a LocalQueue named %q exists in the cluster", defaultLocalQueueName))
+	}
+
+	return triggers, impacted, nil
+}

--- a/pkg/lint/checks/components/kueue/kueue.go
+++ b/pkg/lint/checks/components/kueue/kueue.go
@@ -3,6 +3,7 @@ package kueue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
 	kueuediscovery "github.com/opendatahub-io/odh-cli/pkg/lint/checks/kueue/discovery"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
@@ -20,21 +22,38 @@ const (
 	kind                     = "kueue"
 	checkTypeManagementState = "management-state"
 
-	// Deferred: parameterize hardcoded version references using ComponentRequest.TargetVersion.
-	msgManagedProhibited   = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when you have migrated to the Red Hat build of Kueue Operator and the Kueue managementState is Unmanaged."
-	msgUnmanagedProhibited = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. A future 3.3.x release might allow an upgrade when the Kueue managementState is Unmanaged."
-	msgManagedBlocking     = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Managed but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
-	msgUnmanagedBlocking   = "The 3.3.2 upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Unmanaged but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this script to proceed with migration."
+	// Version-parameterized message formats. The single %s is the target's major.minor label
+	// (e.g. "3.5"), supplied via version.MajorMinorLabel(req.TargetVersion) at call time.
+	msgManagedProhibitedFmt   = "The %s upgrade does not support the Kueue managementState of Managed. Migrate Kueue to Unmanaged with the Red Hat build of Kueue Operator before upgrading."
+	msgManagedBlockingFmt     = "The %s upgrade currently only supports the Kueue managementState of Removed. The Kueue managementState is currently Managed but no workloads on the cluster are using Kueue. Set the Kueue managementState to Removed and then re-run this check to proceed with migration."
+	msgUnmanagedCompatibleFmt = "The Kueue managementState is Unmanaged, which is supported for the %s upgrade."
+
+	// remediationManagedMigrate advises migrating away from embedded (Managed) Kueue. Mirrors
+	// operatorInstalledManagedRemediation in kueue_operator_installed.go for consistency.
+	remediationManagedMigrate = "Migrate to the Red Hat build of Kueue operator following https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.25/html/managing_openshift_ai/managing-workloads-with-kueue#migrating-to-the-rhbok-operator_kueue before upgrading"
+
+	// msgDefaultLocalQueueFmt describes the "default" LocalQueue hazard. The single %s is the
+	// semicolon-joined list of triggers that fired.
+	msgDefaultLocalQueueFmt = "Potential \"default\" LocalQueue naming conflict detected (%s). When Kueue is Unmanaged, workloads in kueue-managed namespaces that are not explicitly assigned to a queue are implicitly placed on the LocalQueue named \"default\", which may route them to an unintended queue."
+
+	// remediationDefaultLocalQueue advises resolving the "default" LocalQueue hazard.
+	remediationDefaultLocalQueue = "Rename spec.components.kueue.defaultLocalQueueName to a value other than \"default\", drain workloads from the existing \"default\" LocalQueue, and delete it"
 )
 
-// ManagementStateCheck validates that Kueue managementState is Removed before upgrading to 3.x.
-// In RHOAI 3.3.2, only the Removed state is supported. A future 3.3.x release will support
-// Unmanaged with the Red Hat build of Kueue Operator.
+// ManagementStateCheck validates the Kueue managementState is compatible before upgrading to 3.x.
 //
 // The check distinguishes between clusters that are actively using Kueue (namespaces or workloads
 // labeled for Kueue) and those that have Kueue enabled but are not actually using it:
-//   - Managed/Unmanaged + in use: prohibited (upgrade not possible)
-//   - Managed/Unmanaged + not in use: blocking (recoverable — set managementState to Removed)
+//   - Managed + in use: prohibited — migrate to the Red Hat build of Kueue Operator (Unmanaged) first
+//   - Managed + not in use: blocking (recoverable — set managementState to Removed)
+//   - Unmanaged (either): pass — a supported target state; the RHBoK operator requirement is
+//     enforced separately by the components.kueue.operator-installed check
+//
+// In addition, whenever the upgrade could proceed onto an Unmanaged state (Managed+in use, which
+// requires migration to Unmanaged; or already Unmanaged) it emits an advisory warning if a
+// potentially dangerous "default" LocalQueue configuration is detected. The advisory layers on top
+// of the base condition without escalating overall severity, because GetImpact() returns the max
+// impact across conditions.
 type ManagementStateCheck struct {
 	check.BaseCheck
 }
@@ -73,36 +92,108 @@ func (c *ManagementStateCheck) CanApply(ctx context.Context, target check.Target
 func (c *ManagementStateCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
 	return validate.Component(c, target).
 		Run(ctx, func(ctx context.Context, req *validate.ComponentRequest) error {
-			kueueInUse, err := isKueueInUse(ctx, req.Client)
-			if err != nil {
-				return fmt.Errorf("checking kueue usage: %w", err)
-			}
+			label := version.MajorMinorLabel(req.TargetVersion)
 
-			setCondition := func(msg string, impact result.Impact) {
-				req.Result.SetCondition(check.NewCondition(
-					check.ConditionTypeCompatible,
-					metav1.ConditionFalse,
-					check.WithReason(check.ReasonVersionIncompatible),
-					check.WithMessage("%s", msg),
-					check.WithImpact(impact),
-				))
-			}
-
-			switch {
-			case req.ManagementState == constants.ManagementStateManaged && kueueInUse:
-				setCondition(msgManagedProhibited, result.ImpactProhibited)
-			case req.ManagementState == constants.ManagementStateManaged && !kueueInUse:
-				setCondition(msgManagedBlocking, result.ImpactBlocking)
-			case req.ManagementState == constants.ManagementStateUnmanaged && kueueInUse:
-				setCondition(msgUnmanagedProhibited, result.ImpactProhibited)
-			case req.ManagementState == constants.ManagementStateUnmanaged && !kueueInUse:
-				setCondition(msgUnmanagedBlocking, result.ImpactBlocking)
+			switch req.ManagementState {
+			case constants.ManagementStateManaged:
+				return c.validateManaged(ctx, req, label)
+			case constants.ManagementStateUnmanaged:
+				return c.validateUnmanaged(ctx, req, label)
 			default:
 				return fmt.Errorf("unexpected management state %q for kueue", req.ManagementState)
 			}
-
-			return nil
 		})
+}
+
+// validateManaged handles the Managed state. When Kueue is in use there is no supported upgrade
+// path from embedded Kueue, so the base condition is prohibited (with migration remediation) and a
+// default-LocalQueue advisory is layered on since the migration target is Unmanaged. When Kueue is
+// not in use the state is recoverable, so the base condition is blocking (set managementState to
+// Removed) and the advisory is not relevant.
+func (c *ManagementStateCheck) validateManaged(
+	ctx context.Context,
+	req *validate.ComponentRequest,
+	label string,
+) error {
+	kueueInUse, err := isKueueInUse(ctx, req.Client)
+	if err != nil {
+		return fmt.Errorf("checking kueue usage: %w", err)
+	}
+
+	if !kueueInUse {
+		req.Result.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonVersionIncompatible),
+			check.WithMessage(msgManagedBlockingFmt, label),
+			check.WithImpact(result.ImpactBlocking),
+		))
+
+		return nil
+	}
+
+	req.Result.SetCondition(check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonVersionIncompatible),
+		check.WithMessage(msgManagedProhibitedFmt, label),
+		check.WithImpact(result.ImpactProhibited),
+		check.WithRemediation(remediationManagedMigrate),
+	))
+
+	return c.addDefaultLocalQueueWarning(ctx, req)
+}
+
+// validateUnmanaged handles the Unmanaged state, which is a supported target for the upgrade. The
+// base condition passes (compatibility confirmed); the RHBoK operator requirement is enforced by
+// the separate components.kueue.operator-installed check. A default-LocalQueue advisory is layered
+// on when the hazard is detected — it never blocks the upgrade.
+func (c *ManagementStateCheck) validateUnmanaged(
+	ctx context.Context,
+	req *validate.ComponentRequest,
+	label string,
+) error {
+	req.Result.SetCondition(check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionTrue,
+		check.WithReason(check.ReasonVersionCompatible),
+		check.WithMessage(msgUnmanagedCompatibleFmt, label),
+	))
+
+	return c.addDefaultLocalQueueWarning(ctx, req)
+}
+
+// addDefaultLocalQueueWarning appends an advisory condition when a potentially dangerous "default"
+// LocalQueue configuration is detected. It layers on top of the base condition already set on the
+// result; because GetImpact() returns the max impact across conditions, the advisory surfaces the
+// hazard without escalating overall severity.
+func (c *ManagementStateCheck) addDefaultLocalQueueWarning(
+	ctx context.Context,
+	req *validate.ComponentRequest,
+) error {
+	triggers, impacted, err := detectDefaultLocalQueue(ctx, req.Client, req.DSC)
+	if err != nil {
+		return fmt.Errorf("detecting default LocalQueue: %w", err)
+	}
+
+	if len(triggers) == 0 {
+		return nil
+	}
+
+	req.Result.SetCondition(check.NewCondition(
+		check.ConditionTypeConfigured,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonDefaultLocalQueueConflict),
+		check.WithMessage(msgDefaultLocalQueueFmt, strings.Join(triggers, "; ")),
+		check.WithImpact(result.ImpactAdvisory),
+		check.WithRemediation(remediationDefaultLocalQueue),
+	))
+
+	if len(impacted) > 0 {
+		req.Result.AddImpactedObjects(resources.LocalQueue, impacted)
+	}
+
+	return nil
 }
 
 // isKueueInUse returns true if at least one namespace is labeled for Kueue management

--- a/pkg/lint/checks/components/kueue/kueue_test.go
+++ b/pkg/lint/checks/components/kueue/kueue_test.go
@@ -28,6 +28,7 @@ var listKinds = map[schema.GroupVersionResource]string{
 	resources.RayCluster.GVR():          resources.RayCluster.ListKind(),
 	resources.RayJob.GVR():              resources.RayJob.ListKind(),
 	resources.PyTorchJob.GVR():          resources.PyTorchJob.ListKind(),
+	resources.LocalQueue.GVR():          resources.LocalQueue.ListKind(),
 }
 
 func newNamespace(name string, labels map[string]string) *unstructured.Unstructured {
@@ -77,6 +78,46 @@ func newWorkload(
 			"metadata":   meta,
 		},
 	}
+}
+
+func newLocalQueue(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.LocalQueue.APIVersion(),
+			"kind":       resources.LocalQueue.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+// newDSCWithDefaultQueue builds a DSC with the given kueue managementState and, when
+// defaultQueueName is non-empty, sets spec.components.kueue.defaultLocalQueueName.
+func newDSCWithDefaultQueue(state, defaultQueueName string) *unstructured.Unstructured {
+	dsc := testutil.NewDSC(map[string]string{"kueue": state})
+	if defaultQueueName != "" {
+		if err := unstructured.SetNestedField(
+			dsc.Object, defaultQueueName,
+			"spec", "components", "kueue", "defaultLocalQueueName",
+		); err != nil {
+			panic(err)
+		}
+	}
+
+	return dsc
+}
+
+// conditionByType returns the first condition of the given type and whether it was found.
+func conditionByType(r *resultpkg.DiagnosticResult, condType string) (resultpkg.Condition, bool) {
+	for _, c := range r.Status.Conditions {
+		if c.Type == condType {
+			return c, true
+		}
+	}
+
+	return resultpkg.Condition{}, false
 }
 
 func TestManagementStateCheck_CanApply_NoDSC(t *testing.T) {
@@ -134,14 +175,17 @@ func TestManagementStateCheck_ManagedProhibited(t *testing.T) {
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
+	// No default-LocalQueue hazard present → base condition only.
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("only supports the Kueue managementState of Removed"), ContainSubstring("migrated to the Red Hat build of Kueue Operator")),
+		"Message": And(ContainSubstring("does not support the Kueue managementState of Managed"), ContainSubstring("Migrate Kueue to Unmanaged")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+	g.Expect(result.Status.Conditions[0].Remediation).ToNot(BeEmpty())
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactProhibited))
 	g.Expect(result.Annotations).To(And(
 		HaveKeyWithValue("component.opendatahub.io/management-state", "Managed"),
 		HaveKeyWithValue("check.opendatahub.io/target-version", "3.3.2"),
@@ -176,11 +220,13 @@ func TestManagementStateCheck_ManagedBlocking(t *testing.T) {
 	)
 }
 
-func TestManagementStateCheck_UnmanagedProhibited(t *testing.T) {
+func TestManagementStateCheck_UnmanagedInUsePass(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Kueue is Unmanaged AND there is a workload labeled for kueue.
+	// Kueue is Unmanaged AND there is a workload labeled for kueue. Unmanaged is a supported
+	// target state, so the base condition passes (the RHBoK operator requirement is enforced
+	// by the separate operator-installed check).
 	nb := newWorkload(resources.Notebook, "team-b", "my-notebook",
 		map[string]string{constants.LabelKueueQueueName: "default-queue"})
 
@@ -197,19 +243,19 @@ func TestManagementStateCheck_UnmanagedProhibited(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
-		"Type":    Equal(check.ConditionTypeCompatible),
-		"Status":  Equal(metav1.ConditionFalse),
-		"Reason":  Equal(check.ReasonVersionIncompatible),
-		"Message": And(ContainSubstring("only supports the Kueue managementState of Removed"), Not(ContainSubstring("migrated to the Red Hat build of Kueue Operator"))),
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
 	}))
-	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactNone))
 }
 
-func TestManagementStateCheck_UnmanagedBlocking(t *testing.T) {
+func TestManagementStateCheck_UnmanagedNotInUsePass(t *testing.T) {
 	g := NewWithT(t)
 	ctx := t.Context()
 
-	// Kueue is Unmanaged but NO namespaces or workloads are labeled for kueue.
+	// Kueue is Unmanaged and NOT in use — still a supported target state → pass.
 	target := testutil.NewTarget(t, testutil.TargetConfig{
 		ListKinds:      listKinds,
 		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"})},
@@ -224,10 +270,198 @@ func TestManagementStateCheck_UnmanagedBlocking(t *testing.T) {
 	g.Expect(result.Status.Conditions).To(HaveLen(1))
 	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
 		"Type":   Equal(check.ConditionTypeCompatible),
-		"Status": Equal(metav1.ConditionFalse),
-		"Reason": Equal(check.ReasonVersionIncompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
 	}))
-	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactNone))
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactNone))
+}
+
+// TestManagementStateCheck_ManagedInUse_DefaultQueueName_Warns verifies the Managed+in-use path
+// layers an advisory default-LocalQueue warning on top of the prohibited base condition when
+// DSC spec.components.kueue.defaultLocalQueueName is "default". Overall impact stays Prohibited.
+func TestManagementStateCheck_ManagedInUse_DefaultQueueName_Warns(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newDSCWithDefaultQueue("Managed", "default"), ns},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.2",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+
+	base, found := conditionByType(result, check.ConditionTypeCompatible)
+	g.Expect(found).To(BeTrue())
+	g.Expect(base.Impact).To(Equal(resultpkg.ImpactProhibited))
+
+	warning, found := conditionByType(result, check.ConditionTypeConfigured)
+	g.Expect(found).To(BeTrue())
+	g.Expect(warning.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(warning.Reason).To(Equal(check.ReasonDefaultLocalQueueConflict))
+	g.Expect(warning.Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(warning.Remediation).ToNot(BeEmpty())
+
+	// Prohibited base dominates the advisory warning.
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactProhibited))
+}
+
+// TestManagementStateCheck_ManagedInUse_DefaultQueueResource_Warns verifies the warning also fires
+// when a LocalQueue named "default" exists on the cluster, and that the LocalQueue is recorded as
+// an impacted object.
+func TestManagementStateCheck_ManagedInUse_DefaultQueueResource_Warns(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	ns := newNamespace("team-a", map[string]string{constants.LabelKueueManaged: "true"})
+	lq := newLocalQueue("team-a", "default")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Managed"}), ns, lq},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.2",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+
+	warning, found := conditionByType(result, check.ConditionTypeConfigured)
+	g.Expect(found).To(BeTrue())
+	g.Expect(warning.Reason).To(Equal(check.ReasonDefaultLocalQueueConflict))
+	g.Expect(warning.Impact).To(Equal(resultpkg.ImpactAdvisory))
+
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("default"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("team-a"))
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactProhibited))
+}
+
+// TestManagementStateCheck_Unmanaged_DefaultQueueName_Warns verifies that when Kueue is Unmanaged
+// (whether or not workloads are in use) and defaultLocalQueueName is "default", the base passes and
+// the advisory warning surfaces without blocking the upgrade (overall impact Advisory).
+func TestManagementStateCheck_Unmanaged_DefaultQueueName_Warns(t *testing.T) {
+	testCases := []struct {
+		name    string
+		objects []*unstructured.Unstructured
+	}{
+		{
+			name: "in use",
+			objects: []*unstructured.Unstructured{
+				newDSCWithDefaultQueue("Unmanaged", "default"),
+				newWorkload(resources.Notebook, "team-b", "my-notebook",
+					map[string]string{constants.LabelKueueQueueName: "team-queue"}),
+			},
+		},
+		{
+			name: "not in use",
+			objects: []*unstructured.Unstructured{
+				newDSCWithDefaultQueue("Unmanaged", "default"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			target := testutil.NewTarget(t, testutil.TargetConfig{
+				ListKinds:      listKinds,
+				Objects:        tc.objects,
+				CurrentVersion: "2.25.0",
+				TargetVersion:  "3.3.2",
+			})
+
+			chk := kueue.NewManagementStateCheck()
+			result, err := chk.Validate(ctx, target)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result.Status.Conditions).To(HaveLen(2))
+
+			base, found := conditionByType(result, check.ConditionTypeCompatible)
+			g.Expect(found).To(BeTrue())
+			g.Expect(base.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(base.Impact).To(Equal(resultpkg.ImpactNone))
+
+			warning, found := conditionByType(result, check.ConditionTypeConfigured)
+			g.Expect(found).To(BeTrue())
+			g.Expect(warning.Reason).To(Equal(check.ReasonDefaultLocalQueueConflict))
+			g.Expect(warning.Impact).To(Equal(resultpkg.ImpactAdvisory))
+
+			// Advisory warning surfaces but does not block the upgrade.
+			g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactAdvisory))
+		})
+	}
+}
+
+// TestManagementStateCheck_Unmanaged_DefaultQueueResource_Warns verifies the advisory fires for an
+// Unmanaged cluster with a LocalQueue named "default" and records the impacted object.
+func TestManagementStateCheck_Unmanaged_DefaultQueueResource_Warns(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	lq := newLocalQueue("team-b", "default")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kueue": "Unmanaged"}), lq},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.2",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(2))
+
+	warning, found := conditionByType(result, check.ConditionTypeConfigured)
+	g.Expect(found).To(BeTrue())
+	g.Expect(warning.Reason).To(Equal(check.ReasonDefaultLocalQueueConflict))
+	g.Expect(warning.Impact).To(Equal(resultpkg.ImpactAdvisory))
+
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("default"))
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactAdvisory))
+}
+
+// TestManagementStateCheck_Unmanaged_NoDefaultQueue_NoWarning verifies that a non-"default"
+// LocalQueue and no defaultLocalQueueName produce only the passing base condition.
+func TestManagementStateCheck_Unmanaged_NoDefaultQueue_NoWarning(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	lq := newLocalQueue("team-b", "team-queue")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newDSCWithDefaultQueue("Unmanaged", "team-queue"), lq},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.3.2",
+	})
+
+	chk := kueue.NewManagementStateCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Type).To(Equal(check.ConditionTypeCompatible))
+
+	_, found := conditionByType(result, check.ConditionTypeConfigured)
+	g.Expect(found).To(BeFalse())
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactNone))
 }
 
 func TestManagementStateCheck_CanApply_ManagementState(t *testing.T) {
@@ -292,7 +526,7 @@ func TestManagementStateCheck_KueueUsageViaNamespaceLabel(t *testing.T) {
 		result, err := chk.Validate(ctx, target)
 
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+		g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactProhibited))
 	})
 
 	t.Run("kueue.openshift.io/managed label", func(t *testing.T) {
@@ -313,7 +547,7 @@ func TestManagementStateCheck_KueueUsageViaNamespaceLabel(t *testing.T) {
 		result, err := chk.Validate(ctx, target)
 
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+		g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactProhibited))
 	})
 }
 
@@ -336,5 +570,5 @@ func TestManagementStateCheck_KueueUsageViaWorkloadLabel(t *testing.T) {
 	result, err := chk.Validate(ctx, target)
 
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactProhibited))
+	g.Expect(result.GetImpact()).To(Equal(resultpkg.ImpactProhibited))
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-81955

## Description

Enhances Kueue Lint checks to include handling an Unmanaged state and checking for LocalQueue values. Validated on OpenShift 4.21.3 with RHOAI 2.25.9

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for conflicts involving Kueue’s default LocalQueue configuration.
  - Reports affected LocalQueue resources and provides guidance for resolving conflicts.
  - Improved Kueue management-state validation, distinguishing Managed and Unmanaged configurations.
  - Added version-specific messages and clearer remediation guidance.

- **Bug Fixes**
  - Unmanaged Kueue configurations are now correctly treated as compatible, including when in use.
  - Missing LocalQueue resource definitions no longer trigger erroneous failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->