### PR TITLE
feat(version): add CLI_NAME build arg for downstream branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY . .
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG DATE=unknown
+ARG CLI_NAME=odh-cli
 
 # Build using Makefile with cross-compilation
 RUN make build \
@@ -37,7 +38,8 @@ RUN make build \
     GOARCH=${TARGETARCH} \
     VERSION=${VERSION} \
     COMMIT=${COMMIT} \
-    DATE=${DATE}
+    DATE=${DATE} \
+    CLI_NAME=${CLI_NAME}
 
 # Runtime stage
 FROM registry.access.redhat.com/ubi9/ubi:latest

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BINARY_NAME=bin/kubectl-odh
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+CLI_NAME ?= odh-cli
 
 # Pinned commit SHA from odh-gitops for reproducible builds
 ODH_GITOPS_COMMIT ?= 1a55af06b8fe85c8ed63b1eff680477d9bf86be3
@@ -15,6 +16,7 @@ ODH_GITOPS_COMMIT ?= 1a55af06b8fe85c8ed63b1eff680477d9bf86be3
 LDFLAGS = -X 'github.com/opendatahub-io/odh-cli/internal/version.Version=$(VERSION)' \
           -X 'github.com/opendatahub-io/odh-cli/internal/version.Commit=$(COMMIT)' \
           -X 'github.com/opendatahub-io/odh-cli/internal/version.Date=$(DATE)' \
+          -X 'github.com/opendatahub-io/odh-cli/internal/version.CLIName=$(CLI_NAME)' \
           -X 'github.com/opendatahub-io/odh-cli/pkg/deps.gitopsRef=$(ODH_GITOPS_COMMIT)'
 
 # Linter configuration
@@ -163,6 +165,7 @@ build-image:
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(COMMIT) \
 		--build-arg DATE=$(DATE) \
+		--build-arg CLI_NAME=$(CLI_NAME) \
 		--manifest=$$MANIFEST_NAME \
 		.
 	@echo "Container image built successfully: localhost/odh-cli:$(VERSION)"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,7 @@ func main() {
 	flags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 
 	cmd := &cobra.Command{
-		Use:     "kubectl-odh",
+		Use:     internalversion.GetCLIName(),
 		Short:   "kubectl plugin for ODH/RHOAI",
 		Version: internalversion.GetVersion(),
 	}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -85,6 +85,7 @@ func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
 			}
 
 			data := map[string]string{
+				"name":    version.GetCLIName(),
 				"version": version.GetVersion(),
 				"commit":  version.GetCommit(),
 				"date":    version.GetDate(),
@@ -101,13 +102,13 @@ func AddCommand(root *cobra.Command, _ *genericclioptions.ConfigFlags) {
 
 			if verbose {
 				return writeTextVersion(out,
-					"kubectl-odh version %s\n  Commit:     %s\n  Built:      %s\n  Go version: %s\n  Platform:   %s\n",
-					data["version"], data["commit"], data["date"], data["goVersion"], data["platform"])
+					"%s version %s\n  Commit:     %s\n  Built:      %s\n  Go version: %s\n  Platform:   %s\n",
+					version.GetCLIName(), data["version"], data["commit"], data["date"], data["goVersion"], data["platform"])
 			}
 
 			return writeTextVersion(out,
-				"kubectl-odh version %s (commit: %s, built: %s)\n",
-				data["version"], data["commit"], data["date"])
+				"%s version %s (commit: %s, built: %s)\n",
+				version.GetCLIName(), data["version"], data["commit"], data["date"])
 		},
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,6 +10,8 @@ var (
 	Commit = "unknown"
 	// Date is the build date.
 	Date = "unknown"
+	// CLIName is the display name of the CLI binary.
+	CLIName = "odh-cli"
 )
 
 // GetVersion returns the current version string.
@@ -27,8 +29,14 @@ func GetDate() string {
 	return Date
 }
 
+// GetCLIName returns the CLI display name.
+func GetCLIName() string {
+	return CLIName
+}
+
 // Info holds version information for JSON/YAML output.
 type Info struct {
+	Name    string `json:"name"    jsonschema:"description=CLI display name"`
 	Version string `json:"version" jsonschema:"description=CLI version string"`
 	Commit  string `json:"commit"  jsonschema:"description=Git commit hash"`
 	Date    string `json:"date"    jsonschema:"description=Build date"`
@@ -36,6 +44,7 @@ type Info struct {
 
 // VerboseInfo holds extended version information including Go runtime details.
 type VerboseInfo struct {
+	Name      string `json:"name"      jsonschema:"description=CLI display name"`
 	Version   string `json:"version"   jsonschema:"description=CLI version string"`
 	Commit    string `json:"commit"    jsonschema:"description=Git commit hash"`
 	Date      string `json:"date"      jsonschema:"description=Build date"`
@@ -46,6 +55,7 @@ type VerboseInfo struct {
 // GetInfo returns the version info struct.
 func GetInfo() Info {
 	return Info{
+		Name:    CLIName,
 		Version: Version,
 		Commit:  Commit,
 		Date:    Date,


### PR DESCRIPTION
## Summary
- Add `CLI_NAME` build-time variable (ldflags) to customize CLI display name
- Upstream defaults to `odh-cli`, downstream sets `rhoai-cli` via `make build CLI_NAME=rhoai-cli` or `--build-arg CLI_NAME=rhoai-cli`
- CLI name now appears in cobra root command, version text output, version JSON output, and `Info`/`VerboseInfo` structs

## Changes
- `internal/version/version.go` — new `CLIName` var + `GetCLIName()` getter, added `Name` field to `Info`/`VerboseInfo` structs
- `cmd/main.go` — cobra `Use` reads from `version.GetCLIName()`
- `cmd/version/version.go` — text and JSON version output include CLI name
- `Makefile` — `CLI_NAME` variable + ldflag + `build-image` build-arg
- `Dockerfile` — `CLI_NAME` build arg passed to `make build`

## Test plan
- [x] `make build` — default shows `odh-cli` in `version` output
- [x] `make build CLI_NAME=rhoai-cli` — shows `rhoai-cli` in `version` and `version -v` output
- [x] `version -o json` — includes `"name"` field
- [x] `make test` — all tests pass
- [x] `make lint` — zero issues

🤖 Generated with [Claude Code](https://claude.ai/code)