### PR TITLE
fix(migrate): capture pod health state during migrate run

### DIFF
--- a/pkg/migrate/actions/aipipelines/capture_pod_health_test.go
+++ b/pkg/migrate/actions/aipipelines/capture_pod_health_test.go
@@ -1,0 +1,179 @@
+package aipipelines_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/util/iostreams"
+
+	. "github.com/onsi/gomega"
+)
+
+func newTestRecorder() action.RootRecorder {
+	io := iostreams.NewIOStreams(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{})
+
+	return action.NewVerboseRootRecorder(io)
+}
+
+func TestCaptureAndSavePodHealth(t *testing.T) {
+	t.Run("captures and saves state when no DSPAs exist", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "dspa_pre_upgrade_pods.json")
+		cleanup := aipipelines.SetDefaultStatePath(statePath)
+		defer cleanup()
+
+		c := newFakeClient()
+		recorder := newTestRecorder()
+
+		aipipelines.CaptureAndSavePodHealth(context.Background(), c, recorder, false, false)
+
+		_, err := os.Stat(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		state, err := aipipelines.LoadPodHealthState(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state.DSPAs).To(BeEmpty())
+		g.Expect(state.CapturedAt).ToNot(BeEmpty())
+	})
+
+	t.Run("captures and saves state with DSPAs and pods", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "dspa_pre_upgrade_pods.json")
+		cleanup := aipipelines.SetDefaultStatePath(statePath)
+		defer cleanup()
+
+		pod := aipipelines.MakePodUnstructured("ds-pipeline-mydspa-abc", "ns1", "Running", "True")
+		c := newFakeClient(
+			makeDSPA("mydspa", "ns1", "v1"),
+			&pod,
+		)
+		recorder := newTestRecorder()
+
+		aipipelines.CaptureAndSavePodHealth(context.Background(), c, recorder, false, false)
+
+		state, err := aipipelines.LoadPodHealthState(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state.DSPAs).To(HaveLen(1))
+		g.Expect(state.DSPAs[0].Name).To(Equal("mydspa"))
+	})
+
+	t.Run("dry-run does not write state file", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "dspa_pre_upgrade_pods.json")
+		cleanup := aipipelines.SetDefaultStatePath(statePath)
+		defer cleanup()
+
+		c := newFakeClient()
+		recorder := newTestRecorder()
+
+		aipipelines.CaptureAndSavePodHealth(context.Background(), c, recorder, true, false)
+
+		_, err := os.Stat(statePath)
+		g.Expect(os.IsNotExist(err)).To(BeTrue())
+
+		res := recorder.Build()
+		g.Expect(findStep(res, "save-state")).ToNot(BeNil())
+		g.Expect(findStep(res, "save-state").Status).To(Equal(result.StepSkipped))
+	})
+
+	t.Run("skipIfExists skips when state file already exists", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "dspa_pre_upgrade_pods.json")
+		cleanup := aipipelines.SetDefaultStatePath(statePath)
+		defer cleanup()
+
+		existing := aipipelines.PodHealthState{CapturedAt: "2026-01-01T00:00:00Z"}
+		err := aipipelines.SavePodHealthState(existing, statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		c := newFakeClient()
+		recorder := newTestRecorder()
+
+		aipipelines.CaptureAndSavePodHealth(context.Background(), c, recorder, false, true)
+
+		state, err := aipipelines.LoadPodHealthState(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state.CapturedAt).To(Equal("2026-01-01T00:00:00Z"))
+	})
+
+	t.Run("skipIfExists captures when no state file exists", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "dspa_pre_upgrade_pods.json")
+		cleanup := aipipelines.SetDefaultStatePath(statePath)
+		defer cleanup()
+
+		c := newFakeClient()
+		recorder := newTestRecorder()
+
+		aipipelines.CaptureAndSavePodHealth(context.Background(), c, recorder, false, true)
+
+		_, err := os.Stat(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		state, err := aipipelines.LoadPodHealthState(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state.CapturedAt).ToNot(BeEmpty())
+	})
+
+	t.Run("prepare path always overwrites existing state", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "dspa_pre_upgrade_pods.json")
+		cleanup := aipipelines.SetDefaultStatePath(statePath)
+		defer cleanup()
+
+		existing := aipipelines.PodHealthState{CapturedAt: "2026-01-01T00:00:00Z"}
+		err := aipipelines.SavePodHealthState(existing, statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		c := newFakeClient()
+		recorder := newTestRecorder()
+
+		aipipelines.CaptureAndSavePodHealth(context.Background(), c, recorder, false, false)
+
+		state, err := aipipelines.LoadPodHealthState(statePath)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state.CapturedAt).ToNot(Equal("2026-01-01T00:00:00Z"))
+	})
+}
+
+func findStep(res *result.ActionResult, name string) *result.ActionStep {
+	for i := range res.Status.Steps {
+		if s := findStepRecursive(&res.Status.Steps[i], name); s != nil {
+			return s
+		}
+	}
+
+	return nil
+}
+
+func findStepRecursive(step *result.ActionStep, name string) *result.ActionStep {
+	if step.Name == name {
+		return step
+	}
+
+	for i := range step.Children {
+		if s := findStepRecursive(&step.Children[i], name); s != nil {
+			return s
+		}
+	}
+
+	return nil
+}

--- a/pkg/migrate/actions/aipipelines/export_test.go
+++ b/pkg/migrate/actions/aipipelines/export_test.go
@@ -15,7 +15,18 @@ var (
 	ListDSPAs                   = listDSPAs
 	HasV1Alpha1StoredVersion    = hasV1Alpha1StoredVersion
 	RemoveV1Alpha1StoredVersion = removeV1Alpha1StoredVersion
+	CaptureAndSavePodHealth     = captureAndSavePodHealth
 )
+
+// SetDefaultStatePath overrides the state file path for testing.
+// Returns a cleanup function that restores the original.
+func SetDefaultStatePath(path string) func() {
+	original := defaultStatePathFunc
+
+	defaultStatePathFunc = func() string { return path }
+
+	return func() { defaultStatePathFunc = original }
+}
 
 func MakePodUnstructured(name, namespace, phase, readyStatus string) unstructured.Unstructured {
 	conditions := []any{}

--- a/pkg/migrate/actions/aipipelines/pod_health.go
+++ b/pkg/migrate/actions/aipipelines/pod_health.go
@@ -271,6 +271,10 @@ func loadPodHealthState(path string) (PodHealthState, error) {
 	return state, nil
 }
 
-func defaultStatePath() string {
+var defaultStatePathFunc = func() string { //nolint:gochecknoglobals // Overridden in tests via export_test.go
 	return filepath.Join(defaultStateDir, stateFileName)
+}
+
+func defaultStatePath() string {
+	return defaultStatePathFunc()
 }

--- a/pkg/migrate/actions/aipipelines/precheck.go
+++ b/pkg/migrate/actions/aipipelines/precheck.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
 
 // PreUpgradeCheckAction captures DSPA pod health, migrates v1alpha1→v1, and detects RBAC gaps.
@@ -52,40 +53,7 @@ func (t *preUpgradeCheckPrepareTask) discover(
 	recorder action.RootRecorder,
 ) {
 	// Step 1: Capture pod health state for v1 DSPAs
-	healthStep := recorder.Child("capture-pod-health", "Capture pre-upgrade DSPA pod health")
-
-	v1DSPAs, err := listDSPAs(ctx, target.Client, resources.DataSciencePipelinesApplicationV1)
-	if err != nil {
-		healthStep.Completef(result.StepFailed, "Failed to list v1 DSPAs: %v", err)
-
-		return
-	}
-
-	var state PodHealthState
-
-	if len(v1DSPAs) == 0 {
-		healthStep.Completef(result.StepCompleted, "No v1 DSPAs found")
-
-		state = PodHealthState{
-			CapturedAt: time.Now().UTC().Format(time.RFC3339),
-			DSPAs:      []DSPAState{},
-		}
-	} else {
-		var captureErr error
-
-		state, captureErr = capturePodHealth(ctx, target.Client, healthStep, v1DSPAs)
-		if captureErr != nil {
-			healthStep.Completef(result.StepFailed, "Failed to capture pod health: %v", captureErr)
-
-			return
-		}
-
-		healthStep.Completef(result.StepCompleted, "Captured pod health for %d DSPA(s)", len(v1DSPAs))
-	}
-
-	if !target.DryRun {
-		t.saveState(target, recorder, state)
-	}
+	captureAndSavePodHealth(ctx, target.Client, recorder, target.DryRun, false)
 
 	// Step 2: Detect v1alpha1 DSPAs by checking CRD storedVersions
 	v1alpha1Step := recorder.Child("detect-v1alpha1", "Detect deprecated v1alpha1 DSPAs")
@@ -105,30 +73,6 @@ func (t *preUpgradeCheckPrepareTask) discover(
 
 	// Step 3: Detect custom roles needing RBAC update
 	_, _ = findRolesNeedingFix(ctx, target.Client, recorder)
-}
-
-func (t *preUpgradeCheckPrepareTask) saveState(
-	target action.Target,
-	recorder action.StepRecorder,
-	state PodHealthState,
-) {
-	saveStep := recorder.Child("save-state", "Save pre-upgrade state")
-
-	if target.DryRun {
-		saveStep.Completef(result.StepSkipped, "Would save pre-upgrade pod health state")
-
-		return
-	}
-
-	statePath := defaultStatePath()
-
-	if err := savePodHealthState(state, statePath); err != nil {
-		saveStep.Completef(result.StepFailed, "Failed to save state: %v", err)
-
-		return
-	}
-
-	saveStep.Completef(result.StepCompleted, "State saved to %s", statePath)
 }
 
 // --- Run task: migrate v1alpha1 DSPAs to v1 ---
@@ -159,9 +103,81 @@ func (t *preUpgradeCheckRunTask) Validate(ctx context.Context, target action.Tar
 func (t *preUpgradeCheckRunTask) Execute(ctx context.Context, target action.Target) (*result.ActionResult, error) {
 	recorder := action.NewVerboseRootRecorder(target.IO)
 
+	// Capture pod health state so post-upgrade-check can compare even if
+	// the user did not run "migrate prepare" separately.
+	captureAndSavePodHealth(ctx, target.Client, recorder, target.DryRun, true)
+
 	if err := migrateAllDSPAsToV1(ctx, target.Client, recorder, migrateOpts{DryRun: target.DryRun}); err != nil {
 		return recorder.Build(), fmt.Errorf("v1alpha1 migration failed: %w", err)
 	}
 
 	return recorder.Build(), nil
+}
+
+// captureAndSavePodHealth captures DSPA pod health state and persists it to disk.
+// When skipIfExists is true, it skips capture if a state file already exists (used
+// by the run task to avoid overwriting state saved by a prior "migrate prepare").
+func captureAndSavePodHealth(
+	ctx context.Context,
+	c client.Client,
+	recorder action.RootRecorder,
+	dryRun bool,
+	skipIfExists bool,
+) {
+	statePath := defaultStatePath()
+
+	if skipIfExists {
+		if _, err := loadPodHealthState(statePath); err == nil {
+			recorder.Recordf("pod-health-state", "Pre-upgrade pod health state already exists at %s", result.StepCompleted, statePath)
+
+			return
+		}
+	}
+
+	healthStep := recorder.Child("capture-pod-health", "Capture pre-upgrade DSPA pod health")
+
+	v1DSPAs, err := listDSPAs(ctx, c, resources.DataSciencePipelinesApplicationV1)
+	if err != nil {
+		healthStep.Completef(result.StepFailed, "Failed to list v1 DSPAs: %v", err)
+
+		return
+	}
+
+	var state PodHealthState
+
+	if len(v1DSPAs) == 0 {
+		healthStep.Completef(result.StepCompleted, "No v1 DSPAs found")
+
+		state = PodHealthState{
+			CapturedAt: time.Now().UTC().Format(time.RFC3339),
+			DSPAs:      []DSPAState{},
+		}
+	} else {
+		var captureErr error
+
+		state, captureErr = capturePodHealth(ctx, c, healthStep, v1DSPAs)
+		if captureErr != nil {
+			healthStep.Completef(result.StepFailed, "Failed to capture pod health: %v", captureErr)
+
+			return
+		}
+
+		healthStep.Completef(result.StepCompleted, "Captured pod health for %d DSPA(s)", len(v1DSPAs))
+	}
+
+	saveStep := recorder.Child("save-state", "Save pre-upgrade state")
+
+	if dryRun {
+		saveStep.Completef(result.StepSkipped, "Would save pre-upgrade pod health state")
+
+		return
+	}
+
+	if err := savePodHealthState(state, statePath); err != nil {
+		saveStep.Completef(result.StepFailed, "Failed to save state: %v", err)
+
+		return
+	}
+
+	saveStep.Completef(result.StepCompleted, "State saved to %s", statePath)
 }


### PR DESCRIPTION
## Description

The pre-upgrade-check run task did not capture DSPA pod health state, causing the post-upgrade-check to fail with "Pre-upgrade state not found" when users followed the documented workflow of running `migrate run` without a prior `migrate prepare`.

Extract a shared `captureAndSavePodHealth` helper used by both the prepare and run tasks. The run task skips capture if state already exists from a prior prepare. Dry-run mode now emits a StepSkipped record for state saving, matching the prepare task behavior.
## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration preparation and execution so pod health state is captured and saved consistently.
  * Avoids unnecessary recapture when a valid existing state is available.
  * Ensures preparation mode can refresh previously saved state when required.

* **Tests**
  * Added coverage for empty and populated environments, dry-run behavior, existing state files, and state replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->