### PR TITLE
feat(lint): warn on TrainJob podTemplateOverrides for 3.6 upgrades

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,6 +18,7 @@ const (
 	ComponentDashboard        = "dashboard"
 	ComponentKServe           = "kserve"
 	ComponentRay              = "ray"
+	ComponentTrainer          = "trainer"
 	ComponentTrainingOperator = "trainingoperator"
 	ComponentWorkbenches      = "workbenches"
 )

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides.go
@@ -35,8 +35,9 @@ func NewPodTemplateOverridesCheck() *PodTemplateOverridesCheck {
 			CheckName:  "Workloads :: Trainer :: PodTemplateOverrides (3.6+)",
 			CheckDescription: "Detects TrainJobs using podTemplateOverrides that may fail pause/resume " +
 				"after upgrading to OpenShift AI 3.6",
-			CheckRemediation: "Wait for these jobs to complete before upgrading. After upgrade, recreate " +
-				"TrainJobs using runtimePatches. See " + kbArticleURL,
+			CheckRemediation: "We recommend waiting for TrainJobs that use podTemplateOverrides to complete " +
+				"before upgrading when possible. After upgrade, recreate TrainJobs using runtimePatches. " +
+				"See " + kbArticleURL,
 		},
 	}
 }

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides.go
@@ -33,10 +33,10 @@ func NewPodTemplateOverridesCheck() *PodTemplateOverridesCheck {
 			Type:       check.CheckTypeImpactedWorkloads,
 			CheckID:    "workloads.trainer.podtemplateoverrides",
 			CheckName:  "Workloads :: Trainer :: PodTemplateOverrides (3.6+)",
-			CheckDescription: "Detects TrainJobs using podTemplateOverrides that must be migrated to " +
-				"runtimePatches before or after upgrading to OpenShift AI 3.6",
-			CheckRemediation: "Migrate TrainJobs from podTemplateOverrides to runtimePatches before upgrading. " +
-				"See " + kbArticleURL,
+			CheckDescription: "Detects TrainJobs using podTemplateOverrides that may fail pause/resume " +
+				"after upgrading to OpenShift AI 3.6",
+			CheckRemediation: "Wait for these jobs to complete before upgrading. After upgrade, recreate " +
+				"TrainJobs using runtimePatches. See " + kbArticleURL,
 		},
 	}
 }

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides.go
@@ -1,0 +1,74 @@
+package trainer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	ConditionTypePodTemplateOverridesCompatible = "PodTemplateOverridesCompatible"
+	kbArticleURL                                = "https://access.redhat.com/articles/7146204"
+)
+
+// PodTemplateOverridesCheck warns about TrainJobs that still use podTemplateOverrides
+// when upgrading to OpenShift AI 3.6+ (Trainer v2.3 replaces that field with runtimePatches).
+type PodTemplateOverridesCheck struct {
+	check.BaseCheck
+}
+
+func NewPodTemplateOverridesCheck() *PodTemplateOverridesCheck {
+	return &PodTemplateOverridesCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup: check.GroupWorkload,
+			Kind:       constants.ComponentTrainer,
+			Type:       check.CheckTypeImpactedWorkloads,
+			CheckID:    "workloads.trainer.podtemplateoverrides",
+			CheckName:  "Workloads :: Trainer :: PodTemplateOverrides (3.6+)",
+			CheckDescription: "Detects TrainJobs using podTemplateOverrides that must be migrated to " +
+				"runtimePatches before or after upgrading to OpenShift AI 3.6",
+			CheckRemediation: "Migrate TrainJobs from podTemplateOverrides to runtimePatches before upgrading. " +
+				"See " + kbArticleURL,
+		},
+	}
+}
+
+// CanApply returns whether this check should run for the given target.
+// Applies when upgrading from <=3.5.x to >=3.6 and Trainer is Managed.
+func (c *PodTemplateOverridesCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	//nolint:mnd // Version numbers 3.6
+	if !version.IsVersionAtLeast(target.TargetVersion, 3, 6) {
+		return false, nil
+	}
+
+	//nolint:mnd // Version numbers 3.6
+	if version.IsVersionAtLeast(target.CurrentVersion, 3, 6) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, constants.ComponentTrainer, constants.ManagementStateManaged), nil
+}
+
+// Validate lists TrainJobs with non-empty podTemplateOverrides and returns an advisory warning.
+func (c *PodTemplateOverridesCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.Workloads(c, target, resources.TrainJob).
+		ForComponent(constants.ComponentTrainer).
+		Filter(hasPodTemplateOverrides).
+		Complete(ctx, c.newPodTemplateOverridesCondition)
+}

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides_support.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides_support.go
@@ -51,8 +51,8 @@ func (c *PodTemplateOverridesCheck) newPodTemplateOverridesCondition(
 			"Found %d TrainJob(s) that use podTemplateOverrides. In OpenShift AI 3.6, Trainer v2.3 removes "+
 				"podTemplateOverrides and replaces it with runtimePatches. Pause and resume of these "+
 				"pre-upgrade TrainJobs may fail after upgrade, including when managed by Kueue. "+
-				"Wait for these jobs to complete before upgrading. After upgrade, recreate TrainJobs "+
-				"using runtimePatches. See %s",
+				"We recommend waiting for these jobs to complete before upgrading when possible. "+
+				"After upgrade, recreate TrainJobs using runtimePatches. See %s",
 			count,
 			kbArticleURL,
 		),

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides_support.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides_support.go
@@ -51,7 +51,8 @@ func (c *PodTemplateOverridesCheck) newPodTemplateOverridesCondition(
 			"Found %d TrainJob(s) that use podTemplateOverrides. In OpenShift AI 3.6, Trainer v2.3 removes "+
 				"podTemplateOverrides and replaces it with runtimePatches. Pause and resume of these "+
 				"pre-upgrade TrainJobs may fail after upgrade, including when managed by Kueue. "+
-				"Migrate affected workloads before upgrading. See %s",
+				"Wait for these jobs to complete before upgrading. After upgrade, recreate TrainJobs "+
+				"using runtimePatches. See %s",
 			count,
 			kbArticleURL,
 		),

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides_support.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides_support.go
@@ -1,0 +1,61 @@
+package trainer
+
+import (
+	"context"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+// hasPodTemplateOverrides returns true when TrainJob.spec.podTemplateOverrides is present
+// and non-empty.
+func hasPodTemplateOverrides(obj *unstructured.Unstructured) (bool, error) {
+	val, err := jq.Query[[]any](obj, ".spec.podTemplateOverrides")
+
+	switch {
+	case errors.Is(err, jq.ErrNotFound):
+		return false, nil
+	case err != nil:
+		return false, err
+	default:
+		return len(val) > 0, nil
+	}
+}
+
+func (c *PodTemplateOverridesCheck) newPodTemplateOverridesCondition(
+	_ context.Context,
+	req *validate.WorkloadRequest[*unstructured.Unstructured],
+) ([]result.Condition, error) {
+	count := len(req.Items)
+
+	if count == 0 {
+		return []result.Condition{check.NewCondition(
+			ConditionTypePodTemplateOverridesCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonVersionCompatible),
+			check.WithMessage("No TrainJob(s) with podTemplateOverrides found - ready for OpenShift AI 3.6 Trainer upgrade"),
+		)}, nil
+	}
+
+	return []result.Condition{check.NewCondition(
+		ConditionTypePodTemplateOverridesCompatible,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonWorkloadsImpacted),
+		check.WithMessage(
+			"Found %d TrainJob(s) that use podTemplateOverrides. In OpenShift AI 3.6, Trainer v2.3 removes "+
+				"podTemplateOverrides and replaces it with runtimePatches. Pause and resume of these "+
+				"pre-upgrade TrainJobs may fail after upgrade, including when managed by Kueue. "+
+				"Migrate affected workloads before upgrading. See %s",
+			count,
+			kbArticleURL,
+		),
+		check.WithImpact(result.ImpactAdvisory),
+		check.WithRemediation(c.CheckRemediation),
+	)}, nil
+}

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides_test.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides_test.go
@@ -1,0 +1,277 @@
+package trainer_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainer"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var listKinds = map[schema.GroupVersionResource]string{
+	resources.TrainJob.GVR():           resources.TrainJob.ListKind(),
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func managedTrainerDSC() *unstructured.Unstructured {
+	return testutil.NewDSC(map[string]string{"trainer": "Managed"})
+}
+
+func newTrainJob(name, namespace string, spec map[string]any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.TrainJob.APIVersion(),
+			"kind":       resources.TrainJob.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func TestPodTemplateOverridesCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trainer.NewPodTemplateOverridesCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.trainer.podtemplateoverrides"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: Trainer :: PodTemplateOverrides (3.6+)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.CheckKind()).To(Equal("trainer"))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestPodTemplateOverridesCheck_CanApply_TargetBelow36(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC()},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	canApply, err := trainer.NewPodTemplateOverridesCheck().CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestPodTemplateOverridesCheck_CanApply_CurrentAlready36(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC()},
+		CurrentVersion: "3.6.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	canApply, err := trainer.NewPodTemplateOverridesCheck().CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestPodTemplateOverridesCheck_CanApply_TrainerRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds,
+		Objects: []*unstructured.Unstructured{
+			testutil.NewDSC(map[string]string{"trainer": "Removed"}),
+		},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	canApply, err := trainer.NewPodTemplateOverridesCheck().CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestPodTemplateOverridesCheck_CanApply_Upgrade35To36_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC()},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	canApply, err := trainer.NewPodTemplateOverridesCheck().CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestPodTemplateOverridesCheck_NoTrainJobs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC()},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	result, err := trainer.NewPodTemplateOverridesCheck().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainer.ConditionTypePodTemplateOverridesCompatible),
+		"Status":  Equal(metav1.ConditionTrue),
+		"Reason":  Equal(check.ReasonVersionCompatible),
+		"Message": ContainSubstring("No TrainJob(s) with podTemplateOverrides found"),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestPodTemplateOverridesCheck_TrainJobWithoutOverrides(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	job := newTrainJob("plain-job", "test-ns", map[string]any{
+		"runtimeRef": map[string]any{
+			"name": "torch-distributed",
+		},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC(), job},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	result, err := trainer.NewPodTemplateOverridesCheck().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(trainer.ConditionTypePodTemplateOverridesCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestPodTemplateOverridesCheck_TrainJobWithEmptyOverrides(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	job := newTrainJob("empty-overrides", "test-ns", map[string]any{
+		"podTemplateOverrides": []any{},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC(), job},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	result, err := trainer.NewPodTemplateOverridesCheck().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(trainer.ConditionTypePodTemplateOverridesCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+}
+
+func TestPodTemplateOverridesCheck_TrainJobWithOverrides(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	job := newTrainJob("legacy-job", "test-ns", map[string]any{
+		"podTemplateOverrides": []any{
+			map[string]any{
+				"targetJobs": []any{"node"},
+				"spec": map[string]any{
+					"serviceAccountName": "training-sa",
+				},
+			},
+		},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC(), job},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	result, err := trainer.NewPodTemplateOverridesCheck().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(trainer.ConditionTypePodTemplateOverridesCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonWorkloadsImpacted),
+		"Message": And(
+			ContainSubstring("Found 1 TrainJob(s) that use podTemplateOverrides"),
+			ContainSubstring("runtimePatches"),
+			ContainSubstring("https://access.redhat.com/articles/7146204"),
+		),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("legacy-job"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("test-ns"))
+}
+
+func TestPodTemplateOverridesCheck_MixedTrainJobs(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	legacyJob := newTrainJob("legacy-job", "ns1", map[string]any{
+		"podTemplateOverrides": []any{
+			map[string]any{
+				"targetJobs": []any{"node"},
+			},
+		},
+	})
+	plainJob := newTrainJob("plain-job", "ns1", map[string]any{
+		"runtimeRef": map[string]any{"name": "torch-distributed"},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{managedTrainerDSC(), legacyJob, plainJob},
+		CurrentVersion: "3.5.0",
+		TargetVersion:  "3.6.0",
+	})
+
+	result, err := trainer.NewPodTemplateOverridesCheck().Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainer.ConditionTypePodTemplateOverridesCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Message": ContainSubstring("Found 1 TrainJob(s) that use podTemplateOverrides"),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("legacy-job"))
+}

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides_test.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides_test.go
@@ -229,7 +229,7 @@ func TestPodTemplateOverridesCheck_TrainJobWithOverrides(t *testing.T) {
 		"Reason": Equal(check.ReasonWorkloadsImpacted),
 		"Message": And(
 			ContainSubstring("Found 1 TrainJob(s) that use podTemplateOverrides"),
-			ContainSubstring("Wait for these jobs to complete before upgrading"),
+			ContainSubstring("We recommend waiting for these jobs to complete before upgrading when possible"),
 			ContainSubstring("recreate TrainJobs using runtimePatches"),
 			ContainSubstring("https://access.redhat.com/articles/7146204"),
 		),

--- a/pkg/lint/checks/workloads/trainer/podtemplateoverrides_test.go
+++ b/pkg/lint/checks/workloads/trainer/podtemplateoverrides_test.go
@@ -229,7 +229,8 @@ func TestPodTemplateOverridesCheck_TrainJobWithOverrides(t *testing.T) {
 		"Reason": Equal(check.ReasonWorkloadsImpacted),
 		"Message": And(
 			ContainSubstring("Found 1 TrainJob(s) that use podTemplateOverrides"),
-			ContainSubstring("runtimePatches"),
+			ContainSubstring("Wait for these jobs to complete before upgrading"),
+			ContainSubstring("recreate TrainJobs using runtimePatches"),
 			ContainSubstring("https://access.redhat.com/articles/7146204"),
 		),
 	}))

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -41,6 +41,7 @@ import (
 	llamastackworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/llamastack"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/notebook"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/ray"
+	trainerworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainer"
 	trainingoperatorworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainingoperator"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/schema"
@@ -133,7 +134,7 @@ func NewCommand(
 	registry.MustRegister(sharedossm.NewCheck())
 	registry.MustRegister(sharedserverless.NewCheck())
 
-	// Workloads (21)
+	// Workloads (22)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
@@ -154,6 +155,7 @@ func NewCommand(
 	registry.MustRegister(notebook.NewImpactedWorkloadsCheck())
 	registry.MustRegister(notebook.NewNonStoppedWorkloadsCheck())
 	registry.MustRegister(ray.NewImpactedWorkloadsCheck())
+	registry.MustRegister(trainerworkloads.NewPodTemplateOverridesCheck())
 	registry.MustRegister(trainingoperatorworkloads.NewImpactedWorkloadsCheck())
 
 	c := &Command{

--- a/pkg/resources/types.go
+++ b/pkg/resources/types.go
@@ -363,8 +363,8 @@ var (
 
 	// TrainJob is the Kubeflow Trainer v2 TrainJob resource.
 	TrainJob = ResourceType{
-		Group:    "kubeflow.org",
-		Version:  "v2alpha1",
+		Group:    "trainer.kubeflow.org",
+		Version:  "v1alpha1",
 		Kind:     "TrainJob",
 		Resource: "trainjobs",
 	}


### PR DESCRIPTION
## Summary
- Adds advisory lint check `workloads.trainer.podtemplateoverrides` for [RHOAIENG-80806](https://redhat.atlassian.net/browse/RHOAIENG-80806)
- When upgrading from ≤3.5 to ≥3.6 with Trainer Managed, warns if TrainJobs still use `spec.podTemplateOverrides` and links the migration KB (`https://access.redhat.com/articles/7146204`)
- Corrects `resources.TrainJob` to `trainer.kubeflow.org/v1alpha1` so listings use the real Trainer v2 CRD
- Adds `constants.ComponentTrainer`

## Test plan
- [x] `go test ./pkg/lint/checks/workloads/trainer/...`
- [x] `go test ./pkg/resources/... ./pkg/migrate/actions/training/... ./pkg/lint/`
- [ ] `rhai-cli lint --target-version 3.6.0` on a 3.5 cluster with Trainer Managed and a TrainJob using `podTemplateOverrides`


Made with [Cursor](https://cursor.com)

[RHOAIENG-80806]: https://redhat.atlassian.net/browse/RHOAIENG-80806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added upgrade validation for managed Trainer workloads when upgrading from versions before 3.6 to 3.6 or later.
  - Detects TrainJobs using pod template overrides that may require migration.
  - Provides compatibility details, upgrade guidance, and remediation recommendations for affected workloads.

- **Bug Fixes**
  - Updated TrainJob resource recognition to align with the current Trainer API version.
  - Improved identification of affected workloads during upgrade readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Testing.

### Manual cluster verification

Built from this branch and ran against a RHOAI **3.5.0-ea.1** cluster with Trainer Managed and TrainJobs still using `podTemplateOverrides`:

```bash
./bin/kubectl-odh lint --target-version 3.6.0 --checks 'workloads.trainer.podtemplateoverrides' -v -o table
```

```text
Assessing upgrade readiness: 3.5.0-ea.1 → 3.6.0

Running upgrade compatibility checks...

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ STATUS  KIND     GROUP     CHECK               IMPACT   MESSAGE                                                                                         │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ⚠       trainer  workload  impacted-workloads  warning  Found 13 TrainJob(s) that use podTemplateOverrides. In OpenShift AI 3.6, Trainer v2.3 removes   │
│                                                         podTemplateOverrides and replaces it with runtimePatches. Pause and resume of these pre-upgrade │
│                                                         TrainJobs may fail after upgrade, including when managed by Kueue. Migrate affected workloads   │
│                                                         before upgrading. See https://access.redhat.com/articles/7146204                                │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Environment:
  OpenShift AI version: 3.5.0-ea.1 -> 3.6.0
  OpenShift version:    4.21.16

Summary:
  Total: 1 | Passed: 0 | Warnings: 1 | Failed: 0 | Prohibited: 0

Impacted Objects:

┌────────────────────────────────────────────────────────────────┐
│ STATUS  KIND     GROUP     CHECK               IMPACT          │
├────────────────────────────────────────────────────────────────┤
│ ⚠       trainer  workload  impacted-workloads  warning         │
│                                                                │
│     astefanu (requester: astefanu@redhat.com):                 │
│       - c78f5132ad0d (TrainJob)                                │
│       - w5780ac30242 (TrainJob)                                │
│     cluster-monitor-agent:                                     │
│       - granite-sft-lora (TrainJob)                            │
│     grpo-benchmark:                                            │
│       - grpo-7b-min (TrainJob)                                 │
│     hrathina-test (requester: hrathina@redhat.com):            │
│       - speculator-train-test (TrainJob)                       │
│     ksuta-nemotron:                                            │
│       - nano30b-lora-v1 (TrainJob)                             │
│       - nemotron-lora-rfe-v4 (TrainJob)                        │
│       - qwen-lora-v3 (TrainJob)                                │
│       - qwen-lora-v4 (TrainJob)                                │
│     model-checkpointing-demo (requester: training_plain_user): │
│       - llama-ddp-test (TrainJob)                              │
│       - priority-job (TrainJob)                                │
│       - speculator-smoke-test (TrainJob)                       │
│     umberto-test (requester: umangani@redhat.com):             │
│       - alpha-borrow-4571u (TrainJob)                          │
│                                                                │
│                                                                │
└────────────────────────────────────────────────────────────────┘

Result:
  WARNING - advisory findings detected
```