### PR TITLE
feat(lint): add MaaS modularization support and 3.4→3.5 field migration check

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,6 +20,7 @@ const (
 	ComponentRay              = "ray"
 	ComponentTrainingOperator = "trainingoperator"
 	ComponentWorkbenches      = "workbenches"
+	ComponentAIGateway        = "aigateway"
 )
 
 // Component names for Kueue integration.

--- a/pkg/lint/checks/components/aigateway/maas_migration.go
+++ b/pkg/lint/checks/components/aigateway/maas_migration.go
@@ -65,7 +65,7 @@ func (c *MaaSFieldMigrationCheck) CanApply(ctx context.Context, target check.Tar
 		return false, fmt.Errorf("querying kserve modelsAsService state: %w", err)
 	}
 
-	return state == constants.ManagementStateManaged, nil
+	return state == constants.ManagementStateManaged || state == constants.ManagementStateUnmanaged, nil
 }
 
 // Validate executes the check against the provided target.

--- a/pkg/lint/checks/components/aigateway/maas_migration.go
+++ b/pkg/lint/checks/components/aigateway/maas_migration.go
@@ -1,0 +1,112 @@
+package aigateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	kind = constants.ComponentAIGateway
+
+	// kserveMaaSField is the 3.4 DSC path for MaaS nested under kserve.
+	kserveMaaSField = ".spec.components.kserve.modelsAsService.managementState"
+)
+
+// MaaSFieldMigrationCheck detects when Models as a Service is configured via the
+// deprecated kserve.modelsAsService field (3.4) instead of aigateway.modelsAsAService (3.5+).
+type MaaSFieldMigrationCheck struct {
+	check.BaseCheck
+}
+
+// NewMaaSFieldMigrationCheck creates a new MaaSFieldMigrationCheck.
+func NewMaaSFieldMigrationCheck() *MaaSFieldMigrationCheck {
+	return &MaaSFieldMigrationCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupComponent,
+			Kind:             kind,
+			Type:             "maas-field-migration",
+			CheckID:          "components.aigateway.maas-field-migration",
+			CheckName:        "Components :: AIGateway :: MaaS Field Migration (3.4 to 3.5)",
+			CheckDescription: "Detects when Models as a Service is configured via the deprecated kserve.modelsAsService field instead of the new aigateway.modelsAsAService location",
+			CheckRemediation: "Set spec.components.aigateway.managementState: Managed and spec.components.aigateway.modelsAsAService.managementState: Managed in DataScienceCluster, then set spec.components.kserve.modelsAsService.managementState: Removed to clear the deprecated field",
+		},
+	}
+}
+
+// CanApply returns true when upgrading from 3.4 to 3.5 with MaaS enabled via the deprecated field.
+func (c *MaaSFieldMigrationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom34To35(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	state, err := jq.Query[string](dsc, kserveMaaSField)
+	if errors.Is(err, jq.ErrNotFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("querying kserve modelsAsService state: %w", err)
+	}
+
+	return state == constants.ManagementStateManaged, nil
+}
+
+// Validate executes the check against the provided target.
+func (c *MaaSFieldMigrationCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
+	tv := version.MajorMinorLabel(target.TargetVersion)
+
+	return validate.DSC(c, target).Run(ctx, func(dr *result.DiagnosticResult, dsc *unstructured.Unstructured) error {
+		state, err := jq.Query[string](dsc, kserveMaaSField)
+
+		switch {
+		case errors.Is(err, jq.ErrNotFound):
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeConfigured,
+				metav1.ConditionTrue,
+				check.WithReason(check.ReasonRequirementsMet),
+				check.WithMessage("Models as a Service is not configured via the deprecated kserve.modelsAsService field"),
+			))
+		case err != nil:
+			return fmt.Errorf("querying kserve modelsAsService state: %w", err)
+		case state == constants.ManagementStateManaged || state == constants.ManagementStateUnmanaged:
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeCompatible,
+				metav1.ConditionFalse,
+				check.WithReason(check.ReasonVersionIncompatible),
+				check.WithMessage(
+					"Models as a Service is enabled via the deprecated kserve.modelsAsService field (state: %s). "+
+						"In RHOAI %s, MaaS is configured under aigateway.modelsAsAService",
+					state, tv,
+				),
+				check.WithImpact(result.ImpactAdvisory),
+				check.WithRemediation(c.CheckRemediation),
+			))
+		default:
+			dr.SetCondition(check.NewCondition(
+				check.ConditionTypeConfigured,
+				metav1.ConditionTrue,
+				check.WithReason(check.ReasonRequirementsMet),
+				check.WithMessage("Models as a Service is not enabled via the deprecated kserve.modelsAsService field"),
+			))
+		}
+
+		return nil
+	})
+}

--- a/pkg/lint/checks/components/aigateway/maas_migration_test.go
+++ b/pkg/lint/checks/components/aigateway/maas_migration_test.go
@@ -1,0 +1,216 @@
+package aigateway_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/aigateway"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals // Test fixture - shared across test functions
+var listKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+// newDSCWithKserveMaaS creates a DSC with the deprecated kserve.modelsAsService field set.
+func newDSCWithKserveMaaS(state string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataScienceCluster.APIVersion(),
+			"kind":       resources.DataScienceCluster.Kind,
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"spec": map[string]any{
+				"components": map[string]any{
+					"kserve": map[string]any{
+						"managementState": "Managed",
+						"modelsAsService": map[string]any{
+							"managementState": state,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestMaaSFieldMigrationCheck_CanApply_NoDSC(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestMaaSFieldMigrationCheck_CanApply_OldFieldNotSet(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestMaaSFieldMigrationCheck_CanApply_OldFieldManaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newDSCWithKserveMaaS("Managed")},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestMaaSFieldMigrationCheck_CanApply_OldFieldRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newDSCWithKserveMaaS("Removed")},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestMaaSFieldMigrationCheck_CanApply_NotUpgrade34To35(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		target  string
+	}{
+		{"no current version", "", "3.5.0"},
+		{"same version 3.5", "3.5.0", "3.5.0"},
+		{"3.5 to 3.6", "3.5.0", "3.6.0"},
+		{"2.x to 3.5", "2.17.0", "3.5.0"},
+		{"3.3 to 3.5", "3.3.0", "3.5.0"},
+		{"3.4 to 3.6", "3.4.0", "3.6.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cfg := testutil.TargetConfig{
+				ListKinds: listKinds,
+				Objects:   []*unstructured.Unstructured{newDSCWithKserveMaaS("Managed")},
+			}
+			if tt.current != "" {
+				cfg.CurrentVersion = tt.current
+			}
+			if tt.target != "" {
+				cfg.TargetVersion = tt.target
+			}
+
+			target := testutil.NewTarget(t, cfg)
+			chk := aigateway.NewMaaSFieldMigrationCheck()
+			canApply, err := chk.CanApply(t.Context(), target)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(canApply).To(BeFalse())
+		})
+	}
+}
+
+func TestMaaSFieldMigrationCheck_Validate_OldFieldManaged_Advisory(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newDSCWithKserveMaaS("Managed")},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	res, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.Status.Conditions).To(HaveLen(1))
+	g.Expect(res.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionFalse),
+		"Reason": Equal(check.ReasonVersionIncompatible),
+		"Message": And(
+			ContainSubstring("kserve.modelsAsService"),
+			ContainSubstring("aigateway.modelsAsAService"),
+			ContainSubstring("3.5"),
+		),
+	}))
+	g.Expect(res.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+}
+
+func TestMaaSFieldMigrationCheck_Validate_OldFieldNotSet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"kserve": "Managed"})},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	res, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.Status.Conditions).To(HaveLen(1))
+	g.Expect(res.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeConfigured),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonRequirementsMet),
+	}))
+}
+
+func TestMaaSFieldMigrationCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+
+	g.Expect(chk.ID()).To(Equal("components.aigateway.maas-field-migration"))
+	g.Expect(chk.Name()).To(Equal("Components :: AIGateway :: MaaS Field Migration (3.4 to 3.5)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupComponent))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+	g.Expect(chk.Remediation()).ToNot(BeEmpty())
+}

--- a/pkg/lint/checks/components/aigateway/maas_migration_test.go
+++ b/pkg/lint/checks/components/aigateway/maas_migration_test.go
@@ -95,6 +95,23 @@ func TestMaaSFieldMigrationCheck_CanApply_OldFieldManaged(t *testing.T) {
 	g.Expect(canApply).To(BeTrue())
 }
 
+func TestMaaSFieldMigrationCheck_CanApply_OldFieldUnmanaged(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newDSCWithKserveMaaS("Unmanaged")},
+		CurrentVersion: "3.4.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	chk := aigateway.NewMaaSFieldMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
 func TestMaaSFieldMigrationCheck_CanApply_OldFieldRemoved(t *testing.T) {
 	g := NewWithT(t)
 

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/cmd"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/aigateway"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/dashboard"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/datasciencepipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/components/kserve"
@@ -109,7 +110,8 @@ func NewCommand(
 	registry.MustRegister(dscinitialization.NewDSCInitializationReadinessCheck())
 	registry.MustRegister(datasciencecluster.NewDataScienceClusterReadinessCheck())
 
-	// Components (13)
+	// Components (14)
+	registry.MustRegister(aigateway.NewMaaSFieldMigrationCheck())
 	registry.MustRegister(raycomponent.NewCodeFlareRemovalCheck())
 	registry.MustRegister(dashboard.NewAcceleratorProfileMigrationCheck())
 	registry.MustRegister(dashboard.NewHardwareProfileMigrationCheck())

--- a/pkg/lint/registry_check_test.go
+++ b/pkg/lint/registry_check_test.go
@@ -1,0 +1,38 @@
+//nolint:testpackage // internal test: accesses unexported registry field on Command
+package lint
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestNewCommand_RegistersAIGatewayMaaSCheck verifies that the MaaS field migration
+// check is registered in the command's check registry and is discoverable by its ID.
+func TestNewCommand_RegistersAIGatewayMaaSCheck(t *testing.T) {
+	g := NewWithT(t)
+
+	cmd := newTestCommand()
+	ids := cmd.registry.AllCheckIDs()
+
+	g.Expect(ids).To(ContainElement("components.aigateway.maas-field-migration"))
+}
+
+// TestNewCommand_AIGatewayCheckGroup verifies the check is in the component group.
+func TestNewCommand_AIGatewayCheckGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	cmd := newTestCommand()
+
+	var found bool
+	for _, chk := range cmd.registry.ListAll() {
+		if chk.ID() == "components.aigateway.maas-field-migration" {
+			g.Expect(string(chk.Group())).To(Equal("component"))
+			found = true
+
+			break
+		}
+	}
+
+	g.Expect(found).To(BeTrue(), "check components.aigateway.maas-field-migration not found in registry")
+}

--- a/pkg/resources/component_crs.go
+++ b/pkg/resources/component_crs.go
@@ -16,6 +16,7 @@ const (
 //nolint:gochecknoglobals // Component CR mapping is static configuration
 var ComponentCRResourceTypes = map[string]ResourceType{
 	// DSC v2 component names
+	"aigateway":          newComponentCR("aigateways", "AIGateway"),
 	"aipipelines":        newComponentCR("datasciencepipelines", "DataSciencePipelines"),
 	"dashboard":          newComponentCR("dashboards", "Dashboard"),
 	"feastoperator":      newComponentCR("feastoperators", "FeastOperator"),

--- a/pkg/resources/component_crs_test.go
+++ b/pkg/resources/component_crs_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestComponentCRResourceTypes(t *testing.T) {
 	expectedComponents := []string{
+		"aigateway",
 		"aipipelines",
 		"dashboard",
 		"feastoperator",
@@ -80,6 +81,7 @@ func TestAllComponentsHaveVerifiedLabels(t *testing.T) {
 	// When adding a new component, verify its actual label by checking deployed resources:
 	//   oc get pods -n opendatahub -l app.kubernetes.io/part-of=<component> --show-labels
 	expectedLabels := map[string]string{
+		"aigateway":          "aigateway",
 		"aipipelines":        "data-science-pipelines-operator",
 		"dashboard":          "dashboard",
 		"feastoperator":      "feastoperator",

--- a/pkg/util/components/components.go
+++ b/pkg/util/components/components.go
@@ -46,3 +46,38 @@ func HasManagementState(obj client.Object, componentKey string, states ...string
 
 	return slices.Contains(states, state)
 }
+
+// GetSubComponentManagementState queries a DSC sub-component's management state.
+// parentKey is the top-level component key (e.g. "aigateway").
+// subKey is the nested sub-component key (e.g. "modelsAsAService").
+// Returns "Removed" if not configured (semantically equivalent), or an error on query failure.
+func GetSubComponentManagementState(obj client.Object, parentKey, subKey string) (string, error) {
+	path := fmt.Sprintf(".spec.components.%s.%s.managementState", parentKey, subKey)
+
+	state, err := jq.Query[string](obj, path)
+	if err != nil {
+		if errors.Is(err, jq.ErrNotFound) {
+			return constants.ManagementStateRemoved, nil
+		}
+
+		return "", fmt.Errorf("querying %s.%s managementState: %w", parentKey, subKey, err)
+	}
+
+	return state, nil
+}
+
+// HasSubComponentManagementState checks whether a DSC sub-component is configured with a matching management state.
+// With states: returns true if the sub-component's state matches any of the provided values.
+// Without states: returns true always (sub-component exists or defaults to Removed).
+func HasSubComponentManagementState(obj client.Object, parentKey, subKey string, states ...string) bool {
+	state, err := GetSubComponentManagementState(obj, parentKey, subKey)
+	if err != nil {
+		return false
+	}
+
+	if len(states) == 0 {
+		return true
+	}
+
+	return slices.Contains(states, state)
+}

--- a/pkg/util/components/components_test.go
+++ b/pkg/util/components/components_test.go
@@ -1,0 +1,152 @@
+package components_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+
+	. "github.com/onsi/gomega"
+)
+
+// newDSCWithSubComponent builds an unstructured DSC with one sub-component nested under parent.
+func newDSCWithSubComponent(parent, sub, state string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "datasciencecluster.opendatahub.io/v2",
+			"kind":       "DataScienceCluster",
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"spec": map[string]any{
+				"components": map[string]any{
+					parent: map[string]any{
+						"managementState": "Managed",
+						sub: map[string]any{
+							"managementState": state,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// newDSCWithoutSubComponent builds a DSC where parent exists but sub is absent.
+func newDSCWithoutSubComponent(parent string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "datasciencecluster.opendatahub.io/v2",
+			"kind":       "DataScienceCluster",
+			"metadata": map[string]any{
+				"name": "default-dsc",
+			},
+			"spec": map[string]any{
+				"components": map[string]any{
+					parent: map[string]any{
+						"managementState": "Managed",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestGetSubComponentManagementState_Found(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{"Managed", constants.ManagementStateManaged},
+		{"Unmanaged", constants.ManagementStateUnmanaged},
+		{"Removed", constants.ManagementStateRemoved},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			dsc := newDSCWithSubComponent("aigateway", "modelsAsAService", tt.state)
+			state, err := components.GetSubComponentManagementState(dsc, "aigateway", "modelsAsAService")
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(state).To(Equal(tt.state))
+		})
+	}
+}
+
+func TestGetSubComponentManagementState_NotFound_ReturnsRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSCWithoutSubComponent("aigateway")
+	state, err := components.GetSubComponentManagementState(dsc, "aigateway", "modelsAsAService")
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(state).To(Equal(constants.ManagementStateRemoved))
+}
+
+func TestGetSubComponentManagementState_ParentAbsent_ReturnsRemoved(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := &unstructured.Unstructured{
+		Object: map[string]any{
+			"spec": map[string]any{
+				"components": map[string]any{},
+			},
+		},
+	}
+	state, err := components.GetSubComponentManagementState(dsc, "aigateway", "modelsAsAService")
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(state).To(Equal(constants.ManagementStateRemoved))
+}
+
+func TestHasSubComponentManagementState_MatchingState(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSCWithSubComponent("aigateway", "modelsAsAService", constants.ManagementStateManaged)
+	result := components.HasSubComponentManagementState(dsc, "aigateway", "modelsAsAService", constants.ManagementStateManaged)
+
+	g.Expect(result).To(BeTrue())
+}
+
+func TestHasSubComponentManagementState_NonMatchingState(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSCWithSubComponent("aigateway", "modelsAsAService", constants.ManagementStateRemoved)
+	result := components.HasSubComponentManagementState(dsc, "aigateway", "modelsAsAService", constants.ManagementStateManaged)
+
+	g.Expect(result).To(BeFalse())
+}
+
+func TestHasSubComponentManagementState_NoStates_AlwaysTrue(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSCWithSubComponent("aigateway", "modelsAsAService", constants.ManagementStateRemoved)
+	result := components.HasSubComponentManagementState(dsc, "aigateway", "modelsAsAService")
+
+	g.Expect(result).To(BeTrue())
+}
+
+func TestHasSubComponentManagementState_NotFound_ReturnsFalse(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSCWithoutSubComponent("aigateway")
+	result := components.HasSubComponentManagementState(dsc, "aigateway", "modelsAsAService", constants.ManagementStateManaged)
+
+	g.Expect(result).To(BeFalse())
+}
+
+func TestHasSubComponentManagementState_MultipleStates(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := newDSCWithSubComponent("aigateway", "modelsAsAService", constants.ManagementStateUnmanaged)
+	result := components.HasSubComponentManagementState(
+		dsc, "aigateway", "modelsAsAService",
+		constants.ManagementStateManaged, constants.ManagementStateUnmanaged,
+	)
+
+	g.Expect(result).To(BeTrue())
+}


### PR DESCRIPTION
## Summary

- Registers `aigateway` as a recognized DSC component in the component CR map, enabling health checks and component listing for the AIGateway module
- Adds `GetSubComponentManagementState` / `HasSubComponentManagementState` utilities for querying nested DSC paths (e.g. `aigateway.modelsAsAService.managementState`)
- Adds lint check `components.aigateway.maas-field-migration` that detects when MaaS is still configured via the deprecated `kserve.modelsAsService` field during a 3.4 → 3.5 upgrade and surfaces an advisory with migration instructions

## Background

As part of MaaS modularization (RHOAI 3.5), Models as a Service moved from `spec.components.kserve.modelsAsService` (3.4) to `spec.components.aigateway.modelsAsAService` (3.5). Without this change, the CLI was blind to the new field location and gave users no guidance during an upgrade assessment. The old field is deprecated and a CEL rule blocks re-enabling it once cleared, making the migration advisory important for users to see.

## Risk analysis

**Risk rating: 2**

**Why:** Additive-only change — new component registration, new utility functions, and a new lint check. No existing check logic is modified. The new check fires as advisory (exit code 2, not 1) so it cannot block any currently-passing upgrade assessments. The `aigateway` component CR entry follows the identical pattern of all other 13 existing entries.

## Test plan

- [x] Unit tests: 31 packages, all passing (`make test`)
- [x] Registry test: verifies `components.aigateway.maas-field-migration` is registered and in the `component` group
- [x] Utility tests: `GetSubComponentManagementState` / `HasSubComponentManagementState` covering found, not-found, parent-absent, multi-state scenarios

### Live cluster results (OCP 4.19.16, ODH 2.35.0 with simulated 3.4 version)

| Scenario | Command | Expected | Actual |
|----------|---------|----------|--------|
| `kserve.modelsAsService: Managed`, upgrading 3.4→3.5 | `lint --target-version 3.5 --checks components.aigateway.maas-field-migration` | ⚠ Advisory | ✅ Advisory fired, exit 2 |
| `kserve.modelsAsService: Managed`, upgrading 3.4→3.6 | `lint --target-version 3.6 --checks components.aigateway.maas-field-migration` | ✅ Pass (skipped) | ✅ Pass, exit 0 |
| Field absent, upgrading 3.4→3.5 | `lint --target-version 3.5 --checks components.aigateway.maas-field-migration` | ✅ Pass | ✅ Pass, exit 0 |

Advisory message confirmed: correctly references both the deprecated path (`kserve.modelsAsService`) and the new location (`aigateway.modelsAsAService`).

## Jira

[RHOAIENG-83202](https://redhat.atlassian.net/browse/RHOAIENG-83202)

[RHOAIENG-83202]: https://redhat.atlassian.net/browse/RHOAIENG-83202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI Gateway component support to resource detection and lint checks.
  * Added upgrade guidance for moving MaaS configuration during RHOAI 3.4-to-3.5 upgrades.
  * Added validation for nested component management states.

* **Bug Fixes**
  * Identifies deprecated MaaS configuration and provides remediation guidance.

* **Tests**
  * Added comprehensive coverage for migration scenarios, component registration, resource mapping, and management-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->