### PR TITLE
feat: add blocking removal check for TrainingOperator v1 in 3.6

### DIFF
--- a/pkg/lint/checks/components/trainingoperator/removal.go
+++ b/pkg/lint/checks/components/trainingoperator/removal.go
@@ -27,7 +27,7 @@ func NewRemovalCheck() *RemovalCheck {
 			CheckID:          "components.trainingoperator.removal",
 			CheckName:        "Components :: TrainingOperator :: Removal (3.6)",
 			CheckDescription: "Validates that TrainingOperator (Kubeflow Training Operator v1) is disabled before upgrading to RHOAI 3.6 (component is removed, use Trainer v2)",
-			CheckRemediation: "Set trainingoperator managementState to 'Removed' in DataScienceCluster and delete the TrainingOperator CR before upgrading. Drain active PyTorchJobs first.",
+			CheckRemediation: "Before upgrading, drain active PyTorchJobs then set trainingoperator managementState to 'Removed' in DataScienceCluster and delete the TrainingOperator CR.",
 		},
 	}
 }

--- a/pkg/lint/checks/components/trainingoperator/removal.go
+++ b/pkg/lint/checks/components/trainingoperator/removal.go
@@ -1,0 +1,56 @@
+package trainingoperator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+// RemovalCheck validates that TrainingOperator v1 is disabled before upgrading to 3.6.
+type RemovalCheck struct {
+	check.BaseCheck
+}
+
+func NewRemovalCheck() *RemovalCheck {
+	return &RemovalCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupComponent,
+			Kind:             constants.ComponentTrainingOperator,
+			Type:             check.CheckTypeRemoval,
+			CheckID:          "components.trainingoperator.removal",
+			CheckName:        "Components :: TrainingOperator :: Removal (3.6)",
+			CheckDescription: "Validates that TrainingOperator (Kubeflow Training Operator v1) is disabled before upgrading to RHOAI 3.6 (component is removed, use Trainer v2)",
+			CheckRemediation: "Set trainingoperator managementState to 'Removed' in DataScienceCluster and delete the TrainingOperator CR before upgrading. Drain active PyTorchJobs first.",
+		},
+	}
+}
+
+// CanApply returns whether this check should run for the given target.
+// Applies when target version >= 3.6 and TrainingOperator is Managed.
+func (c *RemovalCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	//nolint:mnd // Version numbers 3.6
+	if !version.IsVersionAtLeast(target.TargetVersion, 3, 6) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, constants.ComponentTrainingOperator, constants.ManagementStateManaged), nil
+}
+
+func (c *RemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	return validate.Component(c, target).
+		Run(ctx, validate.Removal("TrainingOperator (Kubeflow v1) is enabled (state: %s) but is removed in RHOAI %s. Use Trainer v2 instead.",
+			check.WithImpact(result.ImpactBlocking),
+			check.WithRemediation(c.CheckRemediation)))
+}

--- a/pkg/lint/checks/components/trainingoperator/removal_test.go
+++ b/pkg/lint/checks/components/trainingoperator/removal_test.go
@@ -1,0 +1,164 @@
+package trainingoperator_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/trainingoperator"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestTrainingOperatorRemovalCheck_CanApply_NoDSC(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		TargetVersion: "3.6.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestTrainingOperatorRemovalCheck_CanApply_NotConfigured(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"dashboard": "Managed"})},
+		TargetVersion: "3.6.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestTrainingOperatorRemovalCheck_ManagedBlocking(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed"})},
+		TargetVersion: "3.6.0",
+	})
+
+	removalCheck := trainingoperator.NewRemovalCheck()
+	result, err := removalCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonVersionIncompatible),
+		"Message": And(ContainSubstring("enabled"), ContainSubstring("removed in RHOAI 3.6")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(And(
+		HaveKeyWithValue("component.opendatahub.io/management-state", "Managed"),
+		HaveKeyWithValue("check.opendatahub.io/target-version", "3.6.0"),
+	))
+}
+
+func TestTrainingOperatorRemovalCheck_CanApply_Unmanaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Unmanaged"})},
+		TargetVersion: "3.6.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestTrainingOperatorRemovalCheck_CanApply_Removed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Removed"})},
+		TargetVersion: "3.6.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestTrainingOperatorRemovalCheck_CanApply_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed"})},
+		TargetVersion: "3.6.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestTrainingOperatorRemovalCheck_CanApply_Version35(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed"})},
+		TargetVersion: "3.5.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestTrainingOperatorRemovalCheck_CanApply_Version37(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed"})},
+		TargetVersion: "3.7.0",
+	})
+
+	chk := trainingoperator.NewRemovalCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestTrainingOperatorRemovalCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	removalCheck := trainingoperator.NewRemovalCheck()
+
+	g.Expect(removalCheck.ID()).To(Equal("components.trainingoperator.removal"))
+	g.Expect(removalCheck.Name()).To(Equal("Components :: TrainingOperator :: Removal (3.6)"))
+	g.Expect(removalCheck.Group()).To(Equal(check.GroupComponent))
+	g.Expect(removalCheck.Description()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/components/trainingoperator/trainingoperator.go
+++ b/pkg/lint/checks/components/trainingoperator/trainingoperator.go
@@ -28,18 +28,21 @@ func NewDeprecationCheck() *DeprecationCheck {
 			Kind:             constants.ComponentTrainingOperator,
 			Type:             checkType,
 			CheckID:          "components.trainingoperator.deprecation",
-			CheckName:        "Components :: TrainingOperator :: Deprecation (3.3+)",
-			CheckDescription: "Validates that TrainingOperator (Kubeflow Training Operator v1) deprecation is acknowledged - will be replaced by Trainer v2 in future RHOAI releases",
-			CheckRemediation: "Plan migration from TrainingOperator (Kubeflow v1) to Trainer v2 in a future release",
+			CheckName:        "Components :: TrainingOperator :: Deprecation (3.3–3.5)",
+			CheckDescription: "Validates that TrainingOperator (Kubeflow Training Operator v1) deprecation is acknowledged - removed in RHOAI 3.6, use Trainer v2",
+			CheckRemediation: "Plan migration from TrainingOperator (Kubeflow v1) to Trainer v2 before upgrading to 3.6",
 		},
 	}
 }
 
 // CanApply returns whether this check should run for the given target.
-// This check only applies when target version is >= 3.3 and TrainingOperator is Managed.
+// This check applies when target version is >= 3.3 and < 3.6 (removal check takes over at 3.6).
 func (c *DeprecationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	//nolint:mnd // Version numbers 3.3
+	//nolint:mnd // Version numbers 3.3, 3.6
 	if !version.IsVersionAtLeast(target.TargetVersion, 3, 3) {
+		return false, nil
+	}
+	if version.IsVersionAtLeast(target.TargetVersion, 3, 6) {
 		return false, nil
 	}
 
@@ -62,9 +65,9 @@ func newDeprecationCondition(_ context.Context, req *validate.ComponentRequest) 
 			check.ConditionTypeCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonDeprecated),
-			check.WithMessage("TrainingOperator (Kubeflow Training Operator v1) is enabled (state: %s) but is deprecated in RHOAI 3.3 and will be replaced by Trainer v2 in a future release", req.ManagementState),
+			check.WithMessage("TrainingOperator (Kubeflow Training Operator v1) is enabled (state: %s) but is deprecated since RHOAI 3.3 and removed in 3.6. Migrate to Trainer v2.", req.ManagementState),
 			check.WithImpact(result.ImpactAdvisory),
-			check.WithRemediation("Plan migration from TrainingOperator (Kubeflow v1) to Trainer v2 in a future release"),
+			check.WithRemediation("Plan migration from TrainingOperator (Kubeflow v1) to Trainer v2 before upgrading to 3.6"),
 		),
 	}, nil
 }

--- a/pkg/lint/checks/components/trainingoperator/trainingoperator.go
+++ b/pkg/lint/checks/components/trainingoperator/trainingoperator.go
@@ -38,10 +38,11 @@ func NewDeprecationCheck() *DeprecationCheck {
 // CanApply returns whether this check should run for the given target.
 // This check applies when target version is >= 3.3 and < 3.6 (removal check takes over at 3.6).
 func (c *DeprecationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
-	//nolint:mnd // Version numbers 3.3, 3.6
+	//nolint:mnd // Version numbers 3.3
 	if !version.IsVersionAtLeast(target.TargetVersion, 3, 3) {
 		return false, nil
 	}
+	//nolint:mnd // Version numbers 3.6
 	if version.IsVersionAtLeast(target.TargetVersion, 3, 6) {
 		return false, nil
 	}

--- a/pkg/lint/checks/components/trainingoperator/trainingoperator_test.go
+++ b/pkg/lint/checks/components/trainingoperator/trainingoperator_test.go
@@ -73,7 +73,7 @@ func TestTrainingOperatorDeprecationCheck_ManagedDeprecated(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonDeprecated),
-		"Message": And(ContainSubstring("enabled"), ContainSubstring("deprecated in RHOAI 3.3")),
+		"Message": And(ContainSubstring("enabled"), ContainSubstring("deprecated since RHOAI 3.3")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
 	g.Expect(result.Annotations).To(And(
@@ -181,7 +181,7 @@ func TestTrainingOperatorDeprecationCheck_Metadata(t *testing.T) {
 	trainingoperatorCheck := trainingoperator.NewDeprecationCheck()
 
 	g.Expect(trainingoperatorCheck.ID()).To(Equal("components.trainingoperator.deprecation"))
-	g.Expect(trainingoperatorCheck.Name()).To(Equal("Components :: TrainingOperator :: Deprecation (3.3+)"))
+	g.Expect(trainingoperatorCheck.Name()).To(Equal("Components :: TrainingOperator :: Deprecation (3.3–3.5)"))
 	g.Expect(trainingoperatorCheck.Group()).To(Equal(check.GroupComponent))
 	g.Expect(trainingoperatorCheck.Description()).ToNot(BeEmpty())
 }

--- a/pkg/lint/checks/components/trainingoperator/trainingoperator_test.go
+++ b/pkg/lint/checks/components/trainingoperator/trainingoperator_test.go
@@ -175,6 +175,36 @@ func TestTrainingOperatorDeprecationCheck_CanApply_Version34(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
+func TestTrainingOperatorDeprecationCheck_CanApply_Version36(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed"})},
+		TargetVersion: "3.6.0",
+	})
+
+	chk := trainingoperator.NewDeprecationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestTrainingOperatorDeprecationCheck_CanApply_Version55(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trainingoperator": "Managed"})},
+		TargetVersion: "3.5.0",
+	})
+
+	chk := trainingoperator.NewDeprecationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
 func TestTrainingOperatorDeprecationCheck_Metadata(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/lint/checks/workloads/trainingoperator/impacted.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted.go
@@ -33,8 +33,8 @@ func NewImpactedWorkloadsCheck() *ImpactedWorkloadsCheck {
 			Type:             check.CheckTypeImpactedWorkloads,
 			CheckID:          "workloads.trainingoperator.impacted-workloads",
 			CheckName:        "Workloads :: TrainingOperator :: Impacted Workloads (3.3+)",
-			CheckDescription: "Lists PyTorchJobs using deprecated TrainingOperator (Kubeflow v1) that will be impacted by transition to Trainer v2",
-			CheckRemediation: "Complete or delete active PyTorchJobs before upgrading; plan migration to Trainer v2 API",
+			CheckDescription: "Lists PyTorchJobs using deprecated TrainingOperator (Kubeflow v1) that will be impacted by removal in 3.6 and transition to Trainer v2",
+			CheckRemediation: "Complete or delete active PyTorchJobs before upgrading; migrate to Trainer v2 TrainJob API",
 		},
 	}
 }
@@ -81,7 +81,9 @@ func (c *ImpactedWorkloadsCheck) Validate(
 				}
 			}
 
-			req.Result.SetCondition(c.newPyTorchJobCondition(len(active), len(completed)))
+			//nolint:mnd // Version 3.6 — component removed
+			isRemoval := version.IsVersionAtLeast(target.TargetVersion, 3, 6)
+			req.Result.SetCondition(c.newPyTorchJobCondition(len(active), len(completed), isRemoval))
 
 			return nil
 		})

--- a/pkg/lint/checks/workloads/trainingoperator/impacted_support.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted_support.go
@@ -15,15 +15,23 @@ import (
 func (c *ImpactedWorkloadsCheck) newPyTorchJobCondition(
 	activeCount int,
 	completedCount int,
+	isRemoval bool,
 ) result.Condition {
 	totalCount := activeCount + completedCount
+
+	impact := result.ImpactAdvisory
+	verb := "deprecated"
+	if isRemoval {
+		impact = result.ImpactBlocking
+		verb = "removed in 3.6"
+	}
 
 	if totalCount == 0 {
 		return check.NewCondition(
 			ConditionTypePyTorchJobsCompatible,
 			metav1.ConditionTrue,
 			check.WithReason(check.ReasonVersionCompatible),
-			check.WithMessage("No PyTorchJob(s) found - no workloads impacted by TrainingOperator deprecation"),
+			check.WithMessage("No PyTorchJob(s) found - no workloads impacted by TrainingOperator removal"),
 		)
 	}
 
@@ -32,8 +40,8 @@ func (c *ImpactedWorkloadsCheck) newPyTorchJobCondition(
 			ConditionTypePyTorchJobsCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonWorkloadsImpacted),
-			check.WithMessage("Found %d PyTorchJob(s) (%d active, %d completed) - workloads use deprecated TrainingOperator (Kubeflow v1) which will be replaced by Trainer v2", totalCount, activeCount, completedCount),
-			check.WithImpact(result.ImpactAdvisory),
+			check.WithMessage("Found %d PyTorchJob(s) (%d active, %d completed) - TrainingOperator (Kubeflow v1) is %s, migrate to Trainer v2", totalCount, activeCount, completedCount, verb),
+			check.WithImpact(impact),
 			check.WithRemediation(c.CheckRemediation),
 		)
 	}
@@ -43,8 +51,8 @@ func (c *ImpactedWorkloadsCheck) newPyTorchJobCondition(
 			ConditionTypePyTorchJobsCompatible,
 			metav1.ConditionFalse,
 			check.WithReason(check.ReasonWorkloadsImpacted),
-			check.WithMessage("Found %d active PyTorchJob(s) - workloads use deprecated TrainingOperator (Kubeflow v1) which will be replaced by Trainer v2", activeCount),
-			check.WithImpact(result.ImpactAdvisory),
+			check.WithMessage("Found %d active PyTorchJob(s) - TrainingOperator (Kubeflow v1) is %s, drain and migrate to Trainer v2", activeCount, verb),
+			check.WithImpact(impact),
 			check.WithRemediation(c.CheckRemediation),
 		)
 	}
@@ -53,7 +61,7 @@ func (c *ImpactedWorkloadsCheck) newPyTorchJobCondition(
 		ConditionTypePyTorchJobsCompatible,
 		metav1.ConditionTrue,
 		check.WithReason(check.ReasonVersionCompatible),
-		check.WithMessage("Found %d completed PyTorchJob(s) - workloads previously used deprecated TrainingOperator (Kubeflow v1)", completedCount),
+		check.WithMessage("Found %d completed PyTorchJob(s) - workloads previously used TrainingOperator (Kubeflow v1)", completedCount),
 	)
 }
 

--- a/pkg/lint/checks/workloads/trainingoperator/impacted_test.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted_test.go
@@ -84,7 +84,7 @@ func TestImpactedWorkloadsCheck_ActiveJobs(t *testing.T) {
 		"Type":    Equal(trainingoperator.ConditionTypePyTorchJobsCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonWorkloadsImpacted),
-		"Message": And(ContainSubstring("Found 1 active PyTorchJob(s)"), ContainSubstring("deprecated TrainingOperator")),
+		"Message": And(ContainSubstring("Found 1 active PyTorchJob(s)"), ContainSubstring("TrainingOperator (Kubeflow v1)")),
 	}))
 	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
 	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))

--- a/pkg/lint/checks/workloads/trainingoperator/impacted_test.go
+++ b/pkg/lint/checks/workloads/trainingoperator/impacted_test.go
@@ -297,6 +297,154 @@ func TestImpactedWorkloadsCheck_JobWithoutStatus(t *testing.T) {
 	g.Expect(result.ImpactedObjects).To(HaveLen(1))
 }
 
+func TestImpactedWorkloadsCheck_ActiveJobs_BlockingAt36(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	activeJob := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.PyTorchJob.APIVersion(),
+			"kind":       resources.PyTorchJob.Kind,
+			"metadata": map[string]any{
+				"name":      "active-pytorch-job",
+				"namespace": "test-ns",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Running",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{activeJob},
+		TargetVersion: "3.6.0",
+	})
+
+	impactedCheck := &trainingoperator.ImpactedWorkloadsCheck{}
+	result, err := impactedCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainingoperator.ConditionTypePyTorchJobsCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonWorkloadsImpacted),
+		"Message": And(ContainSubstring("Found 1 active PyTorchJob(s)"), ContainSubstring("removed in 3.6")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
+func TestImpactedWorkloadsCheck_MixedJobs_BlockingAt36(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	activeJob := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.PyTorchJob.APIVersion(),
+			"kind":       resources.PyTorchJob.Kind,
+			"metadata": map[string]any{
+				"name":      "active-job",
+				"namespace": "ns1",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Running",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+
+	completedJob := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.PyTorchJob.APIVersion(),
+			"kind":       resources.PyTorchJob.Kind,
+			"metadata": map[string]any{
+				"name":      "completed-job",
+				"namespace": "ns1",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Succeeded",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{activeJob, completedJob},
+		TargetVersion: "3.6.0",
+	})
+
+	impactedCheck := &trainingoperator.ImpactedWorkloadsCheck{}
+	result, err := impactedCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(trainingoperator.ConditionTypePyTorchJobsCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonWorkloadsImpacted),
+		"Message": And(ContainSubstring("1 active"), ContainSubstring("1 completed"), ContainSubstring("removed in 3.6")),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+}
+
+func TestImpactedWorkloadsCheck_CompletedOnly_NonBlockingAt36(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	completedJob := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.PyTorchJob.APIVersion(),
+			"kind":       resources.PyTorchJob.Kind,
+			"metadata": map[string]any{
+				"name":      "completed-job",
+				"namespace": "test-ns",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Succeeded",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:     listKinds,
+		Objects:       []*unstructured.Unstructured{completedJob},
+		TargetVersion: "3.6.0",
+	})
+
+	impactedCheck := &trainingoperator.ImpactedWorkloadsCheck{}
+	result, err := impactedCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(trainingoperator.ConditionTypePyTorchJobsCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonVersionCompatible),
+	}))
+}
+
 func TestImpactedWorkloadsCheck_Metadata(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -110,7 +110,7 @@ func NewCommand(
 	registry.MustRegister(dscinitialization.NewDSCInitializationReadinessCheck())
 	registry.MustRegister(datasciencecluster.NewDataScienceClusterReadinessCheck())
 
-	// Components (14)
+	// Components (16)
 	registry.MustRegister(aigateway.NewMaaSFieldMigrationCheck())
 	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
 	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -126,6 +126,7 @@ func NewCommand(
 	registry.MustRegister(llamastack.NewRemovalCheck())
 	registry.MustRegister(modelmesh.NewRemovalCheck())
 	registry.MustRegister(trainingoperator.NewDeprecationCheck())
+	registry.MustRegister(trainingoperator.NewRemovalCheck())
 
 	// Dependencies (6)
 	registry.MustRegister(certmanager.NewCheck())


### PR DESCRIPTION
## Description

Blocking removal check for TrainingOperator v1 (KFTO) at RHOAI 3.6, following LlamaStack/ModelMesh pattern.

User scenarios : https://docs.google.com/document/d/1mHPNBSlWpZKNB-3TPkd2ZccD4wvBbG_RJeFhNv1pQSU/edit?tab=t.4tbpwzp9oyi3
Related PR: https://github.com/opendatahub-io/opendatahub-operator/pull/3868

Ref: [RHOAIENG-80805](https://redhat.atlassian.net/browse/RHOAIENG-80805)

- New `components.trainingoperator.removal` check — blocks upgrade to 3.6+ when `trainingoperator` is `Managed`
- Deprecation check capped at 3.3–3.5 to avoid overlap
- Workload check escalates to `ImpactBlocking` at 3.6+ (active PyTorchJobs must drain first)

| Target | Component | Workload |
|--------|-----------|----------|
| < 3.3 | Skipped | Skipped |
| 3.3–3.5 | Advisory (deprecated) | Advisory |
| >= 3.6 | Blocking (removed) | Blocking (if active jobs) |

## Example Output

### Target 3.5 — advisory (table)

```
STATUS  KIND               GROUP      CHECK                                                    IMPACT    MESSAGE
⚠       trainingoperator   Component  Components :: TrainingOperator :: Deprecation (3.3–3.5)   advisory  TrainingOperator (Kubeflow Training Operator v1) is enabled (state: Managed) but is deprecated since RHOAI 3.3 and removed in 3.6. Migrate to Trainer v2.
⚠       trainingoperator   Workload   Workloads :: TrainingOperator :: Impacted Workloads       advisory  Found 2 active PyTorchJob(s) - TrainingOperator (Kubeflow v1) is deprecated, drain and migrate to Trainer v2
Result: ⚠ WARNING
```

### Target 3.6 — blocking (table)

```
STATUS  KIND               GROUP      CHECK                                                 IMPACT     MESSAGE
✗       trainingoperator   Component  Components :: TrainingOperator :: Removal (3.6)        blocking   TrainingOperator (Kubeflow v1) is enabled (state: Managed) but is removed in RHOAI 3.6. Use Trainer v2 instead.
✗       trainingoperator   Workload   Workloads :: TrainingOperator :: Impacted Workloads    blocking   Found 2 active PyTorchJob(s) - TrainingOperator (Kubeflow v1) is removed in 3.6, drain and migrate to Trainer v2
Result: ✗ FAIL
```

### Target 3.6 — blocking (JSON, shows remediation)

```json
{
  "components": [
    {
      "checkId": "components.trainingoperator.removal",
      "checkName": "Components :: TrainingOperator :: Removal (3.6)",
      "group": "Component",
      "status": "False",
      "impact": "blocking",
      "message": "TrainingOperator (Kubeflow v1) is enabled (state: Managed) but is removed in RHOAI 3.6. Use Trainer v2 instead.",
      "remediation": "Before upgrading, drain active PyTorchJobs then set trainingoperator managementState to 'Removed' in DataScienceCluster and delete the TrainingOperator CR."
    }
  ],
  "workloads": [
    {
      "checkId": "workloads.trainingoperator.impacted",
      "checkName": "Workloads :: TrainingOperator :: Impacted Workloads",
      "group": "Workload",
      "status": "False",
      "impact": "blocking",
      "message": "Found 2 active PyTorchJob(s) - TrainingOperator (Kubeflow v1) is removed in 3.6, drain and migrate to Trainer v2",
      "remediation": "Before upgrading, drain active PyTorchJobs then set trainingoperator managementState to 'Removed' in DataScienceCluster and delete the TrainingOperator CR."
    }
  ]
}
```

### Target 3.6 — completed only (table)

```
STATUS  KIND               GROUP      CHECK                                                 IMPACT     MESSAGE
✗       trainingoperator   Component  Components :: TrainingOperator :: Removal (3.6)        blocking   TrainingOperator (Kubeflow v1) is enabled (state: Managed) but is removed in RHOAI 3.6. Use Trainer v2 instead.
✓       trainingoperator   Workload   Workloads :: TrainingOperator :: Impacted Workloads    none       Found 3 completed PyTorchJob(s) - workloads previously used TrainingOperator (Kubeflow v1)
Result: ✗ FAIL
```

### Target 3.6 — TrainingOperator Removed

No checks fire — `CanApply` returns false for both removal and deprecation.

## Testing

`go build`, `go vet`, `go test ./pkg/lint/checks/.../trainingoperator/...` — all pass.

[RHOAIENG-80805]: https://redhat.atlassian.net/browse/RHOAIENG-80805
