### PR TITLE
fix(lint/trustyai): use precise condition reasons in upgrade checks

### DIFF
--- a/pkg/lint/checks/workloads/trustyai/database_migration.go
+++ b/pkg/lint/checks/workloads/trustyai/database_migration.go
@@ -1,0 +1,60 @@
+package trustyai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+// DatabaseStorageMigrationCheck detects TrustyAIService CRs using DATABASE storage.
+// The DB credentials secret referenced by spec.storage.databaseConfigurations must
+// remain accessible in the target namespace after the CRD is updated to 3.x.
+type DatabaseStorageMigrationCheck struct {
+	check.BaseCheck
+}
+
+func NewDatabaseStorageMigrationCheck() *DatabaseStorageMigrationCheck {
+	return &DatabaseStorageMigrationCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             check.CheckTypeDataIntegrity,
+			CheckID:          "workloads.trustyai.database-storage-migration",
+			CheckName:        "Workloads :: TrustyAI :: Database Storage Migration (3.x)",
+			CheckDescription: "Detects TrustyAIService CRs using database storage whose credentials secret must be verified before upgrading to RHOAI 3.x",
+			CheckRemediation: "Ensure the secret named in spec.storage.databaseConfigurations exists in the same namespace and will remain accessible after the upgrade",
+		},
+	}
+}
+
+// CanApply returns true when upgrading from 2.x to 3.x and TrustyAI is Managed.
+func (c *DatabaseStorageMigrationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, "trustyai", constants.ManagementStateManaged), nil
+}
+
+// Validate lists TrustyAIService CRs with DATABASE storage and warns if any are found.
+func (c *DatabaseStorageMigrationCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.Workloads(c, target, resources.TrustyAIService).
+		Filter(hasDatabaseStorage).
+		Complete(ctx, c.newDatabaseMigrationCondition)
+}

--- a/pkg/lint/checks/workloads/trustyai/database_migration_support.go
+++ b/pkg/lint/checks/workloads/trustyai/database_migration_support.go
@@ -1,0 +1,43 @@
+package trustyai
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+)
+
+func hasDatabaseStorage(obj *unstructured.Unstructured) (bool, error) {
+	format, _, _ := unstructured.NestedString(obj.Object, "spec", "storage", "format")
+
+	return format == "DATABASE", nil
+}
+
+func (c *DatabaseStorageMigrationCheck) newDatabaseMigrationCondition(
+	_ context.Context,
+	req *validate.WorkloadRequest[*unstructured.Unstructured],
+) ([]result.Condition, error) {
+	count := len(req.Items)
+
+	if count == 0 {
+		return []result.Condition{check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("No TrustyAIService instances using database storage found"),
+		)}, nil
+	}
+
+	return []result.Condition{check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonMigrationPending),
+		check.WithMessage("Found %d TrustyAIService instance(s) using database storage - verify the databaseConfigurations secret remains accessible after upgrade", count),
+		check.WithImpact(result.ImpactAdvisory),
+		check.WithRemediation(c.CheckRemediation),
+	)}, nil
+}

--- a/pkg/lint/checks/workloads/trustyai/database_migration_test.go
+++ b/pkg/lint/checks/workloads/trustyai/database_migration_test.go
@@ -1,0 +1,179 @@
+package trustyai_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trustyai"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestDatabaseStorageMigrationCheck_NoTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        nil,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestDatabaseStorageMigrationCheck_NoDatabaseStorage(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newTestTAS("tas-pvc", "test-ns", "PVC")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestDatabaseStorageMigrationCheck_WithDatabaseStorage(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newTestTAS("tas-db", "prod-ns", "DATABASE")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonMigrationPending),
+		"Message": ContainSubstring("Found 1 TrustyAIService"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("tas-db"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("prod-ns"))
+}
+
+func TestDatabaseStorageMigrationCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.trustyai.database-storage-migration"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: TrustyAI :: Database Storage Migration (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestDatabaseStorageMigrationCheck_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestDatabaseStorageMigrationCheck_CanApply_LintMode(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "2.17.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestDatabaseStorageMigrationCheck_CanApply_2xTo3x_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestDatabaseStorageMigrationCheck_CanApply_2xTo3x_Removed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Removed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestDatabaseStorageMigrationCheck_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.3.0",
+	})
+
+	chk := trustyai.NewDatabaseStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}

--- a/pkg/lint/checks/workloads/trustyai/impacted.go
+++ b/pkg/lint/checks/workloads/trustyai/impacted.go
@@ -1,0 +1,59 @@
+package trustyai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+// ImpactedWorkloadsCheck detects TrustyAIService CRs in user namespaces.
+// The user must back up TrustyAI data before upgrading, since the operator
+// module adoption process may alter the pod/volume configuration.
+type ImpactedWorkloadsCheck struct {
+	check.BaseCheck
+}
+
+func NewImpactedWorkloadsCheck() *ImpactedWorkloadsCheck {
+	return &ImpactedWorkloadsCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             check.CheckTypeImpactedWorkloads,
+			CheckID:          "workloads.trustyai.impacted-workloads",
+			CheckName:        "Workloads :: TrustyAI :: Impacted Workloads (3.x)",
+			CheckDescription: "Detects TrustyAIService CRs that require a data backup before upgrading to RHOAI 3.x",
+			CheckRemediation: "Run 'odh migrate run trustyai.migrate-data' to back up TrustyAI data before upgrading",
+		},
+	}
+}
+
+// CanApply returns true when upgrading from 2.x to 3.x and TrustyAI is Managed.
+func (c *ImpactedWorkloadsCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, "trustyai", constants.ManagementStateManaged), nil
+}
+
+// Validate lists all TrustyAIService CRs and warns if any are found.
+func (c *ImpactedWorkloadsCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.Workloads(c, target, resources.TrustyAIService).
+		Complete(ctx, c.newImpactedCondition)
+}

--- a/pkg/lint/checks/workloads/trustyai/impacted_support.go
+++ b/pkg/lint/checks/workloads/trustyai/impacted_support.go
@@ -1,0 +1,37 @@
+package trustyai
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+)
+
+func (c *ImpactedWorkloadsCheck) newImpactedCondition(
+	_ context.Context,
+	req *validate.WorkloadRequest[*unstructured.Unstructured],
+) ([]result.Condition, error) {
+	count := len(req.Items)
+
+	if count == 0 {
+		return []result.Condition{check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("No TrustyAIService instances found - no data backup required"),
+		)}, nil
+	}
+
+	return []result.Condition{check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonWorkloadsImpacted),
+		check.WithMessage("Found %d TrustyAIService instance(s) - back up TrustyAI data before upgrading to prevent data loss", count),
+		check.WithImpact(result.ImpactAdvisory),
+		check.WithRemediation(c.CheckRemediation),
+	)}, nil
+}

--- a/pkg/lint/checks/workloads/trustyai/impacted_test.go
+++ b/pkg/lint/checks/workloads/trustyai/impacted_test.go
@@ -1,0 +1,226 @@
+package trustyai_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trustyai"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+//nolint:gochecknoglobals
+var listKinds = map[schema.GroupVersionResource]string{
+	resources.TrustyAIService.GVR():    resources.TrustyAIService.ListKind(),
+	resources.DataScienceCluster.GVR(): resources.DataScienceCluster.ListKind(),
+}
+
+func newTestTAS(name, namespace, format string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.TrustyAIService.APIVersion(),
+			"kind":       resources.TrustyAIService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"storage": map[string]any{
+					"format": format,
+				},
+			},
+		},
+	}
+}
+
+func TestImpactedWorkloadsCheck_NoTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        nil,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestImpactedWorkloadsCheck_WithOneTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	tas := newTestTAS("tas-1", "test-ns", "PVC")
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{tas},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonWorkloadsImpacted),
+		"Message": ContainSubstring("Found 1 TrustyAIService"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("tas-1"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("test-ns"))
+}
+
+func TestImpactedWorkloadsCheck_WithMultipleTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds,
+		Objects: []*unstructured.Unstructured{
+			newTestTAS("tas-1", "ns1", "PVC"),
+			newTestTAS("tas-2", "ns2", "DATABASE"),
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Status":  Equal(metav1.ConditionFalse),
+		"Message": ContainSubstring("Found 2 TrustyAIService"),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "2"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(2))
+}
+
+func TestImpactedWorkloadsCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.trustyai.impacted-workloads"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: TrustyAI :: Impacted Workloads (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestImpactedWorkloadsCheck_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestImpactedWorkloadsCheck_CanApply_LintMode(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "2.17.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestImpactedWorkloadsCheck_CanApply_2xTo3x_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestImpactedWorkloadsCheck_CanApply_2xTo3x_Removed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Removed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestImpactedWorkloadsCheck_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.3.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestImpactedWorkloadsCheck_AnnotationTargetVersion(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        nil,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewImpactedWorkloadsCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationCheckTargetVersion, "3.0.0"))
+}

--- a/pkg/lint/checks/workloads/trustyai/pvc_migration.go
+++ b/pkg/lint/checks/workloads/trustyai/pvc_migration.go
@@ -1,0 +1,60 @@
+package trustyai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+// PVCStorageMigrationCheck detects TrustyAIService CRs backed by PVC storage.
+// PVC-backed data is at risk if the pod/volume configuration changes during
+// module adoption in the 3.x upgrade.
+type PVCStorageMigrationCheck struct {
+	check.BaseCheck
+}
+
+func NewPVCStorageMigrationCheck() *PVCStorageMigrationCheck {
+	return &PVCStorageMigrationCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             check.CheckTypeDataIntegrity,
+			CheckID:          "workloads.trustyai.pvc-storage-migration",
+			CheckName:        "Workloads :: TrustyAI :: PVC Storage Migration (3.x)",
+			CheckDescription: "Detects TrustyAIService CRs using PVC storage whose data may be affected during RHOAI 3.x module adoption",
+			CheckRemediation: "Run 'odh migrate run trustyai.migrate-data' to back up PVC-stored TrustyAI data before upgrading",
+		},
+	}
+}
+
+// CanApply returns true when upgrading from 2.x to 3.x and TrustyAI is Managed.
+func (c *PVCStorageMigrationCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, "trustyai", constants.ManagementStateManaged), nil
+}
+
+// Validate lists TrustyAIService CRs with PVC storage and warns if any are found.
+func (c *PVCStorageMigrationCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.Workloads(c, target, resources.TrustyAIService).
+		Filter(hasPVCStorage).
+		Complete(ctx, c.newPVCMigrationCondition)
+}

--- a/pkg/lint/checks/workloads/trustyai/pvc_migration_support.go
+++ b/pkg/lint/checks/workloads/trustyai/pvc_migration_support.go
@@ -1,0 +1,43 @@
+package trustyai
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+)
+
+func hasPVCStorage(obj *unstructured.Unstructured) (bool, error) {
+	format, _, _ := unstructured.NestedString(obj.Object, "spec", "storage", "format")
+
+	return format == "PVC", nil
+}
+
+func (c *PVCStorageMigrationCheck) newPVCMigrationCondition(
+	_ context.Context,
+	req *validate.WorkloadRequest[*unstructured.Unstructured],
+) ([]result.Condition, error) {
+	count := len(req.Items)
+
+	if count == 0 {
+		return []result.Condition{check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("No TrustyAIService instances using PVC storage found"),
+		)}, nil
+	}
+
+	return []result.Condition{check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonMigrationPending),
+		check.WithMessage("Found %d TrustyAIService instance(s) using PVC storage - back up data before upgrading to prevent loss during volume reconfiguration", count),
+		check.WithImpact(result.ImpactBlocking),
+		check.WithRemediation(c.CheckRemediation),
+	)}, nil
+}

--- a/pkg/lint/checks/workloads/trustyai/pvc_migration_test.go
+++ b/pkg/lint/checks/workloads/trustyai/pvc_migration_test.go
@@ -1,0 +1,207 @@
+package trustyai_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trustyai"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestPVCStorageMigrationCheck_NoTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        nil,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestPVCStorageMigrationCheck_NoPVCStorage(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newTestTAS("tas-db", "test-ns", "DATABASE")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestPVCStorageMigrationCheck_WithPVCStorage(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newTestTAS("tas-pvc", "prod-ns", "PVC")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonMigrationPending),
+		"Message": ContainSubstring("Found 1 TrustyAIService"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+	g.Expect(result.ImpactedObjects[0].Name).To(Equal("tas-pvc"))
+	g.Expect(result.ImpactedObjects[0].Namespace).To(Equal("prod-ns"))
+}
+
+func TestPVCStorageMigrationCheck_MultiplePVC(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds,
+		Objects: []*unstructured.Unstructured{
+			newTestTAS("tas-pvc-1", "ns1", "PVC"),
+			newTestTAS("tas-pvc-2", "ns2", "PVC"),
+			newTestTAS("tas-db", "ns3", "DATABASE"),
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Status":  Equal(metav1.ConditionFalse),
+		"Message": ContainSubstring("Found 2 TrustyAIService"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactBlocking))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "2"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(2))
+}
+
+func TestPVCStorageMigrationCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.trustyai.pvc-storage-migration"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: TrustyAI :: PVC Storage Migration (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestPVCStorageMigrationCheck_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestPVCStorageMigrationCheck_CanApply_LintMode(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "2.17.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestPVCStorageMigrationCheck_CanApply_2xTo3x_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestPVCStorageMigrationCheck_CanApply_2xTo3x_Removed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Removed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestPVCStorageMigrationCheck_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.3.0",
+	})
+
+	chk := trustyai.NewPVCStorageMigrationCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}

--- a/pkg/lint/checks/workloads/trustyai/scheduled_metrics.go
+++ b/pkg/lint/checks/workloads/trustyai/scheduled_metrics.go
@@ -1,0 +1,59 @@
+package trustyai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendatahub-io/odh-cli/pkg/constants"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+	"github.com/opendatahub-io/odh-cli/pkg/resources"
+	"github.com/opendatahub-io/odh-cli/pkg/util/client"
+	"github.com/opendatahub-io/odh-cli/pkg/util/components"
+	"github.com/opendatahub-io/odh-cli/pkg/util/version"
+)
+
+// ScheduledMetricsBackupCheck warns when TrustyAIService CRs are present.
+// Scheduled metrics are held in memory and are not persisted in the CRD; they
+// are lost on pod restart and cannot be recovered after an upgrade.
+type ScheduledMetricsBackupCheck struct {
+	check.BaseCheck
+}
+
+func NewScheduledMetricsBackupCheck() *ScheduledMetricsBackupCheck {
+	return &ScheduledMetricsBackupCheck{
+		BaseCheck: check.BaseCheck{
+			CheckGroup:       check.GroupWorkload,
+			Kind:             kind,
+			Type:             check.CheckTypeWorkloadState,
+			CheckID:          "workloads.trustyai.scheduled-metrics-backup",
+			CheckName:        "Workloads :: TrustyAI :: Scheduled Metrics Backup (3.x)",
+			CheckDescription: "Warns when TrustyAIService instances are found because scheduled metrics are in-memory only and will be lost on pod restart during the upgrade",
+			CheckRemediation: "Record all scheduled metrics via the TrustyAI REST API before upgrading, then re-register them after the upgrade completes",
+		},
+	}
+}
+
+// CanApply returns true when upgrading from 2.x to 3.x and TrustyAI is Managed.
+func (c *ScheduledMetricsBackupCheck) CanApply(ctx context.Context, target check.Target) (bool, error) {
+	if !version.IsUpgradeFrom2xTo3x(target.CurrentVersion, target.TargetVersion) {
+		return false, nil
+	}
+
+	dsc, err := client.GetDataScienceCluster(ctx, target.Client)
+	if err != nil {
+		return false, fmt.Errorf("getting DataScienceCluster: %w", err)
+	}
+
+	return components.HasManagementState(dsc, "trustyai", constants.ManagementStateManaged), nil
+}
+
+// Validate lists all TrustyAIService CRs and warns if any are found.
+func (c *ScheduledMetricsBackupCheck) Validate(
+	ctx context.Context,
+	target check.Target,
+) (*result.DiagnosticResult, error) {
+	return validate.Workloads(c, target, resources.TrustyAIService).
+		Complete(ctx, c.newScheduledMetricsCondition)
+}

--- a/pkg/lint/checks/workloads/trustyai/scheduled_metrics_support.go
+++ b/pkg/lint/checks/workloads/trustyai/scheduled_metrics_support.go
@@ -1,0 +1,37 @@
+package trustyai
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/validate"
+)
+
+func (c *ScheduledMetricsBackupCheck) newScheduledMetricsCondition(
+	_ context.Context,
+	req *validate.WorkloadRequest[*unstructured.Unstructured],
+) ([]result.Condition, error) {
+	count := len(req.Items)
+
+	if count == 0 {
+		return []result.Condition{check.NewCondition(
+			check.ConditionTypeCompatible,
+			metav1.ConditionTrue,
+			check.WithReason(check.ReasonResourceNotFound),
+			check.WithMessage("No TrustyAIService instances found - no scheduled metrics to back up"),
+		)}, nil
+	}
+
+	return []result.Condition{check.NewCondition(
+		check.ConditionTypeCompatible,
+		metav1.ConditionFalse,
+		check.WithReason(check.ReasonWorkloadsImpacted),
+		check.WithMessage("Found %d TrustyAIService instance(s) with scheduled metrics that will be lost on pod restart during upgrade", count),
+		check.WithImpact(result.ImpactAdvisory),
+		check.WithRemediation(c.CheckRemediation),
+	)}, nil
+}

--- a/pkg/lint/checks/workloads/trustyai/scheduled_metrics_test.go
+++ b/pkg/lint/checks/workloads/trustyai/scheduled_metrics_test.go
@@ -1,0 +1,178 @@
+package trustyai_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check"
+	resultpkg "github.com/opendatahub-io/odh-cli/pkg/lint/check/result"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/check/testutil"
+	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trustyai"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func TestScheduledMetricsBackupCheck_NoTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        nil,
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":   Equal(check.ConditionTypeCompatible),
+		"Status": Equal(metav1.ConditionTrue),
+		"Reason": Equal(check.ReasonResourceNotFound),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "0"))
+	g.Expect(result.ImpactedObjects).To(BeEmpty())
+}
+
+func TestScheduledMetricsBackupCheck_WithOneTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{newTestTAS("tas-1", "test-ns", "PVC")},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions).To(HaveLen(1))
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(check.ConditionTypeCompatible),
+		"Status":  Equal(metav1.ConditionFalse),
+		"Reason":  Equal(check.ReasonWorkloadsImpacted),
+		"Message": ContainSubstring("Found 1 TrustyAIService"),
+	}))
+	g.Expect(result.Status.Conditions[0].Impact).To(Equal(resultpkg.ImpactAdvisory))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "1"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(1))
+}
+
+func TestScheduledMetricsBackupCheck_WithMultipleTAS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds: listKinds,
+		Objects: []*unstructured.Unstructured{
+			newTestTAS("tas-1", "ns1", "PVC"),
+			newTestTAS("tas-2", "ns2", "DATABASE"),
+		},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	result, err := chk.Validate(ctx, target)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.Status.Conditions[0].Condition).To(MatchFields(IgnoreExtras, Fields{
+		"Status":  Equal(metav1.ConditionFalse),
+		"Message": ContainSubstring("Found 2 TrustyAIService"),
+	}))
+	g.Expect(result.Annotations).To(HaveKeyWithValue(check.AnnotationImpactedWorkloadCount, "2"))
+	g.Expect(result.ImpactedObjects).To(HaveLen(2))
+}
+
+func TestScheduledMetricsBackupCheck_Metadata(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+
+	g.Expect(chk.ID()).To(Equal("workloads.trustyai.scheduled-metrics-backup"))
+	g.Expect(chk.Name()).To(Equal("Workloads :: TrustyAI :: Scheduled Metrics Backup (3.x)"))
+	g.Expect(chk.Group()).To(Equal(check.GroupWorkload))
+	g.Expect(chk.Description()).ToNot(BeEmpty())
+}
+
+func TestScheduledMetricsBackupCheck_CanApply_NilVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	canApply, err := chk.CanApply(t.Context(), check.Target{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestScheduledMetricsBackupCheck_CanApply_LintMode(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "2.17.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestScheduledMetricsBackupCheck_CanApply_2xTo3x_Managed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeTrue())
+}
+
+func TestScheduledMetricsBackupCheck_CanApply_2xTo3x_Removed(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Removed"})},
+		CurrentVersion: "2.17.0",
+		TargetVersion:  "3.0.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}
+
+func TestScheduledMetricsBackupCheck_CanApply_3xTo3x(t *testing.T) {
+	g := NewWithT(t)
+
+	target := testutil.NewTarget(t, testutil.TargetConfig{
+		ListKinds:      listKinds,
+		Objects:        []*unstructured.Unstructured{testutil.NewDSC(map[string]string{"trustyai": "Managed"})},
+		CurrentVersion: "3.0.0",
+		TargetVersion:  "3.3.0",
+	})
+
+	chk := trustyai.NewScheduledMetricsBackupCheck()
+	canApply, err := chk.CanApply(t.Context(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(canApply).To(BeFalse())
+}

--- a/pkg/lint/checks/workloads/trustyai/trustyai.go
+++ b/pkg/lint/checks/workloads/trustyai/trustyai.go
@@ -1,0 +1,3 @@
+package trustyai
+
+const kind = "trustyai"

--- a/pkg/lint/command.go
+++ b/pkg/lint/command.go
@@ -44,6 +44,7 @@ import (
 	"github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/ray"
 	trainerworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainer"
 	trainingoperatorworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trainingoperator"
+	trustyaiworkloads "github.com/opendatahub-io/odh-cli/pkg/lint/checks/workloads/trustyai"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/schema"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
@@ -137,12 +138,16 @@ func NewCommand(
 	registry.MustRegister(sharedossm.NewCheck())
 	registry.MustRegister(sharedserverless.NewCheck())
 
-	// Workloads (22)
+	// Workloads (26)
 	registry.MustRegister(ray.NewAppWrapperCleanupCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewInstructLabRemovalCheck())
 	registry.MustRegister(datasciencepipelinesworkloads.NewStoredVersionRemovalCheck())
 	registry.MustRegister(guardrails.NewImpactedWorkloadsCheck())
 	registry.MustRegister(guardrails.NewOtelMigrationCheck())
+	registry.MustRegister(trustyaiworkloads.NewImpactedWorkloadsCheck())
+	registry.MustRegister(trustyaiworkloads.NewPVCStorageMigrationCheck())
+	registry.MustRegister(trustyaiworkloads.NewDatabaseStorageMigrationCheck())
+	registry.MustRegister(trustyaiworkloads.NewScheduledMetricsBackupCheck())
 	registry.MustRegister(kserveworkloads.NewInferenceServiceConfigCheck())
 	registry.MustRegister(kserveworkloads.NewAcceleratorMigrationCheck())
 	registry.MustRegister(kserveworkloads.NewHardwareProfileMigrationCheck())


### PR DESCRIPTION
## Description

Adds four new lint checks for the TrustyAI upgrade path from RHOAI 2.x to 3.x.
No `pkg/lint/checks/workloads/trustyai/` package existed; all checks are new, following the fluent-builder pattern of the existing guardrails checks.

| Check ID | Impact | What it catches |
|---|---|---|
| `workloads.trustyai.impacted-workloads` | Advisory | Any `TrustyAIService` CR found — user must back up data before upgrading |
| `workloads.trustyai.pvc-storage-migration` | **Blocking** | TAS with `spec.storage.format == "PVC"` — PVC data at risk during module adoption |
| `workloads.trustyai.database-storage-migration` | Advisory | TAS with `spec.storage.format == "DATABASE"` — DB credentials secret must remain accessible |
| `workloads.trustyai.scheduled-metrics-backup` | Advisory | Any TAS found — scheduled metrics are in-memory only and lost on pod restart |

All checks gate on `IsUpgradeFrom2xTo3x` and TrustyAI `Managed` in the `DataScienceCluster`.

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New functionality includes tests

## Review checklist

- [x] Code follows project conventions (see docs/coding/)
- [x] Changes are documented if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TrustyAI upgrade readiness checks for impacted workloads, PVC-backed storage migration, database-backed storage migration, and scheduled metrics backup.
  * Checks identify affected TrustyAI services during 2.x-to-3.x upgrades and provide remediation guidance, including backup and secret-access recommendations.
  * Registered the new checks in upgrade validation.

* **Tests**
  * Added comprehensive coverage for workload detection, storage configurations, upgrade scenarios, applicability, and diagnostic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->