### PR TITLE
feat(migrate): detect and convert PVC-backed models in modelmesh-to-raw

### DIFF
--- a/pkg/migrate/actions/modelserving/helpers_test.go
+++ b/pkg/migrate/actions/modelserving/helpers_test.go
@@ -3,6 +3,7 @@ package modelserving_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 
 	"github.com/blang/semver/v4"
 
@@ -12,6 +13,7 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
+	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
 	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 )
@@ -175,6 +177,22 @@ func newModelServingDynamicClient(objects ...runtime.Object) *dynamicfake.FakeDy
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(), listKinds, objects...,
 	)
+}
+
+// hasStepMessageContaining walks the step tree recursively and returns true
+// if any step with the given status has a message containing substr.
+func hasStepMessageContaining(steps []result.ActionStep, status result.StepStatus, substr string) bool {
+	for _, s := range steps {
+		if s.Status == status && strings.Contains(s.Message, substr) {
+			return true
+		}
+
+		if hasStepMessageContaining(s.Children, status, substr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // newModelMeshISVCWithStorage creates a ModelMesh ISVC with a storage key reference.

--- a/pkg/migrate/actions/modelserving/helpers_test.go
+++ b/pkg/migrate/actions/modelserving/helpers_test.go
@@ -1,6 +1,9 @@
 package modelserving_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
+
 	"github.com/blang/semver/v4"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -152,5 +155,68 @@ func newTestTarget(dynamicClient *dynamicfake.FakeDynamicClient, currentVersion 
 		DryRun:         dryRun,
 		SkipConfirm:    true,
 		Recorder:       action.NewRootRecorder(),
+	}
+}
+
+// newModelMeshISVCWithStorage creates a ModelMesh ISVC with a storage key reference.
+func newModelMeshISVCWithStorage(namespace, name, runtimeName, storageKey, storagePath string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.InferenceService.APIVersion(),
+			"kind":       resources.InferenceService.Kind,
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+				"uid":       "test-uid-mm-storage-123",
+				"annotations": map[string]any{
+					"serving.kserve.io/deploymentMode": "ModelMesh",
+				},
+			},
+			"spec": map[string]any{
+				"predictor": map[string]any{
+					"model": map[string]any{
+						"runtime": runtimeName,
+						"storage": map[string]any{
+							"key":  storageKey,
+							"path": storagePath,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// storageConfigEntryJSON is a helper to build storage-config secret entries.
+type storageConfigEntryJSON struct {
+	Type      string `json:"type"`
+	Bucket    string `json:"bucket,omitempty"`
+	LocalPath string `json:"localPath,omitempty"`
+}
+
+// newStorageConfigSecret creates a storage-config secret with the given entries.
+// Each key maps to a storageConfigEntryJSON that gets JSON-marshaled and base64-encoded.
+func newStorageConfigSecret(namespace string, entries map[string]storageConfigEntryJSON) *unstructured.Unstructured {
+	data := make(map[string]any, len(entries))
+
+	for key, entry := range entries {
+		jsonBytes, err := json.Marshal(entry)
+		if err != nil {
+			panic("test helper: failed to marshal storage-config entry: " + err.Error())
+		}
+
+		data[key] = base64.StdEncoding.EncodeToString(jsonBytes)
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": resources.Secret.APIVersion(),
+			"kind":       resources.Secret.Kind,
+			"metadata": map[string]any{
+				"name":      "storage-config",
+				"namespace": namespace,
+			},
+			"data": data,
+		},
 	}
 }

--- a/pkg/migrate/actions/modelserving/helpers_test.go
+++ b/pkg/migrate/actions/modelserving/helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/blang/semver/v4"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
@@ -156,6 +158,23 @@ func newTestTarget(dynamicClient *dynamicfake.FakeDynamicClient, currentVersion 
 		SkipConfirm:    true,
 		Recorder:       action.NewRootRecorder(),
 	}
+}
+
+// newModelServingDynamicClient builds a fake dynamic client with list kinds used by model-serving actions.
+func newModelServingDynamicClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	listKinds := map[schema.GroupVersionResource]string{
+		resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+		resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+		resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+		resources.Role.GVR():             resources.Role.ListKind(),
+		resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+		resources.Namespace.GVR():        resources.Namespace.ListKind(),
+		resources.Secret.GVR():           resources.Secret.ListKind(),
+	}
+
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(), listKinds, objects...,
+	)
 }
 
 // newModelMeshISVCWithStorage creates a ModelMesh ISVC with a storage key reference.

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
@@ -34,7 +34,8 @@ const (
 	msgPVCRuntimeUpdate     = "Updated ServingRuntime %s/%s with OVMS single-model args, port 8888, readiness probe"
 	msgPVCRuntimeDryRun     = "Would update ServingRuntime %s/%s with OVMS single-model args, port 8888, readiness probe"
 	msgPVCRuntimeFailed     = "Failed to update ServingRuntime %s/%s for PVC single-model: %v"
-	msgPVCRuntimeShared     = "ServingRuntime %s/%s is shared by multiple PVC ISVCs; --model_name set to last ISVC processed"
+	msgPVCRuntimeShared     = "ServingRuntime %s/%s is already patched for another PVC InferenceService; --model_name keeps the first ISVC processed. Create a dedicated ServingRuntime for %s/%s"
+	msgPVCStorageURIInvalid = "Failed to build storageUri for InferenceService %s/%s: %v"
 	msgPVCStorageURISet     = "Set storageUri=%s and deploymentMode=RawDeployment on InferenceService %s/%s"
 	msgPVCStorageURIDryRun  = "Would set storageUri=%s and deploymentMode=RawDeployment on InferenceService %s/%s"
 	msgPVCStorageURIFailed  = "Failed to update InferenceService %s/%s for PVC conversion: %v"
@@ -100,8 +101,15 @@ func (a *ModelMeshToRawAction) convertISVCs(
 
 	step.Recordf("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeModelMesh)
 
-	// Classify ISVCs by storage type
-	standardISVCs, pvcISVCs := a.classifyISVCsByStorageType(ctx, target, isvcs, step)
+	// Classify ISVCs by storage type (detection only — no mutations, safe before consent)
+	detectionStep := step.Child(
+		"detect-storage-types",
+		"Detect PVC-backed InferenceServices",
+	)
+
+	standardISVCs, pvcISVCs := a.classifyISVCsByStorageType(ctx, target, isvcs, detectionStep)
+
+	detectionStep.Completef(result.StepCompleted, "Detected %d standard and %d PVC-backed InferenceService(s)", len(standardISVCs), len(pvcISVCs))
 
 	// Confirm with user
 	if !target.SkipConfirm && !target.DryRun {
@@ -340,9 +348,15 @@ func (a *ModelMeshToRawAction) convertPVCISVC(
 	step action.StepRecorder,
 	patchedRuntimes map[string]bool,
 ) bool {
-	storageURI := buildPVCStorageURI(pi.entry)
 	ns := pi.isvc.GetNamespace()
 	name := pi.isvc.GetName()
+
+	storageURI, err := buildPVCStorageURI(pi.entry)
+	if err != nil {
+		step.Recordf("pvc-storageuri-"+name, msgPVCStorageURIInvalid, result.StepFailed, ns, name, err)
+
+		return false
+	}
 
 	if target.DryRun {
 		step.Recordf("pvc-storageuri-"+name, msgPVCStorageURIDryRun, result.StepSkipped, storageURI, ns, name)
@@ -369,7 +383,7 @@ func (a *ModelMeshToRawAction) convertPVCISVC(
 	annotations[annotationDeploymentMode] = deploymentModeRawDeployment
 	pi.isvc.SetAnnotations(annotations)
 
-	_, err := target.Client.Dynamic().Resource(resources.InferenceService.GVR()).
+	_, err = target.Client.Dynamic().Resource(resources.InferenceService.GVR()).
 		Namespace(ns).
 		Update(ctx, pi.isvc, metav1.UpdateOptions{})
 	if err != nil {
@@ -409,7 +423,7 @@ func (a *ModelMeshToRawAction) updateServingRuntimeForPVC(
 	)
 
 	if patchedRuntimes[runtimeKey] {
-		step.Completef(result.StepFailed, msgPVCRuntimeShared, ns, runtimeName)
+		step.Completef(result.StepFailed, msgPVCRuntimeShared, ns, runtimeName, ns, isvcName)
 
 		return
 	}

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
@@ -24,10 +24,21 @@ const (
 
 	msgModelMeshConfirm    = "About to convert %d InferenceService(s) from ModelMesh to RawDeployment"
 	msgModelMeshCancelled  = "User cancelled ModelMesh to RawDeployment conversion"
-	msgModelMeshComplete   = "Processed %d InferenceService(s) for ModelMesh to RawDeployment conversion"
-	msgModelMeshDryRun     = "Dry-run: would convert %d InferenceService(s) from ModelMesh to RawDeployment"
+	msgModelMeshComplete   = "Processed %d InferenceService(s): %d standard, %d PVC-backed"
+	msgModelMeshDryRun     = "Dry-run: would convert %d InferenceService(s) from ModelMesh to RawDeployment (%d standard, %d PVC-backed)"
 	msgModelMeshBackupDone = "Backed up %d ModelMesh InferenceServices to %s"
 	msgModelMeshNoISVCs    = "No ModelMesh InferenceServices found"
+
+	msgPVCDetected          = "InferenceService %s/%s uses PVC storage (key: %s)"
+	msgPVCClassifyFailed    = "Failed to detect storage type for InferenceService %s/%s: %v (treating as standard)"
+	msgPVCRuntimeUpdate     = "Updated ServingRuntime %s/%s with OVMS single-model args, port 8888, readiness probe"
+	msgPVCRuntimeDryRun     = "Would update ServingRuntime %s/%s with OVMS single-model args, port 8888, readiness probe"
+	msgPVCRuntimeFailed     = "Failed to update ServingRuntime %s/%s for PVC single-model: %v"
+	msgPVCRuntimeShared     = "ServingRuntime %s/%s is shared by multiple PVC ISVCs; --model_name set to last ISVC processed"
+	msgPVCStorageURISet     = "Set storageUri=%s and deploymentMode=RawDeployment on InferenceService %s/%s"
+	msgPVCStorageURIDryRun  = "Would set storageUri=%s and deploymentMode=RawDeployment on InferenceService %s/%s"
+	msgPVCStorageURIFailed  = "Failed to update InferenceService %s/%s for PVC conversion: %v"
+	msgPVCConversionAborted = "Skipping remaining steps for InferenceService %s/%s due to PVC conversion failure"
 )
 
 // ModelMeshToRawAction converts InferenceServices from ModelMesh to RawDeployment mode.
@@ -89,10 +100,17 @@ func (a *ModelMeshToRawAction) convertISVCs(
 
 	step.Recordf("list-isvcs", msgFoundISVCs, result.StepCompleted, len(isvcs), deploymentModeModelMesh)
 
+	// Classify ISVCs by storage type
+	standardISVCs, pvcISVCs := a.classifyISVCsByStorageType(ctx, target, isvcs, step)
+
 	// Confirm with user
 	if !target.SkipConfirm && !target.DryRun {
 		target.IO.Fprintln()
 		target.IO.Errorf(msgModelMeshConfirm, len(isvcs))
+
+		if len(pvcISVCs) > 0 {
+			target.IO.Errorf("  (%d standard, %d PVC-backed requiring storageUri rewrite)", len(standardISVCs), len(pvcISVCs))
+		}
 
 		if !confirmation.Prompt(target.IO, "Proceed with conversion?") {
 			step.Completef(result.StepSkipped, msgModelMeshCancelled)
@@ -101,35 +119,55 @@ func (a *ModelMeshToRawAction) convertISVCs(
 		}
 	}
 
-	convertedCount := 0
-	processedNamespaces := make(map[string]bool)
+	var (
+		standardCount       int
+		pvcCount            int
+		processedNamespaces = make(map[string]bool)
+		patchedRuntimes     = make(map[string]bool)
+	)
 
-	for _, isvc := range isvcs {
+	// Convert standard (S3/HDFS) ISVCs
+	for _, isvc := range standardISVCs {
 		isvcStep := step.Child(
 			fmt.Sprintf("convert-%s-%s", isvc.GetNamespace(), isvc.GetName()),
 			fmt.Sprintf("Convert %s/%s", isvc.GetNamespace(), isvc.GetName()),
 		)
 
-		// Update associated ServingRuntime if multi-model
 		a.updateServingRuntime(ctx, target, isvc, isvcStep)
-
-		// Patch deployment mode
 		patchISVCDeploymentMode(ctx, target, isvc, deploymentModeRawDeployment, isvcStep)
+		finalizeISVCConversion(ctx, target, isvc, isvcStep, processedNamespaces)
 
-		// Create auth resources only when auth is enabled
-		if hasAuthEnabled(isvc) {
-			ensureAuthResources(ctx, target, isvc, isvcStep)
-		} else {
+		standardCount++
+	}
+
+	// Convert PVC-backed ISVCs
+	for _, pi := range pvcISVCs {
+		isvcStep := step.Child(
+			fmt.Sprintf("convert-pvc-%s-%s", pi.isvc.GetNamespace(), pi.isvc.GetName()),
+			fmt.Sprintf("Convert PVC-backed %s/%s", pi.isvc.GetNamespace(), pi.isvc.GetName()),
+		)
+
+		isvcStep.Recordf(
+			"pvc-detected-"+pi.isvc.GetName(),
+			msgPVCDetected,
+			result.StepCompleted,
+			pi.isvc.GetNamespace(), pi.isvc.GetName(), pi.storageKey,
+		)
+
+		if !a.convertPVCISVC(ctx, target, pi, isvcStep, patchedRuntimes) {
 			isvcStep.Recordf(
-				"auth-skip-"+isvc.GetName(),
-				msgAuthSkipped,
-				result.StepSkipped,
-				isvc.GetNamespace(), isvc.GetName(),
+				"pvc-aborted-"+pi.isvc.GetName(),
+				msgPVCConversionAborted,
+				result.StepFailed,
+				pi.isvc.GetNamespace(), pi.isvc.GetName(),
 			)
+
+			continue
 		}
 
-		processedNamespaces[isvc.GetNamespace()] = true
-		convertedCount++
+		finalizeISVCConversion(ctx, target, pi.isvc, isvcStep, processedNamespaces)
+
+		pvcCount++
 	}
 
 	// Remove modelmesh-enabled label from processed namespaces
@@ -137,10 +175,12 @@ func (a *ModelMeshToRawAction) convertISVCs(
 		removeModelMeshLabel(ctx, target, ns, step)
 	}
 
+	total := standardCount + pvcCount
+
 	if target.DryRun {
-		step.Completef(result.StepSkipped, msgModelMeshDryRun, convertedCount)
+		step.Completef(result.StepSkipped, msgModelMeshDryRun, total, standardCount, pvcCount)
 	} else {
-		step.Completef(result.StepCompleted, msgModelMeshComplete, convertedCount)
+		step.Completef(result.StepCompleted, msgModelMeshComplete, total, standardCount, pvcCount)
 	}
 }
 
@@ -210,6 +250,249 @@ func (a *ModelMeshToRawAction) updateServingRuntime(
 	}
 
 	step.Completef(result.StepCompleted, "Updated ServingRuntime %s/%s (multiModel=false, container renamed to %s)", ns, runtimeName, kserveContainerName)
+}
+
+// finalizeISVCConversion handles auth resources and namespace tracking common to all ISVC conversions.
+func finalizeISVCConversion(
+	ctx context.Context,
+	target action.Target,
+	isvc *unstructured.Unstructured,
+	step action.StepRecorder,
+	processedNamespaces map[string]bool,
+) {
+	if hasAuthEnabled(isvc) {
+		ensureAuthResources(ctx, target, isvc, step)
+	} else {
+		step.Recordf(
+			"auth-skip-"+isvc.GetName(),
+			msgAuthSkipped,
+			result.StepSkipped,
+			isvc.GetNamespace(), isvc.GetName(),
+		)
+	}
+
+	processedNamespaces[isvc.GetNamespace()] = true
+}
+
+// pvcISVCInfo holds a PVC-backed ISVC with its resolved storage config.
+type pvcISVCInfo struct {
+	isvc       *unstructured.Unstructured
+	storageKey string
+	entry      *storageConfigEntry
+}
+
+// classifyISVCsByStorageType splits ISVCs into standard (S3/HDFS) and PVC-backed.
+func (a *ModelMeshToRawAction) classifyISVCsByStorageType(
+	ctx context.Context,
+	target action.Target,
+	isvcs []*unstructured.Unstructured,
+	step action.StepRecorder,
+) ([]*unstructured.Unstructured, []pvcISVCInfo) {
+	var (
+		standard  []*unstructured.Unstructured
+		pvcBacked []pvcISVCInfo
+	)
+
+	for _, isvc := range isvcs {
+		storageKey := getISVCStorageKey(isvc)
+		if storageKey == "" {
+			standard = append(standard, isvc)
+
+			continue
+		}
+
+		entry, err := getStorageConfigEntry(ctx, target, isvc.GetNamespace(), storageKey)
+		if err != nil {
+			step.Recordf(
+				"classify-"+isvc.GetName(),
+				msgPVCClassifyFailed,
+				result.StepFailed,
+				isvc.GetNamespace(), isvc.GetName(), err,
+			)
+
+			standard = append(standard, isvc)
+
+			continue
+		}
+
+		if entry == nil || entry.Type != storageTypePVC {
+			standard = append(standard, isvc)
+
+			continue
+		}
+
+		pvcBacked = append(pvcBacked, pvcISVCInfo{
+			isvc:       isvc,
+			storageKey: storageKey,
+			entry:      entry,
+		})
+	}
+
+	return standard, pvcBacked
+}
+
+// convertPVCISVC rewrites an ISVC's storage and deployment mode for PVC-backed models,
+// and updates its ServingRuntime. Returns true on success, false if the ISVC was not modified.
+func (a *ModelMeshToRawAction) convertPVCISVC(
+	ctx context.Context,
+	target action.Target,
+	pi pvcISVCInfo,
+	step action.StepRecorder,
+	patchedRuntimes map[string]bool,
+) bool {
+	storageURI := buildPVCStorageURI(pi.entry)
+	ns := pi.isvc.GetNamespace()
+	name := pi.isvc.GetName()
+
+	if target.DryRun {
+		step.Recordf("pvc-storageuri-"+name, msgPVCStorageURIDryRun, result.StepSkipped, storageURI, ns, name)
+		a.updateServingRuntimeForPVC(ctx, target, pi.isvc, step, patchedRuntimes)
+
+		return true
+	}
+
+	if err := jq.Transform(pi.isvc, ".spec.predictor.model.storageUri = %q", storageURI); err != nil {
+		step.Recordf("pvc-storageuri-"+name, msgPVCStorageURIFailed, result.StepFailed, ns, name, err)
+
+		return false
+	}
+
+	// Remove ModelMesh storage key/path — storageUri replaces them
+	unstructured.RemoveNestedField(pi.isvc.Object, "spec", "predictor", "model", "storage")
+
+	// Set deployment mode to RawDeployment in the same update
+	annotations := pi.isvc.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[annotationDeploymentMode] = deploymentModeRawDeployment
+	pi.isvc.SetAnnotations(annotations)
+
+	_, err := target.Client.Dynamic().Resource(resources.InferenceService.GVR()).
+		Namespace(ns).
+		Update(ctx, pi.isvc, metav1.UpdateOptions{})
+	if err != nil {
+		step.Recordf("pvc-storageuri-"+name, msgPVCStorageURIFailed, result.StepFailed, ns, name, err)
+
+		return false
+	}
+
+	step.Recordf("pvc-storageuri-"+name, msgPVCStorageURISet, result.StepCompleted, storageURI, ns, name)
+
+	a.updateServingRuntimeForPVC(ctx, target, pi.isvc, step, patchedRuntimes)
+
+	return true
+}
+
+// updateServingRuntimeForPVC patches a ServingRuntime for PVC single-model OVMS deployment:
+// sets multiModel=false, renames container, replaces args, adds port 8888 and readiness probe.
+func (a *ModelMeshToRawAction) updateServingRuntimeForPVC(
+	ctx context.Context,
+	target action.Target,
+	isvc *unstructured.Unstructured,
+	parentStep action.StepRecorder,
+	patchedRuntimes map[string]bool,
+) {
+	runtimeName, err := jq.Query[string](isvc, ".spec.predictor.model.runtime")
+	if err != nil {
+		return
+	}
+
+	ns := isvc.GetNamespace()
+	isvcName := isvc.GetName()
+	runtimeKey := ns + "/" + runtimeName
+
+	step := parentStep.Child(
+		fmt.Sprintf("update-pvc-runtime-%s-%s", ns, runtimeName),
+		fmt.Sprintf("Update ServingRuntime %s/%s for PVC single-model", ns, runtimeName),
+	)
+
+	if patchedRuntimes[runtimeKey] {
+		step.Completef(result.StepFailed, msgPVCRuntimeShared, ns, runtimeName)
+
+		return
+	}
+
+	runtime, err := target.Client.Dynamic().Resource(resources.ServingRuntime.GVR()).
+		Namespace(ns).
+		Get(ctx, runtimeName, metav1.GetOptions{})
+	if err != nil {
+		step.Completef(result.StepSkipped, "ServingRuntime %s/%s not found (skipped)", ns, runtimeName)
+
+		return
+	}
+
+	if target.DryRun {
+		step.Completef(result.StepSkipped, msgPVCRuntimeDryRun, ns, runtimeName)
+		patchedRuntimes[runtimeKey] = true
+
+		return
+	}
+
+	// Set multiModel=false
+	if err := jq.Transform(runtime, ".spec.multiModel = false"); err != nil {
+		step.Completef(result.StepFailed, msgPVCRuntimeFailed, ns, runtimeName, err)
+
+		return
+	}
+
+	// Rename container to kserve-container
+	if err := jq.Transform(runtime, ".spec.containers[0].name = %q", kserveContainerName); err != nil {
+		step.Completef(result.StepFailed, msgPVCRuntimeFailed, ns, runtimeName, err)
+
+		return
+	}
+
+	// Replace container args with single-model OVMS args
+	containers, _, _ := unstructured.NestedSlice(runtime.Object, "spec", "containers")
+	if len(containers) > 0 {
+		container, ok := containers[0].(map[string]any)
+		if ok {
+			container["args"] = []any{
+				"--model_name=" + isvcName,
+				"--model_path=/mnt/models",
+				fmt.Sprintf("--port=%d", ovmsGRPCPort),
+				fmt.Sprintf("--rest_port=%d", ovmsRESTPort),
+			}
+
+			container["ports"] = []any{
+				map[string]any{
+					"containerPort": ovmsRESTPort,
+					"protocol":      "TCP",
+				},
+			}
+
+			container["readinessProbe"] = map[string]any{
+				"tcpSocket": map[string]any{
+					"port": ovmsRESTPort,
+				},
+				"initialDelaySeconds": ovmsReadinessInitialDelay,
+				"periodSeconds":       ovmsReadinessPeriod,
+			}
+
+			containers[0] = container
+
+			if err := unstructured.SetNestedSlice(runtime.Object, containers, "spec", "containers"); err != nil {
+				step.Completef(result.StepFailed, msgPVCRuntimeFailed, ns, runtimeName, err)
+
+				return
+			}
+		}
+	}
+
+	_, err = target.Client.Dynamic().Resource(resources.ServingRuntime.GVR()).
+		Namespace(ns).
+		Update(ctx, runtime, metav1.UpdateOptions{})
+	if err != nil {
+		step.Completef(result.StepFailed, msgPVCRuntimeFailed, ns, runtimeName, err)
+
+		return
+	}
+
+	patchedRuntimes[runtimeKey] = true
+
+	step.Completef(result.StepCompleted, msgPVCRuntimeUpdate, ns, runtimeName)
 }
 
 // --- Prepare Task ---

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw.go
@@ -30,7 +30,7 @@ const (
 	msgModelMeshNoISVCs    = "No ModelMesh InferenceServices found"
 
 	msgPVCDetected          = "InferenceService %s/%s uses PVC storage (key: %s)"
-	msgPVCClassifyFailed    = "Failed to detect storage type for InferenceService %s/%s: %v (treating as standard)"
+	msgPVCClassifyFailed    = "Failed to detect storage type for InferenceService %s/%s: %v (skipped — resolve and retry)"
 	msgPVCRuntimeUpdate     = "Updated ServingRuntime %s/%s with OVMS single-model args, port 8888, readiness probe"
 	msgPVCRuntimeDryRun     = "Would update ServingRuntime %s/%s with OVMS single-model args, port 8888, readiness probe"
 	msgPVCRuntimeFailed     = "Failed to update ServingRuntime %s/%s for PVC single-model: %v"
@@ -108,13 +108,18 @@ func (a *ModelMeshToRawAction) convertISVCs(
 	)
 
 	standardISVCs, pvcISVCs := a.classifyISVCsByStorageType(ctx, target, isvcs, detectionStep)
+	skippedCount := len(isvcs) - len(standardISVCs) - len(pvcISVCs)
 
-	detectionStep.Completef(result.StepCompleted, "Detected %d standard and %d PVC-backed InferenceService(s)", len(standardISVCs), len(pvcISVCs))
+	if skippedCount > 0 {
+		detectionStep.Completef(result.StepFailed, "Detected %d standard, %d PVC-backed, %d skipped (detection failed) InferenceService(s)", len(standardISVCs), len(pvcISVCs), skippedCount)
+	} else {
+		detectionStep.Completef(result.StepCompleted, "Detected %d standard and %d PVC-backed InferenceService(s)", len(standardISVCs), len(pvcISVCs))
+	}
 
 	// Confirm with user
 	if !target.SkipConfirm && !target.DryRun {
 		target.IO.Fprintln()
-		target.IO.Errorf(msgModelMeshConfirm, len(isvcs))
+		target.IO.Errorf(msgModelMeshConfirm, len(standardISVCs)+len(pvcISVCs))
 
 		if len(pvcISVCs) > 0 {
 			target.IO.Errorf("  (%d standard, %d PVC-backed requiring storageUri rewrite)", len(standardISVCs), len(pvcISVCs))
@@ -317,8 +322,6 @@ func (a *ModelMeshToRawAction) classifyISVCsByStorageType(
 				result.StepFailed,
 				isvc.GetNamespace(), isvc.GetName(), err,
 			)
-
-			standard = append(standard, isvc)
 
 			continue
 		}

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
@@ -7,15 +7,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/action/result"
 	"github.com/opendatahub-io/odh-cli/pkg/migrate/actions/modelserving"
 	"github.com/opendatahub-io/odh-cli/pkg/resources"
-	"github.com/opendatahub-io/odh-cli/pkg/util/client"
 
 	. "github.com/onsi/gomega"
 )
@@ -135,15 +131,7 @@ func TestModelMeshToRawAction_RunValidate(t *testing.T) {
 
 		isvc := newModelMeshISVC(testISVCNamespace, "mm-model", "ovms")
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -173,36 +161,9 @@ func TestModelMeshToRawAction_RunExecute(t *testing.T) {
 		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
 		ns := newNamespace(testISVCNamespace, map[string]string{"modelmesh-enabled": "true"})
 
-		scheme := runtime.NewScheme()
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns)
 
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns,
-		)
-
-		testClient := client.NewForTesting(client.TestClientConfig{
-			Dynamic: dynamicClient,
-		})
-
-		v := semver.MustParse("2.25.0")
-		tv := semver.MustParse("3.0.0")
-
-		target := action.Target{
-			Client:         testClient,
-			CurrentVersion: &v,
-			TargetVersion:  &tv,
-			DryRun:         false,
-			SkipConfirm:    true,
-			Recorder:       action.NewRootRecorder(),
-		}
+		target := newTestTarget(dynamicClient, "2.25.0", false)
 
 		a := &modelserving.ModelMeshToRawAction{}
 		actionResult, err := a.Run().Execute(ctx, target)
@@ -251,20 +212,7 @@ func TestModelMeshToRawAction_RunExecute(t *testing.T) {
 		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
 		ns := newNamespace(testISVCNamespace, nil)
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -289,20 +237,7 @@ func TestModelMeshToRawAction_RunExecute(t *testing.T) {
 		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
 		ns := newNamespace(testISVCNamespace, nil)
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -323,13 +258,7 @@ func TestModelMeshToRawAction_RunExecute(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+		dynamicClient := newModelServingDynamicClient()
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -357,20 +286,7 @@ func TestModelMeshToRawAction_RunExecute(t *testing.T) {
 		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
 		ns := newNamespace(testISVCNamespace, map[string]string{"modelmesh-enabled": "true"})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns)
 
 		target := newTestTarget(dynamicClient, "2.25.0", true)
 
@@ -417,21 +333,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"my-pvc-key": {Type: "pvc", Bucket: "my-pvc-volume", LocalPath: "/models/my-model"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -473,21 +375,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"pvc-key": {Type: "pvc", Bucket: "data-pvc", LocalPath: "/model-dir"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -551,21 +439,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"s3-key": {Type: "s3", Bucket: "my-bucket"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -606,21 +480,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"pvc-key": {Type: "pvc", Bucket: "pvc-volume", LocalPath: "/pvc-path"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, s3ISVC, pvcISVC, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(s3ISVC, pvcISVC, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -674,21 +534,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"pvc-key": {Type: "pvc", Bucket: "my-pvc", LocalPath: "/model-dir"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", true)
 
@@ -722,21 +568,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
 		ns := newNamespace(testISVCNamespace, nil)
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -768,21 +600,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"other-key": {Type: "s3", Bucket: "some-bucket"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -813,21 +631,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"pvc-key": {Type: "pvc", Bucket: "vol", LocalPath: "/path"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -864,21 +668,7 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 			"pvc-key-2": {Type: "pvc", Bucket: "vol2", LocalPath: "/path2"},
 		})
 
-		scheme := runtime.NewScheme()
-
-		listKinds := map[schema.GroupVersionResource]string{
-			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
-			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
-			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
-			resources.Role.GVR():             resources.Role.ListKind(),
-			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
-			resources.Namespace.GVR():        resources.Namespace.ListKind(),
-			resources.Secret.GVR():           resources.Secret.ListKind(),
-		}
-
-		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-			scheme, listKinds, isvc1, isvc2, sr, ns, secret,
-		)
+		dynamicClient := newModelServingDynamicClient(isvc1, isvc2, sr, ns, secret)
 
 		target := newTestTarget(dynamicClient, "2.25.0", false)
 
@@ -902,5 +692,84 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 
 		// Result should contain a failed step for the shared runtime
 		g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+
+		// Verify runtime keeps --model_name from first ISVC processed
+		updatedSR, err := dynamicClient.Resource(resources.ServingRuntime.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "shared-runtime", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		containers, _, _ := unstructured.NestedSlice(updatedSR.Object, "spec", "containers")
+		g.Expect(containers).To(HaveLen(1))
+
+		container := containers[0].(map[string]any)
+		args, ok := container["args"].([]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(args).To(ContainElement("--model_name=pvc-model-1"))
+	})
+
+	t.Run("should reject PVC ISVC with empty bucket in storage-config", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "empty-bucket-model", "ovms-runtime", "bad-key", "path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"bad-key": {Type: "pvc", Bucket: "", LocalPath: "/model"},
+		})
+
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+
+		// ISVC should NOT have storageUri set (validation failed)
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "empty-bucket-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, storageURIFound, _ := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(storageURIFound).To(BeFalse())
+	})
+
+	t.Run("should reject PVC ISVC with path traversal in localPath", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "traversal-model", "ovms-runtime", "bad-key", "path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"bad-key": {Type: "pvc", Bucket: "my-pvc", LocalPath: "/../../etc/passwd"},
+		})
+
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+
+		// ISVC should NOT have storageUri set (validation failed)
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "traversal-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, storageURIFound, _ := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(storageURIFound).To(BeFalse())
 	})
 }

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
@@ -557,6 +557,16 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 		// Verify storage key still present (not mutated in dry-run)
 		_, storageKeyFound, _ := unstructured.NestedString(original.Object, "spec", "predictor", "model", "storage", "key")
 		g.Expect(storageKeyFound).To(BeTrue())
+
+		// Verify PVC-specific dry-run step was recorded
+		g.Expect(hasStepMessageContaining(
+			actionResult.Status.Steps, result.StepSkipped, "Would set storageUri=",
+		)).To(BeTrue())
+
+		// Verify detection step recorded PVC-backed count
+		g.Expect(hasStepMessageContaining(
+			actionResult.Status.Steps, result.StepCompleted, "PVC-backed",
+		)).To(BeTrue())
 	})
 
 	t.Run("should handle missing storage-config secret gracefully", func(t *testing.T) {
@@ -618,6 +628,54 @@ func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
 
 		annotations := updated.GetAnnotations()
 		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+	})
+
+	t.Run("should skip ISVC when storage-config entry is malformed", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "bad-json-model", "ovms-runtime", "corrupt-key", "path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+
+		// Create secret with invalid base64 data for the storage key
+		secret := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": resources.Secret.APIVersion(),
+				"kind":       resources.Secret.Kind,
+				"metadata": map[string]any{
+					"name":      "storage-config",
+					"namespace": testISVCNamespace,
+				},
+				"data": map[string]any{
+					"corrupt-key": "not-valid-base64!!!",
+				},
+			},
+		}
+
+		dynamicClient := newModelServingDynamicClient(isvc, sr, ns, secret)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// ISVC should NOT be converted — detection failure means skip, not convert
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "bad-json-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "ModelMesh"))
+
+		// Detection step should report failure
+		g.Expect(hasStepMessageContaining(
+			actionResult.Status.Steps, result.StepFailed, "Failed to detect storage type",
+		)).To(BeTrue())
 	})
 
 	t.Run("should set deploymentMode in single update with storageUri", func(t *testing.T) {

--- a/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
+++ b/pkg/migrate/actions/modelserving/modelmesh_to_raw_test.go
@@ -404,3 +404,503 @@ func TestModelMeshToRawAction_RunExecute(t *testing.T) {
 		g.Expect(firstContainer).To(HaveKeyWithValue("name", "ovms"))
 	})
 }
+
+func TestModelMeshToRawAction_PVCConversion(t *testing.T) {
+	t.Run("should convert PVC-backed ISVCs with storageUri rewrite", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-model", "ovms-runtime", "my-pvc-key", "models/my-model")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, map[string]string{"modelmesh-enabled": "true"})
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"my-pvc-key": {Type: "pvc", Bucket: "my-pvc-volume", LocalPath: "/models/my-model"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ISVC was patched to RawDeployment with storageUri
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "pvc-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+
+		// Verify storageUri was set
+		storageURI, found, err := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(storageURI).To(Equal("pvc://my-pvc-volume/models/my-model"))
+
+		// Verify storage key was removed
+		_, storageKeyFound, _ := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storage", "key")
+		g.Expect(storageKeyFound).To(BeFalse())
+	})
+
+	t.Run("should patch OVMS args and port for PVC-backed ISVCs", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-model", "ovms-runtime", "pvc-key", "model-dir")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"pvc-key": {Type: "pvc", Bucket: "data-pvc", LocalPath: "/model-dir"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		_, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify ServingRuntime was updated
+		updatedSR, err := dynamicClient.Resource(resources.ServingRuntime.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "ovms-runtime", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify multiModel=false
+		multiModel, _, _ := unstructured.NestedBool(updatedSR.Object, "spec", "multiModel")
+		g.Expect(multiModel).To(BeFalse())
+
+		// Verify container name
+		containers, _, _ := unstructured.NestedSlice(updatedSR.Object, "spec", "containers")
+		g.Expect(containers).To(HaveLen(1))
+
+		container := containers[0].(map[string]any)
+		g.Expect(container).To(HaveKeyWithValue("name", "kserve-container"))
+
+		// Verify OVMS single-model args
+		args, ok := container["args"].([]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(args).To(ContainElement("--model_name=pvc-model"))
+		g.Expect(args).To(ContainElement("--model_path=/mnt/models"))
+		g.Expect(args).To(ContainElement("--port=8001"))
+		g.Expect(args).To(ContainElement("--rest_port=8888"))
+
+		// Verify port 8888
+		ports, ok := container["ports"].([]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(ports).To(HaveLen(1))
+
+		port := ports[0].(map[string]any)
+		g.Expect(port).To(HaveKeyWithValue("containerPort", int64(8888)))
+		g.Expect(port).To(HaveKeyWithValue("protocol", "TCP"))
+
+		// Verify readiness probe
+		probe, ok := container["readinessProbe"].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+
+		tcpSocket, ok := probe["tcpSocket"].(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(tcpSocket).To(HaveKeyWithValue("port", int64(8888)))
+	})
+
+	t.Run("should convert S3-backed ISVCs with storage key normally", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "s3-model", "ovms-runtime", "s3-key", "model-path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"s3-key": {Type: "s3", Bucket: "my-bucket"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		_, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify ISVC was patched to RawDeployment (standard path, no storageUri rewrite)
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "s3-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+
+		// Verify storageUri was NOT set (S3 uses existing storage path)
+		_, storageURIFound, _ := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(storageURIFound).To(BeFalse())
+
+		// Verify storage key is still present
+		_, storageKeyFound, _ := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storage", "key")
+		g.Expect(storageKeyFound).To(BeTrue())
+	})
+
+	t.Run("should handle mixed S3 and PVC ISVCs", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		s3ISVC := newModelMeshISVCWithStorage(testISVCNamespace, "s3-model", "ovms-runtime", "s3-key", "s3-path")
+		pvcISVC := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-model", "ovms-runtime", "pvc-key", "pvc-path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"s3-key":  {Type: "s3", Bucket: "s3-bucket"},
+			"pvc-key": {Type: "pvc", Bucket: "pvc-volume", LocalPath: "/pvc-path"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, s3ISVC, pvcISVC, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		_, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Both should be RawDeployment
+		for _, name := range []string{"s3-model", "pvc-model"} {
+			updated, getErr := dynamicClient.Resource(resources.InferenceService.GVR()).
+				Namespace(testISVCNamespace).
+				Get(ctx, name, metav1.GetOptions{})
+
+			g.Expect(getErr).ToNot(HaveOccurred())
+
+			annotations := updated.GetAnnotations()
+			g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+		}
+
+		// PVC ISVC should have storageUri
+		pvcUpdated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "pvc-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		storageURI, found, _ := unstructured.NestedString(pvcUpdated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(found).To(BeTrue())
+		g.Expect(storageURI).To(Equal("pvc://pvc-volume/pvc-path"))
+
+		// S3 ISVC should NOT have storageUri
+		s3Updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "s3-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, s3URIFound, _ := unstructured.NestedString(s3Updated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(s3URIFound).To(BeFalse())
+	})
+
+	t.Run("should surface PVC detection in dry-run mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-model", "ovms-runtime", "pvc-key", "model-dir")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, map[string]string{"modelmesh-enabled": "true"})
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"pvc-key": {Type: "pvc", Bucket: "my-pvc", LocalPath: "/model-dir"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", true)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Verify ISVC was NOT mutated
+		original, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "pvc-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := original.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "ModelMesh"))
+
+		// Verify storage key still present (not mutated in dry-run)
+		_, storageKeyFound, _ := unstructured.NestedString(original.Object, "spec", "predictor", "model", "storage", "key")
+		g.Expect(storageKeyFound).To(BeTrue())
+	})
+
+	t.Run("should handle missing storage-config secret gracefully", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// ISVC has storage key but no storage-config secret exists
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "no-secret-model", "ovms-runtime", "missing-key", "path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		_, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Should be treated as standard and converted normally
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "no-secret-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+	})
+
+	t.Run("should handle missing storage key in secret", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		// ISVC references a key not in the storage-config secret
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "orphan-key-model", "ovms-runtime", "nonexistent-key", "path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"other-key": {Type: "s3", Bucket: "some-bucket"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		_, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Should be treated as standard and converted normally
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "orphan-key-model", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+	})
+
+	t.Run("should set deploymentMode in single update with storageUri", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-single-update", "ovms-runtime", "pvc-key", "path")
+		sr := newServingRuntime(testISVCNamespace, "ovms-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"pvc-key": {Type: "pvc", Bucket: "vol", LocalPath: "/path"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		_, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updated, err := dynamicClient.Resource(resources.InferenceService.GVR()).
+			Namespace(testISVCNamespace).
+			Get(ctx, "pvc-single-update", metav1.GetOptions{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Both storageUri and deploymentMode should be set
+		storageURI, found, _ := unstructured.NestedString(updated.Object, "spec", "predictor", "model", "storageUri")
+		g.Expect(found).To(BeTrue())
+		g.Expect(storageURI).To(Equal("pvc://vol/path"))
+
+		annotations := updated.GetAnnotations()
+		g.Expect(annotations).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+	})
+
+	t.Run("should warn when multiple PVC ISVCs share a ServingRuntime", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		isvc1 := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-model-1", "shared-runtime", "pvc-key-1", "path1")
+		isvc2 := newModelMeshISVCWithStorage(testISVCNamespace, "pvc-model-2", "shared-runtime", "pvc-key-2", "path2")
+		sr := newServingRuntime(testISVCNamespace, "shared-runtime", true)
+		ns := newNamespace(testISVCNamespace, nil)
+		secret := newStorageConfigSecret(testISVCNamespace, map[string]storageConfigEntryJSON{
+			"pvc-key-1": {Type: "pvc", Bucket: "vol1", LocalPath: "/path1"},
+			"pvc-key-2": {Type: "pvc", Bucket: "vol2", LocalPath: "/path2"},
+		})
+
+		scheme := runtime.NewScheme()
+
+		listKinds := map[schema.GroupVersionResource]string{
+			resources.InferenceService.GVR(): resources.InferenceService.ListKind(),
+			resources.ServingRuntime.GVR():   resources.ServingRuntime.ListKind(),
+			resources.ServiceAccount.GVR():   resources.ServiceAccount.ListKind(),
+			resources.Role.GVR():             resources.Role.ListKind(),
+			resources.RoleBinding.GVR():      resources.RoleBinding.ListKind(),
+			resources.Namespace.GVR():        resources.Namespace.ListKind(),
+			resources.Secret.GVR():           resources.Secret.ListKind(),
+		}
+
+		dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme, listKinds, isvc1, isvc2, sr, ns, secret,
+		)
+
+		target := newTestTarget(dynamicClient, "2.25.0", false)
+
+		a := &modelserving.ModelMeshToRawAction{}
+		actionResult, err := a.Run().Execute(ctx, target)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(actionResult).ToNot(BeNil())
+
+		// Both ISVCs should still be converted to RawDeployment
+		for _, name := range []string{"pvc-model-1", "pvc-model-2"} {
+			updated, getErr := dynamicClient.Resource(resources.InferenceService.GVR()).
+				Namespace(testISVCNamespace).
+				Get(ctx, name, metav1.GetOptions{})
+
+			g.Expect(getErr).ToNot(HaveOccurred())
+
+			ann := updated.GetAnnotations()
+			g.Expect(ann).To(HaveKeyWithValue("serving.kserve.io/deploymentMode", "RawDeployment"))
+		}
+
+		// Result should contain a failed step for the shared runtime
+		g.Expect(actionResult.HasFailedSteps()).To(BeTrue())
+	})
+}

--- a/pkg/migrate/actions/modelserving/support.go
+++ b/pkg/migrate/actions/modelserving/support.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -820,12 +821,22 @@ func getISVCStorageKey(isvc *unstructured.Unstructured) string {
 }
 
 // buildPVCStorageURI constructs a KServe-compatible PVC storage URI.
-func buildPVCStorageURI(entry *storageConfigEntry) string {
-	path := strings.TrimPrefix(entry.LocalPath, "/")
-
-	if path == "" {
-		return fmt.Sprintf("pvc://%s/", entry.Bucket)
+// Returns an error when the storage-config entry cannot produce a valid URI.
+func buildPVCStorageURI(entry *storageConfigEntry) (string, error) {
+	if entry.Bucket == "" {
+		return "", errors.New("storage-config entry has empty bucket (PVC name)")
 	}
 
-	return fmt.Sprintf("pvc://%s/%s", entry.Bucket, path)
+	trimmed := strings.TrimPrefix(entry.LocalPath, "/")
+
+	if trimmed == "" {
+		return fmt.Sprintf("pvc://%s/", entry.Bucket), nil
+	}
+
+	cleaned := path.Clean(trimmed)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("storage-config localPath %q escapes the volume root", entry.LocalPath)
+	}
+
+	return fmt.Sprintf("pvc://%s/%s", entry.Bucket, cleaned), nil
 }

--- a/pkg/migrate/actions/modelserving/support.go
+++ b/pkg/migrate/actions/modelserving/support.go
@@ -2,6 +2,7 @@ package modelserving
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -100,6 +101,16 @@ const (
 	msgDeleteIstioRouteFail = "Failed to delete Istio VirtualService %s/%s: %v (continuing)"
 	msgDeleteIstioRouteDry  = "Would delete Istio VirtualService %s/%s"
 	msgDeleteIstioRouteNF   = "Istio VirtualService %s/%s not found (already cleaned up)"
+
+	// Storage-config constants.
+	storageConfigSecretName = "storage-config"
+	storageTypePVC          = "pvc"
+
+	// OVMS single-model constants.
+	ovmsRESTPort              int64 = 8888
+	ovmsGRPCPort              int64 = 8001
+	ovmsReadinessInitialDelay int64 = 5
+	ovmsReadinessPeriod       int64 = 10
 )
 
 // inferenceServiceConfig preserves all fields in the inferenceService JSON
@@ -741,4 +752,80 @@ func deleteIstioRoute(
 	}
 
 	step.Recordf("delete-istio-route", msgDeleteIstioRoute, result.StepCompleted, istioSystemNamespace, vsName)
+}
+
+// storageConfigEntry represents a decoded entry from the storage-config secret.
+type storageConfigEntry struct {
+	Type      string `json:"type"`
+	Bucket    string `json:"bucket"`
+	LocalPath string `json:"localPath"`
+}
+
+// getStorageConfigEntry fetches the storage-config secret in the given namespace,
+// decodes the base64 value for storageKey, and parses it as JSON.
+// Returns nil with no error when the secret or key is not found.
+func getStorageConfigEntry(
+	ctx context.Context,
+	target action.Target,
+	namespace string,
+	storageKey string,
+) (*storageConfigEntry, error) {
+	secret, err := target.Client.Dynamic().Resource(resources.Secret.GVR()).
+		Namespace(namespace).
+		Get(ctx, storageConfigSecretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("getting storage-config secret in %s: %w", namespace, err)
+	}
+
+	data, found, err := unstructured.NestedMap(secret.Object, "data")
+	if err != nil || !found {
+		return nil, nil
+	}
+
+	encodedVal, ok := data[storageKey]
+	if !ok {
+		return nil, nil
+	}
+
+	encodedStr, ok := encodedVal.(string)
+	if !ok {
+		return nil, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encodedStr)
+	if err != nil {
+		return nil, fmt.Errorf("decoding storage-config entry %q: %w", storageKey, err)
+	}
+
+	var entry storageConfigEntry
+	if err := json.Unmarshal(decoded, &entry); err != nil {
+		return nil, fmt.Errorf("parsing storage-config entry %q: %w", storageKey, err)
+	}
+
+	return &entry, nil
+}
+
+// getISVCStorageKey extracts the storage key from an ISVC's spec.
+func getISVCStorageKey(isvc *unstructured.Unstructured) string {
+	key, err := jq.Query[string](isvc, ".spec.predictor.model.storage.key")
+	if err != nil {
+		return ""
+	}
+
+	return key
+}
+
+// buildPVCStorageURI constructs a KServe-compatible PVC storage URI.
+func buildPVCStorageURI(entry *storageConfigEntry) string {
+	path := strings.TrimPrefix(entry.LocalPath, "/")
+
+	if path == "" {
+		return fmt.Sprintf("pvc://%s/", entry.Bucket)
+	}
+
+	return fmt.Sprintf("pvc://%s/%s", entry.Bucket, path)
 }


### PR DESCRIPTION
## Summary

- Adds PVC storage type detection via `storage-config` secret inspection during `modelmesh-to-raw` migration
- Implements full PVC conversion: `storageUri` rewrite to `pvc://<name>/<path>`, OVMS single-model args (`--model_name`, `--model_path`, `--port`, `--rest_port`), containerPort 8888, TCP readiness probe
- Folds deployment mode annotation into single ISVC Update (no separate Patch) to prevent broken state if conversion fails
- Warns when multiple PVC ISVCs share a ServingRuntime (single-model constraint)
- Dry-run mode surfaces PVC detection and planned changes
- Migration summary distinguishes standard vs PVC-backed ISVC counts

## Test plan

- [x] PVC-backed ISVC converted with storageUri rewrite and storage key removed
- [x] ServingRuntime patched with single-model OVMS args, port 8888, readiness probe
- [x] S3-backed ISVCs with storage key convert via standard path (no storageUri rewrite)
- [x] Mixed S3 and PVC ISVCs both convert correctly
- [x] Dry-run detects PVC storage and reports without mutation
- [x] Missing storage-config secret treated as standard (graceful fallback)
- [x] Missing storage key in secret treated as standard
- [x] Deployment mode set atomically with storageUri in single update
- [x] Shared ServingRuntime across multiple PVC ISVCs produces failed step warning
- [x] All 79 modelserving tests pass, lint 0 issues, vet clean

Resolves: [RHOAIENG-88891](https://redhat.atlassian.net/browse/RHOAIENG-88891)

🤖 Generated with [Claude Code](https://claude.ai/code)

[RHOAIENG-88891]: https://redhat.atlassian.net/browse/RHOAIENG-88891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration support for models stored on persistent volumes.
  * Rewrites model storage locations and configures serving runtimes for single-model deployment.
  * Supports mixed persistent-volume and object-storage migrations.
  * Provides warnings when multiple converted models share a serving runtime.

* **Bug Fixes**
  * Added handling for missing, encoded, or malformed storage configuration data.
  * Preserves atomic updates and dry-run behavior during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->