### PR TITLE
fix(migrate): address migration guide validation findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ RUN set -e; \
     mv oc /usr/local/bin/oc; \
     rm -f openshift-client.tar.gz kubectl README.md
 
+# Install jq for JSON processing in migration verification steps
+RUN dnf install -y jq && dnf clean all
+
 # Copy binary from builder (cross-compiled for target platform)
 COPY --from=builder /workspace/bin/kubectl-odh /opt/rhai-cli/bin/rhai-cli
 

--- a/pkg/migrate/actions/raycluster/backup.go
+++ b/pkg/migrate/actions/raycluster/backup.go
@@ -77,7 +77,7 @@ func (t *backupPrepareTask) Execute(ctx context.Context, target action.Target) (
 func (t *backupPrepareTask) runPreflightChecks(ctx context.Context, target action.Target) {
 	step := target.Recorder.Child("preflight-checks", "Run RayCluster pre-upgrade checks")
 
-	checks := rcpkg.RunPreUpgradeChecks(ctx, target.Client)
+	checks := rcpkg.RunPreUpgradeChecks(ctx, target.Client, false)
 
 	allPassed := true
 	hasRequiredFailure := false
@@ -125,7 +125,7 @@ func (t *backupRunTask) Execute(ctx context.Context, target action.Target) (*res
 
 	step := target.Recorder.Child("backup-rayclusters", "Backup RayCluster configurations")
 
-	checks := rcpkg.RunPreUpgradeChecks(ctx, target.Client)
+	checks := rcpkg.RunPreUpgradeChecks(ctx, target.Client, !target.DryRun)
 
 	if target.DryRun {
 		clusters, err := rcpkg.GetClusters(ctx, target.Client, t.opts.ClusterName, t.opts.Namespace)

--- a/pkg/migrate/actions/training/verify_workloads.go
+++ b/pkg/migrate/actions/training/verify_workloads.go
@@ -20,7 +20,7 @@ func (a *VerifyWorkloadsAction) Name() string        { return verifyWorkloadsNam
 func (a *VerifyWorkloadsAction) Description() string { return verifyWorkloadsDescription }
 
 func (a *VerifyWorkloadsAction) Group() action.ActionGroup { return action.GroupValidation }
-func (a *VerifyWorkloadsAction) Phase() action.ActionPhase { return action.PhasePreUpgrade }
+func (a *VerifyWorkloadsAction) Phase() action.ActionPhase { return action.PhasePostUpgrade }
 
 func (a *VerifyWorkloadsAction) CanApply(target action.Target) bool {
 	return target.CurrentVersion != nil && target.TargetVersion != nil &&

--- a/pkg/migrate/actions/training/verify_workloads_test.go
+++ b/pkg/migrate/actions/training/verify_workloads_test.go
@@ -111,7 +111,7 @@ func TestVerifyWorkloadsAction_Metadata(t *testing.T) {
 	a := &trainingaction.VerifyWorkloadsAction{}
 	g.Expect(a.ID()).To(Equal("training.verify-workloads"))
 	g.Expect(a.Group()).To(Equal(action.GroupValidation))
-	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
 	g.Expect(a.Prepare()).To(BeNil())
 	g.Expect(a.Run()).ToNot(BeNil())
 }

--- a/pkg/migrate/actions/trustyai/otelexporter/otelexporter.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/otelexporter.go
@@ -21,7 +21,7 @@ func (a *MigrateOtelExporterAction) Group() action.ActionGroup {
 }
 
 func (a *MigrateOtelExporterAction) Phase() action.ActionPhase {
-	return action.PhasePreUpgrade
+	return action.PhasePostUpgrade
 }
 
 func (a *MigrateOtelExporterAction) CanApply(target action.Target) bool {

--- a/pkg/migrate/actions/trustyai/otelexporter/run_task_test.go
+++ b/pkg/migrate/actions/trustyai/otelexporter/run_task_test.go
@@ -102,7 +102,7 @@ func TestMigrateOtelExporterAction_Metadata(t *testing.T) {
 	g.Expect(a.Name()).To(ContainSubstring("otelExporter"))
 	g.Expect(a.Description()).To(ContainSubstring("otelExporter"))
 	g.Expect(a.Group()).To(Equal(action.GroupMigration))
-	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
 	g.Expect(a.Prepare()).To(BeNil())
 	g.Expect(a.Run()).ToNot(BeNil())
 }

--- a/pkg/migrate/actions/workbenches/authmodel/authmodel.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel.go
@@ -43,7 +43,7 @@ func (a *PatchAuthModelAction) Group() action.ActionGroup {
 }
 
 func (a *PatchAuthModelAction) Phase() action.ActionPhase {
-	return action.PhasePreUpgrade
+	return action.PhasePostUpgrade
 }
 
 func (a *PatchAuthModelAction) AddFlags(fs *pflag.FlagSet) {

--- a/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
@@ -430,7 +430,7 @@ func TestPatchAuthModelAction_Metadata(t *testing.T) {
 	g.Expect(a.Name()).To(ContainSubstring("auth model"))
 	g.Expect(a.Description()).To(ContainSubstring("oauth-proxy"))
 	g.Expect(a.Group()).To(Equal(action.GroupMigration))
-	g.Expect(a.Phase()).To(Equal(action.PhasePreUpgrade))
+	g.Expect(a.Phase()).To(Equal(action.PhasePostUpgrade))
 }
 
 func TestPatchAuthModelAction_CanApply(t *testing.T) {

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -116,8 +116,6 @@ func (c *PrepareCommand) Complete() error {
 	return nil
 }
 
-const fallbackBackupParentDir = "/tmp/rhoai-upgrade-backup"
-
 func defaultBackupDir() (string, error) {
 	pattern := "backup-migrate-" + time.Now().Format("20060102-150405") + "-*"
 
@@ -126,12 +124,7 @@ func defaultBackupDir() (string, error) {
 		return dir, nil
 	}
 
-	//nolint:mnd // standard directory permission for shared backup location
-	if mkErr := os.MkdirAll(fallbackBackupParentDir, 0o750); mkErr != nil {
-		return "", fmt.Errorf("creating fallback backup parent directory: %w", mkErr)
-	}
-
-	dir, err = os.MkdirTemp(fallbackBackupParentDir, pattern)
+	dir, err = os.MkdirTemp("", pattern)
 	if err != nil {
 		return "", fmt.Errorf("creating default backup directory: %w", err)
 	}

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -105,23 +105,38 @@ func (c *PrepareCommand) Complete() error {
 
 	// Set default output directory if not specified
 	if c.OutputDir == "" {
-		timestamp := time.Now().Format("20060102-150405")
-
-		defaultDir, err := os.MkdirTemp(".", "backup-migrate-"+timestamp+"-*")
+		dir, err := defaultBackupDir()
 		if err != nil {
-			defaultDir, err = os.MkdirTemp(
-				"/tmp/rhoai-upgrade-backup",
-				"backup-migrate-"+timestamp+"-*",
-			)
-			if err != nil {
-				return fmt.Errorf("creating default backup directory: %w", err)
-			}
+			return err
 		}
 
-		c.OutputDir = defaultDir
+		c.OutputDir = dir
 	}
 
 	return nil
+}
+
+const fallbackBackupParentDir = "/tmp/rhoai-upgrade-backup"
+
+func defaultBackupDir() (string, error) {
+	pattern := "backup-migrate-" + time.Now().Format("20060102-150405") + "-*"
+
+	dir, err := os.MkdirTemp(".", pattern)
+	if err == nil {
+		return dir, nil
+	}
+
+	//nolint:mnd // standard directory permission for shared backup location
+	if mkErr := os.MkdirAll(fallbackBackupParentDir, 0o750); mkErr != nil {
+		return "", fmt.Errorf("creating fallback backup parent directory: %w", mkErr)
+	}
+
+	dir, err = os.MkdirTemp(fallbackBackupParentDir, pattern)
+	if err != nil {
+		return "", fmt.Errorf("creating default backup directory: %w", err)
+	}
+
+	return dir, nil
 }
 
 func (c *PrepareCommand) Validate() error {

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -107,13 +106,16 @@ func (c *PrepareCommand) Complete() error {
 	// Set default output directory if not specified
 	if c.OutputDir == "" {
 		timestamp := time.Now().Format("20060102-150405")
-		defaultDir := filepath.Join(".", "backup-migrate-"+timestamp)
 
-		if f, err := os.CreateTemp(".", ".rhai-cli-probe-*"); err != nil {
-			defaultDir = filepath.Join("/tmp/rhoai-upgrade-backup", "backup-migrate-"+timestamp)
-		} else {
-			_ = f.Close()
-			_ = os.Remove(f.Name())
+		defaultDir, err := os.MkdirTemp(".", "backup-migrate-"+timestamp+"-*")
+		if err != nil {
+			defaultDir, err = os.MkdirTemp(
+				"/tmp/rhoai-upgrade-backup",
+				"backup-migrate-"+timestamp+"-*",
+			)
+			if err != nil {
+				return fmt.Errorf("creating default backup directory: %w", err)
+			}
 		}
 
 		c.OutputDir = defaultDir

--- a/pkg/migrate/command_prepare.go
+++ b/pkg/migrate/command_prepare.go
@@ -107,7 +107,16 @@ func (c *PrepareCommand) Complete() error {
 	// Set default output directory if not specified
 	if c.OutputDir == "" {
 		timestamp := time.Now().Format("20060102-150405")
-		c.OutputDir = filepath.Join(".", "backup-migrate-"+timestamp)
+		defaultDir := filepath.Join(".", "backup-migrate-"+timestamp)
+
+		if f, err := os.CreateTemp(".", ".rhai-cli-probe-*"); err != nil {
+			defaultDir = filepath.Join("/tmp/rhoai-upgrade-backup", "backup-migrate-"+timestamp)
+		} else {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		}
+
+		c.OutputDir = defaultDir
 	}
 
 	return nil

--- a/pkg/migrate/raycluster/client_test.go
+++ b/pkg/migrate/raycluster/client_test.go
@@ -574,7 +574,7 @@ func TestRunPreUpgradeChecks_AllPass(t *testing.T) {
 
 	c := newFakeClientWithAPIExtensions(t, []runtime.Object{certManagerCRD}, ns, rc, dsc)
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks).To(HaveLen(3))
 	for _, chk := range checks {
 		g.Expect(chk.Passed).To(BeTrue(), "check %s should pass", chk.Name)
@@ -601,7 +601,7 @@ func TestRunPreUpgradeChecks_PermissionsDenied(t *testing.T) {
 		APIExtensions: apiextClient,
 	})
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks).To(HaveLen(3))
 	g.Expect(checks[0].Passed).To(BeFalse())
 	g.Expect(checks[0].Name).To(Equal("Permissions"))
@@ -630,7 +630,7 @@ func TestRunPreUpgradeChecks_CertManagerNotFound(t *testing.T) {
 		APIExtensions: apiextClient,
 	})
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks).To(HaveLen(3))
 	g.Expect(checks[1].Name).To(Equal("cert-manager"))
 	g.Expect(checks[1].Passed).To(BeFalse())
@@ -658,7 +658,7 @@ func TestRunPreUpgradeChecks_CertManagerNamespaceFound(t *testing.T) {
 		APIExtensions: apiextClient,
 	})
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks[1].Name).To(Equal("cert-manager"))
 	g.Expect(checks[1].Passed).To(BeTrue())
 	g.Expect(checks[1].Message).To(ContainSubstring("cert-manager namespace found"))
@@ -678,10 +678,38 @@ func TestRunPreUpgradeChecks_CodeflareManaged(t *testing.T) {
 
 	c := newFakeClientWithAPIExtensions(t, []runtime.Object{certManagerCRD}, ns, dsc)
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks[2].Name).To(Equal("codeflare-operator"))
 	g.Expect(checks[2].Passed).To(BeFalse())
 	g.Expect(checks[2].Message).To(ContainSubstring("Managed"))
+}
+
+func TestRunPreUpgradeChecks_CodeflareAutoRemove(t *testing.T) {
+	g := NewWithT(t)
+
+	ns := makeNamespace("ns-a")
+	dsc := makeDSC("default-dsc", map[string]any{
+		"codeflare": map[string]any{"managementState": "Managed"},
+	})
+
+	certManagerCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "certificates.cert-manager.io"},
+	}
+
+	c := newFakeClientWithAPIExtensions(t, []runtime.Object{certManagerCRD}, ns, dsc)
+
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, true)
+	g.Expect(checks[2].Name).To(Equal("codeflare-operator"))
+	g.Expect(checks[2].Passed).To(BeTrue())
+	g.Expect(checks[2].Message).To(ContainSubstring("Set codeflare to Removed"))
+
+	// Verify DSC was actually patched
+	updated, err := c.Dynamic().Resource(resources.DataScienceCluster.GVR()).
+		Get(t.Context(), "default-dsc", metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	state, _, _ := unstructured.NestedString(updated.Object, "spec", "components", "codeflare", "managementState")
+	g.Expect(state).To(Equal("Removed"))
 }
 
 func TestRunPreUpgradeChecks_CodeflareUnmanaged(t *testing.T) {
@@ -697,7 +725,7 @@ func TestRunPreUpgradeChecks_CodeflareUnmanaged(t *testing.T) {
 
 	c := newFakeClientWithAPIExtensions(t, []runtime.Object{certManagerCRD}, dsc)
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks[2].Passed).To(BeTrue())
 	g.Expect(checks[2].Message).To(ContainSubstring("Unmanaged"))
 }
@@ -711,7 +739,7 @@ func TestRunPreUpgradeChecks_NoDSC(t *testing.T) {
 
 	c := newFakeClientWithAPIExtensions(t, []runtime.Object{certManagerCRD})
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks[2].Name).To(Equal("codeflare-operator"))
 	g.Expect(checks[2].Passed).To(BeTrue())
 }
@@ -729,7 +757,7 @@ func TestRunPreUpgradeChecks_CodeflareNoManagementState(t *testing.T) {
 
 	c := newFakeClientWithAPIExtensions(t, []runtime.Object{certManagerCRD}, dsc)
 
-	checks := raycluster.RunPreUpgradeChecks(t.Context(), c)
+	checks := raycluster.RunPreUpgradeChecks(t.Context(), c, false)
 	g.Expect(checks[2].Passed).To(BeTrue())
 	g.Expect(checks[2].Message).To(ContainSubstring("without managementState"))
 }

--- a/pkg/migrate/raycluster/preflight.go
+++ b/pkg/migrate/raycluster/preflight.go
@@ -173,12 +173,12 @@ func checkCodeflareOperator(ctx context.Context, c client.Client, autoRemove boo
 }
 
 func patchCodeflareToRemoved(ctx context.Context, c client.Client) error {
-	err := wait.ExponentialBackoff(wait.Backoff{
+	err := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
 		Duration: retryInitialDuration,
 		Factor:   retryFactor,
 		Jitter:   retryJitter,
 		Steps:    retryMaxSteps,
-	}, func() (bool, error) {
+	}, func(ctx context.Context) (bool, error) {
 		latestDSC, err := client.GetDataScienceCluster(ctx, c)
 		if err != nil {
 			return false, fmt.Errorf("getting DataScienceCluster: %w", err)

--- a/pkg/migrate/raycluster/preflight.go
+++ b/pkg/migrate/raycluster/preflight.go
@@ -2,10 +2,14 @@ package raycluster
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -22,8 +26,16 @@ type PreflightCheck struct {
 	Details  []string
 }
 
+const (
+	retryInitialDuration = 500 * time.Millisecond
+	retryFactor          = 2.0
+	retryJitter          = 0.1
+	retryMaxSteps        = 5
+)
+
 // RunPreUpgradeChecks runs pre-upgrade checks (permissions, cert-manager, codeflare-operator).
-func RunPreUpgradeChecks(ctx context.Context, c client.Client) []PreflightCheck {
+// When autoRemoveCodeflare is true, CodeFlare is automatically set to Removed if currently Managed.
+func RunPreUpgradeChecks(ctx context.Context, c client.Client, autoRemoveCodeflare bool) []PreflightCheck {
 	const numChecks = 3
 	checks := make([]PreflightCheck, 0, numChecks)
 
@@ -52,7 +64,7 @@ func RunPreUpgradeChecks(ctx context.Context, c client.Client) []PreflightCheck 
 	})
 
 	// Codeflare-operator in DSC
-	cfOK, cfMsg := checkCodeflareOperator(ctx, c)
+	cfOK, cfMsg := checkCodeflareOperator(ctx, c, autoRemoveCodeflare)
 	checks = append(checks, PreflightCheck{
 		Name:     "codeflare-operator",
 		Passed:   cfOK,
@@ -110,7 +122,7 @@ func checkCertManager(ctx context.Context, c client.Client) (bool, string) {
 	return false, "cert-manager not detected"
 }
 
-func checkCodeflareOperator(ctx context.Context, c client.Client) (bool, string) {
+func checkCodeflareOperator(ctx context.Context, c client.Client, autoRemove bool) (bool, string) {
 	dsc, err := client.GetDataScienceCluster(ctx, c)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -144,10 +156,60 @@ func checkCodeflareOperator(ctx context.Context, c client.Client) (bool, string)
 	case "unmanaged":
 		return true, "codeflare is Unmanaged in DSC '" + dscName + "'"
 	case "managed":
+		if autoRemove {
+			if err := patchCodeflareToRemoved(ctx, c); err != nil {
+				return false, fmt.Sprintf("failed to auto-remove codeflare in DSC '%s': %v", dscName, err)
+			}
+
+			return true, "Set codeflare to Removed in DataScienceCluster '" + dscName + "'"
+		}
+
 		return false, "codeflare is Managed in DSC '" + dscName + "' (should be Removed)"
 	case "":
 		return true, "codeflare present without managementState in DSC '" + dscName + "' (OK to proceed)"
 	default:
 		return false, "codeflare is '" + state + "' in DSC '" + dscName + "'"
 	}
+}
+
+func patchCodeflareToRemoved(ctx context.Context, c client.Client) error {
+	err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: retryInitialDuration,
+		Factor:   retryFactor,
+		Jitter:   retryJitter,
+		Steps:    retryMaxSteps,
+	}, func() (bool, error) {
+		latestDSC, err := client.GetDataScienceCluster(ctx, c)
+		if err != nil {
+			return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+		}
+
+		if err := jq.Transform(latestDSC, `.spec.components.codeflare.managementState = "Removed"`); err != nil {
+			return false, fmt.Errorf("setting codeflare managementState: %w", err)
+		}
+
+		gvk := latestDSC.GroupVersionKind()
+		gvr := schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: resources.DataScienceCluster.Resource,
+		}
+
+		_, err = c.Dynamic().Resource(gvr).
+			Update(ctx, latestDSC, metav1.UpdateOptions{})
+		if err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("updating DataScienceCluster: %w", err)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("patching codeflare to Removed: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/migrate/raycluster/preflight.go
+++ b/pkg/migrate/raycluster/preflight.go
@@ -184,6 +184,13 @@ func patchCodeflareToRemoved(ctx context.Context, c client.Client) error {
 			return false, fmt.Errorf("getting DataScienceCluster: %w", err)
 		}
 
+		currentState, _ := jq.Query[string](latestDSC, ".spec.components.codeflare.managementState")
+		currentState = strings.ToLower(currentState)
+
+		if currentState == "removed" || currentState == "unmanaged" {
+			return true, nil
+		}
+
 		if err := jq.Transform(latestDSC, `.spec.components.codeflare.managementState = "Removed"`); err != nil {
 			return false, fmt.Errorf("setting codeflare managementState: %w", err)
 		}


### PR DESCRIPTION
## Description

Fix 4 issues found during RHOAI 2.25→3.5 migration guide validation:

- Change phase from pre-upgrade to post-upgrade for 3 migrations (trustyai.migrate-gorch-otel-exporter, workbenches.patch-auth-model, training.verify-workloads) to match documented usage in migration guide
- Default backup output dir to /tmp/rhoai-upgrade-backup when CWD is not writable, preventing permission denied errors in the rhai-cli container
- Add jq to the container image for JSON processing in migration steps
- Auto-remove CodeFlare from DSC when Managed instead of failing with a precondition error, matching the documented raycluster.backup behavior
## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] New functionality includes tests

## Review checklist

- [ ] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration preflight checks can automatically remove managed CodeFlare components when required, with retry handling for temporary update conflicts.
  * Backup preparation now selects a writable fallback location when the current directory cannot create temporary files.

* **Bug Fixes**
  * Workload verification, telemetry exporter migration, and authentication model updates now run after upgrades, improving migration sequencing.
  * Backup operations now correctly respect dry-run and preparation-only modes.
  * Runtime tooling now supports JSON processing through `jq`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->