### PR TITLE
feat(lint): add AI Pipelines upgrade gates for RHOAI 2.x to 3.x

### DIFF
--- a/pkg/aipipelines/component.go
+++ b/pkg/aipipelines/component.go
@@ -1,0 +1,84 @@
+package aipipelines
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/jq"
+)
+
+const (
+	// ComponentKeyV1 is the DSC v1 component key for DataSciencePipelines.
+	ComponentKeyV1 = "datasciencepipelines"
+	// ComponentKeyV2 is the DSC v2 component key for AI Pipelines.
+	ComponentKeyV2 = "aipipelines"
+)
+
+// ShouldApplyChecks reports whether AI Pipelines upgrade checks should run.
+// Checks apply when the component is Managed under either DSC key, or when DSPAs
+// exist on the cluster (for example, component Removed but workloads remain).
+func ShouldApplyChecks(ctx context.Context, dsc *unstructured.Unstructured, r client.Reader) (bool, error) {
+	if components.HasManagementState(dsc, ComponentKeyV2, constants.ManagementStateManaged) ||
+		components.HasManagementState(dsc, ComponentKeyV1, constants.ManagementStateManaged) {
+		return true, nil
+	}
+
+	exists, err := HasDSPAs(ctx, r)
+	if err != nil {
+		return false, fmt.Errorf("checking for DataSciencePipelinesApplications: %w", err)
+	}
+
+	return exists, nil
+}
+
+// HasComponentKey reports whether componentKey is present under spec.components.
+func HasComponentKey(dsc *unstructured.Unstructured, componentKey string) (bool, error) {
+	path := ".spec.components." + componentKey
+
+	_, err := jq.Query[any](dsc, path)
+	if err != nil {
+		if errors.Is(err, jq.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("querying %s: %w", path, err)
+	}
+
+	return true, nil
+}
+
+// UsesComponentKeyV2 reports whether AI Pipelines is configured under the DSC v2 component key.
+func UsesComponentKeyV2(dsc *unstructured.Unstructured) (bool, error) {
+	return HasComponentKey(dsc, ComponentKeyV2)
+}
+
+// EffectiveManagementState returns the management state for AI Pipelines, preferring the
+// DSC v2 component key when present and falling back to the v1 key.
+func EffectiveManagementState(dsc *unstructured.Unstructured) (string, error) {
+	usesV2, err := UsesComponentKeyV2(dsc)
+	if err != nil {
+		return "", fmt.Errorf("checking AI Pipelines v2 component key: %w", err)
+	}
+
+	if usesV2 {
+		state, err := components.GetManagementState(dsc, ComponentKeyV2)
+		if err != nil {
+			return "", fmt.Errorf("querying %s management state: %w", ComponentKeyV2, err)
+		}
+
+		return state, nil
+	}
+
+	state, err := components.GetManagementState(dsc, ComponentKeyV1)
+	if err != nil {
+		return "", fmt.Errorf("querying %s management state: %w", ComponentKeyV1, err)
+	}
+
+	return state, nil
+}

--- a/pkg/aipipelines/component_test.go
+++ b/pkg/aipipelines/component_test.go
@@ -1,0 +1,127 @@
+package aipipelines_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoglobals // Test fixture - shared across test functions
+var componentListKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR():                resources.DataScienceCluster.ListKind(),
+	resources.DataSciencePipelinesApplicationV1.GVR(): resources.DataSciencePipelinesApplicationV1.ListKind(),
+}
+
+func TestShouldApplyChecks_ManagedV2(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: constants.ManagementStateManaged})
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: componentListKinds,
+		Objects:   []*unstructured.Unstructured{dsc},
+	})
+
+	apply, err := aipipelines.ShouldApplyChecks(t.Context(), dsc, target.Client)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(apply).To(BeTrue())
+}
+
+func TestShouldApplyChecks_ManagedV1(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateManaged})
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: componentListKinds,
+		Objects:   []*unstructured.Unstructured{dsc},
+	})
+
+	apply, err := aipipelines.ShouldApplyChecks(t.Context(), dsc, target.Client)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(apply).To(BeTrue())
+}
+
+func TestShouldApplyChecks_RemovedWithDSPAs(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateRemoved})
+	dspa := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataSciencePipelinesApplicationV1.APIVersion(),
+			"kind":       resources.DataSciencePipelinesApplicationV1.Kind,
+			"metadata": map[string]any{
+				"name":      "dspa",
+				"namespace": "team-ns",
+			},
+		},
+	}
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: componentListKinds,
+		Objects:   []*unstructured.Unstructured{dsc, dspa},
+	})
+
+	apply, err := aipipelines.ShouldApplyChecks(t.Context(), dsc, target.Client)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(apply).To(BeTrue())
+}
+
+func TestShouldApplyChecks_RemovedWithoutDSPAs(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateRemoved})
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: componentListKinds,
+		Objects:   []*unstructured.Unstructured{dsc},
+	})
+
+	apply, err := aipipelines.ShouldApplyChecks(t.Context(), dsc, target.Client)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(apply).To(BeFalse())
+}
+
+func TestHasComponentKey(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateManaged})
+	hasV1, err := aipipelines.HasComponentKey(dsc, aipipelines.ComponentKeyV1)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasV1).To(BeTrue())
+
+	hasV2, err := aipipelines.HasComponentKey(dsc, aipipelines.ComponentKeyV2)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(hasV2).To(BeFalse())
+}
+
+func TestUsesComponentKeyV2(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: constants.ManagementStateManaged})
+	usesV2, err := aipipelines.UsesComponentKeyV2(dsc)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(usesV2).To(BeTrue())
+}
+
+func TestEffectiveManagementState_PrefersV2(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: constants.ManagementStateManaged})
+	state, err := aipipelines.EffectiveManagementState(dsc)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(state).To(Equal(constants.ManagementStateManaged))
+}
+
+func TestEffectiveManagementState_FallsBackToV1(t *testing.T) {
+	g := NewWithT(t)
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateManaged})
+	state, err := aipipelines.EffectiveManagementState(dsc)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(state).To(Equal(constants.ManagementStateManaged))
+}

--- a/pkg/aipipelines/dspa.go
+++ b/pkg/aipipelines/dspa.go
@@ -1,0 +1,45 @@
+package aipipelines
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// ListDSPAs returns DSPA objects, preferring v1 and falling back to v1alpha1 when v1 is unavailable.
+// The returned ResourceType identifies which API version was used for the list.
+func ListDSPAs(
+	ctx context.Context,
+	r client.Reader,
+) ([]*unstructured.Unstructured, resources.ResourceType, error) {
+	dspasV1, err := r.List(ctx, resources.DataSciencePipelinesApplicationV1)
+	if err == nil {
+		return dspasV1, resources.DataSciencePipelinesApplicationV1, nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return nil, resources.ResourceType{}, fmt.Errorf("listing DataSciencePipelinesApplications v1: %w", err)
+	}
+
+	dspasV1Alpha1, err := r.List(ctx, resources.DataSciencePipelinesApplicationV1Alpha1)
+	if err != nil {
+		return nil, resources.ResourceType{}, fmt.Errorf("listing DataSciencePipelinesApplications v1alpha1: %w", err)
+	}
+
+	return dspasV1Alpha1, resources.DataSciencePipelinesApplicationV1Alpha1, nil
+}
+
+// HasDSPAs reports whether any DSPA objects exist on the cluster.
+func HasDSPAs(ctx context.Context, r client.Reader) (bool, error) {
+	dspas, _, err := ListDSPAs(ctx, r)
+	if err != nil {
+		return false, err
+	}
+
+	return len(dspas) > 0, nil
+}

--- a/pkg/aipipelines/dspa_test.go
+++ b/pkg/aipipelines/dspa_test.go
@@ -1,0 +1,67 @@
+package aipipelines_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+)
+
+//nolint:gochecknoglobals // Test fixture - shared across test functions
+var dspaListKinds = map[schema.GroupVersionResource]string{
+	resources.DataSciencePipelinesApplicationV1.GVR():       resources.DataSciencePipelinesApplicationV1.ListKind(),
+	resources.DataSciencePipelinesApplicationV1Alpha1.GVR(): resources.DataSciencePipelinesApplicationV1Alpha1.ListKind(),
+}
+
+func TestListDSPAs_V1(t *testing.T) {
+	g := NewWithT(t)
+
+	dspa := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataSciencePipelinesApplicationV1.APIVersion(),
+			"kind":       resources.DataSciencePipelinesApplicationV1.Kind,
+			"metadata": map[string]any{
+				"name":      "dspa",
+				"namespace": "team-ns",
+			},
+		},
+	}
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dspaListKinds,
+		Objects:   []*unstructured.Unstructured{dspa},
+	})
+
+	objs, usedType, err := aipipelines.ListDSPAs(t.Context(), target.Client)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(usedType).To(Equal(resources.DataSciencePipelinesApplicationV1))
+	g.Expect(objs).To(HaveLen(1))
+}
+
+func TestHasDSPAs(t *testing.T) {
+	g := NewWithT(t)
+
+	dspa := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.DataSciencePipelinesApplicationV1.APIVersion(),
+			"kind":       resources.DataSciencePipelinesApplicationV1.Kind,
+			"metadata": map[string]any{
+				"name":      "dspa",
+				"namespace": "team-ns",
+			},
+		},
+	}
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: dspaListKinds,
+		Objects:   []*unstructured.Unstructured{dspa},
+	})
+
+	exists, err := aipipelines.HasDSPAs(t.Context(), target.Client)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(exists).To(BeTrue())
+}

--- a/pkg/aipipelines/rbac/classifier.go
+++ b/pkg/aipipelines/rbac/classifier.go
@@ -6,7 +6,13 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const systemNamespacePattern = `^(kube-system|default|openshift.*|redhat-ods-.*)$`
+const (
+	systemNamespacePattern = `^(kube-system|default|openshift.*|redhat-ods-.*)$`
+
+	dspaAPIGroup       = "datasciencepipelinesapplications.opendatahub.io"
+	dspaAPISubresource = "datasciencepipelinesapplications/api"
+	routeAPIGroup      = "route.openshift.io"
+)
 
 var (
 	systemNamespaceRe   = regexp.MustCompile(systemNamespacePattern)
@@ -55,17 +61,14 @@ func ClassifyRole(role *unstructured.Unstructured) Classification {
 		ruleResources, _ := ExtractStringSlice(rule, "resources")
 		verbs, _ := ExtractStringSlice(rule, "verbs")
 
-		for _, g := range apiGroups {
-			if g == "route.openshift.io" {
-				hasRouteAPIGroup = true
-				classification.RouteVerbs = mergeStringSlices(classification.RouteVerbs, verbs)
-			}
+		if containsStringOrWildcard(apiGroups, routeAPIGroup) {
+			hasRouteAPIGroup = true
+			classification.RouteVerbs = mergeStringSlices(classification.RouteVerbs, verbs)
 		}
 
-		for _, res := range ruleResources {
-			if res == "datasciencepipelinesapplications/api" {
-				hasDSPASubresource = true
-			}
+		if containsStringOrWildcard(apiGroups, dspaAPIGroup) &&
+			containsStringOrWildcard(ruleResources, dspaAPISubresource) {
+			hasDSPASubresource = true
 		}
 	}
 
@@ -100,6 +103,16 @@ func ExtractStringSlice(obj map[string]any, key string) ([]string, bool) {
 	}
 
 	return out, len(out) > 0
+}
+
+func containsStringOrWildcard(values []string, target string) bool {
+	for _, v := range values {
+		if v == target || v == "*" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func mergeStringSlices(a, b []string) []string {

--- a/pkg/aipipelines/rbac/classifier.go
+++ b/pkg/aipipelines/rbac/classifier.go
@@ -1,0 +1,122 @@
+package rbac
+
+import (
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const systemNamespacePattern = `^(kube-system|default|openshift.*|redhat-ods-.*)$`
+
+var (
+	systemNamespaceRe   = regexp.MustCompile(systemNamespacePattern)
+	operatorManagedRole = regexp.MustCompile(`^(ds-pipeline-|pipeline-runner-)`)
+)
+
+// Classification describes whether a Role needs the datasciencepipelinesapplications/api subresource.
+type Classification struct {
+	NeedsFix   bool
+	RoleName   string
+	Namespace  string
+	RouteVerbs []string // verbs from the route.openshift.io rule, used to infer DSPA verbs
+}
+
+// ClassifyRole determines whether a Role grants route.openshift.io permissions without the
+// datasciencepipelinesapplications/api subresource required after the kube-rbac-proxy migration.
+func ClassifyRole(role *unstructured.Unstructured) Classification {
+	classification := Classification{
+		RoleName:  role.GetName(),
+		Namespace: role.GetNamespace(),
+	}
+
+	if IsSystemNamespace(classification.Namespace) {
+		return classification
+	}
+
+	if operatorManagedRole.MatchString(classification.RoleName) {
+		return classification
+	}
+
+	rules, found, _ := unstructured.NestedSlice(role.Object, "rules")
+	if !found {
+		return classification
+	}
+
+	hasRouteAPIGroup := false
+	hasDSPASubresource := false
+
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		apiGroups, _ := ExtractStringSlice(rule, "apiGroups")
+		ruleResources, _ := ExtractStringSlice(rule, "resources")
+		verbs, _ := ExtractStringSlice(rule, "verbs")
+
+		for _, g := range apiGroups {
+			if g == "route.openshift.io" {
+				hasRouteAPIGroup = true
+				classification.RouteVerbs = mergeStringSlices(classification.RouteVerbs, verbs)
+			}
+		}
+
+		for _, res := range ruleResources {
+			if res == "datasciencepipelinesapplications/api" {
+				hasDSPASubresource = true
+			}
+		}
+	}
+
+	classification.NeedsFix = hasRouteAPIGroup && !hasDSPASubresource
+
+	return classification
+}
+
+// IsSystemNamespace reports whether the namespace is managed by the platform or ODH.
+func IsSystemNamespace(ns string) bool {
+	return systemNamespaceRe.MatchString(ns)
+}
+
+// ExtractStringSlice reads a string slice from an unstructured rule field.
+func ExtractStringSlice(obj map[string]any, key string) ([]string, bool) {
+	raw, ok := obj[key]
+	if !ok {
+		return nil, false
+	}
+
+	slice, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+
+	out := make([]string, 0, len(slice))
+
+	for _, v := range slice {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+
+	return out, len(out) > 0
+}
+
+func mergeStringSlices(a, b []string) []string {
+	seen := make(map[string]bool, len(a))
+
+	for _, v := range a {
+		seen[v] = true
+	}
+
+	merged := append([]string{}, a...)
+
+	for _, v := range b {
+		if !seen[v] {
+			merged = append(merged, v)
+			seen[v] = true
+		}
+	}
+
+	return merged
+}

--- a/pkg/aipipelines/rbac/classifier_test.go
+++ b/pkg/aipipelines/rbac/classifier_test.go
@@ -1,18 +1,39 @@
-package aipipelines_test
+package rbac_test
 
 import (
 	"testing"
 
-	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/aipipelines"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/aipipelines/rbac"
 
 	. "github.com/onsi/gomega"
 )
+
+func makeRoleUnstructured(name, namespace string, rules []map[string]any) unstructured.Unstructured {
+	rulesAny := make([]any, len(rules))
+	for i, r := range rules {
+		rulesAny[i] = r
+	}
+
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "Role",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"rules": rulesAny,
+		},
+	}
+}
 
 func TestClassifyRole(t *testing.T) {
 	t.Run("role needing fix — has route.openshift.io but missing dspa subresource", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+		role := makeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
 			{
 				"apiGroups": []any{"route.openshift.io"},
 				"resources": []any{"routes"},
@@ -20,7 +41,7 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeTrue())
 		g.Expect(result.RoleName).To(Equal("my-custom-role"))
 		g.Expect(result.Namespace).To(Equal("user-ns"))
@@ -30,7 +51,7 @@ func TestClassifyRole(t *testing.T) {
 	t.Run("role needing fix — infers verbs including create and update", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+		role := makeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
 			{
 				"apiGroups": []any{"route.openshift.io"},
 				"resources": []any{"routes"},
@@ -38,7 +59,7 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeTrue())
 		g.Expect(result.RouteVerbs).To(Equal([]string{"get", "list", "create", "update", "delete"}))
 	})
@@ -46,7 +67,7 @@ func TestClassifyRole(t *testing.T) {
 	t.Run("role already has dspa subresource — no fix needed", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+		role := makeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
 			{
 				"apiGroups": []any{"route.openshift.io"},
 				"resources": []any{"routes"},
@@ -59,14 +80,14 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeFalse())
 	})
 
 	t.Run("role without route.openshift.io — no fix needed", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("my-role", "user-ns", []map[string]any{
+		role := makeRoleUnstructured("my-role", "user-ns", []map[string]any{
 			{
 				"apiGroups": []any{""},
 				"resources": []any{"pods"},
@@ -74,14 +95,14 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeFalse())
 	})
 
 	t.Run("operator-managed role is excluded — ds-pipeline prefix", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("ds-pipeline-mydspa", "user-ns", []map[string]any{
+		role := makeRoleUnstructured("ds-pipeline-mydspa", "user-ns", []map[string]any{
 			{
 				"apiGroups": []any{"route.openshift.io"},
 				"resources": []any{"routes"},
@@ -89,14 +110,14 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeFalse())
 	})
 
 	t.Run("operator-managed role is excluded — pipeline-runner prefix", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("pipeline-runner-mydspa", "user-ns", []map[string]any{
+		role := makeRoleUnstructured("pipeline-runner-mydspa", "user-ns", []map[string]any{
 			{
 				"apiGroups": []any{"route.openshift.io"},
 				"resources": []any{"routes"},
@@ -104,14 +125,14 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeFalse())
 	})
 
 	t.Run("system namespace is excluded", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("my-role", "kube-system", []map[string]any{
+		role := makeRoleUnstructured("my-role", "kube-system", []map[string]any{
 			{
 				"apiGroups": []any{"route.openshift.io"},
 				"resources": []any{"routes"},
@@ -119,16 +140,16 @@ func TestClassifyRole(t *testing.T) {
 			},
 		})
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeFalse())
 	})
 
 	t.Run("role with no rules", func(t *testing.T) {
 		g := NewWithT(t)
 
-		role := aipipelines.MakeRoleUnstructured("empty-role", "user-ns", nil)
+		role := makeRoleUnstructured("empty-role", "user-ns", nil)
 
-		result := aipipelines.ClassifyRole(&role)
+		result := rbac.ClassifyRole(&role)
 		g.Expect(result.NeedsFix).To(BeFalse())
 	})
 }
@@ -153,7 +174,7 @@ func TestIsSystemNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.ns, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(aipipelines.IsSystemNamespace(tt.ns)).To(Equal(tt.expected))
+			g.Expect(rbac.IsSystemNamespace(tt.ns)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -166,7 +187,7 @@ func TestExtractStringSlice(t *testing.T) {
 			"verbs": []any{"get", "list", "watch"},
 		}
 
-		result, ok := aipipelines.ExtractStringSlice(obj, "verbs")
+		result, ok := rbac.ExtractStringSlice(obj, "verbs")
 		g.Expect(ok).To(BeTrue())
 		g.Expect(result).To(Equal([]string{"get", "list", "watch"}))
 	})
@@ -176,7 +197,7 @@ func TestExtractStringSlice(t *testing.T) {
 
 		obj := map[string]any{}
 
-		_, ok := aipipelines.ExtractStringSlice(obj, "verbs")
+		_, ok := rbac.ExtractStringSlice(obj, "verbs")
 		g.Expect(ok).To(BeFalse())
 	})
 
@@ -187,7 +208,7 @@ func TestExtractStringSlice(t *testing.T) {
 			"verbs": "get",
 		}
 
-		_, ok := aipipelines.ExtractStringSlice(obj, "verbs")
+		_, ok := rbac.ExtractStringSlice(obj, "verbs")
 		g.Expect(ok).To(BeFalse())
 	})
 }

--- a/pkg/aipipelines/rbac/classifier_test.go
+++ b/pkg/aipipelines/rbac/classifier_test.go
@@ -64,6 +64,66 @@ func TestClassifyRole(t *testing.T) {
 		g.Expect(result.RouteVerbs).To(Equal([]string{"get", "list", "create", "update", "delete"}))
 	})
 
+	t.Run("role with dspa resource under unrelated api group in same rule — still needs fix", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := makeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+			{
+				"apiGroups": []any{"example.invalid"},
+				"resources": []any{"datasciencepipelinesapplications/api"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := rbac.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeTrue())
+	})
+
+	t.Run("role with wildcard dspa grant — no fix needed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := makeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+			{
+				"apiGroups": []any{"*"},
+				"resources": []any{"datasciencepipelinesapplications/api"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := rbac.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
+	t.Run("role with wildcard dspa resource — no fix needed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		role := makeRoleUnstructured("my-custom-role", "user-ns", []map[string]any{
+			{
+				"apiGroups": []any{"route.openshift.io"},
+				"resources": []any{"routes"},
+				"verbs":     []any{"get"},
+			},
+			{
+				"apiGroups": []any{"datasciencepipelinesapplications.opendatahub.io"},
+				"resources": []any{"*"},
+				"verbs":     []any{"get"},
+			},
+		})
+
+		result := rbac.ClassifyRole(&role)
+		g.Expect(result.NeedsFix).To(BeFalse())
+	})
+
 	t.Run("role already has dspa subresource — no fix needed", func(t *testing.T) {
 		g := NewWithT(t)
 

--- a/pkg/aipipelines/rbac/scan.go
+++ b/pkg/aipipelines/rbac/scan.go
@@ -1,0 +1,29 @@
+package rbac
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+)
+
+// FindRolesNeedingFix scans cluster Roles and returns those missing the
+// datasciencepipelinesapplications/api subresource while granting route.openshift.io access.
+func FindRolesNeedingFix(ctx context.Context, r client.Reader) ([]Classification, error) {
+	roleList, err := r.List(ctx, resources.Role)
+	if err != nil {
+		return nil, fmt.Errorf("listing roles: %w", err)
+	}
+
+	needsFix := make([]Classification, 0)
+
+	for _, role := range roleList {
+		classification := ClassifyRole(role)
+		if classification.NeedsFix {
+			needsFix = append(needsFix, classification)
+		}
+	}
+
+	return needsFix, nil
+}

--- a/pkg/lint/checks/components/datasciencepipelines/renaming.go
+++ b/pkg/lint/checks/components/datasciencepipelines/renaming.go
@@ -39,7 +39,8 @@ func NewRenamingCheck() *RenamingCheck {
 }
 
 // CanApply returns whether this check should run for the given target.
-// This check only applies when upgrading FROM 2.x TO 3.x and DataSciencePipelines is Managed.
+// This check applies when upgrading FROM 2.x TO 3.x and DataSciencePipelines is Managed
+// under the v1 component key. DSC v2 clusters that only expose aipipelines skip this check.
 func (c *RenamingCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
 	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
 		return false, nil

--- a/pkg/lint/checks/components/datasciencepipelines/renaming_test.go
+++ b/pkg/lint/checks/components/datasciencepipelines/renaming_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/aipipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -19,7 +20,8 @@ import (
 
 //nolint:gochecknoglobals // Test fixture - shared across test functions
 var listKinds = map[schema.GroupVersionResource]string{
-	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+	resources.DataScienceCluster.GVR():   resources.DataScienceCluster.ListKind(),
+	resources.DataScienceClusterV1.GVR(): resources.DataScienceClusterV1.ListKind(),
 }
 
 func TestRenamingCheck_CanApply_NoDSC(t *testing.T) {
@@ -116,6 +118,26 @@ func TestRenamingCheck_CanApply_Managed(t *testing.T) {
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(canApply).To(BeTrue())
+}
+
+func TestRenamingCheck_CanApply_V2ComponentKeySkips(t *testing.T) {
+	g := NewWithT(t)
+
+	// DSC v2 only carries aipipelines; datasciencepipelines is absent (treated as Removed).
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: "Managed"})
+	dsc.SetAPIVersion(resources.DataScienceCluster.APIVersion())
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := datasciencepipelines.NewRenamingCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
 }
 
 func TestRenamingCheck_CanApply_VersionFiltering(t *testing.T) {

--- a/pkg/lint/checks/workloads/datasciencepipelines/custom_rbac_api_subresource.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/custom_rbac_api_subresource.go
@@ -1,0 +1,116 @@
+package datasciencepipelines
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	pipelinescomponent "github.com/opendatahub-io/odh-cli/pkg/aipipelines"
+	pipelinesrbac "github.com/opendatahub-io/odh-cli/pkg/aipipelines/rbac"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+const (
+	checkTypeCustomRBACAPISubresource = "custom-rbac-api-subresource"
+
+	msgCustomRBACFound = "Found %d custom Role(s) with route.openshift.io permissions missing the datasciencepipelinesapplications/api subresource required in RHOAI %s"
+	msgCustomRBACClear = "No custom Roles missing datasciencepipelinesapplications/api subresource - ready for RHOAI %s upgrade"
+)
+
+// CustomRBACAPISubresourceCheck validates that custom Roles grant the DSPA API subresource
+// required after the kube-rbac-proxy migration in RHOAI 3.x.
+type CustomRBACAPISubresourceCheck struct {
+	check.BaseCheck
+}
+
+// NewCustomRBACAPISubresourceCheck creates a new CustomRBACAPISubresourceCheck.
+func NewCustomRBACAPISubresourceCheck() *CustomRBACAPISubresourceCheck {
+	return &CustomRBACAPISubresourceCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             checkTypeCustomRBACAPISubresource,
+			CheckID:          "workloads.datasciencepipelines.custom-rbac-api-subresource",
+			CheckName:        "Workloads :: DataSciencePipelines :: Custom RBAC API Subresource (3.x)",
+			CheckDescription: "Validates that custom Roles with route.openshift.io permissions also grant the datasciencepipelinesapplications/api subresource required after the kube-rbac-proxy migration in RHOAI 3.x",
+			CheckRemediation: "Run 'kubectl odh migrate run -m ai-pipelines.update-dsp-role' to patch affected Roles",
+		},
+	}
+}
+
+// CanApply returns whether this check should run for the given target.
+func (c *CustomRBACAPISubresourceCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	apply, err := pipelinescomponent.ShouldApplyChecks(ctx, dsc, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("checking AI Pipelines component applicability: %w", err)
+	}
+
+	return apply, nil
+}
+
+// Validate scans cluster Roles for missing datasciencepipelinesapplications/api permissions.
+func (c *CustomRBACAPISubresourceCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	dr := c.NewResult()
+	tv := version.MajorMinorLabel(target.TargetVersion)
+
+	if target.TargetVersion != nil {
+		dr.Annotations[check.AnnotationCheckTargetVersion] = target.TargetVersion.String()
+	}
+
+	roles, err := pipelinesrbac.FindRolesNeedingFix(ctx, target.Client)
+	if err != nil {
+		return nil, fmt.Errorf("scanning roles for DSPA API subresource gaps: %w", err)
+	}
+
+	dr.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(len(roles))
+
+	if len(roles) > 0 {
+		impacted := make([]types.NamespacedName, 0, len(roles))
+		for _, role := range roles {
+			impacted = append(impacted, types.NamespacedName{
+				Namespace: role.Namespace,
+				Name:      role.RoleName,
+			})
+		}
+
+		dr.SetImpactedObjects(resources.Role, impacted)
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonVersionIncompatible),
+			check.WithMessage(msgCustomRBACFound, len(roles), tv),
+			check.WithImpact(result.ImpactBlocking),
+			check.WithRemediation(c.CheckRemediation),
+		))
+
+		return dr, nil
+	}
+
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionTrue,
+		check.WithReason(check.ReasonVersionCompatible),
+		check.WithMessage(msgCustomRBACClear, tv),
+	))
+
+	return dr, nil
+}

--- a/pkg/lint/checks/workloads/datasciencepipelines/custom_rbac_api_subresource_test.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/custom_rbac_api_subresource_test.go
@@ -1,0 +1,180 @@
+package datasciencepipelines_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/datasciencepipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals // Test fixture - shared across test functions
+var customRBACListKinds = map[schema.GroupVersionResource]string{
+	resources.DataScienceCluster.GVR():                resources.DataScienceCluster.ListKind(),
+	resources.DataScienceClusterV1.GVR():              resources.DataScienceClusterV1.ListKind(),
+	resources.Role.GVR():                              resources.Role.ListKind(),
+	resources.DataSciencePipelinesApplicationV1.GVR(): resources.DataSciencePipelinesApplicationV1.ListKind(),
+}
+
+func makeCustomRBACRole(name, namespace string, rules []map[string]any) *unstructured.Unstructured {
+	rulesAny := make([]any, len(rules))
+	for i, r := range rules {
+		rulesAny[i] = r
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Role.APIVersion(),
+			"kind":       resources.Role.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"rules": rulesAny,
+		},
+	}
+}
+
+func TestCustomRBACAPISubresourceCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := datasciencepipelines.NewCustomRBACAPISubresourceCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.datasciencepipelines.custom-rbac-api-subresource"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: DataSciencePipelines :: Custom RBAC API Subresource (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestCustomRBACAPISubresourceCheck_CanApply(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	chk := datasciencepipelines.NewCustomRBACAPISubresourceCheck()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      customRBACListKinds,
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "2.25.0",
+	})
+	canApply, err := chk.CanApply(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateManaged})
+	target = testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      customRBACListKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.5.0",
+	})
+	canApply, err = chk.CanApply(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+
+	dsc = testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: constants.ManagementStateManaged})
+	dsc.SetAPIVersion(resources.DataScienceCluster.APIVersion())
+	target = testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      customRBACListKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.5.0",
+	})
+	canApply, err = chk.CanApply(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+
+	dsc = testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateRemoved})
+	target = testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      customRBACListKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.5.0",
+	})
+	canApply, err = chk.CanApply(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestCustomRBACAPISubresourceCheck_Validate_NoRolesNeedingFix(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	chk := datasciencepipelines.NewCustomRBACAPISubresourceCheck()
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateManaged})
+	role := makeCustomRBACRole("already-fixed", "team-ns", []map[string]any{
+		{
+			"apiGroups": []any{"route.openshift.io"},
+			"resources": []any{"routes"},
+			"verbs":     []any{"get"},
+		},
+		{
+			"apiGroups": []any{"datasciencepipelinesapplications.opendatahub.io"},
+			"resources": []any{"datasciencepipelinesapplications/api"},
+			"verbs":     []any{"get"},
+		},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      customRBACListKinds,
+		Objects:        []*unstructured.Unstructured{dsc, role},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	dr, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dr.Status.Conditions).To(HaveLen(1))
+	g.Expect(dr.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Status":  Equal(metav1.ConditionTrue),
+		"Message": ContainSubstring("ready for RHOAI 3.5 upgrade"),
+	}))
+	g.Expect(dr.Status.Conditions[0].Impact).To(Equal(result.ImpactNone))
+}
+
+func TestCustomRBACAPISubresourceCheck_Validate_RolesNeedingFix(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	chk := datasciencepipelines.NewCustomRBACAPISubresourceCheck()
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateManaged})
+	role := makeCustomRBACRole("custom-role", "team-ns", []map[string]any{
+		{
+			"apiGroups": []any{"route.openshift.io"},
+			"resources": []any{"routes"},
+			"verbs":     []any{"get", "list"},
+		},
+	})
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      customRBACListKinds,
+		Objects:        []*unstructured.Unstructured{dsc, role},
+		CurrentVersion: "2.25.0",
+		TargetVersion:  "3.5.0",
+	})
+
+	dr, err := chk.Validate(ctx, target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dr.Status.Conditions).To(HaveLen(1))
+	g.Expect(dr.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Status": Equal(metav1.ConditionFalse),
+		"Message": ContainSubstring(
+			"custom Role(s) with route.openshift.io permissions missing the datasciencepipelinesapplications/api subresource",
+		),
+	}))
+	g.Expect(dr.Status.Conditions[0].Impact).To(Equal(result.ImpactBlocking))
+	g.Expect(dr.ImpactedObjects).To(HaveLen(1))
+	g.Expect(dr.ImpactedObjects[0].Name).To(Equal("custom-role"))
+	g.Expect(dr.ImpactedObjects[0].Namespace).To(Equal("team-ns"))
+}

--- a/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
@@ -5,18 +5,13 @@ import (
 	"fmt"
 	"strconv"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	pipelinescomponent "github.com/opendatahub-io/odh-cli/pkg/aipipelines"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
-	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
-	"github.com/opendatahub-io/odh-cli/pkg/util/components"
 	"github.com/opendatahub-io/odh-cli/pkg/util/inspect"
 	"github.com/opendatahub-io/odh-cli/pkg/util/version"
 )
@@ -24,7 +19,19 @@ import (
 const (
 	kind                        = "datasciencepipelines"
 	checkTypeInstructLabRemoval = "instructlab-removal"
+
+	msgDeprecatedManagedPipelineFieldsFound = "Found %d DataSciencePipelinesApplication(s) with deprecated apiServer managed-pipelines fields removed in RHOAI %s"
+	msgDeprecatedManagedPipelineFieldsClear = "No DataSciencePipelinesApplications found using deprecated apiServer managed-pipelines fields - ready for RHOAI %s upgrade"
 )
+
+//nolint:gochecknoglobals // Deprecated DSPA apiServer field paths removed in RHOAI 3.x
+var deprecatedAPIServerFieldPaths = []string{
+	".spec.apiServer.managedPipelines.instructLab",
+	".spec.apiServer.runtimeGenericImage",
+	".spec.apiServer.toolboxImage",
+	".spec.apiServer.rhelAIImage",
+	".spec.apiServer.initResources",
+}
 
 type InstructLabRemovalCheck struct {
 	check.BaseCheck
@@ -37,15 +44,16 @@ func NewInstructLabRemovalCheck() *InstructLabRemovalCheck {
 			Kind:             kind,
 			Type:             checkTypeInstructLabRemoval,
 			CheckID:          "workloads.datasciencepipelines.instructlab-removal",
-			CheckName:        "Workloads :: DataSciencePipelines :: InstructLab ManagedPipelines Removal (3.x)",
-			CheckDescription: "Validates that DSPA objects do not use the removed InstructLab managedPipelines field before upgrading to RHOAI 3.x",
-			CheckRemediation: "Remove the '.spec.apiServer.managedPipelines.instructLab' field from affected DSPA objects before upgrading",
+			CheckName:        "Workloads :: DataSciencePipelines :: Deprecated apiServer Managed-Pipelines Fields (3.x)",
+			CheckDescription: "Validates that DSPA objects do not use deprecated apiServer managed-pipelines fields (including instructLab, runtimeGenericImage, toolboxImage, rhelAIImage, and initResources) before upgrading to RHOAI 3.x",
+			CheckRemediation: "Remove deprecated '.spec.apiServer' managed-pipelines fields (instructLab, runtimeGenericImage, toolboxImage, rhelAIImage, initResources) from affected DSPA objects before upgrading",
 		},
 	}
 }
 
 // CanApply returns whether this check should run for the given target.
-// This check only applies when upgrading FROM 2.x TO 3.x and DataSciencePipelines is Managed.
+// This check applies when upgrading FROM 2.x TO 3.x and AI Pipelines is Managed
+// under either DSC component key, or when DSPAs remain on the cluster.
 func (c *InstructLabRemovalCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
 	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
 		return false, nil
@@ -56,90 +64,82 @@ func (c *InstructLabRemovalCheck) CanApply(ctx context.Context, target check.Tar
 		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
-	return components.HasManagementState(dsc, kind, constants.ManagementStateManaged), nil
+	apply, err := pipelinescomponent.ShouldApplyChecks(ctx, dsc, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("checking AI Pipelines component applicability: %w", err)
+	}
+
+	return apply, nil
 }
 
 func (c *InstructLabRemovalCheck) Validate(ctx context.Context, target check.Target) (*result.DiagnosticResult, error) {
-	return validate.Component(c, target).
-		Run(ctx, func(ctx context.Context, req *validate.ComponentRequest) error {
-			dspas, usedResourceType, err := c.listDSPAs(ctx, req.Client)
-			if err != nil {
-				return err
-			}
+	dr := c.NewResult()
+	tv := version.MajorMinorLabel(target.TargetVersion)
 
-			tv := version.MajorMinorLabel(req.TargetVersion)
-			impactedDSPAs := make([]types.NamespacedName, 0)
-
-			for i := range dspas {
-				dspa := dspas[i]
-
-				found, err := inspect.HasFields(dspa, ".spec.apiServer.managedPipelines.instructLab")
-				if err != nil {
-					return fmt.Errorf("querying managedPipelines.instructLab for DSPA %s/%s: %w",
-						dspa.GetNamespace(), dspa.GetName(), err)
-				}
-
-				if len(found) == 0 {
-					continue
-				}
-
-				impactedDSPAs = append(impactedDSPAs, types.NamespacedName{
-					Namespace: dspa.GetNamespace(),
-					Name:      dspa.GetName(),
-				})
-			}
-
-			req.Result.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(len(impactedDSPAs))
-
-			if len(impactedDSPAs) > 0 {
-				req.Result.SetCondition(check.NewCondition(
-					check.ConditionTypeCompatible,
-					metav1.ConditionFalse,
-					check.WithReason(check.ReasonFeatureRemoved),
-					check.WithMessage("Found %d DataSciencePipelinesApplication(s) with deprecated '.spec.apiServer.managedPipelines.instructLab' field - InstructLab feature was removed in RHOAI %s", len(impactedDSPAs), tv),
-					check.WithImpact(result.ImpactAdvisory),
-					check.WithRemediation(c.CheckRemediation),
-				))
-
-				req.Result.SetImpactedObjects(usedResourceType, impactedDSPAs)
-
-				return nil
-			}
-
-			req.Result.SetCondition(check.NewCondition(
-				check.ConditionTypeCompatible,
-				metav1.ConditionTrue,
-				check.WithReason(check.ReasonVersionCompatible),
-				check.WithMessage("No DataSciencePipelinesApplications found using deprecated 'managedPipelines.instructLab' field - ready for RHOAI %s upgrade", tv),
-			))
-
-			return nil
-		})
-}
-
-// listDSPAs attempts to list DSPAs using v1 first, falling back to v1alpha1 if v1 is not available.
-// Returns the list of DSPAs and the ResourceType that was successfully used.
-func (c *InstructLabRemovalCheck) listDSPAs(
-	ctx context.Context,
-	r client.Reader,
-) ([]*unstructured.Unstructured, resources.ResourceType, error) {
-	// Try v1 first
-	dspasV1, err := r.List(ctx, resources.DataSciencePipelinesApplicationV1)
-	if err == nil {
-		// v1 exists, use it
-		return dspasV1, resources.DataSciencePipelinesApplicationV1, nil
+	if target.TargetVersion != nil {
+		dr.Annotations[check.AnnotationCheckTargetVersion] = target.TargetVersion.String()
 	}
 
-	if !apierrors.IsNotFound(err) {
-		// Not a NotFound error - something else went wrong
-		return nil, resources.ResourceType{}, fmt.Errorf("listing DataSciencePipelinesApplications v1: %w", err)
-	}
-
-	// v1 not found, try v1alpha1
-	dspasV1Alpha1, err := r.List(ctx, resources.DataSciencePipelinesApplicationV1Alpha1)
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
 	if err != nil {
-		return nil, resources.ResourceType{}, fmt.Errorf("listing DataSciencePipelinesApplications v1alpha1: %w", err)
+		return nil, fmt.Errorf("getting DataScienceCluster: %w", err)
 	}
 
-	return dspasV1Alpha1, resources.DataSciencePipelinesApplicationV1Alpha1, nil
+	state, err := pipelinescomponent.EffectiveManagementState(dsc)
+	if err != nil {
+		return nil, fmt.Errorf("resolving AI Pipelines management state: %w", err)
+	}
+
+	dr.Annotations[check.AnnotationComponentManagementState] = state
+
+	dspas, usedResourceType, err := pipelinescomponent.ListDSPAs(ctx, target.Client)
+	if err != nil {
+		return nil, fmt.Errorf("listing DataSciencePipelinesApplications: %w", err)
+	}
+
+	impactedDSPAs := make([]types.NamespacedName, 0)
+
+	for i := range dspas {
+		dspa := dspas[i]
+
+		found, err := inspect.HasFields(dspa, deprecatedAPIServerFieldPaths...)
+		if err != nil {
+			return nil, fmt.Errorf("querying deprecated apiServer fields for DSPA %s/%s: %w",
+				dspa.GetNamespace(), dspa.GetName(), err)
+		}
+
+		if len(found) == 0 {
+			continue
+		}
+
+		impactedDSPAs = append(impactedDSPAs, types.NamespacedName{
+			Namespace: dspa.GetNamespace(),
+			Name:      dspa.GetName(),
+		})
+	}
+
+	dr.Annotations[check.AnnotationImpactedWorkloadCount] = strconv.Itoa(len(impactedDSPAs))
+
+	if len(impactedDSPAs) > 0 {
+		dr.SetImpactedObjects(usedResourceType, impactedDSPAs)
+		dr.SetCondition(check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionFalse,
+			check.WithReason(check.ReasonFeatureRemoved),
+			check.WithMessage(msgDeprecatedManagedPipelineFieldsFound, len(impactedDSPAs), tv),
+			check.WithImpact(result.ImpactAdvisory),
+			check.WithRemediation(c.CheckRemediation),
+		))
+
+		return dr, nil
+	}
+
+	dr.SetCondition(check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionTrue,
+		check.WithReason(check.ReasonVersionCompatible),
+		check.WithMessage(msgDeprecatedManagedPipelineFieldsClear, tv),
+	))
+
+	return dr, nil
 }

--- a/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal.go
@@ -45,8 +45,8 @@ func NewInstructLabRemovalCheck() *InstructLabRemovalCheck {
 			Type:             checkTypeInstructLabRemoval,
 			CheckID:          "workloads.datasciencepipelines.instructlab-removal",
 			CheckName:        "Workloads :: DataSciencePipelines :: Deprecated apiServer Managed-Pipelines Fields (3.x)",
-			CheckDescription: "Validates that DSPA objects do not use deprecated apiServer managed-pipelines fields (including instructLab, runtimeGenericImage, toolboxImage, rhelAIImage, and initResources) before upgrading to RHOAI 3.x",
-			CheckRemediation: "Remove deprecated '.spec.apiServer' managed-pipelines fields (instructLab, runtimeGenericImage, toolboxImage, rhelAIImage, initResources) from affected DSPA objects before upgrading",
+			CheckDescription: "Validates that DSPA objects do not use deprecated apiServer fields before upgrading to RHOAI 3.x",
+			CheckRemediation: "Remove .spec.apiServer.managedPipelines.instructLab and the deprecated .spec.apiServer fields runtimeGenericImage, toolboxImage, rhelAIImage, and initResources from affected DSPA objects before upgrading",
 		},
 	}
 }

--- a/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal_test.go
+++ b/pkg/lint/checks/workloads/datasciencepipelines/instructlab_removal_test.go
@@ -7,6 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/odh-cli/pkg/aipipelines"
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
 	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
@@ -20,20 +22,28 @@ import (
 //nolint:gochecknoglobals // Test fixture - shared across test functions
 var instructLabListKinds = map[schema.GroupVersionResource]string{
 	resources.DataScienceCluster.GVR():                      resources.DataScienceCluster.ListKind(),
+	resources.DataScienceClusterV1.GVR():                    resources.DataScienceClusterV1.ListKind(),
 	resources.DataSciencePipelinesApplicationV1.GVR():       resources.DataSciencePipelinesApplicationV1.ListKind(),
 	resources.DataSciencePipelinesApplicationV1Alpha1.GVR(): resources.DataSciencePipelinesApplicationV1Alpha1.ListKind(),
 }
 
 func newDSPAv1(name string, namespace string, withInstructLab bool) *unstructured.Unstructured {
-	spec := map[string]any{}
+	apiServer := map[string]any{}
 	if withInstructLab {
-		spec["apiServer"] = map[string]any{
-			"managedPipelines": map[string]any{
-				"instructLab": map[string]any{
-					"enabled": true,
-				},
+		apiServer["managedPipelines"] = map[string]any{
+			"instructLab": map[string]any{
+				"enabled": true,
 			},
 		}
+	}
+
+	return newDSPAv1WithAPIServer(name, namespace, apiServer)
+}
+
+func newDSPAv1WithAPIServer(name, namespace string, apiServer map[string]any) *unstructured.Unstructured {
+	spec := map[string]any{}
+	if len(apiServer) > 0 {
+		spec["apiServer"] = apiServer
 	}
 
 	return &unstructured.Unstructured{
@@ -63,6 +73,42 @@ func TestInstructLabRemovalCheck_CanApply_NoDSC(t *testing.T) {
 
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(canApply).To(BeFalse())
+}
+
+func TestInstructLabRemovalCheck_CanApply_AIPipelinesManagedV2(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := datasciencepipelines.NewInstructLabRemovalCheck()
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: constants.ManagementStateManaged})
+	dsc.SetAPIVersion(resources.DataScienceCluster.APIVersion())
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      instructLabListKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestInstructLabRemovalCheck_CanApply_RemovedWithDSPAs(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := datasciencepipelines.NewInstructLabRemovalCheck()
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV1: constants.ManagementStateRemoved})
+	dspa := newDSPAv1("my-dspa", "test-ns", false)
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      instructLabListKinds,
+		Objects:        []*unstructured.Unstructured{dsc, dspa},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
 }
 
 func TestInstructLabRemovalCheck_CanApply_ManagementState(t *testing.T) {
@@ -145,13 +191,57 @@ func TestInstructLabRemovalCheck_DSPAWithInstructLab(t *testing.T) {
 		"Type":    Equal(check.ConditionTypeCompatible),
 		"Status":  Equal(metav1.ConditionFalse),
 		"Reason":  Equal(check.ReasonFeatureRemoved),
-		"Message": And(ContainSubstring("Found 1"), ContainSubstring("instructLab")),
+		"Message": And(ContainSubstring("Found 1"), ContainSubstring("deprecated apiServer managed-pipelines fields")),
 	}))
 	g.Expect(dr.Status.Conditions[0].Impact).To(Equal(result.ImpactAdvisory))
 	g.Expect(dr.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
 	g.Expect(dr.ImpactedObjects).To(HaveLen(1))
 	g.Expect(dr.ImpactedObjects[0].Name).To(Equal("my-dspa"))
 	g.Expect(dr.ImpactedObjects[0].Namespace).To(Equal("test-ns"))
+}
+
+func TestInstructLabRemovalCheck_DSPAWithRuntimeGenericImage(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := testutil.NewDSC(map[string]string{"datasciencepipelines": "Managed"})
+	dspa := newDSPAv1WithAPIServer("legacy-dspa", "test-ns", map[string]any{
+		"runtimeGenericImage": "registry.example/legacy-runtime:latest",
+	})
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      instructLabListKinds,
+		Objects:        []*unstructured.Unstructured{dsc, dspa},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	ilCheck := datasciencepipelines.NewInstructLabRemovalCheck()
+	dr, err := ilCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dr.Status.Conditions[0].Impact).To(Equal(result.ImpactAdvisory))
+	g.Expect(dr.ImpactedObjects).To(HaveLen(1))
+	g.Expect(dr.ImpactedObjects[0].Name).To(Equal("legacy-dspa"))
+}
+
+func TestInstructLabRemovalCheck_Validate_AIPipelinesManagedV2Annotation(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsc := testutil.NewDSC(map[string]string{aipipelines.ComponentKeyV2: constants.ManagementStateManaged})
+	dsc.SetAPIVersion(resources.DataScienceCluster.APIVersion())
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      instructLabListKinds,
+		Objects:        []*unstructured.Unstructured{dsc},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	ilCheck := datasciencepipelines.NewInstructLabRemovalCheck()
+	dr, err := ilCheck.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(dr.Annotations).To(HaveKeyWithValue(check.AnnotationComponentManagementState, constants.ManagementStateManaged))
 }
 
 func TestInstructLabRemovalCheck_DSPAWithoutInstructLab(t *testing.T) {
@@ -267,7 +357,7 @@ func TestInstructLabRemovalCheck_Metadata(t *testing.T) {
 	ilCheck := datasciencepipelines.NewInstructLabRemovalCheck()
 
 	g.Expect(ilCheck.ID()).To(Equal("workloads.datasciencepipelines.instructlab-removal"))
-	g.Expect(ilCheck.Name()).To(Equal("Workloads :: DataSciencePipelines :: InstructLab ManagedPipelines Removal (3.x)"))
+	g.Expect(ilCheck.Name()).To(Equal("Workloads :: DataSciencePipelines :: Deprecated apiServer Managed-Pipelines Fields (3.x)"))
 	g.Expect(ilCheck.Group()).To(Equal(check.GroupWorkload))
 	g.Expect(ilCheck.Description()).ToNot(BeEmpty())
 }

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -135,8 +135,9 @@ func NewCommand(
 	registry.MustRegister(sharedossm.NewCheck())
 	registry.MustRegister(sharedserverless.NewCheck())
 
-	// Workloads (21)
+	// Workloads (22)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
+	registry.MustRegister(datasciencepipelinesworkloads.NewCustomRBACAPISubresourceCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
 	registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())

--- a/pkg/migrate/actions/aipipelines/constants.go
+++ b/pkg/migrate/actions/aipipelines/constants.go
@@ -30,8 +30,6 @@ const (
 const defaultStateDir = "/tmp/rhoai-upgrade-backup/ai_pipelines"
 const stateFileName = "dspa_pre_upgrade_pods.json"
 
-const systemNamespacePattern = `^(kube-system|default|openshift.*|redhat-ods-.*)$`
-
 const (
 	retryMaxSteps        = 10
 	retryInitialDuration = 1 * time.Second

--- a/pkg/migrate/actions/aipipelines/export_test.go
+++ b/pkg/migrate/actions/aipipelines/export_test.go
@@ -5,13 +5,10 @@ import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 //nolint:gochecknoglobals // Test exports only compiled in test builds
 var (
 	GetPodGroup                 = getPodGroup
-	ClassifyRole                = classifyRole
-	IsSystemNamespace           = isSystemNamespace
 	DefaultStatePath            = defaultStatePath
 	SavePodHealthState          = savePodHealthState
 	LoadPodHealthState          = loadPodHealthState
 	HasAnyDegradation           = hasAnyDegradation
-	ExtractStringSlice          = extractStringSlice
 	ListDSPAs                   = listDSPAs
 	HasV1Alpha1StoredVersion    = hasV1Alpha1StoredVersion
 	RemoveV1Alpha1StoredVersion = removeV1Alpha1StoredVersion
@@ -49,25 +46,6 @@ func MakePodUnstructured(name, namespace, phase, readyStatus string) unstructure
 				"phase":      phase,
 				"conditions": conditions,
 			},
-		},
-	}
-}
-
-func MakeRoleUnstructured(name, namespace string, rules []map[string]any) unstructured.Unstructured {
-	rulesAny := make([]any, len(rules))
-	for i, r := range rules {
-		rulesAny[i] = r
-	}
-
-	return unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "rbac.authorization.k8s.io/v1",
-			"kind":       "Role",
-			"metadata": map[string]any{
-				"name":      name,
-				"namespace": namespace,
-			},
-			"rules": rulesAny,
 		},
 	}
 }

--- a/pkg/migrate/actions/aipipelines/role_classifier.go
+++ b/pkg/migrate/actions/aipipelines/role_classifier.go
@@ -3,113 +3,31 @@ package aipipelines
 import (
 	"context"
 	"fmt"
-	"regexp"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
+	pipelinesrbac "github.com/opendatahub-io/odh-cli/pkg/aipipelines/rbac"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
-	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
-
-var (
-	systemNamespaceRe   = regexp.MustCompile(systemNamespacePattern)
-	operatorManagedRole = regexp.MustCompile(`^(ds-pipeline-|pipeline-runner-)`)
-)
-
-type roleClassification struct {
-	NeedsFix   bool
-	RoleName   string
-	Namespace  string
-	RouteVerbs []string // verbs from the route.openshift.io rule, used to infer DSPA verbs
-}
-
-func classifyRole(role *unstructured.Unstructured) roleClassification {
-	classification := roleClassification{
-		RoleName:  role.GetName(),
-		Namespace: role.GetNamespace(),
-	}
-
-	if isSystemNamespace(classification.Namespace) {
-		return classification
-	}
-
-	if operatorManagedRole.MatchString(classification.RoleName) {
-		return classification
-	}
-
-	rules, found, _ := unstructured.NestedSlice(role.Object, "rules")
-	if !found {
-		return classification
-	}
-
-	hasRouteAPIGroup := false
-	hasDSPASubresource := false
-
-	for _, r := range rules {
-		rule, ok := r.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		apiGroups, _ := extractStringSlice(rule, "apiGroups")
-		ruleResources, _ := extractStringSlice(rule, "resources")
-		verbs, _ := extractStringSlice(rule, "verbs")
-
-		for _, g := range apiGroups {
-			if g == "route.openshift.io" {
-				hasRouteAPIGroup = true
-				classification.RouteVerbs = mergeStringSlices(classification.RouteVerbs, verbs)
-			}
-		}
-
-		for _, res := range ruleResources {
-			if res == "datasciencepipelinesapplications/api" {
-				hasDSPASubresource = true
-			}
-		}
-	}
-
-	classification.NeedsFix = hasRouteAPIGroup && !hasDSPASubresource
-
-	return classification
-}
-
-func isSystemNamespace(ns string) bool {
-	return systemNamespaceRe.MatchString(ns)
-}
 
 func findRolesNeedingFix(
 	ctx context.Context,
 	c client.Client,
 	recorder action.StepRecorder,
-) ([]roleClassification, error) {
+) ([]pipelinesrbac.Classification, error) {
 	step := recorder.Child("scan-roles", "Scan custom roles for RBAC gaps")
 
-	roleList, err := c.Dynamic().Resource(resources.Role.GVR()).
-		Namespace("").
-		List(ctx, metav1.ListOptions{})
+	roles, err := pipelinesrbac.FindRolesNeedingFix(ctx, c)
 	if err != nil {
 		step.Completef(result.StepFailed, "Failed to list roles: %v", err)
 
-		return nil, fmt.Errorf("listing roles: %w", err)
+		return nil, fmt.Errorf("scanning roles for RBAC gaps: %w", err)
 	}
 
-	var needsFix []roleClassification
-
-	for i := range roleList.Items {
-		classification := classifyRole(&roleList.Items[i])
-		if classification.NeedsFix {
-			needsFix = append(needsFix, classification)
-		}
-	}
-
-	if len(needsFix) == 0 {
+	if len(roles) == 0 {
 		step.Completef(result.StepCompleted, "No custom roles need updating")
 	} else {
-		for _, r := range needsFix {
+		for _, r := range roles {
 			step.Recordf(
 				r.RoleName,
 				"Role %s in namespace %s needs datasciencepipelinesapplications/api subresource",
@@ -119,49 +37,8 @@ func findRolesNeedingFix(
 			)
 		}
 
-		step.Completef(result.StepCompleted, "Found %d role(s) needing update", len(needsFix))
+		step.Completef(result.StepCompleted, "Found %d role(s) needing update", len(roles))
 	}
 
-	return needsFix, nil
-}
-
-func extractStringSlice(obj map[string]any, key string) ([]string, bool) {
-	raw, ok := obj[key]
-	if !ok {
-		return nil, false
-	}
-
-	slice, ok := raw.([]any)
-	if !ok {
-		return nil, false
-	}
-
-	out := make([]string, 0, len(slice))
-
-	for _, v := range slice {
-		if s, ok := v.(string); ok {
-			out = append(out, s)
-		}
-	}
-
-	return out, len(out) > 0
-}
-
-func mergeStringSlices(a, b []string) []string {
-	seen := make(map[string]bool, len(a))
-
-	for _, v := range a {
-		seen[v] = true
-	}
-
-	merged := append([]string{}, a...)
-
-	for _, v := range b {
-		if !seen[v] {
-			merged = append(merged, v)
-			seen[v] = true
-		}
-	}
-
-	return merged
+	return roles, nil
 }

--- a/pkg/migrate/actions/aipipelines/updatedsprole.go
+++ b/pkg/migrate/actions/aipipelines/updatedsprole.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	pipelinesrbac "github.com/opendatahub-io/odh-cli/pkg/aipipelines/rbac"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
@@ -86,7 +87,7 @@ func (t *updateDSPRoleRunTask) patchRole(
 	ctx context.Context,
 	target action.Target,
 	recorder action.StepRecorder,
-	role roleClassification,
+	role pipelinesrbac.Classification,
 ) {
 	step := recorder.Child(
 		"patch-"+role.Namespace+"-"+role.RoleName,
@@ -117,7 +118,7 @@ func (t *updateDSPRoleRunTask) patchRoleForDSPA(
 	ctx context.Context,
 	target action.Target,
 	recorder action.StepRecorder,
-	role roleClassification,
+	role pipelinesrbac.Classification,
 	dspa dspaInfo,
 ) {
 	stepID := "add-rule-" + dspa.Name
@@ -193,7 +194,7 @@ func (t *updateDSPRoleRunTask) patchRoleForDSPA(
 		return
 	}
 
-	validated := classifyRole(updatedRole)
+	validated := pipelinesrbac.ClassifyRole(updatedRole)
 	if validated.NeedsFix {
 		step.Completef(result.StepFailed,
 			"Patch succeeded but validation failed — datasciencepipelinesapplications/api rule not found in re-read")


### PR DESCRIPTION
## Description
This PR adds the lint checks needed to gate the DataSciencePipelines / AI Pipelines portion of a RHOAI 2.x → 3.x upgrade, and pulls shared logic into pkg/aipipelines so lint and migrate stay aligned.

**New shared package (pkg/aipipelines)**

Component helpers for DSC v1 (datasciencepipelines) and v2 (aipipelines) keys
Shared DSPA listing with v1 / v1alpha1 fallback
Shared RBAC role classification (moved out of migrate)
New blocking lint check

workloads.datasciencepipelines.custom-rbac-api-subresource — flags custom Roles with route.openshift.io permissions that are missing the datasciencepipelinesapplications/api subresource; remediation points to kubectl odh migrate run -m ai-pipelines.update-dsp-role
Updated existing checks

InstructLab / deprecated apiServer fields — applies when AI Pipelines is managed under either DSC key or DSPAs still exist; scans deprecated apiServer fields (instructLab, runtimeGenericImage, toolboxImage, rhelAIImage, initResources); uses shared DSPA listing
Component renaming — skips on DSC v2 clusters that only expose aipipelines
Migrate refactor

ai-pipelines.update-dsp-role now uses the shared RBAC classifier instead of duplicate migrate-local logic
<!-- What does this PR do? -->

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [ ] Changes are documented if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upgrade checks for deprecated AI Pipelines API server fields.
  * Added detection and reporting for custom roles missing required AI Pipelines API permissions.
  * Added support for AI Pipelines v1 and v2 component configurations and management states.
  * Added discovery of Data Science Pipelines applications across supported API versions.

* **Migration Improvements**
  * Centralized role scanning and classification for consistent RBAC remediation.
  * Updated migration checks for v2 configurations and existing pipeline resources.

* **Tests**
  * Expanded coverage for component states, pipeline resources, deprecated fields, and RBAC compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->