### PR TITLE
fix(cli): enable --version flag on root command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/cmd/migrate"
 	"github.com/opendatahub-io/odh-cli/cmd/status"
 	"github.com/opendatahub-io/odh-cli/cmd/version"
+	internalversion "github.com/opendatahub-io/odh-cli/internal/version"
 	clierrors "github.com/opendatahub-io/odh-cli/pkg/util/errors"
 )
 
@@ -28,8 +29,9 @@ func main() {
 	flags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 
 	cmd := &cobra.Command{
-		Use:   "kubectl-odh",
-		Short: "kubectl plugin for ODH/RHOAI",
+		Use:     "kubectl-odh",
+		Short:   "kubectl plugin for ODH/RHOAI",
+		Version: internalversion.GetVersion(),
 	}
 
 	// Add kubectl-style flags to root command (inherited by subcommands).


### PR DESCRIPTION
## Description

Users expect `rhai-cli --version` to work but it returned "unknown flag: --version". Set cobra Version field on root command so both `--version` flag and `version` subcommand work.

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed
