### PR TITLE
fix: detect notebooks missing auth migration

### DIFF
--- a/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
+++ b/pkg/migrate/actions/workbenches/authmodel/authmodel_test.go
@@ -563,7 +563,7 @@ func TestNeedsAuthModelPatch_AlreadyPatched(t *testing.T) {
 	g.Expect(needsAuthModelPatch(nb)).To(BeFalse())
 }
 
-func TestNeedsAuthModelPatch_CleanNotebook(t *testing.T) {
+func TestNeedsAuthModelPatch_MissingInjectAuthAnnotation(t *testing.T) {
 	g := NewWithT(t)
 
 	nb := newNotebook("wb1", "ns1",
@@ -571,7 +571,7 @@ func TestNeedsAuthModelPatch_CleanNotebook(t *testing.T) {
 		withVolumes(volume("data")),
 	)
 
-	g.Expect(needsAuthModelPatch(nb)).To(BeFalse())
+	g.Expect(needsAuthModelPatch(nb)).To(BeTrue())
 }
 
 func TestAddInjectAuthAnnotation(t *testing.T) {

--- a/pkg/migrate/actions/workbenches/authmodel/patch.go
+++ b/pkg/migrate/actions/workbenches/authmodel/patch.go
@@ -91,14 +91,19 @@ func removeTornadoArg(s string) string {
 	}
 }
 
-// needsAuthModelPatch returns true if the notebook still has any 2.x OAuth
-// artifacts that must be removed before 3.x.
+// needsAuthModelPatch returns true until the notebook has the 3.x auth
+// annotation and no remaining 2.x OAuth artifacts.
 func needsAuthModelPatch(nb *unstructured.Unstructured) bool {
-	return hasOAuthAnnotation(nb) ||
+	return !hasInjectAuthAnnotation(nb) ||
+		hasOAuthAnnotation(nb) ||
 		hasOAuthProxyContainer(nb) ||
 		hasOAuthFinalizer(nb) ||
 		hasOAuthVolumes(nb) ||
 		hasTornadoSettings(nb)
+}
+
+func hasInjectAuthAnnotation(nb *unstructured.Unstructured) bool {
+	return nb.GetAnnotations()[annotationInjectAuth] == "true"
 }
 
 // hasOAuthAnnotation returns true if inject-oauth or oauth-logout-url is present.


### PR DESCRIPTION
## Summary

- treat a Notebook without `inject-auth: "true"` as requiring the auth-model patch, even when it has no legacy OAuth artifacts
- prevent `workbenches.patch-auth-model` from reporting such Notebooks as already patched
- add regression coverage for a minimal Notebook without legacy OAuth artifacts or the 3.x auth annotation

## Testing

- `go test -v ./pkg/migrate/actions/workbenches/authmodel -run '^TestNeedsAuthModelPatch_'`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notebook migration checks to identify notebooks missing the required authentication injection annotation.
  * Ensured notebooks without the 3.x authentication configuration are correctly flagged for an authentication-model patch.
  * Continued detecting legacy OAuth artifacts that require migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->